### PR TITLE
feat: coin value formatting, tests, and dev tooling

### DIFF
--- a/.kiro/hooks/create-pr-develop.kiro.hook
+++ b/.kiro/hooks/create-pr-develop.kiro.hook
@@ -1,0 +1,13 @@
+{
+  "enabled": true,
+  "name": "Create PR into develop",
+  "description": "Creates a GitHub PR from the current branch into develop. Inspects recent commits to write a meaningful title and description, then runs gh pr create.",
+  "version": "1",
+  "when": {
+    "type": "userTriggered"
+  },
+  "then": {
+    "type": "askAgent",
+    "prompt": "Create a GitHub PR from the current branch into develop using the gh cli. 1) Run `git fetch origin develop` to get the latest develop. 2) Run `git log HEAD..origin/develop --oneline` — if there are commits, warn the user that the branch is behind develop and ask if they want to rebase (`git rebase origin/develop`) before continuing; if they decline, abort. 3) Run `git push --set-upstream origin HEAD` to push the branch. 4) Run `git log develop..HEAD --oneline` to see the commits. 5) Derive a concise PR title and a grouped description from the commit messages. 6) Run `gh pr create --base develop` with that title and body. Share the resulting PR URL."
+  }
+}

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,16 +1,16 @@
 # Project Structure
 
-dcrdata is organized as multiple Go modules in a single repository.
+monetarium-explorer is organized as multiple Go modules in a single repository.
 
 ## Go Modules
 
-| Path          | Module                                   | Purpose                                                                                        |
-| ------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `.`           | `github.com/decred/dcrdata/v8`           | Root module — shared packages (blockdata, mempool, pubsub, txhelpers, stakedb, rpcutils, etc.) |
-| `cmd/dcrdata` | `github.com/decred/dcrdata/cmd/dcrdata`  | Main executable — block explorer + APIs                                                        |
-| `db/dcrpg`    | `github.com/decred/dcrdata/db/dcrpg/v8`  | PostgreSQL backend                                                                             |
-| `exchanges`   | `github.com/decred/dcrdata/exchanges/v3` | Exchange rate bot                                                                              |
-| `gov`         | `github.com/decred/dcrdata/gov/v6`       | Governance (agendas, Politeia)                                                                 |
+| Path          | Module                                                  | Purpose                                                                                        |
+| ------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `.`           | `github.com/monetarium/monetarium-explorer`             | Root module — shared packages (blockdata, mempool, pubsub, txhelpers, stakedb, rpcutils, etc.) |
+| `cmd/dcrdata` | `github.com/monetarium/monetarium-explorer/cmd/dcrdata` | Main executable — block explorer + APIs                                                        |
+| `db/dcrpg`    | `github.com/monetarium/monetarium-explorer/db/dcrpg`    | PostgreSQL backend                                                                             |
+| `exchanges`   | `github.com/monetarium/monetarium-explorer/exchanges`   | Exchange rate bot                                                                              |
+| `gov`         | `github.com/monetarium/monetarium-explorer/gov`         | Governance (agendas, Politeia)                                                                 |
 
 Dependent modules use `replace` directives in their `go.mod` to point at local paths.
 

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -2,12 +2,12 @@
 
 ## Backend
 
-- **Language**: Go 1.21+ (multi-module workspace; `cmd/dcrdata` requires Go 1.22)
+- **Language**: Go 1.23 (multi-module workspace)
 - **Big-number arithmetic**: A specialized module is required for SKA token calculations (15 integer + 18 decimal digits — exceeds float64 precision). Do not use standard Go numeric types for SKA amounts.
 - **HTTP router**: `go-chi/chi/v5`
 - **Database**: PostgreSQL via `lib/pq`; Badger (embedded KV) for stake data
 - **Logging**: `decred/slog` with `jrick/logrotate`
-- **RPC**: `decred/dcrd/rpcclient/v8` for dcrd communication; gRPC for exchange rate server
+- **RPC**: `monetarium/monetarium-node/rpcclient` for node communication; gRPC for exchange rate server
 - **WebSocket**: `gorilla/websocket`, `googollee/go-socket.io` (Insight API)
 - **Rate limiting**: `didip/tollbooth/v6`
 - **CORS**: `rs/cors`
@@ -15,11 +15,12 @@
 
 ## Frontend
 
-- **Bundler**: Webpack 5 (configs: `webpack.common.js`, `webpack.dev.js`, `webpack.prod.js`, `webpack.analyze.js`)
-- **JS framework**: Stimulus 3 — one controller per page feature in `public/js/controllers/`
+- **Bundler**: Webpack 5 (configs: `webpack.common.cjs`, `webpack.dev.cjs`, `webpack.prod.cjs`, `webpack.analyze.cjs`)
+- **JS framework**: Stimulus 3 (`@hotwired/stimulus`) — one controller per page feature in `public/js/controllers/`
 - **SPA navigation**: Turbolinks 5.2.0 (vendored at `public/js/vendor/turbolinks.min.js`) — not Hotwire Turbo
 - **CSS**: SCSS compiled via `sass-loader`; Bootstrap 5 as base; custom overrides in `public/scss/`
 - **Templates**: Go `html/template` (`.tmpl` files in `cmd/dcrdata/views/`)
+- **Testing**: Vitest with jsdom environment for unit tests
 - **Key JS deps**: `lodash-es`, `dompurify`, `qrcode`, `mousetrap`, `url-parse`, `regenerator-runtime`
 
 ## Linting
@@ -39,7 +40,10 @@ cd cmd/dcrdata
 npm clean-install        # install node deps
 npm run build            # production webpack bundle → public/dist/
 npm run watch            # dev watch mode
+npm run test             # run vitest unit tests
 npm run lint             # ESLint on public/js
+npm run lint:css         # Stylelint on public/scss
+npm run format           # Prettier format JS and SCSS
 npm run analyze          # webpack bundle analysis
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Monetarium Explorer is a block explorer for the [Monetarium](https://monetarium.
 - [Overview](#overview)
 - [Requirements](#requirements)
 - [Building](#building)
+- [Contributing](#contributing)
 - [Local Testing on Testnet](#local-testing-on-testnet)
 - [Getting Started (Production)](#getting-started-production)
 - [APIs](#apis)
@@ -87,6 +88,50 @@ The `public` and `views` folders must remain in the same directory as the `monet
 
 ---
 
+## Contributing
+
+### Install git hooks
+
+After cloning, run this once to install the pre-commit hooks:
+
+```sh
+./dev/install-hooks.sh
+```
+
+The pre-commit hook runs automatically on every `git commit` and checks only the files you've staged:
+
+| Staged files      | Checks run                                                 |
+| ----------------- | ---------------------------------------------------------- |
+| `*.go`            | `gofmt` format check + `go test ./...` per affected module |
+| `*.js` / `*.scss` | Prettier format check, ESLint, Stylelint, Vitest           |
+
+If any check fails, the commit is blocked with instructions on how to fix it.
+
+### Running checks manually
+
+**Go** (from any module directory):
+
+```sh
+gofmt -l .                        # list files needing formatting
+gofmt -w .                        # fix formatting
+go test ./...                     # run tests
+golangci-lint run -c .golangci.yml
+```
+
+**JS / SCSS** (from `cmd/dcrdata`):
+
+```sh
+npm run format:check   # prettier check
+npm run format         # prettier fix
+npm run lint           # ESLint
+npm run lint:fix       # ESLint fix
+npm run lint:css       # Stylelint
+npm run lint:css:fix   # Stylelint fix
+npm test               # Vitest unit tests
+```
+
+---
+
 ## Local Testing on Testnet
 
 ### Prerequisites
@@ -114,6 +159,7 @@ Start and wait for full sync:
 ```sh
 ./monetarium-node --testnet
 ```
+
 Wait until the log shows `New best block` at the current testnet height before proceeding.
 
 ---
@@ -124,6 +170,7 @@ Wait until the log shows `New best block` at the current testnet height before p
 createuser -P monetarium_testnet    # enter a password, e.g. "testpass"
 createdb -O monetarium_testnet monetarium_testnet
 ```
+
 ---
 
 ### Step 3: Configure monetarium-explorer
@@ -175,7 +222,6 @@ On first run the explorer will create the DB schema and begin syncing all blocks
 
 Once sync reaches the tip, open:
 
-
 http://127.0.0.1:7777
 
 Check the API:
@@ -188,22 +234,22 @@ curl http://127.0.0.1:7777/api/block/best
 
 ### Ports reference
 
-| Service | Port |
-|---|---|
-| monetarium-node P2P (testnet3) | 19508 |
-| monetarium-node RPC (testnet3) | 19509 |
-| monetarium-explorer web/API | 7777 (configurable) |
+| Service                        | Port                |
+| ------------------------------ | ------------------- |
+| monetarium-node P2P (testnet3) | 19508               |
+| monetarium-node RPC (testnet3) | 19509               |
+| monetarium-explorer web/API    | 7777 (configurable) |
 
 ---
 
 ### Troubleshooting
 
-| Error | Fix |
-|---|---|
-| `expected network testnet3, got Unknown CurrencyNet` | Rebuild monetarium-node from source; stale binary has old wire constants |
-| `Connection to dcrd failed` | Verify `dcrdserv`, `dcrduser`, `dcrdpass`, and that the node is fully started |
-| `pq: relation does not exist` | Ensure `pg=1` is set and the DB user has CREATE privileges |
-| `bad project fund address` | Safe to ignore; Monetarium has no treasury |
+| Error                                                | Fix                                                                           |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `expected network testnet3, got Unknown CurrencyNet` | Rebuild monetarium-node from source; stale binary has old wire constants      |
+| `Connection to dcrd failed`                          | Verify `dcrdserv`, `dcrduser`, `dcrdpass`, and that the node is fully started |
+| `pq: relation does not exist`                        | Ensure `pg=1` is set and the DB user has CREATE privileges                    |
+| `bad project fund address`                           | Safe to ignore; Monetarium has no treasury                                    |
 
 ---
 
@@ -226,10 +272,10 @@ On first startup the explorer imports all blockchain data and builds indexes. Th
 
 ### Hardware requirements
 
-| Setup | CPU | RAM | Storage |
-|---|---|---|---|
-| Explorer only (remote DB) | 1 core | 2 GB | 8 GB HDD |
-| Explorer + PostgreSQL | 3+ cores | 12+ GB | 120 GB NVMe SSD |
+| Setup                     | CPU      | RAM    | Storage         |
+| ------------------------- | -------- | ------ | --------------- |
+| Explorer only (remote DB) | 1 core   | 2 GB   | 8 GB HDD        |
+| Explorer + PostgreSQL     | 3+ cores | 12+ GB | 120 GB NVMe SSD |
 
 ---
 
@@ -244,15 +290,15 @@ See [docs/Insight_API_documentation.md](docs/Insight_API_documentation.md) for t
 
 Key dcrdata API endpoints:
 
-| Resource | Path |
-|---|---|
-| Best block summary | `/api/block/best` |
-| Block by height | `/api/block/{height}` |
-| Transaction | `/api/tx/{txid}` |
-| Address | `/api/address/{address}` |
-| Coin supply | `/api/supply` |
-| Mempool tickets | `/api/mempool/sstx` |
-| Status | `/api/status` |
+| Resource           | Path                     |
+| ------------------ | ------------------------ |
+| Best block summary | `/api/block/best`        |
+| Block by height    | `/api/block/{height}`    |
+| Transaction        | `/api/tx/{txid}`         |
+| Address            | `/api/address/{address}` |
+| Coin supply        | `/api/supply`            |
+| Mempool tickets    | `/api/mempool/sstx`      |
+| Status             | `/api/status`            |
 
 All endpoints accept `?indent=true` for pretty-printed JSON.
 

--- a/cmd/dcrdata/.npmrc
+++ b/cmd/dcrdata/.npmrc
@@ -1,0 +1,4 @@
+min-release-age=7
+ignore-scripts=true
+audit=true
+fund=false

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -34,16 +34,86 @@ func TestSimNetName(t *testing.T) {
 }
 
 // func TestThreeSigFigs(t *testing.T) {
-// 	source := rand.NewSource(time.Now().Unix())
-// 	generator := rand.New(source)
-// 	for i := 0; i < 8; i++ {
-// 		flt := generator.Float64()
-// 		flt = flt * math.Pow10(-i)
-// 		fmt.Printf("%.8f -> %s\n", flt, threeSigFigs(flt))
-// 	}
-// 	for i := 0; i < 13; i++ {
-// 		flt := generator.Float64()
-// 		flt = flt * math.Pow10(i)
-// 		fmt.Printf("%.8f -> %s\n", flt, threeSigFigs(flt))
-// 	}
+// ...
 // }
+
+// TestThreeSigFigs covers every threshold branch in threeSigFigs, walking from
+// the largest values down to zero. Each case documents what the function
+// actually produces so the output is self-describing.
+func TestThreeSigFigs(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		// ---- large numbers ----
+		// >= 1e11  → "%dB"   (rounds to nearest billion, no decimal)
+		{1e11, "100B"},
+		{2.5e11, "250B"},
+		{1.999e11, "200B"},
+
+		// >= 1e10  → "%.1fB"  (one decimal billion)
+		{1e10, "10.0B"},
+		{1.55e10, "15.5B"},
+		{9.99e10, "99.9B"}, // stays in 1-decimal bracket, does not round up to next
+		// >= 1e9   → "%.2fB"  (two decimal billion)
+		{1e9, "1.00B"},
+		{1.235e9, "1.24B"},
+		{9.999e9, "10.00B"}, // stays in 2-decimal bracket, does not round up
+
+		// >= 1e8   → "%dM"
+		{1e8, "100M"},
+		{4.5e8, "450M"},
+
+		// >= 1e7   → "%.1fM"
+		{1e7, "10.0M"},
+		{1.55e7, "15.5M"},
+
+		// >= 1e6   → "%.2fM"
+		{1e6, "1.00M"},
+		{1.235e6, "1.24M"},
+
+		// >= 1e5   → "%dk"
+		{1e5, "100k"},
+		{4.5e5, "450k"},
+
+		// >= 1e4   → "%.1fk"
+		{1e4, "10.0k"},
+		{1.55e4, "15.5k"},
+
+		// >= 1e3   → "%.2fk"
+		{1e3, "1.00k"},
+		{1.235e3, "1.24k"},
+
+		// ---- sub-thousand, >= 100 → "%d"
+		{100, "100"},
+		{456, "456"},
+		{999, "999"},
+
+		// ---- >= 10  → "%.1f"
+		{10, "10.0"},
+		{15.5, "15.5"},
+		{99.9, "99.9"},
+
+		// ---- >= 1   → "%.2f"
+		{1, "1.00"},
+		{1.23, "1.23"},
+		{9.99, "9.99"},
+
+		// ---- sub-1: VAR fees can be fractional coins (e.g. 0.001 VAR fee)
+		// threeSigFigs handles these correctly down to ~0.00001.
+		{0.5, "0.500"},
+		{0.1, "0.100"},
+		{0.01, "0.0100"},
+		{0.001, "0.00100"},
+
+		// ---- zero
+		{0, "0"},
+	}
+
+	for _, c := range cases {
+		got := threeSigFigs(c.in)
+		if got != c.want {
+			t.Errorf("threeSigFigs(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/cmd/dcrdata/internal/explorer/home_viewmodel.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel.go
@@ -62,14 +62,26 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 					// VAR row
 					varTxCount = cr.TxCount
 					varAmount = formatCoinAtoms(cr.Amount, cr.CoinType)
-					varSize = fmt.Sprintf("%d B", cr.Size)
+					if cr.Size > 0 {
+						varSize = fmt.Sprintf("%d B", cr.Size)
+					} else {
+						varSize = "—"
+					}
 				} else {
 					// SKA row — add to sub-rows
+					txCount := "—"
+					if cr.TxCount > 0 {
+						txCount = fmt.Sprintf("%d", cr.TxCount)
+					}
+					size := "—"
+					if cr.Size > 0 {
+						size = fmt.Sprintf("%d B", cr.Size)
+					}
 					subRows = append(subRows, SKASubRow{
 						TokenType: cr.Symbol,
-						TxCount:   fmt.Sprintf("%d", cr.TxCount),
+						TxCount:   txCount,
 						Amount:    formatCoinAtoms(cr.Amount, cr.CoinType),
-						Size:      fmt.Sprintf("%d B", cr.Size),
+						Size:      size,
 					})
 				}
 			}

--- a/cmd/dcrdata/internal/explorer/home_viewmodel.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel.go
@@ -61,14 +61,14 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 				if cr.CoinType == 0 {
 					// VAR row
 					varTxCount = cr.TxCount
-					varAmount = cr.Amount
+					varAmount = formatCoinAtoms(cr.Amount, cr.CoinType)
 					varSize = fmt.Sprintf("%d B", cr.Size)
 				} else {
 					// SKA row — add to sub-rows
 					subRows = append(subRows, SKASubRow{
 						TokenType: cr.Symbol,
 						TxCount:   fmt.Sprintf("%d", cr.TxCount),
-						Amount:    cr.Amount,
+						Amount:    formatCoinAtoms(cr.Amount, cr.CoinType),
 						Size:      fmt.Sprintf("%d B", cr.Size),
 					})
 				}

--- a/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
@@ -113,15 +113,17 @@ func TestBuildHomeBlockRows_VAROnly(t *testing.T) {
 	}
 }
 
-// TestBuildHomeBlockRows_WithCoinRows verifies that CoinRows data is correctly
-// mapped to VAR and SKA fields.
+// TestBuildHomeBlockRows_WithCoinRows verifies that CoinRows atom strings are
+// formatted via threeSigFigs for both VAR and SKA fields.
 func TestBuildHomeBlockRows_WithCoinRows(t *testing.T) {
 	b := &types.BlockBasic{
 		Height:       20,
 		Transactions: 7,
 		CoinRows: []types.CoinRowData{
-			{CoinType: 0, Symbol: "VAR", TxCount: 5, Amount: "1.23K VAR", Size: 1024},
-			{CoinType: 1, Symbol: "SKA-1", TxCount: 2, Amount: "4.56M SKA-1", Size: 512},
+			// 1 230 000 000 VAR atoms = 12.3 VAR coins (8 decimals)
+			{CoinType: 0, Symbol: "VAR", TxCount: 5, Amount: "1230000000", Size: 1024},
+			// 1 230 000 000 000 000 000 SKA atoms = 1.23 SKA coins (18 decimals)
+			{CoinType: 1, Symbol: "SKA-1", TxCount: 2, Amount: "1230000000000000000", Size: 512},
 		},
 	}
 	rows := buildHomeBlockRows([]*types.BlockBasic{b})
@@ -133,8 +135,9 @@ func TestBuildHomeBlockRows_WithCoinRows(t *testing.T) {
 	if r.VARTxCount != 5 {
 		t.Errorf("VARTxCount: got %d, want 5", r.VARTxCount)
 	}
-	if r.VARAmount != "1.23K VAR" {
-		t.Errorf("VARAmount: got %q, want %q", r.VARAmount, "1.23K VAR")
+	wantVAR := threeSigFigs(float64(1230000000) / 1e8) // "12.3"
+	if r.VARAmount != wantVAR {
+		t.Errorf("VARAmount: got %q, want %q", r.VARAmount, wantVAR)
 	}
 	if len(r.SKASubRows) != 1 {
 		t.Fatalf("expected 1 SKASubRow, got %d", len(r.SKASubRows))
@@ -142,12 +145,13 @@ func TestBuildHomeBlockRows_WithCoinRows(t *testing.T) {
 	if r.SKASubRows[0].TokenType != "SKA-1" {
 		t.Errorf("SKASubRow TokenType: got %q, want %q", r.SKASubRows[0].TokenType, "SKA-1")
 	}
-	if r.SKASubRows[0].Amount != "4.56M SKA-1" {
-		t.Errorf("SKASubRow Amount: got %q, want %q", r.SKASubRows[0].Amount, "4.56M SKA-1")
+	wantSKA := threeSigFigs(skaCoinValue("1230000000000000000")) // "1.23"
+	if r.SKASubRows[0].Amount != wantSKA {
+		t.Errorf("SKASubRow Amount: got %q, want %q", r.SKASubRows[0].Amount, wantSKA)
 	}
 	// Single SKA type: SKAAmount should equal the sub-row amount.
-	if r.SKAAmount != "4.56M SKA-1" {
-		t.Errorf("SKAAmount: got %q, want %q", r.SKAAmount, "4.56M SKA-1")
+	if r.SKAAmount != wantSKA {
+		t.Errorf("SKAAmount: got %q, want %q", r.SKAAmount, wantSKA)
 	}
 }
 
@@ -157,9 +161,9 @@ func TestBuildHomeBlockRows_MultipleSKATypes(t *testing.T) {
 	b := &types.BlockBasic{
 		Height: 30,
 		CoinRows: []types.CoinRowData{
-			{CoinType: 0, Symbol: "VAR", TxCount: 3, Amount: "100 VAR", Size: 200},
-			{CoinType: 1, Symbol: "SKA-1", TxCount: 1, Amount: "50 SKA-1", Size: 100},
-			{CoinType: 2, Symbol: "SKA-2", TxCount: 2, Amount: "75 SKA-2", Size: 150},
+			{CoinType: 0, Symbol: "VAR", TxCount: 3, Amount: "10000000000", Size: 200},
+			{CoinType: 1, Symbol: "SKA-1", TxCount: 1, Amount: "50000000000000000000", Size: 100},
+			{CoinType: 2, Symbol: "SKA-2", TxCount: 2, Amount: "75000000000000000000", Size: 150},
 		},
 	}
 	rows := buildHomeBlockRows([]*types.BlockBasic{b})
@@ -183,9 +187,9 @@ func TestBuildHomeBlockRows_SKASubRowTokenTypeNonEmpty(t *testing.T) {
 	b := &types.BlockBasic{
 		Height: 40,
 		CoinRows: []types.CoinRowData{
-			{CoinType: 0, Symbol: "VAR", Amount: "10 VAR"},
-			{CoinType: 1, Symbol: "SKA-1", Amount: "20 SKA-1"},
-			{CoinType: 3, Symbol: "SKA-3", Amount: "30 SKA-3"},
+			{CoinType: 0, Symbol: "VAR", Amount: "1000000000"},
+			{CoinType: 1, Symbol: "SKA-1", Amount: "1000000000000000000"},
+			{CoinType: 3, Symbol: "SKA-3", Amount: "2000000000000000000"},
 		},
 	}
 	rows := buildHomeBlockRows([]*types.BlockBasic{b})
@@ -246,7 +250,81 @@ func TestProp_HomeBlockRowFieldPreservation(t *testing.T) {
 	})
 }
 
-// TestProp_VARAmountPreFormatted verifies that VARAmount matches threeSigFigs
+// TestFormatCoinAtoms verifies the adapter routes VAR and SKA atom strings
+// to the correct divisor and formatter.
+func TestFormatCoinAtoms(t *testing.T) {
+	cases := []struct {
+		atomStr  string
+		coinType uint8
+		want     string
+	}{
+		// VAR: 8 decimal places
+		{"1000000000", 0, "10.0"}, // 10 VAR coins
+		{"100000000", 0, "1.00"},  // 1 VAR coin
+		{"0", 0, "0"},
+		// SKA: 18 decimal places
+		{"1000000000000000000", 1, "1.00"},     // 1 SKA coin, type 1
+		{"1000000000000000000000", 2, "1.00k"}, // 1000 SKA coins, type 2
+		{"0", 1, "0"},
+	}
+	for _, c := range cases {
+		got := formatCoinAtoms(c.atomStr, c.coinType)
+		if got != c.want {
+			t.Errorf("formatCoinAtoms(%q, %d) = %q, want %q", c.atomStr, c.coinType, got, c.want)
+		}
+	}
+}
+
+// TestSkaCoinValue covers the canonical conversion cases for skaCoinValue.
+func TestSkaCoinValue(t *testing.T) {
+	cases := []struct {
+		input string
+		want  float64
+	}{
+		{"", 0},
+		{"0", 0},
+		{"notanumber", 0},
+		{"1000000000000000000", 1.0},       // exactly 1 SKA coin
+		{"1500000000000000000", 1.5},       // 1.5 SKA coins
+		{"1000000000000000000000", 1000.0}, // 1 000 SKA coins (k range)
+		{"1000000000000000000000000", 1e6}, // 1 M SKA coins
+		{"500000000000000000", 0.5},        // sub-1: 0.5 coin
+		{"100000000000000000", 0.1},        // sub-1: 0.1 coin
+		{"1000000000000000", 0.001},        // sub-1: 0.001 coin
+		{"1", 1e-18},                       // sub-1: single atom, smallest possible value
+	}
+	for _, c := range cases {
+		got := skaCoinValue(c.input)
+		if got != c.want {
+			t.Errorf("skaCoinValue(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
+}
+
+// TestSkaCoinValue_ThreeSigFigs verifies that skaCoinValue feeds correctly into
+// threeSigFigs for representative magnitudes.
+func TestSkaCoinValue_ThreeSigFigs(t *testing.T) {
+	cases := []struct {
+		atoms string
+		want  string
+	}{
+		{"1000000000000000000", "1.00"},           // 1 coin
+		{"1230000000000000000", "1.23"},           // 1.23 coins
+		{"1000000000000000000000", "1.00k"},       // 1 000 coins
+		{"1000000000000000000000000", "1.00M"},    // 1 M coins
+		{"1000000000000000000000000000", "1.00B"}, // 1 B coins
+		{"500000000000000000", "0.500"},           // sub-1: 0.5 coin
+		{"100000000000000000", "0.100"},           // sub-1: 0.1 coin
+		{"1000000000000000", "0.00100"},           // sub-1: 0.001 coin
+	}
+	for _, c := range cases {
+		got := threeSigFigs(skaCoinValue(c.atoms))
+		if got != c.want {
+			t.Errorf("threeSigFigs(skaCoinValue(%q)) = %q, want %q", c.atoms, got, c.want)
+		}
+	}
+}
+
 // when no CoinRows are present (VAR-only fallback path).
 func TestProp_VARAmountPreFormatted(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"math"
+	"math/big"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -252,6 +253,49 @@ func threeSigFigs(v float64) string {
 		return "0"
 	}
 	return fmt.Sprintf("%.8f", math.Round(v*1e8)/1e8)
+}
+
+// skaDecimals is 10^18 — the number of SKA atoms per coin.
+var skaDecimals = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+// parseInt64 parses a decimal atom string to int64, returning 0 on error.
+func parseInt64(s string) int64 {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// skaCoinValue converts a raw SKA atom string (decimal, up to 33 digits) to a
+// coin float64 suitable for passing to threeSigFigs. Returns 0 on empty or
+// invalid input. Uses big.Float arithmetic to avoid float64 precision loss
+// during the division; the final Float64() call is safe because threeSigFigs
+// only needs ~3 significant digits.
+func skaCoinValue(atomStr string) float64 {
+	if atomStr == "" {
+		return 0
+	}
+	atoms := new(big.Int)
+	if _, ok := atoms.SetString(atomStr, 10); !ok {
+		return 0
+	}
+	bf := new(big.Float).SetPrec(128).SetInt(atoms)
+	divisor := new(big.Float).SetPrec(128).SetInt(skaDecimals)
+	bf.Quo(bf, divisor)
+	v, _ := bf.Float64()
+	return v
+}
+
+// formatCoinAtoms converts a raw atom string to a threeSigFigs-formatted coin
+// string. coinType 0 = VAR (8 decimal places), any other value = SKA (18
+// decimal places). This is the single call site for coin amount display — use
+// this instead of calling skaCoinValue or the VAR division directly.
+func formatCoinAtoms(atomStr string, coinType uint8) string {
+	if coinType == 0 {
+		return threeSigFigs(float64(parseInt64(atomStr)) / 1e8)
+	}
+	return threeSigFigs(skaCoinValue(atomStr))
 }
 
 type periodMap struct {

--- a/cmd/dcrdata/package-lock.json
+++ b/cmd/dcrdata/package-lock.json
@@ -27,7 +27,7 @@
         "babel-loader": "^9.1.2",
         "clean-webpack-plugin": "^4.0.0",
         "css-loader": "^6.7.3",
-        "css-minimizer-webpack-plugin": "^4.2.2",
+        "css-minimizer-webpack-plugin": "^8.0.0",
         "eslint": "^9.0.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-promise": "^7.2.1",
@@ -1722,6 +1722,13 @@
         "@keyv/serialize": "^1.1.1"
       }
     },
+    "node_modules/@colordx/core": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.0.3.tgz",
+      "integrity": "sha512-xBQ0MYRTNNxW3mS2sJtlQTT7C3Sasqgh1/PsHva7fyDb5uqYY+gv9V0utDdX8X80mqzbGz3u/IDJdn2d/uW09g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
@@ -2146,6 +2153,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/schemas": {
@@ -3087,6 +3108,13 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.2",
@@ -4328,13 +4356,13 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
-      "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
+      "integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^10 || ^12 || >=14"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
@@ -4400,21 +4428,21 @@
       }
     },
     "node_modules/css-minimizer-webpack-plugin": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-4.2.2.tgz",
-      "integrity": "sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-8.0.0.tgz",
+      "integrity": "sha512-9bEpzHs8gEq6/cbEj418jXL/YWjBUD2YTLLk905Npt2JODqnRITin0+So5Vx4Dp5vyi2Lpt9pp2QHzQ7fdxNrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssnano": "^5.1.8",
-        "jest-worker": "^29.1.2",
-        "postcss": "^8.4.17",
-        "schema-utils": "^4.0.0",
-        "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1"
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "cssnano": "^7.0.4",
+        "jest-worker": "^30.0.5",
+        "postcss": "^8.4.40",
+        "schema-utils": "^4.2.0",
+        "serialize-javascript": "^7.0.3"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 20.9.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4444,17 +4472,136 @@
         }
       }
     },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
       },
       "funding": {
@@ -4502,115 +4649,117 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.15.tgz",
-      "integrity": "sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.4.tgz",
+      "integrity": "sha512-T9PNS7y+5Nc9Qmu9mRONqfxG1RVY7Vuvky0XN6MZ+9hqplesTEwnj9r0ROtVuSwUVfaDhVlavuzWIVLUgm4hkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssnano-preset-default": "^5.2.14",
-        "lilconfig": "^2.0.3",
-        "yaml": "^1.10.2"
+        "cssnano-preset-default": "^7.0.12",
+        "lilconfig": "^3.1.3"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/cssnano"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "5.2.14",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
-      "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.12.tgz",
+      "integrity": "sha512-B3Eoouzw/sl2zANI0AL9KbacummJTCww+fkHaDBMZad/xuVx8bUduPLly6hKVQAlrmvYkS1jB1CVQEKm3gn0AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "css-declaration-sorter": "^6.3.1",
-        "cssnano-utils": "^3.1.0",
-        "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.1",
-        "postcss-convert-values": "^5.1.3",
-        "postcss-discard-comments": "^5.1.2",
-        "postcss-discard-duplicates": "^5.1.0",
-        "postcss-discard-empty": "^5.1.1",
-        "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.7",
-        "postcss-merge-rules": "^5.1.4",
-        "postcss-minify-font-values": "^5.1.0",
-        "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.4",
-        "postcss-minify-selectors": "^5.2.1",
-        "postcss-normalize-charset": "^5.1.0",
-        "postcss-normalize-display-values": "^5.1.0",
-        "postcss-normalize-positions": "^5.1.1",
-        "postcss-normalize-repeat-style": "^5.1.1",
-        "postcss-normalize-string": "^5.1.0",
-        "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.1",
-        "postcss-normalize-url": "^5.1.0",
-        "postcss-normalize-whitespace": "^5.1.1",
-        "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.2",
-        "postcss-reduce-transforms": "^5.1.0",
-        "postcss-svgo": "^5.1.0",
-        "postcss-unique-selectors": "^5.1.1"
+        "browserslist": "^4.28.1",
+        "css-declaration-sorter": "^7.2.0",
+        "cssnano-utils": "^5.0.1",
+        "postcss-calc": "^10.1.1",
+        "postcss-colormin": "^7.0.7",
+        "postcss-convert-values": "^7.0.9",
+        "postcss-discard-comments": "^7.0.6",
+        "postcss-discard-duplicates": "^7.0.2",
+        "postcss-discard-empty": "^7.0.1",
+        "postcss-discard-overridden": "^7.0.1",
+        "postcss-merge-longhand": "^7.0.5",
+        "postcss-merge-rules": "^7.0.8",
+        "postcss-minify-font-values": "^7.0.1",
+        "postcss-minify-gradients": "^7.0.2",
+        "postcss-minify-params": "^7.0.6",
+        "postcss-minify-selectors": "^7.0.6",
+        "postcss-normalize-charset": "^7.0.1",
+        "postcss-normalize-display-values": "^7.0.1",
+        "postcss-normalize-positions": "^7.0.1",
+        "postcss-normalize-repeat-style": "^7.0.1",
+        "postcss-normalize-string": "^7.0.1",
+        "postcss-normalize-timing-functions": "^7.0.1",
+        "postcss-normalize-unicode": "^7.0.6",
+        "postcss-normalize-url": "^7.0.1",
+        "postcss-normalize-whitespace": "^7.0.1",
+        "postcss-ordered-values": "^7.0.2",
+        "postcss-reduce-initial": "^7.0.6",
+        "postcss-reduce-transforms": "^7.0.1",
+        "postcss-svgo": "^7.1.1",
+        "postcss-unique-selectors": "^7.0.5"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/cssnano-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.1.tgz",
+      "integrity": "sha512-ZIP71eQgG9JwjVZsTPSqhc6GHgEr53uJ7tK5///VfyWj6Xp2DBmixWHqJgPno+PqATzn48pL42ww9x5SSGmhZg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "css-tree": "^1.1.2"
+        "css-tree": "~2.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/csso/node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -4828,26 +4977,29 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -4866,13 +5018,13 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       },
       "engines": {
         "node": ">= 4"
@@ -4891,15 +5043,15 @@
       }
     },
     "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -6920,6 +7072,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -7398,13 +7560,16 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lines-and-columns": {
@@ -7445,9 +7610,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -7765,19 +7930,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/nth-check": {
@@ -8329,105 +8481,111 @@
       }
     },
     "node_modules/postcss-calc": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
-      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
+      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.9",
+        "postcss-selector-parser": "^7.0.0",
         "postcss-value-parser": "^4.2.0"
       },
+      "engines": {
+        "node": "^18.12 || ^20.9 || >=22.0"
+      },
       "peerDependencies": {
-        "postcss": "^8.2.2"
+        "postcss": "^8.4.38"
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
-      "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.7.tgz",
+      "integrity": "sha512-sBQ628lSj3VQpDquQel8Pen5mmjFPsO4pH9lDLaHB1AVkMRHtkl0pRB5DCWznc9upWsxint/kV+AveSj7W1tew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "@colordx/core": "^5.0.0",
+        "browserslist": "^4.28.1",
         "caniuse-api": "^3.0.0",
-        "colord": "^2.9.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
-      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.9.tgz",
+      "integrity": "sha512-l6uATQATZaCa0bckHV+r6dLXfWtUBKXxO3jK+AtxxJJtgMPD+VhhPCCx51I4/5w8U5uHV67g3w7PXj+V3wlMlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.28.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-discard-comments": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.6.tgz",
+      "integrity": "sha512-Sq+Fzj1Eg5/CPf1ERb0wS1Im5cvE2gDXCE+si4HCn1sf+jpQZxDI4DXEp8t77B/ImzDceWE2ebJQFXdqZ6GRJw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-discard-duplicates": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.2.tgz",
+      "integrity": "sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-discard-empty": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.1.tgz",
+      "integrity": "sha512-cFrJKZvcg/uxB6Ijr4l6qmn3pXQBna9zyrPC+sK0zjbkDUZew+6xDltSF7OeB7rAtzaaMVYSdbod+sZOCWnMOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-discard-overridden": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.1.tgz",
+      "integrity": "sha512-7c3MMjjSZ/qYrx3uc1940GSOzN1Iqjtlqe8uoSg+qdVPYyRb0TILSqqmtlSFuE4mTDECwsm397Ya7iXGzfF7lg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-media-query-parser": {
@@ -8438,107 +8596,108 @@
       "license": "MIT"
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
-      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.5.tgz",
+      "integrity": "sha512-Kpu5v4Ys6QI59FxmxtNB/iHUVDn9Y9sYw66D6+SZoIk4QTz1prC4aYkhIESu+ieG1iylod1f8MILMs1Em3mmIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.1"
+        "stylehacks": "^7.0.5"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
-      "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.8.tgz",
+      "integrity": "sha512-BOR1iAM8jnr7zoQSlpeBmCsWV5Uudi/+5j7k05D0O/WP3+OFMPD86c1j/20xiuRtyt45bhxw/7hnhZNhW2mNFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.28.1",
         "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^3.1.0",
-        "postcss-selector-parser": "^6.0.5"
+        "cssnano-utils": "^5.0.1",
+        "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-minify-font-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
-      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.1.tgz",
+      "integrity": "sha512-2m1uiuJeTplll+tq4ENOQSzB8LRnSUChBv7oSyFLsJRtUgAAJGP6LLz0/8lkinTgxrmJSPOEhgY1bMXOQ4ZXhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-minify-gradients": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
-      "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.2.tgz",
+      "integrity": "sha512-fVY3AB8Um7SJR5usHqTY2Ngf9qh8IRN+FFzrBP0ONJy6yYXsP7xyjK2BvSAIrpgs1cST+H91V0TXi3diHLYJtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "colord": "^2.9.1",
-        "cssnano-utils": "^3.1.0",
+        "@colordx/core": "^5.0.0",
+        "cssnano-utils": "^5.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
-      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.6.tgz",
+      "integrity": "sha512-YOn02gC68JijlaXVuKvFSCvQOhTpblkcfDre2hb/Aaa58r2BIaK4AtE/cyZf2wV7YKAG+UlP9DT+By0ry1E4VQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "cssnano-utils": "^3.1.0",
+        "browserslist": "^4.28.1",
+        "cssnano-utils": "^5.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-minify-selectors": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
-      "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.6.tgz",
+      "integrity": "sha512-lIbC0jy3AAwDxEgciZlBullDiMBeBCT+fz5G8RcA9MWqh/hfUkpOI3vNDUNEZHgokaoiv0juB9Y8fGcON7rU/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
+        "cssesc": "^3.0.0",
+        "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -8572,20 +8731,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss-modules-scope": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
@@ -8600,20 +8745,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/postcss-modules-values": {
@@ -8633,196 +8764,195 @@
       }
     },
     "node_modules/postcss-normalize-charset": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.1.tgz",
+      "integrity": "sha512-sn413ofhSQHlZFae//m9FTOfkmiZ+YQXsbosqOWRiVQncU2BA3daX3n0VF3cG6rGLSFVc5Di/yns0dFfh8NFgQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-normalize-display-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
-      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.1.tgz",
+      "integrity": "sha512-E5nnB26XjSYz/mGITm6JgiDpAbVuAkzXwLzRZtts19jHDUBFxZ0BkXAehy0uimrOjYJbocby4FVswA/5noOxrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-normalize-positions": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
-      "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.1.tgz",
+      "integrity": "sha512-pB/SzrIP2l50ZIYu+yQZyMNmnAcwyYb9R1fVWPRxm4zcUFCY2ign7rcntGFuMXDdd9L2pPNUgoODDk91PzRZuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
-      "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.1.tgz",
+      "integrity": "sha512-NsSQJ8zj8TIDiF0ig44Byo3Jk9e4gNt9x2VIlJudnQQ5DhWAHJPF4Tr1ITwyHio2BUi/I6Iv0HRO7beHYOloYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-normalize-string": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
-      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.1.tgz",
+      "integrity": "sha512-QByrI7hAhsoze992kpbMlJSbZ8FuCEc1OT9EFbZ6HldXNpsdpZr+YXC5di3UEv0+jeZlHbZcoCADgb7a+lPmmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-normalize-timing-functions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
-      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.1.tgz",
+      "integrity": "sha512-bHifyuuSNdKKsnNJ0s8fmfLMlvsQwYVxIoUBnowIVl2ZAdrkYQNGVB4RxjfpvkMjipqvbz0u7feBZybkl/6NJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
-      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.6.tgz",
+      "integrity": "sha512-z6bwTV84YW6ZvvNoaNLuzRW4/uWxDKYI1iIDrzk6D2YTL7hICApy+Q1LP6vBEsljX8FM7YSuV9qI79XESd4ddQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.28.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-normalize-url": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
-      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.1.tgz",
+      "integrity": "sha512-sUcD2cWtyK1AOL/82Fwy1aIVm/wwj5SdZkgZ3QiUzSzQQofrbq15jWJ3BA7Z+yVRwamCjJgZJN0I9IS7c6tgeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "normalize-url": "^6.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-normalize-whitespace": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
-      "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.1.tgz",
+      "integrity": "sha512-vsbgFHMFQrJBJKrUFJNZ2pgBeBkC2IvvoHjz1to0/0Xk7sII24T0qFOiJzG6Fu3zJoq/0yI4rKWi7WhApW+EFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-ordered-values": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
-      "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.2.tgz",
+      "integrity": "sha512-AMJjt1ECBffF7CEON/Y0rekRLS6KsePU6PRP08UqYW4UGFRnTXNrByUzYK1h8AC7UWTZdQ9O3Oq9kFIhm0SFEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssnano-utils": "^3.1.0",
+        "cssnano-utils": "^5.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
-      "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.6.tgz",
+      "integrity": "sha512-G6ZyK68AmrPdMB6wyeA37ejnnRG2S8xinJrZJnOv+IaRKf6koPAVbQsiC7MfkmXaGmF1UO+QCijb27wfpxuRNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.28.1",
         "caniuse-api": "^3.0.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-reduce-transforms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
-      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.1.tgz",
+      "integrity": "sha512-MhyEbfrm+Mlp/36hvZ9mT9DaO7dbncU0CvWI8V93LRkY6IYlu38OPg3FObnuKTUxJ4qA8HpurdQOo5CyqqO76g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-resolve-nested-selector": {
@@ -8887,9 +9017,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8901,36 +9031,36 @@
       }
     },
     "node_modules/postcss-svgo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
-      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.1.tgz",
+      "integrity": "sha512-zU9H9oEDrUFKa0JB7w+IYL7Qs9ey1mZyjhbf0KLxwJDdDRtoPvCmaEfknzqfHj44QS9VD6c5sJnBAVYTLRg/Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "svgo": "^2.7.0"
+        "svgo": "^4.0.1"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >= 18"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-unique-selectors": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
-      "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.5.tgz",
+      "integrity": "sha512-3QoYmEt4qg/rUWDn6Tc8+ZVPmbp4G1hXDtCNWDx0st8SjtCbRcxRXDDM1QrEiXGG3A45zscSJFb4QH90LViyxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
+        "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -9056,16 +9186,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -9390,27 +9510,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9596,13 +9695,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-blocking": {
@@ -9866,14 +9965,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -10011,20 +10102,20 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
-      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.8.tgz",
+      "integrity": "sha512-I3f053GBLIiS5Fg6OMFhq/c+yW+5Hc2+1fgq7gElDMMSqwlRb3tBf2ef6ucLStYRpId4q//bQO1FjcyNyy4yDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "postcss-selector-parser": "^6.0.4"
+        "browserslist": "^4.28.1",
+        "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/stylelint": {
@@ -10208,20 +10299,6 @@
       },
       "peerDependencies": {
         "stylelint": "^16.8.2"
-      }
-    },
-    "node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/stylelint-webpack-plugin": {
@@ -10450,20 +10527,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/stylelint/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/stylelint/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -10524,47 +10587,40 @@
       "dev": true
     },
     "node_modules/svgo": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
-      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "sax": "^1.5.0",
-        "stable": "^0.1.8"
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
       },
       "bin": {
-        "svgo": "bin/svgo"
+        "svgo": "bin/svgo.js"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
       }
     },
-    "node_modules/svgo/node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=16"
       }
-    },
-    "node_modules/svgo/node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true,
-      "license": "CC0-1.0"
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -11326,24 +11382,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -11835,16 +11873,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/cmd/dcrdata/package.json
+++ b/cmd/dcrdata/package.json
@@ -45,7 +45,7 @@
     "babel-loader": "^9.1.2",
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.7.3",
-    "css-minimizer-webpack-plugin": "^4.2.2",
+    "css-minimizer-webpack-plugin": "^8.0.0",
     "eslint": "^9.0.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-promise": "^7.2.1",

--- a/cmd/dcrdata/public/js/controllers/blocklist_controller.js
+++ b/cmd/dcrdata/public/js/controllers/blocklist_controller.js
@@ -146,6 +146,11 @@ export default class extends Controller {
 
     const { varTxCount, varAmount, varSize, skaAmount, subRows } = coinRowsToSKAData(block)
 
+    // Re-query after removals — firstBlockRow may have been detached.
+    const currentFirstBlockRow = this.tableTarget.querySelector(
+      'tr[data-ska-accordion-target="blockRow"]'
+    )
+
     const newRow = document.createElement('tr')
     newRow.dataset.height = block.height
     newRow.dataset.linkClass = firstBlockRow.dataset.linkClass
@@ -200,7 +205,9 @@ export default class extends Controller {
       newRow.appendChild(newTd)
     })
 
-    this.tableTarget.insertBefore(newRow, this.tableTarget.firstChild)
+    // Insert the new block row before the current first block row (re-queried
+    // after removals since the original firstBlockRow may have been detached).
+    this.tableTarget.insertBefore(newRow, currentFirstBlockRow)
     const varSubRow = insertVARSubRow(this.tableTarget, newRow, varTxCount, varAmount, varSize)
     insertSKASubRows(this.tableTarget, varSubRow, subRows, block.height)
   }

--- a/cmd/dcrdata/public/js/controllers/blocklist_controller.js
+++ b/cmd/dcrdata/public/js/controllers/blocklist_controller.js
@@ -26,13 +26,13 @@ function coinRowsToSKAData(block) {
     if (cr.coin_type === 0) {
       varTxCount = cr.tx_count
       varAmount = humanize.formatCoinAtoms(cr.amount, cr.coin_type)
-      varSize = `${cr.size} B`
+      varSize = cr.size > 0 ? `${cr.size} B` : '—'
     } else {
       subRows.push({
         tokenType: cr.symbol,
-        txCount: String(cr.tx_count),
+        txCount: cr.tx_count > 0 ? String(cr.tx_count) : '—',
         amount: humanize.formatCoinAtoms(cr.amount, cr.coin_type),
-        size: `${cr.size} B`
+        size: cr.size > 0 ? `${cr.size} B` : '—'
       })
     }
   }
@@ -67,7 +67,7 @@ function insertVARSubRow(tbody, newRow, varTxCount, varAmount, varSize) {
   labelSpan.textContent = 'VAR'
   labelTd.appendChild(labelSpan)
   tr.appendChild(labelTd)
-  tr.appendChild(makeTd('text-end num', String(varTxCount)))
+  tr.appendChild(makeTd('text-end num', varTxCount > 0 ? String(varTxCount) : '—'))
   tr.appendChild(makeTd('text-end num', varAmount))
   tr.appendChild(makeTd('text-end', '—'))
   tr.appendChild(makeTd('text-end num d-none d-sm-table-cell d-md-none d-lg-table-cell', varSize))
@@ -185,7 +185,7 @@ export default class extends Controller {
           newTd.textContent = varAmount
           break
         case 'ska-amount':
-          newTd.textContent = skaAmount
+          newTd.textContent = skaAmount || '—'
           break
         case 'size':
           newTd.textContent = humanize.bytes(block.size)

--- a/cmd/dcrdata/public/js/controllers/blocklist_controller.js
+++ b/cmd/dcrdata/public/js/controllers/blocklist_controller.js
@@ -25,13 +25,13 @@ function coinRowsToSKAData(block) {
   for (const cr of coinRows) {
     if (cr.coin_type === 0) {
       varTxCount = cr.tx_count
-      varAmount = cr.amount
+      varAmount = humanize.formatCoinAtoms(cr.amount, cr.coin_type)
       varSize = `${cr.size} B`
     } else {
       subRows.push({
         tokenType: cr.symbol,
         txCount: String(cr.tx_count),
-        amount: cr.amount,
+        amount: humanize.formatCoinAtoms(cr.amount, cr.coin_type),
         size: `${cr.size} B`
       })
     }

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -78,6 +78,30 @@ const humanize = {
 
     return htmlString
   },
+  // formatCoinAtoms converts a raw atom string to a threeSigFigs-formatted coin
+  // string. coinType 0 = VAR (8 decimal places), any other value = SKA (18
+  // decimal places). Use this instead of calling skaCoinValue or the VAR
+  // division directly.
+  formatCoinAtoms: function (atomStr, coinType) {
+    if (coinType === 0) return humanize.threeSigFigs(parseInt(atomStr) / 1e8)
+    return humanize.threeSigFigs(humanize.skaCoinValue(atomStr))
+  },
+  // skaCoinValue converts a raw SKA atom string (up to 33 decimal digits) to a
+  // coin Number suitable for passing to threeSigFigs. Uses BigInt arithmetic to
+  // avoid float64 precision loss on large atom values. Returns 0 for empty or
+  // invalid input.
+  skaCoinValue: function (atomStr) {
+    if (!atomStr || atomStr === '0') return 0
+    try {
+      const atoms = BigInt(atomStr)
+      const divisor = BigInt('1000000000000000000') // 10^18
+      const whole = Number(atoms / divisor)
+      const remainder = Number(atoms % divisor)
+      return whole + remainder / 1e18
+    } catch {
+      return 0
+    }
+  },
   threeSigFigs: function (v) {
     const sign = v >= 0 ? '' : '-'
     v = Math.abs(v)

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.test.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.test.js
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import humanize from './humanize_helper'
+
+describe('humanize.formatCoinAtoms', () => {
+  // VAR: coinType 0, 8 decimal places
+  it('formats VAR atoms "1000000000" as "10.0"', () =>
+    expect(humanize.formatCoinAtoms('1000000000', 0)).toBe('10.0'))
+  it('formats VAR atoms "100000000" as "1.00"', () =>
+    expect(humanize.formatCoinAtoms('100000000', 0)).toBe('1.00'))
+  it('formats VAR atoms "0" as "0"', () => expect(humanize.formatCoinAtoms('0', 0)).toBe('0'))
+
+  // SKA: coinType != 0, 18 decimal places
+  it('formats SKA atoms "1000000000000000000" as "1.00"', () =>
+    expect(humanize.formatCoinAtoms('1000000000000000000', 1)).toBe('1.00'))
+  it('formats SKA atoms "1000000000000000000000" as "1.00k"', () =>
+    expect(humanize.formatCoinAtoms('1000000000000000000000', 2)).toBe('1.00k'))
+  it('formats SKA atoms "0" as "0"', () => expect(humanize.formatCoinAtoms('0', 1)).toBe('0'))
+})
+
+describe('humanize.threeSigFigs', () => {
+  // >= 1e11 - integer billions
+  it('formats 1e11 as "100B"', () => expect(humanize.threeSigFigs(1e11)).toBe('100B'))
+  it('formats 2.5e11 as "250B"', () => expect(humanize.threeSigFigs(2.5e11)).toBe('250B'))
+  it('formats 1.999e11 as "200B"', () => expect(humanize.threeSigFigs(1.999e11)).toBe('200B'))
+
+  // >= 1e10 - one-decimal billions
+  it('formats 1e10 as "10.0B"', () => expect(humanize.threeSigFigs(1e10)).toBe('10.0B'))
+  it('formats 1.55e10 as "15.5B"', () => expect(humanize.threeSigFigs(1.55e10)).toBe('15.5B'))
+  it('formats 9.99e10 as "99.9B" - stays in bracket, no round-up', () =>
+    expect(humanize.threeSigFigs(9.99e10)).toBe('99.9B'))
+
+  // >= 1e9 - two-decimal billions
+  it('formats 1e9 as "1.00B"', () => expect(humanize.threeSigFigs(1e9)).toBe('1.00B'))
+  it('formats 1.235e9 as "1.24B"', () => expect(humanize.threeSigFigs(1.235e9)).toBe('1.24B'))
+  it('formats 9.999e9 as "10.00B" - stays in bracket, no round-up', () =>
+    expect(humanize.threeSigFigs(9.999e9)).toBe('10.00B'))
+
+  // >= 1e8 - integer millions
+  it('formats 1e8 as "100M"', () => expect(humanize.threeSigFigs(1e8)).toBe('100M'))
+  it('formats 4.5e8 as "450M"', () => expect(humanize.threeSigFigs(4.5e8)).toBe('450M'))
+
+  // >= 1e7 - one-decimal millions
+  it('formats 1e7 as "10.0M"', () => expect(humanize.threeSigFigs(1e7)).toBe('10.0M'))
+  it('formats 1.55e7 as "15.5M"', () => expect(humanize.threeSigFigs(1.55e7)).toBe('15.5M'))
+
+  // >= 1e6 - two-decimal millions
+  it('formats 1e6 as "1.00M"', () => expect(humanize.threeSigFigs(1e6)).toBe('1.00M'))
+  it('formats 1.235e6 as "1.24M"', () => expect(humanize.threeSigFigs(1.235e6)).toBe('1.24M'))
+
+  // >= 1e5 - integer thousands
+  it('formats 1e5 as "100k"', () => expect(humanize.threeSigFigs(1e5)).toBe('100k'))
+  it('formats 4.5e5 as "450k"', () => expect(humanize.threeSigFigs(4.5e5)).toBe('450k'))
+
+  // >= 1e4 - one-decimal thousands
+  it('formats 1e4 as "10.0k"', () => expect(humanize.threeSigFigs(1e4)).toBe('10.0k'))
+  it('formats 1.55e4 as "15.5k"', () => expect(humanize.threeSigFigs(1.55e4)).toBe('15.5k'))
+
+  // >= 1e3 - two-decimal thousands
+  it('formats 1e3 as "1.00k"', () => expect(humanize.threeSigFigs(1e3)).toBe('1.00k'))
+  it('formats 1.235e3 as "1.24k"', () => expect(humanize.threeSigFigs(1.235e3)).toBe('1.24k'))
+
+  // sub-thousand
+  it('formats 100 as "100"', () => expect(humanize.threeSigFigs(100)).toBe('100'))
+  it('formats 456 as "456"', () => expect(humanize.threeSigFigs(456)).toBe('456'))
+  it('formats 999 as "999"', () => expect(humanize.threeSigFigs(999)).toBe('999'))
+
+  it('formats 10 as "10.0"', () => expect(humanize.threeSigFigs(10)).toBe('10.0'))
+  it('formats 15.5 as "15.5"', () => expect(humanize.threeSigFigs(15.5)).toBe('15.5'))
+  it('formats 99.9 as "99.9"', () => expect(humanize.threeSigFigs(99.9)).toBe('99.9'))
+
+  it('formats 1 as "1.00"', () => expect(humanize.threeSigFigs(1)).toBe('1.00'))
+  it('formats 1.23 as "1.23"', () => expect(humanize.threeSigFigs(1.23)).toBe('1.23'))
+  it('formats 9.99 as "9.99"', () => expect(humanize.threeSigFigs(9.99)).toBe('9.99'))
+
+  // sub-1: fractional coin values (e.g. VAR fees)
+  it('formats 0.5 as "0.500"', () => expect(humanize.threeSigFigs(0.5)).toBe('0.500'))
+  it('formats 0.1 as "0.100"', () => expect(humanize.threeSigFigs(0.1)).toBe('0.100'))
+  it('formats 0.01 as "0.0100"', () => expect(humanize.threeSigFigs(0.01)).toBe('0.0100'))
+  it('formats 0.001 as "0.00100"', () => expect(humanize.threeSigFigs(0.001)).toBe('0.00100'))
+
+  // zero
+  it('formats 0 as "0"', () => expect(humanize.threeSigFigs(0)).toBe('0'))
+})
+
+describe('humanize.skaCoinValue', () => {
+  it('returns 0 for empty string', () => expect(humanize.skaCoinValue('')).toBe(0))
+  it('returns 0 for "0"', () => expect(humanize.skaCoinValue('0')).toBe(0))
+  it('returns 0 for invalid input', () => expect(humanize.skaCoinValue('notanumber')).toBe(0))
+
+  it('converts exactly 1 SKA coin (10^18 atoms)', () =>
+    expect(humanize.skaCoinValue('1000000000000000000')).toBe(1.0))
+  it('converts 1.5 SKA coins', () => expect(humanize.skaCoinValue('1500000000000000000')).toBe(1.5))
+  it('converts 0.5 SKA coins', () => expect(humanize.skaCoinValue('500000000000000000')).toBe(0.5))
+  it('converts 0.1 SKA coins', () => expect(humanize.skaCoinValue('100000000000000000')).toBe(0.1))
+  it('converts 0.001 SKA coins', () =>
+    expect(humanize.skaCoinValue('1000000000000000')).toBe(0.001))
+  it('converts a single atom (1e-18)', () => expect(humanize.skaCoinValue('1')).toBe(1e-18))
+  it('converts 1000 SKA coins', () =>
+    expect(humanize.skaCoinValue('1000000000000000000000')).toBe(1000))
+  it('converts 1 000 000 SKA coins', () =>
+    expect(humanize.skaCoinValue('1000000000000000000000000')).toBe(1e6))
+
+  it('does not lose precision on a 33-digit atom string', () => {
+    // 123456789012345 * 10^18 - integer part is 123456789012345 coins
+    const result = humanize.skaCoinValue('123456789012345000000000000000000')
+    expect(result).toBeCloseTo(123456789012345, -3)
+  })
+})
+
+describe('humanize.skaCoinValue + threeSigFigs', () => {
+  it('formats 1 coin as "1.00"', () =>
+    expect(humanize.threeSigFigs(humanize.skaCoinValue('1000000000000000000'))).toBe('1.00'))
+  it('formats 1.23 coins as "1.23"', () =>
+    expect(humanize.threeSigFigs(humanize.skaCoinValue('1230000000000000000'))).toBe('1.23'))
+  it('formats 1000 coins as "1.00k"', () =>
+    expect(humanize.threeSigFigs(humanize.skaCoinValue('1000000000000000000000'))).toBe('1.00k'))
+  it('formats 1 000 000 coins as "1.00M"', () =>
+    expect(humanize.threeSigFigs(humanize.skaCoinValue('1000000000000000000000000'))).toBe('1.00M'))
+  it('formats 1 000 000 000 coins as "1.00B"', () =>
+    expect(humanize.threeSigFigs(humanize.skaCoinValue('1000000000000000000000000000'))).toBe(
+      '1.00B'
+    ))
+  it('formats 0.5 coins as "0.500"', () =>
+    expect(humanize.threeSigFigs(humanize.skaCoinValue('500000000000000000'))).toBe('0.500'))
+  it('formats 0.1 coins as "0.100"', () =>
+    expect(humanize.threeSigFigs(humanize.skaCoinValue('100000000000000000'))).toBe('0.100'))
+  it('formats 0.001 coins as "0.00100"', () =>
+    expect(humanize.threeSigFigs(humanize.skaCoinValue('1000000000000000'))).toBe('0.00100'))
+})

--- a/cmd/dcrdata/public/scss/home.scss
+++ b/cmd/dcrdata/public/scss/home.scss
@@ -101,6 +101,14 @@ body.darkBG .ska-sub-row--visible {
   white-space: nowrap;
 }
 
+// VAR and SKA amount cells may contain longer formatted strings on small
+// screens. Allow them to wrap and break rather than stretching the table.
+.last-blocks-table td[data-type="var-amount"],
+.last-blocks-table td[data-type="ska-amount"] {
+  white-space: normal !important;
+  word-break: break-all;
+}
+
 // Column minimum widths — single source of truth.
 // Sized to the widest expected content so expanding sub-rows never shift columns.
 // Formula: max-content-chars × 1ch + Bootstrap cell padding (0.5rem/side = 1rem total).

--- a/cmd/dcrdata/views/home_latest_blocks.tmpl
+++ b/cmd/dcrdata/views/home_latest_blocks.tmpl
@@ -29,7 +29,7 @@
         </td>
         <td class="text-end num" data-type="tx">{{.Transactions}}</td>
         <td class="text-end num" data-type="var-amount">{{.VARAmount}}</td>
-        <td class="text-end num" data-type="ska-amount">{{.SKAAmount}}</td>
+        <td class="text-end num" data-type="ska-amount">{{if .SKAAmount}}{{.SKAAmount}}{{else}}—{{end}}</td>
         <td class="text-end num d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="size">{{.FormattedBytes}}</td>
         <td class="text-end num" data-type="votes">{{.Voters}}</td>
         <td class="text-end num" data-type="tickets">{{.FreshStake}}</td>
@@ -40,7 +40,7 @@
       </tr>
       <tr class="ska-sub-row" data-ska-accordion-target="subRow" data-block-id="{{$blockHeight}}">
         <td class="text-start ps-1"><span class="sub-row-label">VAR</span></td>
-        <td class="text-end num">{{.VARTxCount}}</td>
+        <td class="text-end num">{{if .VARTxCount}}{{.VARTxCount}}{{else}}—{{end}}</td>
         <td class="text-end num">{{.VARAmount}}</td>
         <td class="text-end">—</td>
         <td class="text-end num d-none d-sm-table-cell d-md-none d-lg-table-cell">{{.VARSize}}</td>

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -5928,6 +5928,9 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	// Populate per-coin amounts from the block summary (computed at collection time).
 	if summary := pgb.GetSummaryByHash(ctx, hash, false); summary != nil && summary.CoinAmounts != nil {
 		block.CoinAmounts = summary.CoinAmounts
+		// Also populate CoinRows on the embedded BlockBasic so the websocket
+		// path (which sends BlockInfo) carries coin_rows for the frontend.
+		block.BlockBasic.CoinRows = coinRowsFromAmounts(summary.CoinAmounts)
 	}
 
 	if data.PoWHash != "" {

--- a/dev/hooks/pre-commit
+++ b/dev/hooks/pre-commit
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Pre-commit hook:
+#   - Go: gofmt check + go test on affected modules
+#   - JS/SCSS: prettier format check + eslint + stylelint + vitest
+
+set -e
+
+ROOT=$(git rev-parse --show-toplevel)
+FAILED=0
+
+# ── Go ────────────────────────────────────────────────────────────────────────
+
+STAGED_GO=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
+
+if [[ -n "$STAGED_GO" ]]; then
+  declare -A MODULES
+  while IFS= read -r file; do
+    dir="$ROOT/$(dirname "$file")"
+    while [[ "$dir" != "/" ]]; do
+      if [[ -f "$dir/go.mod" ]]; then
+        MODULES["$dir"]=1
+        break
+      fi
+      dir=$(dirname "$dir")
+    done
+  done <<< "$STAGED_GO"
+
+  for moddir in "${!MODULES[@]}"; do
+    rel="${moddir#$ROOT/}"
+    echo "==> [$rel] gofmt check"
+    UNFORMATTED=$(gofmt -l "$moddir" 2>/dev/null | grep -v vendor || true)
+    if [[ -n "$UNFORMATTED" ]]; then
+      echo "  gofmt: files need formatting:"
+      echo "$UNFORMATTED" | sed 's/^/    /'
+      echo "  Run: gofmt -w <file>"
+      FAILED=1
+    fi
+
+    echo "==> [$rel] go test ./..."
+    if ! (cd "$moddir" && go test ./...); then
+      echo "  Tests failed in $rel"
+      FAILED=1
+    fi
+  done
+fi
+
+# ── JS / SCSS ─────────────────────────────────────────────────────────────────
+
+STAGED_FRONTEND=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|scss)$' || true)
+
+if [[ -n "$STAGED_FRONTEND" ]]; then
+  FRONTEND_DIR="$ROOT/cmd/dcrdata"
+
+  echo "==> [cmd/dcrdata] prettier format check"
+  if ! (cd "$FRONTEND_DIR" && npm run format:check --silent); then
+    echo "  Prettier: files need formatting. Run: npm run format"
+    FAILED=1
+  fi
+
+  echo "==> [cmd/dcrdata] eslint"
+  if ! (cd "$FRONTEND_DIR" && npm run lint --silent); then
+    echo "  ESLint failed. Run: npm run lint:fix"
+    FAILED=1
+  fi
+
+  echo "==> [cmd/dcrdata] stylelint"
+  if ! (cd "$FRONTEND_DIR" && npm run lint:css --silent); then
+    echo "  Stylelint failed. Run: npm run lint:css:fix"
+    FAILED=1
+  fi
+
+  echo "==> [cmd/dcrdata] vitest"
+  if ! (cd "$FRONTEND_DIR" && npm test --silent); then
+    echo "  JS tests failed."
+    FAILED=1
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+if [[ $FAILED -ne 0 ]]; then
+  echo ""
+  echo "Pre-commit checks failed. Fix the issues above and re-stage your changes."
+  exit 1
+fi
+
+echo "Pre-commit checks passed."

--- a/dev/install-hooks.sh
+++ b/dev/install-hooks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Installs git hooks from dev/hooks/ into .git/hooks/.
+# Run once after cloning: ./dev/install-hooks.sh
+
+set -e
+
+ROOT=$(git rev-parse --show-toplevel)
+HOOKS_SRC="$ROOT/dev/hooks"
+HOOKS_DST="$ROOT/.git/hooks"
+
+if [[ ! -d "$HOOKS_SRC" ]]; then
+  echo "No hooks found in $HOOKS_SRC"
+  exit 1
+fi
+
+for hook in "$HOOKS_SRC"/*; do
+  name=$(basename "$hook")
+  dest="$HOOKS_DST/$name"
+  cp "$hook" "$dest"
+  chmod +x "$dest"
+  echo "Installed: .git/hooks/$name"
+done
+
+echo "All hooks installed."

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -473,11 +473,11 @@ type Vout struct {
 
 // CoinRowData holds per-coin summary data for the expandable blocks table.
 type CoinRowData struct {
-	CoinType uint8
-	Symbol   string // "VAR", "SKA-1", ...
-	TxCount  int
-	Amount   string // formatted amount string
-	Size     uint32
+	CoinType uint8  `json:"coin_type"`
+	Symbol   string `json:"symbol"`
+	TxCount  int    `json:"tx_count"`
+	Amount   string `json:"amount"`
+	Size     uint32 `json:"size"`
 }
 
 // SKASubRow holds per-SKA-type data for the accordion sub-rows in the block table.


### PR DESCRIPTION
## Summary

### Coin formatting
- Updated `threeSigFigs` and related coin formatting utilities
- Added comprehensive test coverage for coin formatting edge cases

### Styling
- Allow amount cells to wrap on small screens (home page)

### Bug fixes
- Fixed `GetExplorerBlock` not populating `CoinRows` on the embedded `BlockBasic` — SKA data was missing from websocket-pushed block updates (live home page updates showed no SKA)
- Fixed `CoinRowData` missing JSON tags — all fields serialized as PascalCase but JS expected snake_case, causing every sub-row field to be `undefined`
- Fixed websocket block prepend inserting before a potentially detached `firstBlockRow` after DOM removal — caused `NotFoundError` in the browser
- Zero/unknown values (tx count, size) in block table sub-rows now render as `—` instead of `0` or `0 B`

### Dependencies
- Upgraded `css-minimizer-webpack-plugin` to v8 to fix 2 high severity `serialize-javascript` vulnerabilities
- Fixed lodash prototype pollution and code injection vulnerabilities via `npm audit fix`
- Added `.npmrc` with `ignore-scripts=true` and `audit=true` to harden against supply chain attacks

### Dev tooling
- Added pre-commit git hook: runs `gofmt` + `go test` for staged Go files, and Prettier/ESLint/Stylelint/Vitest for staged JS/SCSS files
- Added `dev/install-hooks.sh` — run once after cloning to install hooks
- Added `create-pr-develop` Kiro agent hook: pushes branch, checks if behind develop, then creates a PR with auto-generated title and description
- Updated README with a Contributing section documenting the hook setup and manual check commands

### Docs
- Updated steering docs to reference monetarium-explorer instead of dcrdata