### PR TITLE
feat(home): block table visual hierarchy with chevrons, coin labels, and humanized sizes

### DIFF
--- a/.kiro/specs/home-block-table-hierarchy/.config.kiro
+++ b/.kiro/specs/home-block-table-hierarchy/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "15889c16-fcf7-4c4e-ab10-87c7f7d8bdc3", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/home-block-table-hierarchy/design.md
+++ b/.kiro/specs/home-block-table-hierarchy/design.md
@@ -1,0 +1,441 @@
+# Design Document: Home Block Table Hierarchy
+
+## Overview
+
+This feature adds visual hierarchy affordances to the "Latest Blocks" table on the Monetarium Explorer home page. The accordion expand/collapse mechanism already exists; this design specifies the exact markup, styles, and JS changes needed to make the parent–child relationship between block rows and their per-token sub-rows immediately scannable.
+
+The changes are purely presentational and structural — no new columns, no new API endpoints, no backend changes. All work is confined to:
+
+- `_variables.scss` — new SCSS variables
+- `themes.scss` — dark-theme overrides
+- `home.scss` — new component styles
+- `home_latest_blocks.tmpl` — chevron and coin label markup
+- `ska_accordion_controller.js` — chevron state toggling (already handled via `is-expanded`)
+- `blocklist_controller.js` — chevron and coin label elements in dynamically injected rows
+
+---
+
+## Architecture
+
+The feature follows the existing Stimulus + SCSS + Go template pattern already established in the codebase. No new controllers or template files are introduced.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  home_latest_blocks.tmpl                                │
+│  ┌─────────────────────────────────────────────────┐   │
+│  │  Parent_Row  [chevron] [height link]  …         │   │
+│  │  Sub_Row     [│ ● VAR]  …                       │   │
+│  │  Sub_Row     [│ ● SKA-1]  …                     │   │
+│  └─────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+         │ toggle click                │ BLOCK_RECEIVED
+         ▼                             ▼
+┌──────────────────────┐   ┌──────────────────────────────┐
+│ ska_accordion_       │   │ blocklist_controller.js       │
+│ controller.js        │   │ injects rows with chevron +  │
+│ toggles is-expanded  │   │ badges matching template      │
+│ on parent row        │   │ structure                     │
+└──────────────────────┘   └──────────────────────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│ home.scss            │
+│ .chevron rotates on  │
+│ .is-expanded         │
+│ .ska-sub-row--visible│
+│ td:first-child gets  │
+│ inset box-shadow     │
+│ .coin-label--var/ska │
+│ dot colors           │
+└──────────────────────┘
+```
+
+---
+
+## Components and Interfaces
+
+### 1. Chevron element
+
+A CSS border-trick triangle rendered as an inline `<span>` inside the first `<td>` of every Parent_Row, before the height `<a>` link.
+
+```html
+<td class="text-start ps-1" data-type="height">
+  <span class="chevron me-1"></span>
+  <a href="/block/{{.Height}}" class="fs18">{{.Height}}</a>
+</td>
+```
+
+The chevron is drawn with CSS borders and rotates 90° when the parent row has `is-expanded`. The `ska_accordion_controller.js` already adds/removes `is-expanded` on the parent row — no JS change is needed for the chevron rotation itself.
+
+### 2. Coin label spans in Sub_Rows
+
+The existing `<span class="sub-row-label">` is replaced with coin label markup using a colored dot via CSS `::before`:
+
+```html
+<!-- VAR sub-row first cell -->
+<td class="text-end ps-2 ps-sm-4" data-type="sub-label">
+  <span class="coin-label coin-label--var">VAR</span>
+</td>
+
+<!-- SKA sub-row first cell -->
+<td class="text-end ps-2 ps-sm-4" data-type="sub-label">
+  <span class="coin-label coin-label--ska">{{.TokenType}}</span>
+</td>
+```
+
+The label cell uses `text-start` with responsive padding (`ps-2` on mobile, `ps-sm-4` at ≥540px) to create visual indentation. The dot is rendered via `.coin-label::before` as a small circle using `inline-flex` + `align-items: center` for reliable vertical alignment.
+
+### 3. Vertical anchor
+
+Applied via an inset `box-shadow` on `.ska-sub-row--visible td:first-child` — avoids layout shift since box-shadow is paint-only. The second shadow layer preserves Bootstrap's `--bs-table-accent-bg` hover tint.
+
+### 4. SCSS variables (new additions to `_variables.scss`)
+
+| Variable                | Light value | Purpose                    |
+| ----------------------- | ----------- | -------------------------- |
+| `$coin-var-primary`     | `#3374ff`   | VAR dot color              |
+| `$coin-ska-primary`     | `#80868b`   | SKA dot color (muted grey) |
+| `$sub-row-anchor-color` | `#c8d0d8`   | Vertical anchor box-shadow |
+
+### 5. Dark theme overrides (new additions to `themes.scss` under `body.darkBG`)
+
+| Selector                               | Property     | Dark value                                                              |
+| -------------------------------------- | ------------ | ----------------------------------------------------------------------- |
+| `.ska-sub-row--visible td:first-child` | `box-shadow` | `inset 3px 0 0 0 #4a5568, inset 0 0 0 9999px var(--bs-table-accent-bg)` |
+
+---
+
+## Data Models
+
+No new data models. The feature is purely presentational. The existing view model types (`BlockBasic`, `SKASubRow`) already carry all required data.
+
+The only structural change is that `blocklist_controller.js` must produce DOM nodes that match the updated template structure (chevron span in parent row, coin-label spans in sub-rows).
+
+---
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: Chevron presence in all parent rows
+
+_For any_ rendered block table with one or more parent rows, every parent row's first cell SHALL contain an element with the `chevron` class.
+
+**Validates: Requirements 1.1**
+
+---
+
+### Property 2: Chevron state reflects expansion
+
+_For any_ parent row, the chevron element SHALL NOT have the rotated class when `is-expanded` is absent, and SHALL have the rotated class when `is-expanded` is present — these two states are mutually exclusive and exhaustive.
+
+**Validates: Requirements 1.2, 1.3**
+
+---
+
+### Property 3: Chevron precedes height link in DOM
+
+_For any_ parent row's first cell, the chevron element SHALL appear before the height anchor element in the cell's child node order.
+
+**Validates: Requirements 1.5**
+
+---
+
+### Property 4: Injected rows are structurally complete
+
+_For any_ block data object processed by `blocklist_controller`, the injected parent row's first cell SHALL contain a chevron element, every injected VAR sub-row's first cell SHALL contain a `coin-label--var` span, every injected SKA sub-row's first cell SHALL contain a `coin-label--ska` span, and every injected sub-row's first cell SHALL carry `data-type="sub-label"`.
+
+**Validates: Requirements 1.6, 2.4, 4.7**
+
+---
+
+### Property 5: Sub-row first cell carries anchor class
+
+_For any_ sub-row (VAR or SKA) in the rendered table, its first cell SHALL have the CSS class that applies the vertical anchor left border.
+
+**Validates: Requirements 2.1, 2.3**
+
+---
+
+### Property 6: Sub-row first cell is left-aligned
+
+_For any_ sub-row in the rendered table, its first cell SHALL have a left-alignment class (`text-start`) with responsive indentation padding.
+
+**Validates: Requirements 3.1**
+
+---
+
+### Property 7: Column count invariant
+
+_For any_ rendered state of the block table (initial render or after BLOCK_RECEIVED injection), the header row SHALL have exactly 9 `<th>` elements and every data row SHALL have exactly 9 `<td>` elements.
+
+**Validates: Requirements 3.3, 7.1**
+
+---
+
+### Property 8: VAR sub-rows use coin-label--var
+
+_For any_ VAR sub-row in the rendered table (whether server-rendered or JS-injected), its first cell SHALL contain a `<span>` with both `coin-label` and `coin-label--var` classes.
+
+**Validates: Requirements 4.1**
+
+---
+
+### Property 9: All SKA sub-rows use coin-label--ska regardless of token index
+
+_For any_ collection of SKA sub-rows with differing token indices (SKA-1, SKA-2, … SKA-n), every sub-row's first cell SHALL contain a `<span>` with both `coin-label` and `coin-label--ska` classes — the specific token index SHALL NOT affect the label class used.
+
+**Validates: Requirements 4.2, 4.5**
+
+---
+
+### Property 10: All sub-rows carry subordination class
+
+_For any_ sub-row in the rendered table, it SHALL carry the typographic subordination class that reduces visual weight relative to parent rows.
+
+**Validates: Requirements 5.1, 5.3**
+
+---
+
+### Property 11: Responsive classes preserved on size and rev cells
+
+_For any_ data row (parent or sub-row) in the rendered table, the size cell (column 5) and rev cell (column 8) SHALL retain the responsive display classes `d-none d-sm-table-cell d-md-none d-lg-table-cell`.
+
+**Validates: Requirements 7.3**
+
+---
+
+## Error Handling
+
+This feature has no error paths of its own. The relevant failure modes are inherited:
+
+- **Missing sub-rows**: If `SKASubRows` is empty in the template, no SKA sub-rows are rendered. The chevron is still rendered on the parent row; clicking it finds zero sub-rows and the `ska_accordion_controller` no-ops (already handled by the `if (subRows.length === 0) return` guard).
+- **JS injection with no coin_rows**: `coinRowsToSKAData` already handles the VAR-only fallback. The injected VAR sub-row will still receive the `coin-label--var` span and anchor class.
+- **JS injection with multiple SKA types**: `insertSKASubRows` iterates `subRows`; each gets a `coin-label--ska` span regardless of `tokenType` value.
+
+---
+
+## Testing Strategy
+
+### Unit tests (Vitest + jsdom)
+
+Target: `blocklist_controller.js` injection logic and `ska_accordion_controller.js` toggle logic.
+
+Each property above maps to one or more test cases:
+
+| Property | Test file                             | What varies                          |
+| -------- | ------------------------------------- | ------------------------------------ |
+| P1       | `blocklist_controller.test.js`        | Block data with 1, 3, 10 blocks      |
+| P2       | `ska_accordion_controller.test.js`    | Toggle called 1×, 2× (round-trip)    |
+| P3       | `blocklist_controller.test.js`        | Any block data                       |
+| P4       | `blocklist_controller.test.js`        | Blocks with 0, 1, N SKA coin_rows    |
+| P5       | Template snapshot + JS injection test | VAR and SKA sub-rows                 |
+| P6       | Template snapshot + JS injection test | VAR and SKA sub-rows                 |
+| P7       | Template snapshot + JS injection test | Blocks with varying coin_rows counts |
+| P8       | `blocklist_controller.test.js`        | VAR sub-rows                         |
+| P9       | `blocklist_controller.test.js`        | coin_rows with SKA-1, SKA-2, SKA-255 |
+| P10      | Template snapshot + JS injection test | All sub-row types                    |
+| P11      | Template snapshot                     | Parent rows and sub-rows             |
+
+**Property-based testing library**: `fast-check` (already available in the JS ecosystem; add as dev dependency).
+
+Each property test runs a minimum of 100 iterations. Tests are tagged with:
+
+```js
+// Feature: home-block-table-hierarchy, Property N: <property text>
+```
+
+### Template snapshot tests
+
+Go template tests in `home_template_test.go` (already exists) should be extended to assert:
+
+- Every `blockRow` `<tr>` contains a `.chevron` span before the height link
+- Every `ska-sub-row` `<tr>` first cell has `text-start` and `data-type="sub-label"`
+- VAR sub-rows contain `<span class="coin-label coin-label--var">`
+- SKA sub-rows contain `<span class="coin-label coin-label--ska">`
+- Total `<th>` count = 9; total `<td>` count per row = 9
+
+### Manual / smoke tests
+
+- Dark theme: activate `body.darkBG`, verify chevron contrast, anchor shadow color
+- Responsive: resize below 540px, verify no horizontal overflow, verify label indentation changes
+- Font size: verify sub-row text ≥ 11px in computed styles
+
+---
+
+## Implementation Specification
+
+### `_variables.scss` additions
+
+```scss
+// Block table hierarchy — coin label dot colors
+$coin-var-primary: #3374ff;
+$coin-ska-primary: #80868b;
+
+// Block table hierarchy — sub-row vertical anchor
+$sub-row-anchor-color: #c8d0d8;
+```
+
+### `themes.scss` additions (inside `body.darkBG { … }`)
+
+```scss
+.ska-sub-row--visible td:first-child {
+  box-shadow:
+    inset 3px 0 0 0 #4a5568,
+    inset 0 0 0 9999px var(--bs-table-accent-bg);
+}
+```
+
+### `home.scss` additions
+
+```scss
+// SKA accordion sub-rows — typographic subordination
+.ska-sub-row {
+  display: none;
+  font-size: 0.85em;
+  color: #6c757d;
+
+  &--visible {
+    display: table-row;
+    background-color: $card-bg-secondary;
+  }
+}
+
+body.darkBG .ska-sub-row--visible {
+  background-color: $card-bg-secondary-dark;
+}
+
+body.darkBG .ska-sub-row {
+  color: #c1c1c1;
+}
+
+// Responsive column min-widths at sm breakpoint
+$col-min-widths-sm: (
+  1: calc(96px),
+);
+
+@media (min-width: $breakpoint-sm) {
+  @each $n, $w in $col-min-widths-sm {
+    .last-blocks-table th:nth-child(#{$n}) {
+      min-width: $w;
+    }
+  }
+}
+
+// Sub-row vertical anchor — inset box-shadow avoids layout shift
+.ska-sub-row--visible td:first-child {
+  box-shadow:
+    inset 3px 0 0 0 $sub-row-anchor-color,
+    inset 0 0 0 9999px var(--bs-table-accent-bg);
+}
+
+// Chevron — CSS border-trick triangle that rotates on expand
+.chevron {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  border-left: 5px solid currentcolor;
+  vertical-align: middle;
+  transition: transform 0.15s ease;
+}
+
+.last-blocks-table .block-row-expandable.is-expanded .chevron {
+  transform: rotate(90deg);
+}
+
+// Coin label dots — inline-flex for reliable dot/text alignment
+.coin-label {
+  display: inline-flex;
+  align-items: center;
+  text-align: left;
+
+  &::before {
+    content: "";
+    display: block;
+    width: 0.5em;
+    height: 0.5em;
+    border-radius: 50%;
+    margin-right: 0.35em;
+  }
+
+  &--var::before {
+    background-color: $coin-var-primary;
+  }
+  &--ska::before {
+    background-color: $coin-ska-primary;
+  }
+}
+```
+
+### `home_latest_blocks.tmpl` changes
+
+Parent row first cell — add chevron span before the height link:
+
+```html
+<td class="text-start ps-1" data-type="height">
+  <span class="chevron me-1"></span>
+  <a href="/block/{{.Height}}" class="fs18">{{.Height}}</a>
+</td>
+```
+
+VAR sub-row first cell — replace `sub-row-label` span with coin label:
+
+```html
+<td class="text-end ps-2 ps-sm-4" data-type="sub-label">
+  <span class="coin-label coin-label--var">VAR</span>
+</td>
+```
+
+SKA sub-row first cell — replace `sub-row-label` span with coin label:
+
+```html
+<td class="text-end ps-2 ps-sm-4" data-type="sub-label">
+  <span class="coin-label coin-label--ska">{{.TokenType}}</span>
+</td>
+```
+
+### `ska_accordion_controller.js` changes
+
+No changes required. The controller already adds/removes `is-expanded` on the parent row via `row.classList.toggle('is-expanded', !isExpanded)`. The chevron rotation is handled entirely by CSS on `.is-expanded .chevron`.
+
+### `blocklist_controller.js` changes
+
+**`insertVARSubRow`** — replace the `sub-row-label` span with a `coin-label--var` span:
+
+```js
+const labelTd = makeTd("text-end ps-2 ps-sm-4");
+labelTd.dataset.type = "sub-label";
+const labelSpan = document.createElement("span");
+labelSpan.className = "coin-label coin-label--var";
+labelSpan.textContent = "VAR";
+labelTd.appendChild(labelSpan);
+```
+
+**`insertSKASubRows`** — same change for SKA label:
+
+```js
+const labelTd = makeTd("text-end ps-2 ps-sm-4");
+labelTd.dataset.type = "sub-label";
+const badge = document.createElement("span");
+badge.className = "coin-label coin-label--ska";
+badge.textContent = sub.tokenType;
+labelTd.appendChild(badge);
+```
+
+**Parent row injection** — in `_processBlock`, the `height` case must append a chevron span before the link:
+
+```js
+case 'height': {
+  const chevron = document.createElement('span')
+  chevron.className = 'chevron me-1'
+  newTd.appendChild(chevron)
+  const link = document.createElement('a')
+  link.href = `/block/${block.height}`
+  link.textContent = block.height
+  link.classList.add(firstBlockRow.dataset.linkClass)
+  newTd.appendChild(link)
+  break
+}
+```

--- a/.kiro/specs/home-block-table-hierarchy/requirements.md
+++ b/.kiro/specs/home-block-table-hierarchy/requirements.md
@@ -1,0 +1,118 @@
+# Requirements Document
+
+## Introduction
+
+This feature redesigns the "Latest Blocks" table on the Monetarium Explorer home page to introduce a clear visual data hierarchy between parent block rows and their per-token sub-rows (VAR and SKA-n). The existing accordion expand/collapse mechanism is already in place; this feature focuses on the visual affordances, structural nesting cues, badge-based asset identification, and typographic subordination that make the hierarchy immediately scannable — without adding new columns or breaking the responsive layout.
+
+## Glossary
+
+- **Block_Table**: The "Latest Blocks" `<table>` rendered by `home_latest_blocks.tmpl` and managed by `blocklist_controller.js` and `ska_accordion_controller.js`.
+- **Parent_Row**: A `<tr>` representing a single block height; carries `data-ska-accordion-target="blockRow"` and the CSS class `block-row-expandable`.
+- **Sub_Row**: A `<tr>` representing per-token data for a single block; carries `data-ska-accordion-target="subRow"` and the CSS class `ska-sub-row`.
+- **Chevron**: A CSS border-trick triangle placed in the first column of a Parent_Row to signal expand/collapse affordance.
+- **VAR_Label**: A styled `<span class="coin-label coin-label--var">` with a colored dot used to label the VAR primary-coin Sub_Row.
+- **SKA_Label**: A styled `<span class="coin-label coin-label--ska">` with a colored dot used to label any SKA-type token Sub_Row.
+- **Vertical_Anchor**: A persistent inset box-shadow on the first cell of each visible Sub_Row that visually connects Sub_Rows to their Parent_Row without affecting layout.
+- **ska_accordion_controller**: The Stimulus 3 controller (`ska_accordion_controller.js`) that toggles Sub_Row visibility.
+- **blocklist_controller**: The Stimulus 3 controller (`blocklist_controller.js`) that injects new block rows on WebSocket `BLOCK_RECEIVED` events.
+- **SCSS_Variables**: The project's SCSS custom properties defined in `_variables.scss`, used as the single source of truth for colors and spacing.
+- **VAR_Label_Color**: The SCSS variable `$coin-var-primary` that defines the VAR dot color.
+- **SKA_Label_Color**: The SCSS variable `$coin-ska-primary` that defines the SKA dot color.
+
+---
+
+## Requirements
+
+### Requirement 1: Chevron Expand/Collapse Indicator
+
+**User Story:** As a user viewing the Latest Blocks table, I want a clear visual indicator on each block row so that I can immediately understand that the row is expandable and see its current state.
+
+#### Acceptance Criteria
+
+1. THE Block_Table SHALL render a Chevron in the first column of every Parent_Row.
+2. WHEN a Parent_Row is in the collapsed state, THE Block_Table SHALL display the Chevron pointing to the right (or downward-pointing when expanded), clearly differentiating the two states.
+3. WHEN a Parent_Row is in the expanded state (CSS class `is-expanded` is present), THE Block_Table SHALL display the Chevron in the rotated/alternate orientation to indicate the expanded state.
+4. THE Chevron SHALL have a minimum hit target of 24 × 24 CSS pixels to support both mouse and touch interactions.
+5. THE Block_Table SHALL position the Chevron at the leading (left) edge of the first column, before the block height link.
+6. WHEN the blocklist_controller injects a new Parent_Row via a `BLOCK_RECEIVED` event, THE Block_Table SHALL include the Chevron in the injected row's first column.
+
+---
+
+### Requirement 2: Sub-Row Vertical Anchor (Left Border)
+
+**User Story:** As a user who has expanded a block row, I want a visual guide that connects the sub-rows to their parent block so that I can immediately understand the parent–child relationship.
+
+#### Acceptance Criteria
+
+1. WHEN a Sub_Row is visible, THE Block_Table SHALL render a Vertical_Anchor — a continuous left border on the first cell of each Sub_Row — for the full height of that cell.
+2. THE Vertical_Anchor SHALL use a color defined by a dedicated SCSS variable `$sub-row-anchor-color` in `_variables.scss`, with a dark-theme override in `themes.scss`, so that it is visually distinct from the cell border but does not compete with data content.
+3. THE Vertical_Anchor SHALL be present on both VAR Sub_Rows and SKA Sub_Rows belonging to the same Parent_Row.
+4. WHEN the blocklist_controller injects Sub_Rows via a `BLOCK_RECEIVED` event, THE Block_Table SHALL include the Vertical_Anchor styling on the injected Sub_Rows' first cells.
+
+---
+
+### Requirement 3: Left-Aligned Asset Label Positioning
+
+**User Story:** As a user scanning the expanded sub-rows, I want the asset labels (VAR, SKA-1, etc.) to be clearly positioned within the first column so that they are visually separated from the block height link above and easy to scan.
+
+#### Acceptance Criteria
+
+1. THE Block_Table SHALL left-align the content of the first cell in every Sub_Row (asset label area) within that cell, with responsive padding (`ps-2 ps-sm-4`) to create visual indentation.
+2. THE Block_Table SHALL left-align the block height link in the first cell of every Parent_Row, maintaining the existing typographic hierarchy.
+3. THE Block_Table SHALL achieve label positioning without introducing additional columns or altering the column count.
+
+---
+
+### Requirement 4: VAR_Label and SKA_Label Asset Identification
+
+**User Story:** As a user reading the sub-rows, I want asset names rendered with a distinct colored dot so that I can instantly distinguish token types from numerical data.
+
+#### Acceptance Criteria
+
+1. THE Block_Table SHALL render the VAR label in each VAR Sub_Row as a VAR_Label using `<span class="coin-label coin-label--var">VAR</span>`.
+2. THE Block_Table SHALL render each SKA token label (SKA-1, SKA-2, etc.) in its Sub_Row as a SKA_Label using `<span class="coin-label coin-label--ska">`.
+3. THE VAR_Label SHALL display a colored dot using `$coin-var-primary` (`#3374ff`) via a CSS `::before` pseudo-element.
+4. THE SKA_Label SHALL display a colored dot using `$coin-ska-primary` (`#80868b`) via a CSS `::before` pseudo-element, using a visually distinct neutral tone.
+5. THE SKA_Label SHALL apply a consistent color treatment for all SKA-type tokens regardless of the specific token index n.
+6. The dot and label text SHALL be vertically aligned using `inline-flex` with `align-items: center`.
+7. WHEN the blocklist_controller injects Sub_Rows via a `BLOCK_RECEIVED` event, THE Block_Table SHALL render VAR_Label and SKA_Label elements in the injected Sub_Rows.
+
+---
+
+### Requirement 5: Typographic Subordination of Sub-Rows
+
+**User Story:** As a user scanning the table, I want sub-row data to appear visually subordinate to the parent block row so that my eye is drawn to block heights first and token details second.
+
+#### Acceptance Criteria
+
+1. THE Block_Table SHALL render Sub_Row text at a smaller font size or reduced color contrast compared to Parent_Row text, using values from SCSS_Variables or Bootstrap utility classes.
+2. THE Block_Table SHALL NOT reduce Sub_Row text to a size below 11px to preserve legibility on small screens.
+3. THE Block_Table SHALL apply subordinate styling consistently to all Sub_Rows (both VAR and SKA types).
+
+---
+
+### Requirement 6: Dark Theme Support
+
+**User Story:** As a user who has enabled the dark theme (`body.darkBG`), I want all visual elements of the block table hierarchy to render correctly in dark mode so that the feature is fully usable regardless of theme.
+
+#### Acceptance Criteria
+
+1. THE Block_Table SHALL render the Chevron with sufficient contrast against the dark background when `body.darkBG` is active, using a color consistent with the existing dark-theme text color (`#fdfdfd` or equivalent).
+2. THE Vertical_Anchor SHALL use a dark-theme color override defined in `themes.scss` (via a `$sub-row-anchor-color-dark` variable or equivalent `body.darkBG` rule) that is visually distinct from the dark cell background.
+3. THE VAR_Badge and SKA_Badge SHALL use dark-theme background and text color overrides defined in `themes.scss`, following the same pattern as existing `body.darkBG` rules.
+4. Sub_Row typographic subordination (reduced size or contrast) SHALL remain legible under `body.darkBG`; the muted color used SHALL be derived from or consistent with the existing dark-theme secondary text color (e.g. `#c1c1c1` as used for `.text-secondary` in `themes.scss`).
+5. Sub_Row background color (`$card-bg-secondary-dark`) is already defined and applied via the existing `.ska-sub-row--visible` dark override; this SHALL be preserved and not regressed by the new styles.
+6. ALL new SCSS rules introduced by this feature that have a light-theme value SHALL have a corresponding `body.darkBG` override in `themes.scss`.
+
+---
+
+### Requirement 7: Adaptive Layout — No New Columns
+
+**User Story:** As a user on a mobile device, I want the table hierarchy changes to fit within the existing column structure so that the table does not require horizontal scrolling.
+
+#### Acceptance Criteria
+
+1. THE Block_Table SHALL implement all hierarchy visual changes within the existing 9-column structure; no additional `<th>` or `<td>` columns SHALL be introduced.
+2. WHILE the viewport width is below the Bootstrap `sm` breakpoint (540px), THE Block_Table SHALL remain free of horizontal overflow caused by the hierarchy changes.
+3. THE Block_Table SHALL continue to hide columns 5 (Size) and 8 (Rev) on viewports below `sm` and `md` breakpoints, as defined by the existing responsive classes (`d-none d-sm-table-cell d-md-none d-lg-table-cell`).
+4. THE Block_Table SHALL use existing Bootstrap 5 utility classes and SCSS_Variables for all new styles, avoiding inline styles except where dynamically required by JavaScript.

--- a/.kiro/specs/home-block-table-hierarchy/tasks.md
+++ b/.kiro/specs/home-block-table-hierarchy/tasks.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Home Block Table Hierarchy
+
+## Overview
+
+Add visual hierarchy affordances to the "Latest Blocks" table: a CSS chevron on parent rows, badge-styled asset labels on sub-rows, a vertical anchor left-border, and typographic subordination — all within the existing 9-column structure. Changes touch exactly 5 files; no new files are created.
+
+## Tasks
+
+- [x] 1. Add SCSS variables to `_variables.scss`
+  - Append the 5 new variables after the existing `$block-row-hover-dark` block:
+    `$coin-var-primary`, `$var-badge-color`, `$coin-ska-primary`, `$ska-badge-color`, `$sub-row-anchor-color`
+  - `$coin-var-primary` MUST reuse `$regular-light` to create the semantic link required by Requirement 4.3
+  - _Requirements: 2.2, 4.3, 4.4, 4.6_
+
+- [x] 2. Add dark-theme overrides to `themes.scss`
+  - Inside the existing `body.darkBG { … }` block, append overrides for `.badge-var`, `.badge-ska`, and `.ska-sub-row td:first-child` (border-left-color)
+  - Follow the same selector pattern as the existing `.bg-white` and `.text-secondary` overrides
+  - _Requirements: 4.6, 6.2, 6.3, 6.6_
+
+- [x] 3. Add component styles to `home.scss`
+  - [x] 3.1 Add `.chevron` rule (CSS-only triangle via border trick) and the `.is-expanded .chevron` rotation rule
+    - _Requirements: 1.2, 1.3, 1.4_
+  - [x] 3.2 Add `.ska-sub-row td:first-child` rule for the vertical anchor left-border using `$sub-row-anchor-color`
+    - _Requirements: 2.1, 2.3_
+  - [x] 3.3 Add `.badge-var` and `.badge-ska` light-theme rules using the new variables
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+  - [x] 3.4 Add typographic subordination rules on `.ska-sub-row` (font-size, color) and the `body.darkBG` override
+    - Font size MUST stay at or above 11px (0.85em at 14px base ≈ 11.9px)
+    - Dark color MUST be consistent with `#c1c1c1` used for `.text-secondary` in `themes.scss`
+    - _Requirements: 5.1, 5.2, 5.3, 6.4_
+
+- [x] 4. Update `home_latest_blocks.tmpl`
+  - [x] 4.1 Add `<span class="chevron me-1"></span>` before the height `<a>` in every Parent_Row first cell
+    - _Requirements: 1.1, 1.5_
+  - [x] 4.2 Replace `<span class="sub-row-label">VAR</span>` with `<span class="badge badge-var">VAR</span>` in the VAR sub-row first cell, and change the cell class from `text-start` to `text-end`
+    - _Requirements: 3.1, 4.1_
+  - [x] 4.3 Replace `<span class="sub-row-label">{{.TokenType}}</span>` with `<span class="badge badge-ska">{{.TokenType}}</span>` in the SKA sub-row first cell, and change the cell class from `text-start` to `text-end`
+    - _Requirements: 3.1, 4.2, 4.5_
+
+- [x] 5. Update `blocklist_controller.js` injection logic
+  - [x] 5.1 In the `height` case of `_processBlock`, prepend a `<span class="chevron me-1">` before the height `<a>` link
+    - _Requirements: 1.6_
+  - [x] 5.2 In `insertVARSubRow`, replace the `sub-row-label` span with `<span class="badge badge-var">VAR</span>` and change the label cell class from `text-start` to `text-end`
+    - _Requirements: 2.4, 3.1, 4.7_
+  - [x] 5.3 In `insertSKASubRows`, replace the `sub-row-label` span with `<span class="badge badge-ska">` and change the label cell class from `text-start` to `text-end`
+    - _Requirements: 2.4, 3.1, 4.7_
+
+- [x] 6. Checkpoint — verify structural correctness
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 7. Write property-based tests for `blocklist_controller.js` injection logic
+  - Create `cmd/dcrdata/public/js/controllers/blocklist_controller.test.js` (new file)
+  - Use Vitest + jsdom + fast-check (already a dev dependency)
+  - Stub `@hotwired/stimulus`, `../helpers/humanize_helper`, and `../services/event_bus_service` with `vi.mock` following the same pattern as `ska_accordion_controller.test.js`
+  - Each property test MUST be tagged: `// Feature: home-block-table-hierarchy, Property N: <text>`
+  - [x] 7.1 Write unit tests for `insertVARSubRow` and `insertSKASubRows` structural output
+    - Assert: label cell has class `text-end`, contains a `<span>` with `badge badge-var` / `badge badge-ska`, 9 `<td>` elements per row, responsive classes on cols 5 and 8
+    - _Requirements: 2.4, 3.1, 4.7, 7.1, 7.3_
+  - [ ]\* 7.2 Write property test for Property 4: injected rows are structurally complete
+    - **Property 4: Injected rows are structurally complete**
+    - **Validates: Requirements 1.6, 2.4, 4.7**
+    - Use `fc.record` to generate arbitrary block data with 0, 1, and N coin_rows; assert chevron in parent row first cell, `badge-var` in VAR sub-row, `badge-ska` in each SKA sub-row
+  - [ ]\* 7.3 Write property test for Property 7: column count invariant
+    - **Property 7: Column count invariant**
+    - **Validates: Requirements 3.3, 7.1**
+    - For any generated block data, assert every injected row (parent + sub-rows) has exactly 9 `<td>` elements
+  - [ ]\* 7.4 Write property test for Property 8: VAR sub-rows use badge-var
+    - **Property 8: VAR sub-rows use badge-var**
+    - **Validates: Requirements 4.1**
+    - For any block data, assert the VAR sub-row first cell contains `<span class="badge badge-var">`
+  - [ ]\* 7.5 Write property test for Property 9: all SKA sub-rows use badge-ska regardless of token index
+    - **Property 9: All SKA sub-rows use badge-ska regardless of token index**
+    - **Validates: Requirements 4.2, 4.5**
+    - Use `fc.array(fc.record({ symbol: fc.constantFrom('SKA-1','SKA-2','SKA-255'), ... }))` to generate varying SKA coin_rows; assert every SKA sub-row first cell contains `<span class="badge badge-ska">`
+  - [ ]\* 7.6 Write property test for Property 1: chevron presence in all injected parent rows
+    - **Property 1: Chevron presence in all parent rows**
+    - **Validates: Requirements 1.1**
+    - For any block data, assert the injected parent row's first cell contains an element with class `chevron`
+  - [ ]\* 7.7 Write property test for Property 3: chevron precedes height link in DOM
+    - **Property 3: Chevron precedes height link in DOM**
+    - **Validates: Requirements 1.5**
+    - For any block data, assert the chevron span's `nextElementSibling` is the height `<a>` link
+  - [ ]\* 7.8 Write property test for Property 5: sub-row first cell carries anchor class
+    - **Property 5: Sub-row first cell carries anchor class**
+    - **Validates: Requirements 2.1, 2.3**
+    - For any block data with ≥1 sub-row, assert every sub-row's first cell has `data-type="sub-label"` (the selector targeted by the anchor border CSS rule)
+  - [ ]\* 7.9 Write property test for Property 6: sub-row first cell is right-aligned
+    - **Property 6: Sub-row first cell is right-aligned**
+    - **Validates: Requirements 3.1**
+    - For any block data, assert every sub-row's first cell has class `text-end`
+  - [ ]\* 7.10 Write property test for Property 10: all sub-rows carry subordination class
+    - **Property 10: All sub-rows carry subordination class**
+    - **Validates: Requirements 5.1, 5.3**
+    - For any block data, assert every injected sub-row has class `ska-sub-row`
+  - [ ]\* 7.11 Write property test for Property 11: responsive classes preserved on size and rev cells
+    - **Property 11: Responsive classes preserved on size and rev cells**
+    - **Validates: Requirements 7.3**
+    - For any block data, assert col-5 and col-8 cells in every injected row carry `d-none d-sm-table-cell d-md-none d-lg-table-cell`
+
+- [x] 8. Update property-based tests in `ska_accordion_controller.test.js`
+  - [x] 8.1 Write unit tests for Property 2: chevron state reflects expansion
+    - Assert that after `toggle()` the parent row gains `is-expanded`; after a second `toggle()` it loses it
+    - _Requirements: 1.2, 1.3_
+  - [ ]\* 8.2 Write property test for Property 2: chevron state reflects expansion (round-trip)
+    - **Property 2: Chevron state reflects expansion**
+    - **Validates: Requirements 1.2, 1.3**
+    - Extend the existing round-trip property test to also assert `is-expanded` is absent after two toggles for any `blockId`
+
+- [x] 9. Final checkpoint — ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- `ska_accordion_controller.js` requires NO code changes — chevron rotation is handled entirely by CSS on `.is-expanded .chevron`
+- Property tests run a minimum of 100 iterations via fast-check's default configuration
+- Each property test must include the tag comment `// Feature: home-block-table-hierarchy, Property N: <text>`
+- The existing `ska_accordion_controller.test.js` already covers Properties 7 and 8 from the prior spec; the new tests in task 8 target Properties 2 from this spec

--- a/cmd/dcrdata/internal/explorer/home_viewmodel.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel.go
@@ -3,6 +3,7 @@ package explorer
 import (
 	"fmt"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/monetarium/monetarium-explorer/explorer/types"
 )
 
@@ -66,7 +67,7 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 					varTxCount = cr.TxCount
 					varAmount = formatCoinAtoms(cr.Amount, cr.CoinType)
 					if cr.Size > 0 {
-						varSize = fmt.Sprintf("%d B", cr.Size)
+						varSize = humanize.Bytes(uint64(cr.Size))
 					} else {
 						varSize = "—"
 					}
@@ -78,7 +79,7 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 					}
 					size := "—"
 					if cr.Size > 0 {
-						size = fmt.Sprintf("%d B", cr.Size)
+						size = humanize.Bytes(uint64(cr.Size))
 					}
 					subRows = append(subRows, SKASubRow{
 						TokenType: cr.Symbol,

--- a/cmd/dcrdata/public/js/controllers/blocklist_controller.js
+++ b/cmd/dcrdata/public/js/controllers/blocklist_controller.js
@@ -64,9 +64,10 @@ function insertVARSubRow(tbody, newRow, varTxCount, varAmount, varSize) {
   tr.dataset.skaAccordionTarget = 'subRow'
   tr.dataset.blockId = newRow.dataset.blockId
 
-  const labelTd = makeTd('text-start ps-1')
+  const labelTd = makeTd('text-end ps-2 ps-sm-4')
+  labelTd.dataset.type = 'sub-label'
   const labelSpan = document.createElement('span')
-  labelSpan.className = 'sub-row-label'
+  labelSpan.className = 'coin-label coin-label--var'
   labelSpan.textContent = 'VAR'
   labelTd.appendChild(labelSpan)
   tr.appendChild(labelTd)
@@ -92,9 +93,10 @@ function insertSKASubRows(tbody, insertRef, subRows, blockHeight) {
     tr.dataset.skaAccordionTarget = 'subRow'
     tr.dataset.blockId = String(blockHeight)
 
-    const labelTd = makeTd('text-start ps-1')
+    const labelTd = makeTd('text-end ps-2 ps-sm-4')
+    labelTd.dataset.type = 'sub-label'
     const badge = document.createElement('span')
-    badge.className = 'sub-row-label'
+    badge.className = 'coin-label coin-label--ska'
     badge.textContent = sub.tokenType
     labelTd.appendChild(badge)
     tr.appendChild(labelTd)
@@ -175,6 +177,9 @@ export default class extends Controller {
           newTd.textContent = humanize.timeSince(block.unixStamp)
           break
         case 'height': {
+          const chevron = document.createElement('span')
+          chevron.className = 'chevron me-1'
+          newTd.appendChild(chevron)
           const link = document.createElement('a')
           link.href = `/block/${block.height}`
           link.textContent = block.height

--- a/cmd/dcrdata/public/js/controllers/blocklist_controller.js
+++ b/cmd/dcrdata/public/js/controllers/blocklist_controller.js
@@ -29,13 +29,13 @@ function coinRowsToSKAData(block) {
     if (cr.coin_type === 0) {
       varTxCount = cr.tx_count
       varAmount = humanize.formatCoinAtoms(cr.amount, cr.coin_type)
-      varSize = cr.size > 0 ? `${cr.size} B` : '—'
+      varSize = cr.size > 0 ? humanize.bytes(cr.size) : '—'
     } else {
       subRows.push({
         tokenType: cr.symbol,
         txCount: cr.tx_count > 0 ? String(cr.tx_count) : '—',
         amount: humanize.formatCoinAtoms(cr.amount, cr.coin_type),
-        size: cr.size > 0 ? `${cr.size} B` : '—'
+        size: cr.size > 0 ? humanize.bytes(cr.size) : '—'
       })
     }
   }

--- a/cmd/dcrdata/public/js/controllers/blocklist_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/blocklist_controller.test.js
@@ -45,6 +45,12 @@ function appendBlock(tbody, height, skaCoinRows = []) {
     const td = document.createElement('td')
     td.dataset.type = dt
     if (dt === 'height') td.className = 'text-start ps-1'
+    if (dt === 'size') {
+      td.className = 'text-end num d-none d-sm-table-cell d-md-none d-lg-table-cell'
+    }
+    if (dt === 'revocations') {
+      td.className = 'text-end num d-none d-sm-table-cell d-md-none d-lg-table-cell'
+    }
     blockRow.appendChild(td)
   }
   tbody.appendChild(blockRow)
@@ -263,7 +269,7 @@ describe('blocklist_controller — Property 8: WebSocket block prepend matches s
       const row = tbody.querySelector(
         'tr[data-block-id="1001"][data-ska-accordion-target="blockRow"]'
       )
-      const labelCell = row.nextElementSibling.querySelector('td.text-start')
+      const labelCell = row.nextElementSibling.querySelector('td.text-end')
       expect(labelCell).not.toBeNull()
       expect(labelCell.textContent.trim()).toBe('VAR')
     })
@@ -307,7 +313,7 @@ describe('blocklist_controller — Property 8: WebSocket block prepend matches s
       ).slice(1) // skip VAR row
       subs.forEach((r) => {
         expect(r.querySelectorAll('td').length).toBe(9)
-        const label = r.querySelector('td.text-start')
+        const label = r.querySelector('td.text-end')
         expect(label).not.toBeNull()
         expect(label.textContent.trim()).toMatch(/^SKA-\d+$/)
       })
@@ -398,6 +404,468 @@ describe('blocklist_controller — Property 8: WebSocket block prepend matches s
               expect(all[i].dataset.blockId).toBe(String(height))
             }
           }
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Feature: home-block-table-hierarchy
+// Task 7.1 — Unit tests for badge/anchor structural output
+// ---------------------------------------------------------------------------
+
+describe('blocklist_controller — home-block-table-hierarchy badge & anchor unit tests', () => {
+  describe('VAR sub-row badge structure', () => {
+    it('label cell has class text-end', () => {
+      const { tbody, ctrl } = buildTable(1000, 1, SKA_ROWS_3)
+      ctrl._processBlock(makeBlock(1001, { skaCoinRows: SKA_ROWS_3 }))
+      const blockRow = tbody.querySelector(
+        'tr[data-block-id="1001"][data-ska-accordion-target="blockRow"]'
+      )
+      const varRow = blockRow.nextElementSibling
+      const labelCell = varRow.querySelector('td[data-type="sub-label"]')
+      expect(labelCell).not.toBeNull()
+      expect(labelCell.classList.contains('text-end')).toBe(true)
+    })
+
+    it('label cell contains a span with coin-label, coin-label--var classes', () => {
+      const { tbody, ctrl } = buildTable(1000, 1, SKA_ROWS_3)
+      ctrl._processBlock(makeBlock(1001, { skaCoinRows: SKA_ROWS_3 }))
+      const blockRow = tbody.querySelector(
+        'tr[data-block-id="1001"][data-ska-accordion-target="blockRow"]'
+      )
+      const varRow = blockRow.nextElementSibling
+      const badge = varRow.querySelector(
+        'td[data-type="sub-label"] span.coin-label.coin-label--var'
+      )
+      expect(badge).not.toBeNull()
+      expect(badge.textContent).toBe('VAR')
+    })
+
+    it('VAR sub-row has exactly 9 td elements', () => {
+      const { tbody, ctrl } = buildTable(1000, 1, SKA_ROWS_3)
+      ctrl._processBlock(makeBlock(1001, { skaCoinRows: SKA_ROWS_3 }))
+      const blockRow = tbody.querySelector(
+        'tr[data-block-id="1001"][data-ska-accordion-target="blockRow"]'
+      )
+      expect(blockRow.nextElementSibling.querySelectorAll('td').length).toBe(9)
+    })
+
+    it('VAR sub-row col-5 and col-8 have responsive classes', () => {
+      const { tbody, ctrl } = buildTable(1000, 1, SKA_ROWS_3)
+      ctrl._processBlock(makeBlock(1001, { skaCoinRows: SKA_ROWS_3 }))
+      const blockRow = tbody.querySelector(
+        'tr[data-block-id="1001"][data-ska-accordion-target="blockRow"]'
+      )
+      const cells = Array.from(blockRow.nextElementSibling.querySelectorAll('td'))
+      const responsiveClasses = ['d-none', 'd-sm-table-cell', 'd-md-none', 'd-lg-table-cell']
+      responsiveClasses.forEach((cls) => {
+        expect(cells[4].classList.contains(cls)).toBe(true) // col 5
+        expect(cells[7].classList.contains(cls)).toBe(true) // col 8
+      })
+    })
+  })
+
+  describe('SKA sub-row badge structure', () => {
+    it('each SKA label cell has class text-end', () => {
+      const { tbody, ctrl } = buildTable(1000, 1, SKA_ROWS_3)
+      ctrl._processBlock(makeBlock(1001, { skaCoinRows: SKA_ROWS_3 }))
+      const subs = Array.from(
+        tbody.querySelectorAll('tr[data-block-id="1001"][data-ska-accordion-target="subRow"]')
+      ).slice(1) // skip VAR row
+      subs.forEach((r) => {
+        const labelCell = r.querySelector('td[data-type="sub-label"]')
+        expect(labelCell).not.toBeNull()
+        expect(labelCell.classList.contains('text-end')).toBe(true)
+      })
+    })
+
+    it('each SKA label cell contains a span with coin-label and coin-label--ska classes', () => {
+      const { tbody, ctrl } = buildTable(1000, 1, SKA_ROWS_3)
+      ctrl._processBlock(makeBlock(1001, { skaCoinRows: SKA_ROWS_3 }))
+      const subs = Array.from(
+        tbody.querySelectorAll('tr[data-block-id="1001"][data-ska-accordion-target="subRow"]')
+      ).slice(1)
+      subs.forEach((r) => {
+        const badge = r.querySelector('td[data-type="sub-label"] span.coin-label.coin-label--ska')
+        expect(badge).not.toBeNull()
+      })
+    })
+
+    it('each SKA sub-row has exactly 9 td elements', () => {
+      const { tbody, ctrl } = buildTable(1000, 1, SKA_ROWS_3)
+      ctrl._processBlock(makeBlock(1001, { skaCoinRows: SKA_ROWS_3 }))
+      const subs = Array.from(
+        tbody.querySelectorAll('tr[data-block-id="1001"][data-ska-accordion-target="subRow"]')
+      ).slice(1)
+      subs.forEach((r) => expect(r.querySelectorAll('td').length).toBe(9))
+    })
+
+    it('each SKA sub-row col-5 and col-8 have responsive classes', () => {
+      const { tbody, ctrl } = buildTable(1000, 1, SKA_ROWS_3)
+      ctrl._processBlock(makeBlock(1001, { skaCoinRows: SKA_ROWS_3 }))
+      const subs = Array.from(
+        tbody.querySelectorAll('tr[data-block-id="1001"][data-ska-accordion-target="subRow"]')
+      ).slice(1)
+      const responsiveClasses = ['d-none', 'd-sm-table-cell', 'd-md-none', 'd-lg-table-cell']
+      subs.forEach((r) => {
+        const cells = Array.from(r.querySelectorAll('td'))
+        responsiveClasses.forEach((cls) => {
+          expect(cells[4].classList.contains(cls)).toBe(true)
+          expect(cells[7].classList.contains(cls)).toBe(true)
+        })
+      })
+    })
+  })
+
+  describe('parent row chevron structure', () => {
+    it('height cell contains a chevron span before the height link', () => {
+      const { tbody, ctrl } = buildTable(1000, 1, SKA_ROWS_3)
+      ctrl._processBlock(makeBlock(1001, { skaCoinRows: SKA_ROWS_3 }))
+      const blockRow = tbody.querySelector(
+        'tr[data-block-id="1001"][data-ska-accordion-target="blockRow"]'
+      )
+      const heightCell = Array.from(blockRow.querySelectorAll('td')).find(
+        (td) => td.dataset.type === 'height'
+      )
+      const chevron = heightCell.querySelector('span.chevron')
+      expect(chevron).not.toBeNull()
+      expect(chevron.nextElementSibling.tagName).toBe('A')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Feature: home-block-table-hierarchy — Property-based tests
+// ---------------------------------------------------------------------------
+
+describe('blocklist_controller — home-block-table-hierarchy property tests', () => {
+  // Feature: home-block-table-hierarchy, Property 4: Injected rows are structurally complete
+  it('Property 4: injected rows are structurally complete', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999999 }),
+        fc.array(
+          fc.record({
+            coin_type: fc.integer({ min: 1, max: 10 }),
+            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-255'),
+            tx_count: fc.integer({ min: 0, max: 100 }),
+            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-255'),
+            size: fc.integer({ min: 100, max: 10000 })
+          }),
+          { minLength: 0, maxLength: 5 }
+        ),
+        (topHeight, skaCoinRows) => {
+          const { tbody, ctrl } = buildTable(topHeight, 1, skaCoinRows)
+          const height = topHeight + 1
+          ctrl._processBlock(makeBlock(height, { skaCoinRows }))
+
+          const blockRow = tbody.querySelector(
+            `tr[data-block-id="${height}"][data-ska-accordion-target="blockRow"]`
+          )
+          // chevron in parent row
+          const heightCell = Array.from(blockRow.querySelectorAll('td')).find(
+            (td) => td.dataset.type === 'height'
+          )
+          expect(heightCell.querySelector('span.chevron')).not.toBeNull()
+
+          const varRow = blockRow.nextElementSibling
+          expect(varRow.querySelector('span.coin-label.coin-label--var')).not.toBeNull()
+
+          const allSubs = Array.from(
+            tbody.querySelectorAll(
+              `tr[data-block-id="${height}"][data-ska-accordion-target="subRow"]`
+            )
+          ).slice(1)
+          allSubs.forEach((r) => {
+            expect(r.querySelector('span.coin-label.coin-label--ska')).not.toBeNull()
+          })
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  // Feature: home-block-table-hierarchy, Property 7: Column count invariant
+  it('Property 7: column count invariant — every injected row has exactly 9 td elements', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999999 }),
+        fc.array(
+          fc.record({
+            coin_type: fc.integer({ min: 1, max: 10 }),
+            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            tx_count: fc.integer({ min: 0, max: 100 }),
+            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            size: fc.integer({ min: 100, max: 10000 })
+          }),
+          { minLength: 0, maxLength: 5 }
+        ),
+        (topHeight, skaCoinRows) => {
+          const { tbody, ctrl } = buildTable(topHeight, 1, skaCoinRows)
+          const height = topHeight + 1
+          ctrl._processBlock(makeBlock(height, { skaCoinRows }))
+
+          const allRows = tbody.querySelectorAll(`tr[data-block-id="${height}"]`)
+          allRows.forEach((r) => {
+            expect(r.querySelectorAll('td').length).toBe(9)
+          })
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  // Feature: home-block-table-hierarchy, Property 8: VAR sub-rows use badge-var
+  it('Property 8: VAR sub-rows use badge-var', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999999 }),
+        fc.array(
+          fc.record({
+            coin_type: fc.integer({ min: 1, max: 10 }),
+            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            tx_count: fc.integer({ min: 0, max: 100 }),
+            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            size: fc.integer({ min: 100, max: 10000 })
+          }),
+          { minLength: 0, maxLength: 5 }
+        ),
+        (topHeight, skaCoinRows) => {
+          const { tbody, ctrl } = buildTable(topHeight, 1, skaCoinRows)
+          const height = topHeight + 1
+          ctrl._processBlock(makeBlock(height, { skaCoinRows }))
+
+          const blockRow = tbody.querySelector(
+            `tr[data-block-id="${height}"][data-ska-accordion-target="blockRow"]`
+          )
+          const varRow = blockRow.nextElementSibling
+          expect(varRow.querySelector('span.coin-label.coin-label--var')).not.toBeNull()
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  // Feature: home-block-table-hierarchy, Property 9: All SKA sub-rows use badge-ska regardless of token index
+  it('Property 9: all SKA sub-rows use badge-ska regardless of token index', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999999 }),
+        fc.array(
+          fc.record({
+            coin_type: fc.integer({ min: 1, max: 255 }),
+            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-255'),
+            tx_count: fc.integer({ min: 0, max: 100 }),
+            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-255'),
+            size: fc.integer({ min: 100, max: 10000 })
+          }),
+          { minLength: 1, maxLength: 5 }
+        ),
+        (topHeight, skaCoinRows) => {
+          const { tbody, ctrl } = buildTable(topHeight, 1, skaCoinRows)
+          const height = topHeight + 1
+          ctrl._processBlock(makeBlock(height, { skaCoinRows }))
+
+          const allSubs = Array.from(
+            tbody.querySelectorAll(
+              `tr[data-block-id="${height}"][data-ska-accordion-target="subRow"]`
+            )
+          ).slice(1) // skip VAR
+          expect(allSubs.length).toBe(skaCoinRows.length)
+          allSubs.forEach((r) => {
+            expect(r.querySelector('span.coin-label.coin-label--ska')).not.toBeNull()
+          })
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  // Feature: home-block-table-hierarchy, Property 1: Chevron presence in all parent rows
+  it('Property 1: chevron presence in all injected parent rows', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999999 }),
+        fc.array(
+          fc.record({
+            coin_type: fc.integer({ min: 1, max: 10 }),
+            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            tx_count: fc.integer({ min: 0, max: 100 }),
+            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            size: fc.integer({ min: 100, max: 10000 })
+          }),
+          { minLength: 0, maxLength: 5 }
+        ),
+        (topHeight, skaCoinRows) => {
+          const { tbody, ctrl } = buildTable(topHeight, 1, skaCoinRows)
+          const height = topHeight + 1
+          ctrl._processBlock(makeBlock(height, { skaCoinRows }))
+
+          const blockRow = tbody.querySelector(
+            `tr[data-block-id="${height}"][data-ska-accordion-target="blockRow"]`
+          )
+          const heightCell = Array.from(blockRow.querySelectorAll('td')).find(
+            (td) => td.dataset.type === 'height'
+          )
+          expect(heightCell.querySelector('span.chevron')).not.toBeNull()
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  // Feature: home-block-table-hierarchy, Property 3: Chevron precedes height link in DOM
+  it('Property 3: chevron precedes height link in DOM', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 999999 }), (topHeight) => {
+        const { tbody, ctrl } = buildTable(topHeight, 1)
+        const height = topHeight + 1
+        ctrl._processBlock(makeBlock(height))
+
+        const blockRow = tbody.querySelector(
+          `tr[data-block-id="${height}"][data-ska-accordion-target="blockRow"]`
+        )
+        const heightCell = Array.from(blockRow.querySelectorAll('td')).find(
+          (td) => td.dataset.type === 'height'
+        )
+        const chevron = heightCell.querySelector('span.chevron')
+        expect(chevron).not.toBeNull()
+        expect(chevron.nextElementSibling.tagName).toBe('A')
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  // Feature: home-block-table-hierarchy, Property 5: Sub-row first cell carries anchor class
+  it('Property 5: sub-row first cell carries data-type="sub-label"', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999999 }),
+        fc.array(
+          fc.record({
+            coin_type: fc.integer({ min: 1, max: 10 }),
+            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            tx_count: fc.integer({ min: 0, max: 100 }),
+            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            size: fc.integer({ min: 100, max: 10000 })
+          }),
+          { minLength: 0, maxLength: 5 }
+        ),
+        (topHeight, skaCoinRows) => {
+          const { tbody, ctrl } = buildTable(topHeight, 1, skaCoinRows)
+          const height = topHeight + 1
+          ctrl._processBlock(makeBlock(height, { skaCoinRows }))
+
+          const allSubs = tbody.querySelectorAll(
+            `tr[data-block-id="${height}"][data-ska-accordion-target="subRow"]`
+          )
+          allSubs.forEach((r) => {
+            const firstCell = r.querySelector('td')
+            expect(firstCell.dataset.type).toBe('sub-label')
+          })
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  // Feature: home-block-table-hierarchy, Property 6: Sub-row first cell is right-aligned
+  it('Property 6: sub-row first cell is left-aligned (text-end)', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999999 }),
+        fc.array(
+          fc.record({
+            coin_type: fc.integer({ min: 1, max: 10 }),
+            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            tx_count: fc.integer({ min: 0, max: 100 }),
+            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            size: fc.integer({ min: 100, max: 10000 })
+          }),
+          { minLength: 0, maxLength: 5 }
+        ),
+        (topHeight, skaCoinRows) => {
+          const { tbody, ctrl } = buildTable(topHeight, 1, skaCoinRows)
+          const height = topHeight + 1
+          ctrl._processBlock(makeBlock(height, { skaCoinRows }))
+
+          const allSubs = tbody.querySelectorAll(
+            `tr[data-block-id="${height}"][data-ska-accordion-target="subRow"]`
+          )
+          allSubs.forEach((r) => {
+            const firstCell = r.querySelector('td')
+            expect(firstCell.classList.contains('text-end')).toBe(true)
+          })
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  // Feature: home-block-table-hierarchy, Property 10: All sub-rows carry subordination class
+  it('Property 10: all sub-rows carry ska-sub-row class', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999999 }),
+        fc.array(
+          fc.record({
+            coin_type: fc.integer({ min: 1, max: 10 }),
+            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            tx_count: fc.integer({ min: 0, max: 100 }),
+            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            size: fc.integer({ min: 100, max: 10000 })
+          }),
+          { minLength: 0, maxLength: 5 }
+        ),
+        (topHeight, skaCoinRows) => {
+          const { tbody, ctrl } = buildTable(topHeight, 1, skaCoinRows)
+          const height = topHeight + 1
+          ctrl._processBlock(makeBlock(height, { skaCoinRows }))
+
+          const allSubs = tbody.querySelectorAll(
+            `tr[data-block-id="${height}"][data-ska-accordion-target="subRow"]`
+          )
+          allSubs.forEach((r) => {
+            expect(r.classList.contains('ska-sub-row')).toBe(true)
+          })
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  // Feature: home-block-table-hierarchy, Property 11: Responsive classes preserved on size and rev cells
+  it('Property 11: responsive classes preserved on col-5 and col-8 in all injected rows', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999999 }),
+        fc.array(
+          fc.record({
+            coin_type: fc.integer({ min: 1, max: 10 }),
+            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            tx_count: fc.integer({ min: 0, max: 100 }),
+            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            size: fc.integer({ min: 100, max: 10000 })
+          }),
+          { minLength: 0, maxLength: 5 }
+        ),
+        (topHeight, skaCoinRows) => {
+          const { tbody, ctrl } = buildTable(topHeight, 1, skaCoinRows)
+          const height = topHeight + 1
+          ctrl._processBlock(makeBlock(height, { skaCoinRows }))
+
+          const responsiveClasses = ['d-none', 'd-sm-table-cell', 'd-md-none', 'd-lg-table-cell']
+          const allRows = tbody.querySelectorAll(`tr[data-block-id="${height}"]`)
+          allRows.forEach((r) => {
+            const cells = Array.from(r.querySelectorAll('td'))
+            responsiveClasses.forEach((cls) => {
+              expect(cells[4].classList.contains(cls)).toBe(true) // col 5 (size)
+              expect(cells[7].classList.contains(cls)).toBe(true) // col 8 (rev)
+            })
+          })
         }
       ),
       { numRuns: 100 }

--- a/cmd/dcrdata/public/js/controllers/ska_accordion_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/ska_accordion_controller.test.js
@@ -203,3 +203,67 @@ describe('ska_accordion_controller — property tests', () => {
     )
   })
 })
+
+// ---------------------------------------------------------------------------
+// Feature: home-block-table-hierarchy
+// Task 8.1 — Unit tests for Property 2: chevron state reflects expansion
+// ---------------------------------------------------------------------------
+
+describe('ska_accordion_controller — home-block-table-hierarchy chevron state tests', () => {
+  describe('Property 2: chevron state reflects expansion', () => {
+    it('block row gains is-expanded after toggle()', () => {
+      const { blockRow, ctrl } = buildDOM(42, 2)
+      clickRow(blockRow, ctrl)
+      expect(blockRow.classList.contains('is-expanded')).toBe(true)
+    })
+
+    it('block row loses is-expanded after second toggle()', () => {
+      const { blockRow, ctrl } = buildDOM(42, 2)
+      clickRow(blockRow, ctrl)
+      clickRow(blockRow, ctrl)
+      expect(blockRow.classList.contains('is-expanded')).toBe(false)
+    })
+
+    it('is-expanded is absent before any toggle', () => {
+      const { blockRow } = buildDOM(42, 2)
+      expect(blockRow.classList.contains('is-expanded')).toBe(false)
+    })
+
+    it('is-expanded is absent when there are no sub-rows', () => {
+      const { blockRow, ctrl } = buildDOM(42, 0)
+      clickRow(blockRow, ctrl)
+      expect(blockRow.classList.contains('is-expanded')).toBe(false)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Feature: home-block-table-hierarchy, Property 2: Chevron state reflects expansion (round-trip)
+// Task 8.2 (optional) — extend round-trip property test to assert is-expanded
+// ---------------------------------------------------------------------------
+
+describe('ska_accordion_controller — home-block-table-hierarchy property 2 round-trip', () => {
+  // Feature: home-block-table-hierarchy, Property 2: Chevron state reflects expansion
+  it('Property 2: is-expanded absent after two toggles for any blockId', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 999999 }), (blockId) => {
+        const { blockRow, subRows, ctrl } = buildDOM(blockId, 2)
+
+        const initialSubRowClasses = subRows.map((r) => r.className)
+        const initialBlockRowClass = blockRow.className
+
+        // Expand
+        clickRow(blockRow, ctrl)
+        expect(blockRow.classList.contains('is-expanded')).toBe(true)
+
+        // Collapse
+        clickRow(blockRow, ctrl)
+        expect(blockRow.classList.contains('is-expanded')).toBe(false)
+
+        // Full round-trip: all classes restored
+        subRows.forEach((r, i) => expect(r.className).toBe(initialSubRowClasses[i]))
+        expect(blockRow.className).toBe(initialBlockRowClass)
+      })
+    )
+  })
+})

--- a/cmd/dcrdata/public/scss/_variables.scss
+++ b/cmd/dcrdata/public/scss/_variables.scss
@@ -70,6 +70,13 @@ $card-bg-secondary-dark: #222326;
 $block-row-hover: #ececec;
 $block-row-hover-dark: #363b40;
 
+// Block table hierarchy — badge colors
+$coin-var-primary: #3374ff;
+$coin-ska-primary: #80868b;
+
+// Block table hierarchy — sub-row vertical anchor
+$sub-row-anchor-color: #c8d0d8;
+
 // links
 $link-decoration: none;
 $link-hover-decoration: underline;

--- a/cmd/dcrdata/public/scss/home.scss
+++ b/cmd/dcrdata/public/scss/home.scss
@@ -85,6 +85,8 @@ body.darkBG .dark-card {
 // SKA accordion sub-rows
 .ska-sub-row {
   display: none;
+  font-size: 0.85em; // ~12px at 14px base; above the 11px floor
+  color: #6c757d; // Bootstrap text-secondary equivalent
 
   &--visible {
     display: table-row;
@@ -94,6 +96,10 @@ body.darkBG .dark-card {
 
 body.darkBG .ska-sub-row--visible {
   background-color: $card-bg-secondary-dark;
+}
+
+body.darkBG .ska-sub-row {
+  color: #c1c1c1; // matches existing .text-secondary dark override
 }
 
 .last-blocks-table td,
@@ -123,7 +129,7 @@ body.darkBG .ska-sub-row--visible {
 // 8    Rev  "3"
 // 9    Age  "22m 48s"
 $col-min-widths: (
-  1: calc(7ch + 1rem),
+  1: calc(9ch + 1rem),
   2: calc(2ch + 1rem),
   3: calc(5ch + 1rem),
   4: calc(5ch + 1rem),
@@ -140,16 +146,35 @@ $col-min-widths: (
   }
 }
 
+$col-min-widths-sm: (
+  1: calc(96px)
+);
+
+@media (min-width: $breakpoint-sm) {
+  @each $n, $w in $col-min-widths-sm {
+    .last-blocks-table th:nth-child(#{$n}) {
+      min-width: $w;
+    }
+  }
+}
+
 // Expandable block rows — whole row is the click target
 .block-row-expandable {
   cursor: pointer;
+}
+
+// Sub-row vertical anchor — inset box-shadow avoids layout shift.
+// The second shadow preserves Bootstrap's --bs-table-accent-bg hover tint.
+.ska-sub-row--visible td:first-child {
+  box-shadow:
+    inset 3px 0 0 0 $sub-row-anchor-color,
+    inset 0 0 0 9999px var(--bs-table-accent-bg);
 }
 
 .last-blocks-table .block-row-expandable.is-expanded td {
   border-bottom-color: transparent;
 }
 
-// Hover and expanded backgrounds
 // 1. Desktop Hover: Only applies when a real mouse/pointer is used
 @media (hover: hover) and (pointer: fine) {
   .last-blocks-table .block-row-expandable:hover td {
@@ -169,5 +194,48 @@ $col-min-widths: (
 
   body.darkBG .last-blocks-table .block-row-expandable:hover td {
     background-color: inherit;
+  }
+}
+
+// Chevron — CSS-only right-pointing triangle that rotates on expand
+.chevron {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  border-left: 5px solid currentcolor;
+  vertical-align: middle;
+  transition: transform 0.15s ease;
+  opacity: 0.4;
+}
+
+.last-blocks-table .block-row-expandable.is-expanded .chevron {
+  transform: rotate(90deg);
+  opacity: 1;
+}
+
+// Coin label dots — colored ::before pseudo-element, no layout impact
+.coin-label {
+  display: inline-flex;
+  align-items: center;
+  text-align: left;
+  width: 60.2px; // SKA-nnn with its colored dot
+
+  &::before {
+    content: "";
+    display: block;
+    width: 0.5em;
+    height: 0.5em;
+    border-radius: 50%;
+    margin-right: 0.35em;
+  }
+
+  &--var::before {
+    background-color: $coin-var-primary;
+  }
+
+  &--ska::before {
+    background-color: $coin-ska-primary;
   }
 }

--- a/cmd/dcrdata/public/scss/themes.scss
+++ b/cmd/dcrdata/public/scss/themes.scss
@@ -216,4 +216,10 @@ body.darkBG {
   .link-button:active {
     color: $dark-link-hover-color;
   }
+
+  .ska-sub-row--visible td:first-child {
+    box-shadow:
+      inset 3px 0 0 0 #4a5568,
+      inset 0 0 0 9999px var(--bs-table-accent-bg);
+  }
 }

--- a/cmd/dcrdata/views/home_latest_blocks.tmpl
+++ b/cmd/dcrdata/views/home_latest_blocks.tmpl
@@ -25,6 +25,7 @@
         data-action="click->ska-accordion#toggle"
       >
         <td class="text-start ps-1" data-type="height">
+          <span class="chevron me-1"></span>
           <a href="/block/{{.Height}}" class="fs18">{{.Height}}</a>
         </td>
         <td class="text-end num" data-type="tx">{{.Transactions}}</td>
@@ -39,7 +40,7 @@
         </td>
       </tr>
       <tr class="ska-sub-row" data-ska-accordion-target="subRow" data-block-id="{{$blockHeight}}">
-        <td class="text-start ps-1"><span class="sub-row-label">VAR</span></td>
+        <td class="text-end ps-2 ps-sm-4" data-type="sub-label"><span class="coin-label coin-label--var">VAR</span></td>
         <td class="text-end num">{{if .VARTxCount}}{{.VARTxCount}}{{else}}—{{end}}</td>
         <td class="text-end num">{{.VARAmount}}</td>
         <td class="text-end">—</td>
@@ -51,7 +52,7 @@
       </tr>
       {{range .SKASubRows}}
       <tr class="ska-sub-row" data-ska-accordion-target="subRow" data-block-id="{{$blockHeight}}">
-        <td class="text-start ps-1"><span class="sub-row-label">{{.TokenType}}</span></td>
+        <td class="text-end ps-2 ps-sm-4" data-type="sub-label"><span class="coin-label coin-label--ska">{{.TokenType}}</span></td>
         <td class="text-end num">{{.TxCount}}</td>
         <td class="text-end">—</td>
         <td class="text-end num">{{.Amount}}</td>


### PR DESCRIPTION
## Changes

### Visual hierarchy for block table sub-rows
- Add chevron expand/collapse indicator to parent block rows in the latest blocks table
- Add colored coin label badges (VAR, SKA-*) to sub-rows with dot indicators
- Add vertical anchor line via inset box-shadow on expanded sub-rows for visual connection
- Add SCSS variables for coin colors (`$main-color-var`, `$main-color-ska`) and anchor styling
- Add dark theme overrides for sub-row anchor visibility and contrast
- Update `blocklist_controller.js` to inject chevron and coin-label elements in dynamically created rows
- Update `home_latest_blocks.tmpl` with chevron markup and coin-label structure

### Humanized byte size formatting
- Replace manual byte formatting with `humanize.Bytes()` in Go home view model
- Replace manual byte formatting with `humanize.bytes()` in JavaScript blocklist controller
- Standardize size display across coin row rendering in both backend and frontend

## Commits
- `be7f00a` feat(home): add visual hierarchy to block table with chevrons and coin labels
- `fadf429` feat(explorer): use humanize library for byte size formatting