### PR TITLE
feat: per-coin mempool tracking with quota-aware fill status fixes #14 #16 #17 #18 #19

### DIFF
--- a/REWRITE_PLAN.md
+++ b/REWRITE_PLAN.md
@@ -943,4 +943,80 @@ via the BlockInfo path has non-zero TxCount and Size when CoinTxStats is present
 Demo: Block detail page and websocket block events show correct per-coin tx_count and size in coin_rows. GET /api/block/{height} returns 
 "coin_tx_stats": {"0": {"tx_count": 5, "size": 2048}, "1": {"tx_count": 2, "size": 512}}.
 
+Task 19: Per-coin mempool tracking (size, amount, tx count)
+Commit: fix: per-coin tx count, size, and amount tracking in mempool
+
+Objective: Mempool currently tracks only a single VAR-based TotalOut float64 and a single LikelyMineable.Size int32. SKA transactions contribute 0 to all totals. Mirror 
+the block-level CoinTxStats pattern to track per-coin tx count, size, and amount in mempool.
+
+Root cause — three broken sites:
+
+1. txhelpers.TotalOutFromMsgTx sums v.Value (int64) for all outputs — SKA outputs have Value == 0, their amount is in v.SKAValue *big.Int, never read.
+2. MempoolTx has no per-coin amount field — only TotalOut float64 (VAR only).
+3. ParseTxns in collector.go accumulates out, _ := dcrutil.NewAmount(tx.TotalOut) into regularTotal, ticketTotal, etc. — all zero for SKA. LikelyMineable totals and 
+CoinFills in StoreMPData are therefore wrong for SKA.
+
+Changes:
+
+txhelpers/txhelpers.go — fix TotalOutFromMsgTx to guard on VAR only:
+go
+func TotalOutFromMsgTx(msgTx *wire.MsgTx) dcrutil.Amount {
+    var amtOut int64
+    for _, v := range msgTx.TxOut {
+        if v.CoinType == cointype.CoinTypeVAR {
+            amtOut += v.Value
+        }
+    }
+    return dcrutil.Amount(amtOut)
+}
+
+
+Add SKATotalsFromMsgTx(msgTx *wire.MsgTx) map[uint8]string — mirrors blockCoinAmounts but for a single tx, returns atom strings keyed by SKA coin type.
+
+explorer/types/explorertypes.go — add to MempoolTx:
+go
+SKATotals map[uint8]string `json:"ska_totals,omitempty"`
+
+Update DeepCopy to copy the map.
+
+Add MempoolCoinStats struct (mirrors CoinTxStats):
+go
+type MempoolCoinStats struct {
+    TxCount int   `json:"tx_count"`
+    Size    int32 `json:"size"`
+    Amount  string `json:"amount"` // VAR: atom int64 string; SKA: big.Int atom string
+}
+
+
+Add to MempoolShort:
+go
+CoinStats map[uint8]MempoolCoinStats `json:"coin_stats,omitempty"`
+
+Update DeepCopy to copy the map.
+
+mempool/monitor.go and mempool/collector.go — populate SKATotals in MempoolTx{}:
+go
+SKATotals: txhelpers.SKATotalsFromMsgTx(msgTx),
+
+
+mempool/collector.go — ParseTxns: after the existing per-type accumulation loop, build CoinStats by iterating all txs, grouping by coin type (VAR from tx.TotalOut, SKA 
+from tx.SKATotals), accumulating count, size, and amount. Assign to mpInfo.MempoolShort.CoinStats.
+
+cmd/dcrdata/internal/explorer/explorer.go — StoreMPData: replace the stub SKA fill loop with one driven by inv.CoinStats:
+go
+// VAR: 10% of bar; SKA types share remaining 90% equally
+for ct, stats := range inv.CoinStats {
+    // compute fill from stats.Size / maxBlockSize
+    // assign symbol, fill pct, color
+}
+inv.CoinFills = fills
+
+
+Test:
+- Unit test for TotalOutFromMsgTx with a mixed VAR+SKA tx — assert VAR amount correct, SKA does not corrupt it.
+- Unit test for SKATotalsFromMsgTx — assert correct atom string for SKA-1 output.
+- Unit test for ParseTxns with a slice containing one VAR tx and one SKA-1 tx — assert CoinStats[0].TxCount == 1 and CoinStats[1].TxCount == 1 with correct sizes.
+
+Demo: Mempool API response includes coin_stats with per-coin tx count, size, and amount. Homepage fill bars show non-zero SKA fill when SKA transactions are in mempool.
+
 

--- a/cmd/dcrdata/go.mod
+++ b/cmd/dcrdata/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/rs/cors v1.8.2
 	golang.org/x/net v0.28.0
 	golang.org/x/text v0.22.0
+	pgregory.net/rapid v1.2.0
 )
 
 require (
@@ -221,6 +222,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect
-	pgregory.net/rapid v1.2.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -470,9 +470,13 @@ func (exp *explorerUI) MempoolSignal() chan<- pstypes.HubMessage {
 // []types.MempoolTx so that it may be modified (e.g. sorted) without affecting
 // other MempoolDataSavers.
 func (exp *explorerUI) StoreMPData(_ *mempool.StakeData, _ []types.MempoolTx, inv *types.MempoolInfo) {
-	maxBlockSize := float64(exp.pageData.BlockchainInfo.MaxBlockSize)
-	if maxBlockSize == 0 {
-		maxBlockSize = 393216
+	exp.pageData.RLock()
+	blockchainInfo := exp.pageData.BlockchainInfo
+	exp.pageData.RUnlock()
+
+	maxBlockSize := 393216.0
+	if blockchainInfo != nil && blockchainInfo.MaxBlockSize > 0 {
+		maxBlockSize = float64(blockchainInfo.MaxBlockSize)
 	}
 	inv.CoinFills = computeCoinFills(inv.CoinStats, maxBlockSize)
 

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -950,10 +950,11 @@ func generateRandomString() string {
 	return string(bytes)
 }
 
-// computeCoinFills builds per-coin fill bar data with quota-aware status.
 // VAR has a guaranteed 10% of maxBlockSize; SKA types share the remaining 90%
 // equally. A coin is "ok" if within its quota, "borrowing" if over quota but
 // the total block is not full, and "full" if the total block is full.
+//
+//nolint:unparam // maxBlockSize comes from the node at runtime; test uses 100.0 for easy math.
 func computeCoinFills(stats map[uint8]types.MempoolCoinStats, maxBlockSize float64) []types.CoinFillData {
 	varQuota := maxBlockSize * 0.10
 	skaPool := maxBlockSize * 0.90

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -470,37 +470,11 @@ func (exp *explorerUI) MempoolSignal() chan<- pstypes.HubMessage {
 // []types.MempoolTx so that it may be modified (e.g. sorted) without affecting
 // other MempoolDataSavers.
 func (exp *explorerUI) StoreMPData(_ *mempool.StakeData, _ []types.MempoolTx, inv *types.MempoolInfo) {
-	// Compute per-coin fill bars from CoinStats.
-	// VAR occupies 10% of the bar; SKA types share the remaining 90% equally.
-	// Fill = min(size/maxBlockSize, 1.0).
-	const maxBlockSize = 393216.0
-	skaCoinTypes := make([]uint8, 0)
-	for ct := range inv.CoinStats {
-		if ct != 0 {
-			skaCoinTypes = append(skaCoinTypes, ct)
-		}
+	maxBlockSize := float64(exp.pageData.BlockchainInfo.MaxBlockSize)
+	if maxBlockSize == 0 {
+		maxBlockSize = 393216
 	}
-	fills := make([]types.CoinFillData, 0, 1+len(skaCoinTypes))
-	if varStats, ok := inv.CoinStats[0]; ok {
-		f := math.Min(float64(varStats.Size)/maxBlockSize, 1.0)
-		fills = append(fills, types.CoinFillData{Symbol: "VAR", FillPct: f * 0.10, Color: fillColor(f)})
-	} else {
-		fills = append(fills, types.CoinFillData{Symbol: "VAR", FillPct: 0, Color: fillColor(0)})
-	}
-	skaShare := 0.0
-	if len(skaCoinTypes) > 0 {
-		skaShare = 0.90 / float64(len(skaCoinTypes))
-	}
-	for _, ct := range skaCoinTypes {
-		s := inv.CoinStats[ct]
-		f := math.Min(float64(s.Size)/maxBlockSize, 1.0)
-		fills = append(fills, types.CoinFillData{
-			Symbol:  fmt.Sprintf("SKA-%d", ct),
-			FillPct: f * skaShare,
-			Color:   fillColor(f),
-		})
-	}
-	inv.CoinFills = fills
+	inv.CoinFills = computeCoinFills(inv.CoinStats, maxBlockSize)
 
 	// Get exclusive access to the Mempool field.
 	exp.invsMtx.Lock()
@@ -972,13 +946,62 @@ func generateRandomString() string {
 	return string(bytes)
 }
 
-// fillColor returns "green", "yellow", or "red" based on fill fraction.
-// green: fits in guaranteed space (<= 1.0), yellow: borrowed space, red: won't fit.
-func fillColor(fill float64) string {
-	if fill <= 1.0 {
-		return "green"
-	} else if fill <= 1.5 {
-		return "yellow"
+// computeCoinFills builds per-coin fill bar data with quota-aware status.
+// VAR has a guaranteed 10% of maxBlockSize; SKA types share the remaining 90%
+// equally. A coin is "ok" if within its quota, "borrowing" if over quota but
+// the total block is not full, and "full" if the total block is full.
+func computeCoinFills(stats map[uint8]types.MempoolCoinStats, maxBlockSize float64) []types.CoinFillData {
+	varQuota := maxBlockSize * 0.10
+	skaPool := maxBlockSize * 0.90
+
+	var numSKA int
+	var totalSKASize float64
+	for ct, s := range stats {
+		if ct != 0 {
+			numSKA++
+			totalSKASize += float64(s.Size)
+		}
 	}
-	return "red"
+
+	varSize := float64(0)
+	if s, ok := stats[0]; ok {
+		varSize = float64(s.Size)
+	}
+	totalUsed := varSize + totalSKASize
+
+	fillStatus := func(size, quota float64) string {
+		switch {
+		case size <= quota:
+			return "ok"
+		case totalUsed <= maxBlockSize:
+			return "borrowing"
+		default:
+			return "full"
+		}
+	}
+
+	fills := make([]types.CoinFillData, 0, 1+numSKA)
+	fills = append(fills, types.CoinFillData{
+		Symbol:  "VAR",
+		FillPct: math.Min(varSize/varQuota, 1.0) * 0.10,
+		Status:  fillStatus(varSize, varQuota),
+	})
+
+	if numSKA == 0 {
+		return fills
+	}
+	perSKAQuota := skaPool / float64(numSKA)
+	skaShare := 0.90 / float64(numSKA)
+	for ct, s := range stats {
+		if ct == 0 {
+			continue
+		}
+		size := float64(s.Size)
+		fills = append(fills, types.CoinFillData{
+			Symbol:  fmt.Sprintf("SKA-%d", ct),
+			FillPct: math.Min(size/perSKAQuota, 1.0) * skaShare,
+			Status:  fillStatus(size, perSKAQuota),
+		})
+	}
+	return fills
 }

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -470,14 +470,37 @@ func (exp *explorerUI) MempoolSignal() chan<- pstypes.HubMessage {
 // []types.MempoolTx so that it may be modified (e.g. sorted) without affecting
 // other MempoolDataSavers.
 func (exp *explorerUI) StoreMPData(_ *mempool.StakeData, _ []types.MempoolTx, inv *types.MempoolInfo) {
-	// Compute per-coin fill bars. VAR occupies 10% of the bar; SKA types share
-	// the remaining 90%. Fill = min(size/maxBlockSize, 1.0).
+	// Compute per-coin fill bars from CoinStats.
+	// VAR occupies 10% of the bar; SKA types share the remaining 90% equally.
+	// Fill = min(size/maxBlockSize, 1.0).
 	const maxBlockSize = 393216.0
-	varFill := math.Min(float64(inv.LikelyMineable.Size)/maxBlockSize, 1.0)
-	inv.CoinFills = []types.CoinFillData{
-		{Symbol: "VAR", FillPct: varFill * 0.10, Color: fillColor(varFill)},
+	skaCoinTypes := make([]uint8, 0)
+	for ct := range inv.CoinStats {
+		if ct != 0 {
+			skaCoinTypes = append(skaCoinTypes, ct)
+		}
 	}
-	// SKA fills are zero until per-coin mempool tracking is implemented.
+	fills := make([]types.CoinFillData, 0, 1+len(skaCoinTypes))
+	if varStats, ok := inv.CoinStats[0]; ok {
+		f := math.Min(float64(varStats.Size)/maxBlockSize, 1.0)
+		fills = append(fills, types.CoinFillData{Symbol: "VAR", FillPct: f * 0.10, Color: fillColor(f)})
+	} else {
+		fills = append(fills, types.CoinFillData{Symbol: "VAR", FillPct: 0, Color: fillColor(0)})
+	}
+	skaShare := 0.0
+	if len(skaCoinTypes) > 0 {
+		skaShare = 0.90 / float64(len(skaCoinTypes))
+	}
+	for _, ct := range skaCoinTypes {
+		s := inv.CoinStats[ct]
+		f := math.Min(float64(s.Size)/maxBlockSize, 1.0)
+		fills = append(fills, types.CoinFillData{
+			Symbol:  fmt.Sprintf("SKA-%d", ct),
+			FillPct: f * skaShare,
+			Color:   fillColor(f),
+		})
+	}
+	inv.CoinFills = fills
 
 	// Get exclusive access to the Mempool field.
 	exp.invsMtx.Lock()

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -314,15 +314,90 @@ func TestCoinRowData_Variants(t *testing.T) {
 
 func TestCoinFillData(t *testing.T) {
 	fills := []types.CoinFillData{
-		{Symbol: "VAR", FillPct: 0.05, Color: "green"},
-		{Symbol: "SKA-1", FillPct: 0.90, Color: "red"},
+		{Symbol: "VAR", FillPct: 0.05, Status: "ok"},
+		{Symbol: "SKA-1", FillPct: 0.90, Status: "full"},
 	}
 	mpi := types.MempoolInfo{}
 	mpi.CoinFills = fills
 	if len(mpi.CoinFills) != 2 {
 		t.Errorf("MempoolInfo.CoinFills: want 2, got %d", len(mpi.CoinFills))
 	}
-	if mpi.CoinFills[0].Symbol != "VAR" || mpi.CoinFills[1].Color != "red" {
+	if mpi.CoinFills[0].Symbol != "VAR" || mpi.CoinFills[1].Status != "full" {
 		t.Errorf("unexpected CoinFills: %v", mpi.CoinFills)
 	}
+}
+
+func TestComputeCoinFills(t *testing.T) {
+	const max = 100.0 // simplified maxBlockSize for easy math
+
+	t.Run("empty stats", func(t *testing.T) {
+		fills := computeCoinFills(nil, max)
+		if len(fills) != 1 || fills[0].Symbol != "VAR" || fills[0].Status != "ok" {
+			t.Errorf("unexpected fills for empty stats: %v", fills)
+		}
+	})
+
+	t.Run("VAR within quota", func(t *testing.T) {
+		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}} // 5 of 10 quota
+		fills := computeCoinFills(stats, max)
+		if fills[0].Status != "ok" {
+			t.Errorf("VAR within quota: want ok, got %s", fills[0].Status)
+		}
+	})
+
+	t.Run("VAR over quota, block not full", func(t *testing.T) {
+		stats := map[uint8]types.MempoolCoinStats{0: {Size: 15}} // 15 > 10 quota, < 100 total
+		fills := computeCoinFills(stats, max)
+		if fills[0].Status != "borrowing" {
+			t.Errorf("VAR borrowing: want borrowing, got %s", fills[0].Status)
+		}
+	})
+
+	t.Run("VAR over quota, block full", func(t *testing.T) {
+		stats := map[uint8]types.MempoolCoinStats{0: {Size: 110}} // > 100 total
+		fills := computeCoinFills(stats, max)
+		if fills[0].Status != "full" {
+			t.Errorf("VAR full: want full, got %s", fills[0].Status)
+		}
+	})
+
+	t.Run("SKA within quota", func(t *testing.T) {
+		// 1 SKA type gets 90% = 90 quota
+		stats := map[uint8]types.MempoolCoinStats{1: {Size: 40}}
+		fills := computeCoinFills(stats, max)
+		var ska types.CoinFillData
+		for _, f := range fills {
+			if f.Symbol == "SKA-1" {
+				ska = f
+			}
+		}
+		if ska.Status != "ok" {
+			t.Errorf("SKA within quota: want ok, got %s", ska.Status)
+		}
+	})
+
+	t.Run("SKA over own quota, pool not exhausted", func(t *testing.T) {
+		// 2 SKA types, each gets 45 quota; SKA-1 uses 50 but total SKA = 50 < 90
+		stats := map[uint8]types.MempoolCoinStats{1: {Size: 50}, 2: {Size: 0}}
+		fills := computeCoinFills(stats, max)
+		var ska1 types.CoinFillData
+		for _, f := range fills {
+			if f.Symbol == "SKA-1" {
+				ska1 = f
+			}
+		}
+		if ska1.Status != "borrowing" {
+			t.Errorf("SKA borrowing: want borrowing, got %s", ska1.Status)
+		}
+	})
+
+	t.Run("SKA does not affect VAR status", func(t *testing.T) {
+		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}, 1: {Size: 95}}
+		fills := computeCoinFills(stats, max)
+		for _, f := range fills {
+			if f.Symbol == "VAR" && f.Status != "ok" {
+				t.Errorf("VAR should be ok regardless of SKA: got %s", f.Status)
+			}
+		}
+	})
 }

--- a/cmd/dcrdata/views/home.tmpl
+++ b/cmd/dcrdata/views/home.tmpl
@@ -67,7 +67,7 @@
                                 <div class="mt-1 d-flex" style="gap:4px">
                                     {{- range .Mempool.CoinFills}}
                                     <div style="flex:1;background:#eee;height:8px;border-radius:3px;overflow:hidden" title="{{.Symbol}}">
-                                        <div style="width:{{printf "%.1f" (mulf .FillPct 100.0)}}%;height:100%;background:{{.Color}}"></div>
+                                        <div style="width:{{printf "%.1f" (mulf .FillPct 100.0)}}%;height:100%" class="fill-{{.Status}}"></div>
                                     </div>
                                     {{- end}}
                                 </div>

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -495,6 +495,13 @@ type CoinFillData struct {
 	Color   string  // "green", "yellow", "red"
 }
 
+// MempoolCoinStats holds per-coin mempool transaction count, size, and amount.
+type MempoolCoinStats struct {
+	TxCount int    `json:"tx_count"`
+	Size    int32  `json:"size"`
+	Amount  string `json:"amount"` // VAR: int64 atom string; SKA: big.Int atom string
+}
+
 // TrimmedBlockInfo models data needed to display block info on the new home page
 type TrimmedBlockInfo struct {
 	Time         TimeDef
@@ -839,6 +846,8 @@ type MempoolShort struct {
 	VotingInfo         VotingInfo          `json:"voting_info"`
 	InvRegular         map[string]struct{} `json:"-"`
 	InvStake           map[string]struct{} `json:"-"`
+	// CoinStats holds per-coin tx count, size, and amount for all mempool txs.
+	CoinStats map[uint8]MempoolCoinStats `json:"coin_stats,omitempty"`
 }
 
 // LikelyMineable holds the totals for all mempool transactions except for votes
@@ -916,6 +925,13 @@ func (mps *MempoolShort) DeepCopy() *MempoolShort {
 	out.InvStake = make(map[string]struct{}, len(mps.InvStake))
 	for s := range mps.InvStake {
 		out.InvStake[s] = struct{}{}
+	}
+
+	if mps.CoinStats != nil {
+		out.CoinStats = make(map[uint8]MempoolCoinStats, len(mps.CoinStats))
+		for k, v := range mps.CoinStats {
+			out.CoinStats[k] = v
+		}
 	}
 
 	return out
@@ -1073,9 +1089,10 @@ type MempoolTx struct {
 	TotalOut  float64        `json:"total"`
 	// Consider atom representation:
 	//TotalOutAmt int64        `json:"total_amount"`
-	Type     string    `json:"Type"`
-	TypeID   int       `json:"typeID"` // stake package types
-	VoteInfo *VoteInfo `json:"vote_info,omitempty"`
+	Type      string            `json:"Type"`
+	TypeID    int               `json:"typeID"` // stake package types
+	VoteInfo  *VoteInfo         `json:"vote_info,omitempty"`
+	SKATotals map[uint8]string  `json:"ska_totals,omitempty"`
 }
 
 func (mpt *MempoolTx) DeepCopy() *MempoolTx {
@@ -1086,6 +1103,12 @@ func (mpt *MempoolTx) DeepCopy() *MempoolTx {
 	out.Vin = make([]MempoolInput, len(mpt.Vin))
 	copy(out.Vin, mpt.Vin)
 	out.VoteInfo = mpt.VoteInfo.DeepCopy()
+	if mpt.SKATotals != nil {
+		out.SKATotals = make(map[uint8]string, len(mpt.SKATotals))
+		for k, v := range mpt.SKATotals {
+			out.SKATotals[k] = v
+		}
+	}
 	return &out
 }
 

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -490,9 +490,9 @@ type SKASubRow struct {
 
 // CoinFillData holds per-coin mempool fill bar data.
 type CoinFillData struct {
-	Symbol  string
-	FillPct float64 // 0.0–1.0
-	Color   string  // "green", "yellow", "red"
+	Symbol  string  `json:"symbol"`
+	FillPct float64 `json:"fill_pct"` // 0.0–1.0, relative to bar width
+	Status  string  `json:"status"`   // "ok", "borrowing", "full"
 }
 
 // MempoolCoinStats holds per-coin mempool transaction count, size, and amount.

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -604,6 +604,7 @@ type TrimmedMempoolInfo struct {
 	Total        float64
 	Time         int64
 	Fees         float64
+	CoinFills    []CoinFillData `json:"coin_fills,omitempty"`
 }
 
 // MempoolInfo models data to update mempool info on the home page.
@@ -661,6 +662,7 @@ func (mpi *MempoolInfo) Trim() *TrimmedMempoolInfo {
 		TAdds:        TrimMempoolTxs(mpi.TAdds),
 		Total:        mpi.TotalOut,
 		Time:         mpi.LastBlockTime,
+		CoinFills:    mpi.CoinFills,
 	}
 
 	mpi.RUnlock()

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -1089,10 +1089,10 @@ type MempoolTx struct {
 	TotalOut  float64        `json:"total"`
 	// Consider atom representation:
 	//TotalOutAmt int64        `json:"total_amount"`
-	Type      string            `json:"Type"`
-	TypeID    int               `json:"typeID"` // stake package types
-	VoteInfo  *VoteInfo         `json:"vote_info,omitempty"`
-	SKATotals map[uint8]string  `json:"ska_totals,omitempty"`
+	Type      string           `json:"Type"`
+	TypeID    int              `json:"typeID"` // stake package types
+	VoteInfo  *VoteInfo        `json:"vote_info,omitempty"`
+	SKATotals map[uint8]string `json:"ska_totals,omitempty"`
 }
 
 func (mpt *MempoolTx) DeepCopy() *MempoolTx {

--- a/mempool/collector.go
+++ b/mempool/collector.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/monetarium/monetarium-node/blockchain/stake"
 	"github.com/monetarium/monetarium-node/chaincfg"
+	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
 	"github.com/monetarium/monetarium-node/dcrutil"
 	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
@@ -105,7 +106,9 @@ func (t *DataCollector) mempoolTxns() ([]exptypes.MempoolTx, txhelpers.MempoolAd
 
 		var totalOut int64
 		for _, v := range msgTx.TxOut {
-			totalOut += v.Value
+			if v.CoinType == cointype.CoinTypeVAR {
+				totalOut += v.Value
+			}
 		}
 
 		txType := txhelpers.DetermineTxType(msgTx)
@@ -154,7 +157,8 @@ func (t *DataCollector) mempoolTxns() ([]exptypes.MempoolTx, txhelpers.MempoolAd
 			TotalOut: dcrutil.Amount(totalOut).ToCoin(),
 			Type:     txhelpers.TxTypeToString(int(txType)),
 			TypeID:   int(txType),
-			VoteInfo: voteInfo,
+			VoteInfo:  voteInfo,
+			SKATotals: txhelpers.SKATotalsFromMsgTx(msgTx),
 		})
 	}
 

--- a/mempool/collector.go
+++ b/mempool/collector.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/monetarium/monetarium-node/blockchain/stake"
 	"github.com/monetarium/monetarium-node/chaincfg"
-	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
+	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/dcrutil"
 	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
 
@@ -151,12 +151,12 @@ func (t *DataCollector) mempoolTxns() ([]exptypes.MempoolTx, txhelpers.MempoolAd
 			VoutCount: len(msgTx.TxOut),
 			Vin:       exptypes.MsgTxMempoolInputs(msgTx),
 			// Coinbase:  txhelpers.IsCoinBaseTx(msgTx), // commented because coinbase is not in mempool
-			Hash:     hashStr, // dup of TxID!
-			Time:     tx.Time,
-			Size:     tx.Size,
-			TotalOut: dcrutil.Amount(totalOut).ToCoin(),
-			Type:     txhelpers.TxTypeToString(int(txType)),
-			TypeID:   int(txType),
+			Hash:      hashStr, // dup of TxID!
+			Time:      tx.Time,
+			Size:      tx.Size,
+			TotalOut:  dcrutil.Amount(totalOut).ToCoin(),
+			Type:      txhelpers.TxTypeToString(int(txType)),
+			TypeID:    int(txType),
 			VoteInfo:  voteInfo,
 			SKATotals: txhelpers.SKATotalsFromMsgTx(msgTx),
 		})

--- a/mempool/collector.go
+++ b/mempool/collector.go
@@ -7,7 +7,9 @@ package mempool
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -467,6 +469,43 @@ func ParseTxns(txs []exptypes.MempoolTx, params *chaincfg.Params, lastBlock *Blo
 	sort.Sort(exptypes.MPTxsByHeight(votes))
 	formattedSize := exptypes.BytesString(uint64(totalSize))
 
+	// Build per-coin stats by iterating all txs once.
+	coinStats := make(map[uint8]exptypes.MempoolCoinStats)
+	for _, tx := range txs {
+		if len(tx.SKATotals) == 0 {
+			// VAR tx
+			s := coinStats[0]
+			s.TxCount++
+			s.Size += tx.Size
+			if tx.TotalOut > 0 {
+				varAtoms := int64(tx.TotalOut * 1e8)
+				if s.Amount == "" {
+					s.Amount = fmt.Sprintf("%d", varAtoms)
+				} else {
+					prev, _ := strconv.ParseInt(s.Amount, 10, 64)
+					s.Amount = fmt.Sprintf("%d", prev+varAtoms)
+				}
+			}
+			coinStats[0] = s
+		} else {
+			for ct, amtStr := range tx.SKATotals {
+				s := coinStats[ct]
+				s.TxCount++
+				s.Size += tx.Size
+				if s.Amount == "" {
+					s.Amount = amtStr
+				} else {
+					a, _ := new(big.Int).SetString(s.Amount, 10)
+					b, _ := new(big.Int).SetString(amtStr, 10)
+					if a != nil && b != nil {
+						s.Amount = new(big.Int).Add(a, b).String()
+					}
+				}
+				coinStats[ct] = s
+			}
+		}
+	}
+
 	// Store mempool data for template rendering
 	mpInfo := exptypes.MempoolInfo{
 		MempoolShort: exptypes.MempoolShort{
@@ -502,6 +541,7 @@ func ParseTxns(txs []exptypes.MempoolTx, params *chaincfg.Params, lastBlock *Blo
 			VotingInfo:         votingInfo,
 			InvRegular:         invRegular,
 			InvStake:           invStake,
+			CoinStats:          coinStats,
 		},
 		Transactions: regular,
 		Tickets:      tickets,

--- a/mempool/collector.go
+++ b/mempool/collector.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -473,41 +472,56 @@ func ParseTxns(txs []exptypes.MempoolTx, params *chaincfg.Params, lastBlock *Blo
 	sort.Sort(exptypes.MPTxsByHeight(votes))
 	formattedSize := exptypes.BytesString(uint64(totalSize))
 
-	// Build per-coin stats by iterating all txs once.
-	coinStats := make(map[uint8]exptypes.MempoolCoinStats)
+	// Build per-coin stats: accumulate counts/sizes and amounts natively,
+	// then convert amounts to strings once at the end.
+	type coinAccum struct {
+		txCount int
+		size    int32
+		varAmt  int64
+		skaAmt  map[uint8]*big.Int
+	}
+	accum := make(map[uint8]*coinAccum)
+	getAccum := func(ct uint8) *coinAccum {
+		if accum[ct] == nil {
+			accum[ct] = &coinAccum{}
+		}
+		return accum[ct]
+	}
 	for _, tx := range txs {
 		if len(tx.SKATotals) == 0 {
-			// VAR tx
-			s := coinStats[0]
-			s.TxCount++
-			s.Size += tx.Size
-			if tx.TotalOut > 0 {
-				varAtoms := int64(tx.TotalOut * 1e8)
-				if s.Amount == "" {
-					s.Amount = fmt.Sprintf("%d", varAtoms)
-				} else {
-					prev, _ := strconv.ParseInt(s.Amount, 10, 64)
-					s.Amount = fmt.Sprintf("%d", prev+varAtoms)
-				}
-			}
-			coinStats[0] = s
+			a := getAccum(0)
+			a.txCount++
+			a.size += tx.Size
+			a.varAmt += int64(tx.TotalOut * 1e8)
 		} else {
 			for ct, amtStr := range tx.SKATotals {
-				s := coinStats[ct]
-				s.TxCount++
-				s.Size += tx.Size
-				if s.Amount == "" {
-					s.Amount = amtStr
-				} else {
-					a, _ := new(big.Int).SetString(s.Amount, 10)
-					b, _ := new(big.Int).SetString(amtStr, 10)
-					if a != nil && b != nil {
-						s.Amount = new(big.Int).Add(a, b).String()
-					}
+				a := getAccum(ct)
+				a.txCount++
+				a.size += tx.Size
+				if a.skaAmt == nil {
+					a.skaAmt = make(map[uint8]*big.Int)
 				}
-				coinStats[ct] = s
+				v, _ := new(big.Int).SetString(amtStr, 10)
+				if v != nil {
+					if a.skaAmt[ct] == nil {
+						a.skaAmt[ct] = new(big.Int)
+					}
+					a.skaAmt[ct].Add(a.skaAmt[ct], v)
+				}
 			}
 		}
+	}
+	coinStats := make(map[uint8]exptypes.MempoolCoinStats, len(accum))
+	for ct, a := range accum {
+		s := exptypes.MempoolCoinStats{TxCount: a.txCount, Size: a.size}
+		if ct == 0 {
+			s.Amount = fmt.Sprintf("%d", a.varAmt)
+		} else if a.skaAmt != nil {
+			if v := a.skaAmt[ct]; v != nil {
+				s.Amount = v.String()
+			}
+		}
+		coinStats[ct] = s
 	}
 
 	// Store mempool data for template rendering

--- a/mempool/collector_test.go
+++ b/mempool/collector_test.go
@@ -1,0 +1,49 @@
+package mempool
+
+import (
+	"testing"
+
+	"github.com/monetarium/monetarium-node/chaincfg"
+	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
+
+	exptypes "github.com/monetarium/monetarium-explorer/explorer/types"
+)
+
+func TestParseTxns_CoinStats(t *testing.T) {
+	params := chaincfg.MainNetParams()
+	lastBlock := &BlockID{Hash: chainhash.Hash{}, Height: 1, Time: 0}
+
+	varTx := exptypes.MempoolTx{
+		Hash:     "aaaa",
+		TxID:     "aaaa",
+		Size:     250,
+		TotalOut: 1.0,
+		TypeID:   0, // regular
+	}
+	skaTx := exptypes.MempoolTx{
+		Hash:      "bbbb",
+		TxID:      "bbbb",
+		Size:      300,
+		TotalOut:  0,
+		TypeID:    0, // regular
+		SKATotals: map[uint8]string{1: "1000000000000000000"},
+	}
+
+	inv := ParseTxns([]exptypes.MempoolTx{varTx, skaTx}, params, lastBlock)
+
+	if inv.CoinStats[0].TxCount != 1 {
+		t.Errorf("VAR TxCount: want 1, got %d", inv.CoinStats[0].TxCount)
+	}
+	if inv.CoinStats[0].Size != 250 {
+		t.Errorf("VAR Size: want 250, got %d", inv.CoinStats[0].Size)
+	}
+	if inv.CoinStats[1].TxCount != 1 {
+		t.Errorf("SKA-1 TxCount: want 1, got %d", inv.CoinStats[1].TxCount)
+	}
+	if inv.CoinStats[1].Size != 300 {
+		t.Errorf("SKA-1 Size: want 300, got %d", inv.CoinStats[1].Size)
+	}
+	if inv.CoinStats[1].Amount != "1000000000000000000" {
+		t.Errorf("SKA-1 Amount: want 1000000000000000000, got %s", inv.CoinStats[1].Amount)
+	}
+}

--- a/mempool/mempoolcache.go
+++ b/mempool/mempoolcache.go
@@ -44,6 +44,8 @@ type DataCache struct {
 // pass a copy of the []types.MempoolTx so that it may be modified (e.g. sorted)
 // without affecting other MempoolDataSavers.
 func (c *DataCache) StoreMPData(stakeData *StakeData, txsCopy []exptypes.MempoolTx, _ *exptypes.MempoolInfo) {
+	// stakeData is nil when called from TxHandler (incremental update path).
+	// In that case we skip the cache update — explorerUI.StoreMPData handles it.
 	if stakeData == nil {
 		return
 	}

--- a/mempool/mempoolcache.go
+++ b/mempool/mempoolcache.go
@@ -44,6 +44,9 @@ type DataCache struct {
 // pass a copy of the []types.MempoolTx so that it may be modified (e.g. sorted)
 // without affecting other MempoolDataSavers.
 func (c *DataCache) StoreMPData(stakeData *StakeData, txsCopy []exptypes.MempoolTx, _ *exptypes.MempoolInfo) {
+	if stakeData == nil {
+		return
+	}
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -354,6 +354,25 @@ func (p *MempoolMonitor) TxHandler(rawTx *chainjson.TxRawResult) error {
 		p.inventory.LikelyMineable.Count++
 	}
 	p.inventory.FormattedTotalSize = exptypes.BytesString(uint64(p.inventory.TotalSize))
+
+	// Update per-coin stats incrementally.
+	if p.inventory.CoinStats == nil {
+		p.inventory.CoinStats = make(map[uint8]exptypes.MempoolCoinStats)
+	}
+	if len(tx.SKATotals) == 0 {
+		s := p.inventory.CoinStats[0]
+		s.TxCount++
+		s.Size += tx.Size
+		p.inventory.CoinStats[0] = s
+	} else {
+		for ct := range tx.SKATotals {
+			s := p.inventory.CoinStats[ct]
+			s.TxCount++
+			s.Size += tx.Size
+			p.inventory.CoinStats[ct] = s
+		}
+	}
+
 	p.inventory.Unlock()
 	p.mtx.RUnlock()
 

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -250,13 +250,13 @@ func (p *MempoolMonitor) TxHandler(rawTx *chainjson.TxRawResult) error {
 		VoutCount: len(msgTx.TxOut),
 		Vin:       exptypes.MsgTxMempoolInputs(msgTx),
 		// Coinbase is not in mempool
-		Hash:     hash,
-		Time:     rawTx.Time,
-		Size:     int32(len(rawTx.Hex) / 2),
-		TotalOut: txhelpers.TotalOutFromMsgTx(msgTx).ToCoin(),
-		Type:     txTypeStr,
-		TypeID:   int(txType),
-		VoteInfo: voteInfo,
+		Hash:      hash,
+		Time:      rawTx.Time,
+		Size:      int32(len(rawTx.Hex) / 2),
+		TotalOut:  txhelpers.TotalOutFromMsgTx(msgTx).ToCoin(),
+		Type:      txTypeStr,
+		TypeID:    int(txType),
+		VoteInfo:  voteInfo,
 		SKATotals: txhelpers.SKATotalsFromMsgTx(msgTx),
 	}
 

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -257,6 +257,7 @@ func (p *MempoolMonitor) TxHandler(rawTx *chainjson.TxRawResult) error {
 		Type:     txTypeStr,
 		TypeID:   int(txType),
 		VoteInfo: voteInfo,
+		SKATotals: txhelpers.SKATotalsFromMsgTx(msgTx),
 	}
 
 	// Maintain a separate total that excludes votes for sidechain

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -7,6 +7,7 @@ package mempool
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"sort"
 	"sync"
 	"time"
@@ -363,12 +364,14 @@ func (p *MempoolMonitor) TxHandler(rawTx *chainjson.TxRawResult) error {
 		s := p.inventory.CoinStats[0]
 		s.TxCount++
 		s.Size += tx.Size
+		s.Amount = addAtomStrings(s.Amount, fmt.Sprintf("%d", int64(tx.TotalOut*1e8)), false)
 		p.inventory.CoinStats[0] = s
 	} else {
-		for ct := range tx.SKATotals {
+		for ct, amtStr := range tx.SKATotals {
 			s := p.inventory.CoinStats[ct]
 			s.TxCount++
 			s.Size += tx.Size
+			s.Amount = addAtomStrings(s.Amount, amtStr, true)
 			p.inventory.CoinStats[ct] = s
 		}
 	}
@@ -551,4 +554,24 @@ func (p *MempoolMonitor) UnconfirmedTxnsForAddress(address string) (*txhelpers.A
 	}
 
 	return outs, int64(len(outs.TxnsStore)), nil
+}
+
+// addAtomStrings adds two decimal atom strings. For SKA (isBig=true) it uses
+// big.Int; for VAR (isBig=false) it uses int64. Returns the sum as a string.
+func addAtomStrings(a, b string, isBig bool) string {
+	if a == "" {
+		return b
+	}
+	if isBig {
+		av, _ := new(big.Int).SetString(a, 10)
+		bv, _ := new(big.Int).SetString(b, 10)
+		if av == nil || bv == nil {
+			return a
+		}
+		return new(big.Int).Add(av, bv).String()
+	}
+	var ai, bi int64
+	fmt.Sscan(a, &ai)
+	fmt.Sscan(b, &bi)
+	return fmt.Sprintf("%d", ai+bi)
 }

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -376,6 +376,17 @@ func (p *MempoolMonitor) TxHandler(rawTx *chainjson.TxRawResult) error {
 	p.inventory.Unlock()
 	p.mtx.RUnlock()
 
+	// Notify savers so CoinFills are recomputed with the new tx included.
+	p.mtx.RLock()
+	invCopy := p.inventory.DeepCopy()
+	savers := p.dataSavers
+	p.mtx.RUnlock()
+	for _, s := range savers {
+		if s != nil {
+			go s.StoreMPData(nil, nil, invCopy)
+		}
+	}
+
 	// Broadcast the new transaction.
 	log.Tracef("Signaling new tx to hub relays...")
 	p.hubSend(pstypes.SigNewTx, &tx, time.Second*10)

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/monetarium/monetarium-node/blockchain/standalone"
 	"github.com/monetarium/monetarium-node/chaincfg"
 	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
+	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/dcrutil"
 	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
 	"github.com/monetarium/monetarium-node/txscript/stdaddr"
@@ -1266,13 +1267,42 @@ func FeeRate(amtIn, amtOut, sizeBytes int64) int64 {
 	return 1000 * (amtIn - amtOut) / sizeBytes
 }
 
-// TotalOutFromMsgTx computes the total value out of a MsgTx
+// TotalOutFromMsgTx computes the total VAR value out of a MsgTx.
+// SKA outputs are excluded (their amounts are in v.SKAValue, not v.Value).
 func TotalOutFromMsgTx(msgTx *wire.MsgTx) dcrutil.Amount {
 	var amtOut int64
 	for _, v := range msgTx.TxOut {
-		amtOut += v.Value
+		if v.CoinType == cointype.CoinTypeVAR {
+			amtOut += v.Value
+		}
 	}
 	return dcrutil.Amount(amtOut)
+}
+
+// SKATotalsFromMsgTx returns per-SKA-coin output totals as decimal atom strings
+// (key = SKA coin type number). Returns nil if the tx has no SKA outputs.
+func SKATotalsFromMsgTx(msgTx *wire.MsgTx) map[uint8]string {
+	var totals map[uint8]*big.Int
+	for _, v := range msgTx.TxOut {
+		if v.CoinType.IsSKA() && v.SKAValue != nil {
+			if totals == nil {
+				totals = make(map[uint8]*big.Int)
+			}
+			k := uint8(v.CoinType)
+			if totals[k] == nil {
+				totals[k] = new(big.Int)
+			}
+			totals[k].Add(totals[k], v.SKAValue)
+		}
+	}
+	if len(totals) == 0 {
+		return nil
+	}
+	out := make(map[uint8]string, len(totals))
+	for k, v := range totals {
+		out[k] = v.String()
+	}
+	return out
 }
 
 // TotalVout computes the total value of a slice of chainjson.Vout

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math/big"
 	"strings"
 	"testing"
 
 	"github.com/monetarium/monetarium-node/chaincfg"
 	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
+	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/dcrutil"
+	"github.com/monetarium/monetarium-node/wire"
 )
 
 type TxGetter struct {
@@ -290,5 +293,49 @@ func TestMsgTxFromHex(t *testing.T) {
 				t.Errorf("MsgTxFromHex() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestTotalOutFromMsgTx_Mixed(t *testing.T) {
+	tx := wire.NewMsgTx()
+	tx.AddTxOut(wire.NewTxOut(100_000_000, nil)) // 1 VAR
+	tx.AddTxOut(wire.NewTxOut(50_000_000, nil))  // 0.5 VAR
+	// SKA output — Value is 0, amount in SKAValue
+	skaBig := new(big.Int).Mul(big.NewInt(1e6), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+	tx.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(1), nil))
+
+	got := TotalOutFromMsgTx(tx)
+	want := dcrutil.Amount(150_000_000)
+	if got != want {
+		t.Errorf("TotalOutFromMsgTx: want %d, got %d", want, got)
+	}
+}
+
+func TestSKATotalsFromMsgTx(t *testing.T) {
+	tx := wire.NewMsgTx()
+	tx.AddTxOut(wire.NewTxOut(100_000_000, nil)) // VAR — should be ignored
+	ska1 := new(big.Int).SetInt64(9e18)
+	tx.AddTxOut(wire.NewTxOutSKA(ska1, cointype.CoinType(1), nil))
+	ska1b := new(big.Int).SetInt64(1e18)
+	tx.AddTxOut(wire.NewTxOutSKA(ska1b, cointype.CoinType(1), nil))
+
+	got := SKATotalsFromMsgTx(tx)
+	if got == nil {
+		t.Fatal("expected non-nil SKATotals")
+	}
+	want := new(big.Int).Add(ska1, ska1b).String()
+	if got[1] != want {
+		t.Errorf("SKA-1 total: want %s, got %s", want, got[1])
+	}
+	if _, hasVAR := got[0]; hasVAR {
+		t.Error("SKATotals should not contain VAR key")
+	}
+}
+
+func TestSKATotalsFromMsgTx_VAROnly(t *testing.T) {
+	tx := wire.NewMsgTx()
+	tx.AddTxOut(wire.NewTxOut(100_000_000, nil))
+	if got := SKATotalsFromMsgTx(tx); got != nil {
+		t.Errorf("expected nil for VAR-only tx, got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

Mempool previously tracked only a single VAR-based TotalOut and a single LikelyMineable.Size. SKA transactions contributed 0 to all totals and fill bars were stubs. This
PR implements full per-coin tracking (tx count, size, amount) and quota-aware fill status, with several bugs fixed during implementation.

## Changes

txhelpers/txhelpers.go
- TotalOutFromMsgTx — guards on CoinTypeVAR; SKA outputs no longer corrupt the VAR total
- SKATotalsFromMsgTx — new function; returns per-SKA-coin output totals as atom strings for a single tx

explorer/types/explorertypes.go
- MempoolCoinStats — new struct (tx_count, size, amount)
- MempoolTx.SKATotals map[uint8]string — per-SKA amounts per tx; DeepCopy updated
- MempoolShort.CoinStats map[uint8]MempoolCoinStats — per-coin mempool totals; DeepCopy updated
- CoinFillData.Color replaced with Status string ("ok", "borrowing", "full")
- TrimmedMempoolInfo.CoinFills — added field and copied in Trim() so homepage template receives it

mempool/collector.go
- mempoolTxns — sets SKATotals on each MempoolTx via SKATotalsFromMsgTx; totalOut loop guards on VAR only
- ParseTxns — builds CoinStats after the main loop, grouping by coin type

mempool/monitor.go
- TxHandler — increments CoinStats for each new tx as it arrives; calls StoreMPData on all savers with a deep copy of inventory so fill bars update immediately without 
waiting for the next block
- mempoolTxns — sets SKATotals on each MempoolTx

mempool/mempoolcache.go
- DataCache.StoreMPData — guards against nil stakeData (passed when called from TxHandler)

cmd/dcrdata/internal/explorer/explorer.go
- fillColor removed; replaced by computeCoinFills with quota rules:
  - VAR: 10% of MaxBlockSize guaranteed; SKA types share 90% equally per active type
  - "ok" = within quota, "borrowing" = over quota but block not full, "full" = block full
- StoreMPData reads MaxBlockSize from BlockchainInfo (fallback 393216); guards nil pointer

cmd/dcrdata/views/home.tmpl — fill bar uses class="fill-{{.Status}}" instead of inline background:{{.Color}}

## Tests

- TestTotalOutFromMsgTx_Mixed, TestSKATotalsFromMsgTx, TestSKATotalsFromMsgTx_VAROnly
- TestParseTxns_CoinStats — one VAR tx + one SKA-1 tx → correct TxCount, Size, Amount per coin
- TestComputeCoinFills — 7 cases covering all status transitions and VAR/SKA independence
- TestCoinFillData — updated to use Status
