### PR TITLE
feat: display TxTypeSSFee on block page and add Vote SKA Reward homepage section

### DIFF
--- a/REWRITE_PLAN.md
+++ b/REWRITE_PLAN.md
@@ -1019,4 +1019,222 @@ Test:
 
 Demo: Mempool API response includes coin_stats with per-coin tx count, size, and amount. Homepage fill bars show non-zero SKA fill when SKA transactions are in mempool.
 
+### Task 20: TxTypeSSFee block display + Vote SKA Reward homepage section
+Commit: feat: handle TxTypeSSFee in block explorer and homepage SKA vote reward
+
+Objective: Two related gaps around TxTypeSSFee (stake fee distribution for SKA token types): the transactions are silently dropped from the block detail page, and the 
+homepage has no "Vote SKA Reward" section. Fix both together since they share the same data source.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+Part A — Fix missing SSFee transactions on block page
+
+txhelpers/txhelpers.go — add string constant and case to TxTypeToString:
+go
+TxTypeSSFee string = "Stake Fee"
+
+case stake.TxTypeSSFee:
+    return TxTypeSSFee
+
+
+explorer/types/explorertypes.go — add to BlockInfo:
+go
+StakeFees []*TrimmedTxInfo
+
+
+db/dcrpg/pgblockchain.go — GetExplorerBlock:
+go
+// declaration:
+stakeFees := make([]*exptypes.TrimmedTxInfo, 0)
+
+// in switch:
+case stake.TxTypeSSFee:
+    stakeFees = append(stakeFees, stx)
+
+// after loop:
+block.StakeFees = stakeFees
+sortTx(block.StakeFees)
+
+// include in TotalSent:
+block.TotalSent = (getTotalSent(block.Tx) + getTotalSent(block.Treasury) +
+    getTotalSent(block.Revs) + getTotalSent(block.Tickets) +
+    getTotalSent(block.Votes) + getTotalSent(block.StakeFees)).ToCoin()
+
+
+cmd/dcrdata/views/block.tmpl — add after the Revocations section:
+html
+{{if .StakeFees}}
+<span class="d-inline-block pt-4 pb-1 h4">Stake Fees</span>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Transaction ID</th>
+            <th class="text-end">Total</th>
+            <th class="text-end">Fee</th>
+            <th class="text-end">Size</th>
+        </tr>
+    </thead>
+    <tbody>
+    {{range .StakeFees}}
+        <tr>
+            <td class="break-word"><a class="hash" href="/tx/{{.TxID}}">{{.TxID}}</a></td>
+            <td class="mono fs15 text-end">{{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}</td>
+            <td class="mono fs15 text-end">{{.Fee}}</td>
+            <td class="mono fs15 text-end">{{.FormattedSize}}</td>
+        </tr>
+    {{end}}
+    </tbody>
+</table>
+{{end}}
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+Part B — Vote SKA Reward homepage section
+
+api/types/apitypes.go — add to BlockExplorerExtraInfo:
+go
+SSFeeTotalsByCoin map[uint8]string `json:"ssfee_totals,omitempty"`
+
+
+blockdata/blockdata.go — add helper and wire into CollectBlockInfo:
+go
+func blockSSFeeTotals(msgBlock *wire.MsgBlock) map[uint8]string {
+    totals := make(map[uint8]*big.Int)
+    for _, tx := range msgBlock.STransactions {
+        if stake.DetermineTxType(tx) != stake.TxTypeSSFee {
+            continue
+        }
+        for _, out := range tx.TxOut {
+            if out.CoinType.IsSKA() && out.SKAValue != nil {
+                ct := uint8(out.CoinType)
+                if totals[ct] == nil {
+                    totals[ct] = new(big.Int)
+                }
+                totals[ct].Add(totals[ct], out.SKAValue)
+            }
+        }
+    }
+    if len(totals) == 0 {
+        return nil
+    }
+    result := make(map[uint8]string, len(totals))
+    for ct, v := range totals {
+        result[ct] = v.String()
+    }
+    return result
+}
+// in CollectBlockInfo:
+extrainfo.SSFeeTotalsByCoin = blockSSFeeTotals(msgBlock)
+
+
+db/dcrpg/internal/blockstmts.go — add ssfee_totals JSONB column to CreateBlockTable and insertBlockRow (as $28); include in all SELECT statements alongside coin_tx_stats
+.
+
+db/dcrpg/queries.go — pass dbtypes.ToJSONB(dbBlock.SSFeeTotalsByCoin) as $28 on insert; scan and unmarshal in retrieveBlockSummaryByHash and related functions.
+
+db/dcrpg/upgrades.go:
+sql
+ALTER TABLE blocks ADD COLUMN IF NOT EXISTS ssfee_totals JSONB;
+
+
+Also add SSFeeTotalsByCoin map[uint8]string to dbtypes.DBBlock and apitypes.BlockDataBasic.
+
+explorer/types/explorertypes.go — add new type and field to HomeInfo:
+go
+type SKAVoteReward struct {
+    CoinType  uint8  `json:"coin_type"`
+    Symbol    string `json:"symbol"`
+    PerBlock  string `json:"per_block"`   // SKA/VAR ratio, 18dp decimal string
+    Per30Days string `json:"per_30_days"`
+    PerYear   string `json:"per_year"`
+}
+
+// in HomeInfo:
+SKAVoteRewards []SKAVoteReward `json:"ska_vote_rewards,omitempty"`
+
+
+cmd/dcrdata/internal/explorer/explorer.go — add helpers and wire into Store():
+
+go
+// formatSKAPerVAR divides skaAtoms by varAtoms with 18dp precision.
+func formatSKAPerVAR(skaAtoms *big.Int, varAtoms int64) string {
+    if varAtoms == 0 {
+        return "0.000000000000000000"
+    }
+    // multiply skaAtoms by 1e18 then divide by varAtoms for 18dp fixed-point
+    scaled := new(big.Int).Mul(skaAtoms, new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+    q := new(big.Int).Div(scaled, big.NewInt(varAtoms))
+    return formatFixed18(q) // format as "integer.18decimals"
+}
+
+// avgSSFeeRate returns the average SKA/VAR rate over the last nBlocks blocks.
+func (exp *explorerUI) avgSSFeeRate(ctx context.Context, coinType uint8, nBlocks int) string {
+    summaries := exp.dataSource.GetExplorerBlocks(ctx, /* tip */, /* tip-nBlocks */)
+    // sum SSFeeTotalsByCoin[coinType] and StakeDiff across summaries, return average
+}
+
+// in Store(), after posSubsPerVote:
+sbits, _ := dcrutil.NewAmount(blockData.Header.SBits)
+ticketPriceAtoms := int64(sbits)
+if ticketPriceAtoms > 0 {
+    rewards := make([]types.SKAVoteReward, 0, len(blockData.ExtraInfo.SSFeeTotalsByCoin))
+    for ct, totalStr := range blockData.ExtraInfo.SSFeeTotalsByCoin {
+        total, ok := new(big.Int).SetString(totalStr, 10)
+        if !ok {
+            continue
+        }
+        blocksIn30Days := int(30 * 24 * time.Hour / exp.ChainParams.TargetTimePerBlock)
+        rewards = append(rewards, types.SKAVoteReward{
+            CoinType:  ct,
+            Symbol:    fmt.Sprintf("SKA-%d", ct),
+            PerBlock:  formatSKAPerVAR(total, ticketPriceAtoms),
+            Per30Days: exp.avgSSFeeRate(ctx, ct, blocksIn30Days),
+            PerYear:   exp.avgSSFeeRate(ctx, ct, blocksIn30Days*12),
+        })
+    }
+    sort.Slice(rewards, func(i, j int) bool { return rewards[i].CoinType < rewards[j].CoinType })
+    p.HomeInfo.SKAVoteRewards = rewards
+}
+
+
+Apply the same logic in pubsub/pubsubhub.go.
+
+cmd/dcrdata/views/home.tmpl — replace the existing Vote VAR Reward block and add Vote SKA Reward below it:
+html
+<div class="fs13 text-secondary">Vote VAR Reward</div>
+<div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+    <span data-homepage-target="bsubsidyPos">
+        {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount (divide .NBlockSubsidy.PoS 5)) 8 true 2)}}
+    </span>
+    <span class="ps-1 unit lh15rem" style="font-size:13px;">VAR/VAR per last block</span>
+</div>
+<div class="fs12 lh1rem text-black-50">
+    <span data-homepage-target="ticketReward">{{printf "%.2f" .TicketReward}}%</span> per 30 days
+</div>
+<div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards">{{printf "%.2f" .ASR}}% per year</div>
+
+{{if .SKAVoteRewards}}
+<div class="fs13 text-secondary mt-2">Vote SKA Reward</div>
+{{range .SKAVoteRewards}}
+<div class="fs12 lh1rem text-black-50">{{.PerBlock}} {{.Symbol}}/VAR per last block</div>
+<div class="fs12 lh1rem text-black-50">{{.Per30Days}} {{.Symbol}}/VAR per 30 days</div>
+<div class="fs12 lh1rem text-black-50">{{.PerYear}} {{.Symbol}}/VAR per year</div>
+{{end}}
+{{end}}
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+Tests:
+- TxTypeToString(int(stake.TxTypeSSFee)) == "Stake Fee"
+- blockSSFeeTotals with a synthetic block containing one TxTypeSSFee tx with SKA-1 output of 1e18 atoms → map[uint8]string{1: "1000000000000000000"}
+- formatSKAPerVAR(big.NewInt(1e18), 100_000_000) → "10.000000000000000000" (1 SKA per 1 VAR)
+- Template renders "Stake Fees" section only when StakeFees non-empty; "Vote SKA Reward" only when SKAVoteRewards non-empty
+
+Demo: Block /block/68032b6621... shows all 9 stake transactions (5 votes, 1 revocation, 3 stake fees). Homepage shows "Vote SKA Reward" with per-SKA rows for last block,
+30-day, and yearly rates.
 

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -728,6 +728,8 @@ type BlockDataBasic struct {
 	CoinAmounts map[uint8]string `json:"coin_amounts,omitempty"`
 	// CoinTxStats holds per-coin tx count and size (key 0=VAR, 1-255=SKA-n).
 	CoinTxStats map[uint8]CoinTxStats `json:"coin_tx_stats,omitempty"`
+	// SSFeeTotalsByCoin holds total SKA atoms distributed via TxTypeSSFee per coin type.
+	SSFeeTotalsByCoin map[uint8]string `json:"ssfee_totals,omitempty"`
 	// TicketPoolInfo may be nil for side chain blocks.
 	PoolInfo *TicketPoolInfo `json:"ticket_pool,omitempty"`
 }
@@ -762,6 +764,8 @@ type BlockExplorerExtraInfo struct {
 	CoinAmounts map[uint8]string `json:"coin_amounts,omitempty"`
 	// CoinTxStats holds per-coin tx count and size (key 0=VAR, 1-255=SKA-n).
 	CoinTxStats map[uint8]CoinTxStats `json:"coin_tx_stats,omitempty"`
+	// SSFeeTotalsByCoin holds total SKA atoms distributed via TxTypeSSFee per coin type.
+	SSFeeTotalsByCoin map[uint8]string `json:"ssfee_totals,omitempty"`
 }
 
 // BlockTransactionCounts contains the regular and stake transaction counts for

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/monetarium/monetarium-node/blockchain/stake"
 	"github.com/monetarium/monetarium-node/chaincfg"
 	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
 	"github.com/monetarium/monetarium-node/cointype"
@@ -253,6 +254,11 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 		extrainfo.CoinTxStats = coinTxStats
 	}
 
+	// Accumulate per-coin SSFee totals for SKA vote reward calculation.
+	if ssfee := blockSSFeeTotals(msgBlock); len(ssfee) > 0 {
+		extrainfo.SSFeeTotalsByCoin = ssfee
+	}
+
 	return blockdata, feeInfoBlock, blockHeaderResults, extrainfo, msgBlock, err
 }
 
@@ -449,4 +455,32 @@ func blockCoinAmounts(msgBlock *wire.MsgBlock) map[uint8]string {
 		out[k] = v.String()
 	}
 	return out
+}
+
+// blockSSFeeTotals sums TxTypeSSFee output SKAValues per coin type.
+// Returns nil if no SSFee transactions are present.
+func blockSSFeeTotals(msgBlock *wire.MsgBlock) map[uint8]string {
+	totals := make(map[uint8]*big.Int)
+	for _, tx := range msgBlock.STransactions {
+		if stake.DetermineTxType(tx) != stake.TxTypeSSFee {
+			continue
+		}
+		for _, out := range tx.TxOut {
+			if out.CoinType.IsSKA() && out.SKAValue != nil {
+				ct := uint8(out.CoinType)
+				if totals[ct] == nil {
+					totals[ct] = new(big.Int)
+				}
+				totals[ct].Add(totals[ct], out.SKAValue)
+			}
+		}
+	}
+	if len(totals) == 0 {
+		return nil
+	}
+	result := make(map[uint8]string, len(totals))
+	for ct, v := range totals {
+		result[ct] = v.String()
+	}
+	return result
 }

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -11,9 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/monetarium/monetarium-node/blockchain/stake"
-	"github.com/monetarium/monetarium-node/chaincfg"
-	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
+	"github.com/monetarium/monetarium-node/chaincfg"	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
 	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/dcrutil"
 	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
@@ -255,7 +253,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	}
 
 	// Accumulate per-coin SSFee totals for SKA vote reward calculation.
-	if ssfee := blockSSFeeTotals(msgBlock); len(ssfee) > 0 {
+	if ssfee := txhelpers.BlockSSFeeTotals(msgBlock); len(ssfee) > 0 {
 		extrainfo.SSFeeTotalsByCoin = ssfee
 	}
 
@@ -455,32 +453,4 @@ func blockCoinAmounts(msgBlock *wire.MsgBlock) map[uint8]string {
 		out[k] = v.String()
 	}
 	return out
-}
-
-// blockSSFeeTotals sums TxTypeSSFee output SKAValues per coin type.
-// Returns nil if no SSFee transactions are present.
-func blockSSFeeTotals(msgBlock *wire.MsgBlock) map[uint8]string {
-	totals := make(map[uint8]*big.Int)
-	for _, tx := range msgBlock.STransactions {
-		if stake.DetermineTxType(tx) != stake.TxTypeSSFee {
-			continue
-		}
-		for _, out := range tx.TxOut {
-			if out.CoinType.IsSKA() && out.SKAValue != nil {
-				ct := uint8(out.CoinType)
-				if totals[ct] == nil {
-					totals[ct] = new(big.Int)
-				}
-				totals[ct].Add(totals[ct], out.SKAValue)
-			}
-		}
-	}
-	if len(totals) == 0 {
-		return nil
-	}
-	result := make(map[uint8]string, len(totals))
-	for ct, v := range totals {
-		result[ct] = v.String()
-	}
-	return result
 }

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -11,7 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/monetarium/monetarium-node/chaincfg"	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
+	"github.com/monetarium/monetarium-node/chaincfg"
+	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
 	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/dcrutil"
 	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -602,6 +602,13 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 		}
 		sum30 := exp.dataSource.GetSummaryRange(ctx, start30, tip)
 		sumYear := exp.dataSource.GetSummaryRange(ctx, startYear, tip)
+		toSummaries := func(blocks []*apitypes.BlockDataBasic) []txhelpers.SSFeeSummary {
+			s := make([]txhelpers.SSFeeSummary, len(blocks))
+			for i, b := range blocks {
+				s[i] = txhelpers.SSFeeSummary{SSFeeTotalsByCoin: b.SSFeeTotalsByCoin, StakeDiff: b.StakeDiff}
+			}
+			return s
+		}
 		rewards := make([]types.SKAVoteReward, 0, len(blockData.ExtraInfo.SSFeeTotalsByCoin))
 		for ct, totalStr := range blockData.ExtraInfo.SSFeeTotalsByCoin {
 			total, ok := new(big.Int).SetString(totalStr, 10)
@@ -613,8 +620,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 				CoinType:  ct,
 				Symbol:    fmt.Sprintf("SKA-%d", ct),
 				PerBlock:  txhelpers.FormatSKAPerVAR(perVote, ticketPriceAtoms),
-				Per30Days: txhelpers.AvgSSFeeRate(sum30, ct, exp.ChainParams.TicketsPerBlock),
-				PerYear:   txhelpers.AvgSSFeeRate(sumYear, ct, exp.ChainParams.TicketsPerBlock),
+				Per30Days: txhelpers.AvgSSFeeRate(toSummaries(sum30), ct, exp.ChainParams.TicketsPerBlock),
+				PerYear:   txhelpers.AvgSSFeeRate(toSummaries(sumYear), ct, exp.ChainParams.TicketsPerBlock),
 			})
 		}
 		sort.Slice(rewards, func(i, j int) bool { return rewards[i].CoinType < rewards[j].CoinType })

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -18,6 +18,7 @@ import (
 	"os/signal"
 	"reflect"
 	"runtime"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -29,6 +30,7 @@ import (
 	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
 	"github.com/monetarium/monetarium-node/wire"
 
+	apitypes "github.com/monetarium/monetarium-explorer/api/types"
 	"github.com/monetarium/monetarium-explorer/blockdata"
 	"github.com/monetarium/monetarium-explorer/db/dbtypes"
 	"github.com/monetarium/monetarium-explorer/exchanges"
@@ -118,6 +120,7 @@ type explorerDataSource interface {
 	GetExplorerFullBlocks(ctx context.Context, start int, end int) []*types.BlockInfo
 	CurrentDifficulty(context.Context) (float64, error)
 	Difficulty(ctx context.Context, timestamp int64) float64
+	GetSummaryRange(ctx context.Context, idx0, idx1 int) []*apitypes.BlockDataBasic
 }
 
 type PoliteiaBackend interface {
@@ -582,6 +585,32 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	p.HomeInfo.RewardPeriod = fmt.Sprintf("%.2f days", float64(avgSSTxToSSGenMaturity)*
 		exp.ChainParams.TargetTimePerBlock.Hours()/24)
 
+	// Compute per-SKA vote rewards from SSFee totals in this block.
+	sbits, _ := dcrutil.NewAmount(blockData.Header.SBits)
+	ticketPriceAtoms := int64(sbits)
+	voters := int64(blockData.Header.Voters)
+	if ticketPriceAtoms > 0 && voters > 0 && len(blockData.ExtraInfo.SSFeeTotalsByCoin) > 0 {
+		blocksIn30Days := int(30 * 24 * time.Hour / exp.ChainParams.TargetTimePerBlock)
+		rewards := make([]types.SKAVoteReward, 0, len(blockData.ExtraInfo.SSFeeTotalsByCoin))
+		for ct, totalStr := range blockData.ExtraInfo.SSFeeTotalsByCoin {
+			total, ok := new(big.Int).SetString(totalStr, 10)
+			if !ok {
+				continue
+			}
+			// per-vote amount = total distributed / number of voters
+			perVote := new(big.Int).Div(total, big.NewInt(voters))
+			rewards = append(rewards, types.SKAVoteReward{
+				CoinType:  ct,
+				Symbol:    fmt.Sprintf("SKA-%d", ct),
+				PerBlock:  formatSKAPerVAR(perVote, ticketPriceAtoms),
+				Per30Days: exp.avgSSFeeRate(ctx, ct, blocksIn30Days),
+				PerYear:   exp.avgSSFeeRate(ctx, ct, blocksIn30Days*12),
+			})
+		}
+		sort.Slice(rewards, func(i, j int) bool { return rewards[i].CoinType < rewards[j].CoinType })
+		p.HomeInfo.SKAVoteRewards = rewards
+	}
+
 	// If exchange monitoring is enabled, set the exchange rate.
 	if exp.xcBot != nil {
 		exchangeConversion := exp.xcBot.Conversion(1.0)
@@ -1009,4 +1038,71 @@ func computeCoinFills(stats map[uint8]types.MempoolCoinStats, maxBlockSize float
 		})
 	}
 	return fills
+}
+
+// formatSKAPerVAR computes (skaAtoms/1e18) / (varAtoms/1e8) — SKA coins per
+// VAR coin — and returns a fixed-point decimal string with 18 decimal places.
+func formatSKAPerVAR(skaAtoms *big.Int, varAtoms int64) string {
+	if varAtoms <= 0 || skaAtoms == nil || skaAtoms.Sign() <= 0 {
+		return "0.000000000000000000"
+	}
+	// result_coins = skaAtoms/1e18 / (varAtoms/1e8) = skaAtoms * 1e8 / varAtoms / 1e18
+	// result_scaled (18dp) = skaAtoms * 1e8 / varAtoms
+	varScale := new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil) // 1e8 VAR atoms/coin
+	resultScaled := new(big.Int).Mul(skaAtoms, varScale)
+	resultScaled.Div(resultScaled, big.NewInt(varAtoms))
+	// split at 1e18 for display
+	dp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	intPart, fracPart := new(big.Int).DivMod(resultScaled, dp, new(big.Int))
+	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
+}
+
+// avgSSFeeRate returns the average SKA/VAR reward rate over the last nBlocks
+// blocks by querying ssfee_totals from the DB.
+func (exp *explorerUI) avgSSFeeRate(ctx context.Context, coinType uint8, nBlocks int) string {
+	tip := int(exp.dataSource.Height())
+	start := tip - nBlocks + 1
+	if start < 0 {
+		start = 0
+	}
+	summaries := exp.dataSource.GetSummaryRange(ctx, start, tip)
+	if len(summaries) == 0 {
+		return "0.000000000000000000"
+	}
+	total := new(big.Int)
+	var count int
+	for _, s := range summaries {
+		if s.SSFeeTotalsByCoin == nil {
+			continue
+		}
+		v, ok := s.SSFeeTotalsByCoin[coinType]
+		if !ok {
+			continue
+		}
+		amt, ok := new(big.Int).SetString(v, 10)
+		if !ok {
+			continue
+		}
+		ticketPriceAtoms := int64(s.StakeDiff * 1e8)
+		if ticketPriceAtoms <= 0 {
+			continue
+		}
+		// per-vote amount = total / expected voters per block
+		voters := int64(exp.ChainParams.TicketsPerBlock)
+		perVote := new(big.Int).Div(amt, big.NewInt(voters))
+		// result_scaled = perVote * 1e8 / ticketPriceAtoms  (same as formatSKAPerVAR)
+		varScale := new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil)
+		rs := new(big.Int).Mul(perVote, varScale)
+		ratio := new(big.Int).Div(rs, big.NewInt(ticketPriceAtoms))
+		total.Add(total, ratio)
+		count++
+	}
+	if count == 0 {
+		return "0.000000000000000000"
+	}
+	avg := new(big.Int).Div(total, big.NewInt(int64(count)))
+	// avg is in 1e26 scale; split at 1e18 for 18dp display
+	dp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	intPart, fracPart := new(big.Int).DivMod(avg, dp, new(big.Int))
+	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
 }

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -591,20 +591,30 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	voters := int64(blockData.Header.Voters)
 	if ticketPriceAtoms > 0 && voters > 0 && len(blockData.ExtraInfo.SSFeeTotalsByCoin) > 0 {
 		blocksIn30Days := int(30 * 24 * time.Hour / exp.ChainParams.TargetTimePerBlock)
+		tip := int(exp.dataSource.Height())
+		start30 := tip - blocksIn30Days
+		if start30 < 0 {
+			start30 = 0
+		}
+		startYear := tip - blocksIn30Days*12
+		if startYear < 0 {
+			startYear = 0
+		}
+		sum30 := exp.dataSource.GetSummaryRange(ctx, start30, tip)
+		sumYear := exp.dataSource.GetSummaryRange(ctx, startYear, tip)
 		rewards := make([]types.SKAVoteReward, 0, len(blockData.ExtraInfo.SSFeeTotalsByCoin))
 		for ct, totalStr := range blockData.ExtraInfo.SSFeeTotalsByCoin {
 			total, ok := new(big.Int).SetString(totalStr, 10)
 			if !ok {
 				continue
 			}
-			// per-vote amount = total distributed / number of voters
 			perVote := new(big.Int).Div(total, big.NewInt(voters))
 			rewards = append(rewards, types.SKAVoteReward{
 				CoinType:  ct,
 				Symbol:    fmt.Sprintf("SKA-%d", ct),
-				PerBlock:  formatSKAPerVAR(perVote, ticketPriceAtoms),
-				Per30Days: exp.avgSSFeeRate(ctx, ct, blocksIn30Days),
-				PerYear:   exp.avgSSFeeRate(ctx, ct, blocksIn30Days*12),
+				PerBlock:  txhelpers.FormatSKAPerVAR(perVote, ticketPriceAtoms),
+				Per30Days: txhelpers.AvgSSFeeRate(sum30, ct, exp.ChainParams.TicketsPerBlock),
+				PerYear:   txhelpers.AvgSSFeeRate(sumYear, ct, exp.ChainParams.TicketsPerBlock),
 			})
 		}
 		sort.Slice(rewards, func(i, j int) bool { return rewards[i].CoinType < rewards[j].CoinType })
@@ -1038,71 +1048,4 @@ func computeCoinFills(stats map[uint8]types.MempoolCoinStats, maxBlockSize float
 		})
 	}
 	return fills
-}
-
-// formatSKAPerVAR computes (skaAtoms/1e18) / (varAtoms/1e8) — SKA coins per
-// VAR coin — and returns a fixed-point decimal string with 18 decimal places.
-func formatSKAPerVAR(skaAtoms *big.Int, varAtoms int64) string {
-	if varAtoms <= 0 || skaAtoms == nil || skaAtoms.Sign() <= 0 {
-		return "0.000000000000000000"
-	}
-	// result_coins = skaAtoms/1e18 / (varAtoms/1e8) = skaAtoms * 1e8 / varAtoms / 1e18
-	// result_scaled (18dp) = skaAtoms * 1e8 / varAtoms
-	varScale := new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil) // 1e8 VAR atoms/coin
-	resultScaled := new(big.Int).Mul(skaAtoms, varScale)
-	resultScaled.Div(resultScaled, big.NewInt(varAtoms))
-	// split at 1e18 for display
-	dp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
-	intPart, fracPart := new(big.Int).DivMod(resultScaled, dp, new(big.Int))
-	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
-}
-
-// avgSSFeeRate returns the average SKA/VAR reward rate over the last nBlocks
-// blocks by querying ssfee_totals from the DB.
-func (exp *explorerUI) avgSSFeeRate(ctx context.Context, coinType uint8, nBlocks int) string {
-	tip := int(exp.dataSource.Height())
-	start := tip - nBlocks + 1
-	if start < 0 {
-		start = 0
-	}
-	summaries := exp.dataSource.GetSummaryRange(ctx, start, tip)
-	if len(summaries) == 0 {
-		return "0.000000000000000000"
-	}
-	total := new(big.Int)
-	var count int
-	for _, s := range summaries {
-		if s.SSFeeTotalsByCoin == nil {
-			continue
-		}
-		v, ok := s.SSFeeTotalsByCoin[coinType]
-		if !ok {
-			continue
-		}
-		amt, ok := new(big.Int).SetString(v, 10)
-		if !ok {
-			continue
-		}
-		ticketPriceAtoms := int64(s.StakeDiff * 1e8)
-		if ticketPriceAtoms <= 0 {
-			continue
-		}
-		// per-vote amount = total / expected voters per block
-		voters := int64(exp.ChainParams.TicketsPerBlock)
-		perVote := new(big.Int).Div(amt, big.NewInt(voters))
-		// result_scaled = perVote * 1e8 / ticketPriceAtoms  (same as formatSKAPerVAR)
-		varScale := new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil)
-		rs := new(big.Int).Mul(perVote, varScale)
-		ratio := new(big.Int).Div(rs, big.NewInt(ticketPriceAtoms))
-		total.Add(total, ratio)
-		count++
-	}
-	if count == 0 {
-		return "0.000000000000000000"
-	}
-	avg := new(big.Int).Div(total, big.NewInt(int64(count)))
-	// avg is in 1e26 scale; split at 1e18 for 18dp display
-	dp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
-	intPart, fracPart := new(big.Int).DivMod(avg, dp, new(big.Int))
-	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
 }

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -572,8 +572,14 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 
 	posSubsPerVote := dcrutil.Amount(blockData.ExtraInfo.NextBlockSubsidy.PoS).ToCoin() /
 		float64(exp.ChainParams.TicketsPerBlock)
-	p.HomeInfo.TicketReward = 100 * posSubsPerVote /
-		blockData.CurrentStakeDiff.CurrentStakeDifficulty
+	ticketRewardPct := 100 * posSubsPerVote / blockData.CurrentStakeDiff.CurrentStakeDifficulty
+	p.HomeInfo.TicketReward = ticketRewardPct
+	p.HomeInfo.VoteVARReward = types.VoteVARReward{
+		PerBlock:  posSubsPerVote / blockData.CurrentStakeDiff.CurrentStakeDifficulty,
+		Per30Days: ticketRewardPct,
+		// PerYear (ASR) is computed asynchronously below; set placeholder here.
+		PerYear: p.HomeInfo.ASR,
+	}
 
 	// The actual reward of a ticket needs to also take into consideration the
 	// ticket maturity (time from ticket purchase until its eligible to vote)
@@ -665,6 +671,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 			float64(height), sdiff)
 		p.Lock()
 		p.HomeInfo.ASR = ASR
+		p.HomeInfo.VoteVARReward.PerYear = ASR
 		p.Unlock()
 	}(newBlockData.Height, blockData.CurrentStakeDiff.CurrentStakeDifficulty,
 		blockData.ExtraInfo.CoinSupply) // eval args now instead of in closure

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -384,6 +384,20 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"txtypeStr": func(txtype int) string {
 			return txhelpers.TxTypeToString(txtype)
 		},
+		// skaSplit splits a fixed-point decimal string (e.g. "0.060682851693627761")
+		// into [intPart, firstTwoDecimals, restDecimals].
+		"skaSplit": func(s string) [3]string {
+			dot := strings.IndexByte(s, '.')
+			if dot < 0 {
+				return [3]string{s, "", ""}
+			}
+			intPart := s[:dot]
+			frac := s[dot+1:]
+			if len(frac) <= 2 {
+				return [3]string{intPart, frac, ""}
+			}
+			return [3]string{intPart, frac[:2], frac[2:]}
+		},
 		"add": func(args ...int64) int64 {
 			var sum int64
 			for _, a := range args {

--- a/cmd/dcrdata/public/js/controllers/homepage_controller.js
+++ b/cmd/dcrdata/public/js/controllers/homepage_controller.js
@@ -79,7 +79,9 @@ export default class extends Controller {
       'convertedDevSub',
       'exchangeRate',
       'convertedStake',
-      'mixedPct'
+      'mixedPct',
+      'skaVoteRewards',
+      'coinFillBars'
     ]
   }
 
@@ -100,6 +102,7 @@ export default class extends Controller {
       this.renderLatestTransactions(m.latest, false)
       this.mempool.replace(m)
       this.setMempoolFigures()
+      this.updateCoinFillBars(m.coin_fills)
       keyNav(evt, false, true)
       ws.send('getmempooltxs', '')
     })
@@ -107,6 +110,7 @@ export default class extends Controller {
       const m = JSON.parse(evt)
       this.mempool.replace(m)
       this.setMempoolFigures()
+      this.updateCoinFillBars(m.coin_fills)
       this.renderLatestTransactions(m.latest, true)
       keyNav(evt, false, true)
     })
@@ -150,6 +154,18 @@ export default class extends Controller {
     this.mpVoteBarTarget.style.width = `${(totals.vote / totals.total) * 100}%`
     this.mpTicketBarTarget.style.width = `${(totals.ticket / totals.total) * 100}%`
     this.mpRevBarTarget.style.width = `${(totals.rev / totals.total) * 100}%`
+  }
+
+  updateCoinFillBars(coinFills) {
+    if (!this.hasCoinFillBarsTarget || !coinFills || !coinFills.length) return
+    this.coinFillBarsTarget.innerHTML = coinFills
+      .map(
+        (f) =>
+          `<div style="flex:1;background:#eee;height:8px;border-radius:3px;overflow:hidden" title="${f.symbol}">
+        <div style="width:${(f.fill_pct * 100).toFixed(1)}%;height:100%" class="fill-${f.status}"></div>
+      </div>`
+      )
+      .join('')
   }
 
   renderLatestTransactions(txs, incremental) {
@@ -215,6 +231,22 @@ export default class extends Controller {
     this.devFundTarget.innerHTML = humanize.decimalParts(treasuryTotal / 100000000, true, 0)
     this.hashrateTarget.innerHTML = humanize.decimalParts(ex.hash_rate, false, 8, 2)
     this.hashrateDeltaTarget.innerHTML = humanize.fmtPercentage(ex.hash_rate_change_month)
+
+    if (this.hasSkaVoteRewardsTarget && ex.ska_vote_rewards && ex.ska_vote_rewards.length) {
+      this.skaVoteRewardsTarget.innerHTML = ex.ska_vote_rewards
+        .map((r) => {
+          const dot = r.per_block.indexOf('.')
+          const sig = dot >= 0 ? r.per_block.slice(0, dot + 3) : r.per_block
+          const rest = dot >= 0 ? r.per_block.slice(dot + 3) : ''
+          return `<div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+          <span>${sig}<span class="fs13 opacity-50">${rest}</span></span>
+          <span class="ps-1 unit lh15rem" style="font-size:13px;">${r.symbol}/VAR per last block</span>
+        </div>
+        <div class="fs12 lh1rem text-black-50">${r.per_30_days} ${r.symbol}/VAR per 30 days</div>
+        <div class="fs12 lh1rem text-black-50">${r.per_year} ${r.symbol}/VAR per year</div>`
+        })
+        .join('')
+    }
 
     if (ex.exchange_rate) {
       const xcRate = ex.exchange_rate.value

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -364,6 +364,34 @@
 		</table>
 		{{- end -}}
 
+		{{if .StakeFees -}}
+		<span class="d-inline-block pt-4 pb-1 h4">Stake Fees</span>
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Transaction ID</th>
+					<th class="text-end">Total</th>
+					<th class="text-end">Fee</th>
+					<th class="text-end">Size</th>
+				</tr>
+			</thead>
+			<tbody>
+			{{range .StakeFees -}}
+				<tr>
+					<td class="break-word">
+						<span><a class="hash" href="/tx/{{.TxID}}">{{.TxID}}</a></span>
+					</td>
+					<td class="mono fs15 text-end">
+						{{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}
+					</td>
+					<td class="mono fs15 text-end">{{.Fee}}</td>
+					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
+				</tr>
+			{{- end}}
+			</tbody>
+		</table>
+		{{- end -}}
+
 		<span class="d-inline-block pt-4 pb-1 h4">Transactions</span>
 		{{if not .TxAvailable -}}
 		<table class="table">

--- a/cmd/dcrdata/views/home.tmpl
+++ b/cmd/dcrdata/views/home.tmpl
@@ -64,13 +64,15 @@
                                 <div class="tx-gauge tx-rev" data-homepage-target="mpRevBar"></div>
                                 <div class="tx-gauge tx-vote rounded-end" data-homepage-target="mpVoteBar"></div>
                                 {{- if .Mempool.CoinFills}}
-                                <div class="mt-1 d-flex" style="gap:4px">
+                                <div class="mt-1 d-flex" style="gap:4px" data-homepage-target="coinFillBars">
                                     {{- range .Mempool.CoinFills}}
                                     <div style="flex:1;background:#eee;height:8px;border-radius:3px;overflow:hidden" title="{{.Symbol}}">
                                         <div style="width:{{printf "%.1f" (mulf .FillPct 100.0)}}%;height:100%" class="fill-{{.Status}}"></div>
                                     </div>
                                     {{- end}}
                                 </div>
+                                {{- else}}
+                                <div class="mt-1 d-flex" style="gap:4px" data-homepage-target="coinFillBars"></div>
                                 {{- end}}
                             </div>
 
@@ -212,12 +214,27 @@
                                 <span data-homepage-target="bsubsidyPos">
                                     {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount (divide .NBlockSubsidy.PoS 5)) 8 true 2)}}
                                 </span>
-                                <span class="ps-1 unit lh15rem" style="font-size:13px;">VAR/vote</span>
+                                <span class="ps-1 unit lh15rem" style="font-size:13px;">VAR/VAR per last block</span>
                             </div>
                             <div class="fs12 lh1rem text-black-50">
-                                <span data-homepage-target="ticketReward">{{printf "%.2f" .TicketReward}}%</span> per ~{{.RewardPeriod}}
+                                <span data-homepage-target="ticketReward">{{printf "%.2f" .TicketReward}}%</span> per 30 days
                             </div>
                             <div class="fs12 lh1rem text-black-50" title="Annual Stake Rewards">{{printf "%.2f" .ASR}}% per year</div>
+                            {{if .SKAVoteRewards}}
+                            <div class="fs13 text-secondary mt-2">Vote SKA Reward</div>
+                            {{end}}
+                            <div data-homepage-target="skaVoteRewards">
+                            {{range .SKAVoteRewards}}
+                            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                                <span>{{- with skaSplit .PerBlock -}}
+                                    {{index . 0}}.{{index . 1}}<span class="fs13 opacity-50">{{index . 2}}</span>
+                                {{- end -}}</span>
+                                <span class="ps-1 unit lh15rem" style="font-size:13px;">{{.Symbol}}/VAR per last block</span>
+                            </div>
+                            <div class="fs12 lh1rem text-black-50">{{.Per30Days}} {{.Symbol}}/VAR per 30 days</div>
+                            <div class="fs12 lh1rem text-black-50">{{.PerYear}} {{.Symbol}}/VAR per year</div>
+                            {{end}}
+                            </div>
                         </div>
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary"><a href="/charts?chart=stake-participation">Total Staked DCR</a></div>

--- a/db/dbtypes/conversion.go
+++ b/db/dbtypes/conversion.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/monetarium/monetarium-node/blockchain/stake"
 	"github.com/monetarium/monetarium-node/chaincfg"
 	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/wire"
@@ -69,34 +68,6 @@ func blockCoinTxStats(msgBlock *wire.MsgBlock) map[uint8]CoinTxStats {
 	return stats
 }
 
-// blockSSFeeTotals sums TxTypeSSFee output SKAValues per coin type.
-// Returns nil if no SSFee transactions are present.
-func blockSSFeeTotals(msgBlock *wire.MsgBlock) map[uint8]string {
-	totals := make(map[uint8]*big.Int)
-	for _, tx := range msgBlock.STransactions {
-		if stake.DetermineTxType(tx) != stake.TxTypeSSFee {
-			continue
-		}
-		for _, out := range tx.TxOut {
-			if out.CoinType.IsSKA() && out.SKAValue != nil {
-				ct := uint8(out.CoinType)
-				if totals[ct] == nil {
-					totals[ct] = new(big.Int)
-				}
-				totals[ct].Add(totals[ct], out.SKAValue)
-			}
-		}
-	}
-	if len(totals) == 0 {
-		return nil
-	}
-	result := make(map[uint8]string, len(totals))
-	for ct, v := range totals {
-		result[ct] = v.String()
-	}
-	return result
-}
-
 // MsgBlockToDBBlock creates a dbtypes.Block from a wire.MsgBlock
 func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params, chainWork string, winners []ChainHash) *Block {
 	// Create the dbtypes.Block structure
@@ -128,7 +99,7 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params, ch
 		Winners:           winners,
 		CoinAmounts:       blockCoinAmounts(msgBlock),
 		CoinTxStats:       blockCoinTxStats(msgBlock),
-		SSFeeTotalsByCoin: blockSSFeeTotals(msgBlock),
+		SSFeeTotalsByCoin: txhelpers.BlockSSFeeTotals(msgBlock),
 	}
 }
 

--- a/db/dbtypes/conversion.go
+++ b/db/dbtypes/conversion.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/monetarium/monetarium-node/blockchain/stake"
 	"github.com/monetarium/monetarium-node/chaincfg"
 	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/wire"
@@ -68,6 +69,34 @@ func blockCoinTxStats(msgBlock *wire.MsgBlock) map[uint8]CoinTxStats {
 	return stats
 }
 
+// blockSSFeeTotals sums TxTypeSSFee output SKAValues per coin type.
+// Returns nil if no SSFee transactions are present.
+func blockSSFeeTotals(msgBlock *wire.MsgBlock) map[uint8]string {
+	totals := make(map[uint8]*big.Int)
+	for _, tx := range msgBlock.STransactions {
+		if stake.DetermineTxType(tx) != stake.TxTypeSSFee {
+			continue
+		}
+		for _, out := range tx.TxOut {
+			if out.CoinType.IsSKA() && out.SKAValue != nil {
+				ct := uint8(out.CoinType)
+				if totals[ct] == nil {
+					totals[ct] = new(big.Int)
+				}
+				totals[ct].Add(totals[ct], out.SKAValue)
+			}
+		}
+	}
+	if len(totals) == 0 {
+		return nil
+	}
+	result := make(map[uint8]string, len(totals))
+	for ct, v := range totals {
+		result[ct] = v.String()
+	}
+	return result
+}
+
 // MsgBlockToDBBlock creates a dbtypes.Block from a wire.MsgBlock
 func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params, chainWork string, winners []ChainHash) *Block {
 	// Create the dbtypes.Block structure
@@ -81,24 +110,25 @@ func MsgBlockToDBBlock(msgBlock *wire.MsgBlock, chainParams *chaincfg.Params, ch
 		Version: uint32(blockHeader.Version),
 		NumTx:   uint32(len(msgBlock.Transactions) + len(msgBlock.STransactions)),
 		// nil []int64 for TxDbIDs
-		NumRegTx:     uint32(len(msgBlock.Transactions)),
-		NumStakeTx:   uint32(len(msgBlock.STransactions)),
-		Time:         NewTimeDef(blockHeader.Timestamp),
-		Nonce:        uint64(blockHeader.Nonce),
-		VoteBits:     blockHeader.VoteBits,
-		Voters:       blockHeader.Voters,
-		FreshStake:   blockHeader.FreshStake,
-		Revocations:  blockHeader.Revocations,
-		PoolSize:     blockHeader.PoolSize,
-		Bits:         blockHeader.Bits,
-		SBits:        uint64(blockHeader.SBits),
-		Difficulty:   txhelpers.GetDifficultyRatio(blockHeader.Bits, chainParams),
-		StakeVersion: blockHeader.StakeVersion,
-		PreviousHash: ChainHash(blockHeader.PrevBlock),
-		ChainWork:    chainWork,
-		Winners:      winners,
-		CoinAmounts:  blockCoinAmounts(msgBlock),
-		CoinTxStats:  blockCoinTxStats(msgBlock),
+		NumRegTx:          uint32(len(msgBlock.Transactions)),
+		NumStakeTx:        uint32(len(msgBlock.STransactions)),
+		Time:              NewTimeDef(blockHeader.Timestamp),
+		Nonce:             uint64(blockHeader.Nonce),
+		VoteBits:          blockHeader.VoteBits,
+		Voters:            blockHeader.Voters,
+		FreshStake:        blockHeader.FreshStake,
+		Revocations:       blockHeader.Revocations,
+		PoolSize:          blockHeader.PoolSize,
+		Bits:              blockHeader.Bits,
+		SBits:             uint64(blockHeader.SBits),
+		Difficulty:        txhelpers.GetDifficultyRatio(blockHeader.Bits, chainParams),
+		StakeVersion:      blockHeader.StakeVersion,
+		PreviousHash:      ChainHash(blockHeader.PrevBlock),
+		ChainWork:         chainWork,
+		Winners:           winners,
+		CoinAmounts:       blockCoinAmounts(msgBlock),
+		CoinTxStats:       blockCoinTxStats(msgBlock),
+		SSFeeTotalsByCoin: blockSSFeeTotals(msgBlock),
 	}
 }
 

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -2155,31 +2155,32 @@ type CoinTxStats struct {
 }
 
 type Block struct {
-	Hash         ChainHash `json:"hash"`
-	Size         uint32    `json:"size"`
-	Height       uint32    `json:"height"`
-	Version      uint32    `json:"version"`
-	NumTx        uint32
-	NumRegTx     uint32
-	TxDbIDs      []uint64
-	NumStakeTx   uint32
-	STxDbIDs     []uint64
-	Time         TimeDef               `json:"time"`
-	Nonce        uint64                `json:"nonce"`
-	VoteBits     uint16                `json:"votebits"`
-	Voters       uint16                `json:"voters"`
-	FreshStake   uint8                 `json:"freshstake"`
-	Revocations  uint8                 `json:"revocations"`
-	PoolSize     uint32                `json:"poolsize"`
-	Bits         uint32                `json:"bits"`
-	SBits        uint64                `json:"sbits"`
-	Difficulty   float64               `json:"difficulty"`
-	StakeVersion uint32                `json:"stakeversion"`
-	PreviousHash ChainHash             `json:"previousblockhash"`
-	ChainWork    string                `json:"chainwork"`
-	Winners      []ChainHash           `json:"winners"`
-	CoinAmounts  map[uint8]string      `json:"coin_amounts,omitempty"`
-	CoinTxStats  map[uint8]CoinTxStats `json:"coin_tx_stats,omitempty"`
+	Hash              ChainHash `json:"hash"`
+	Size              uint32    `json:"size"`
+	Height            uint32    `json:"height"`
+	Version           uint32    `json:"version"`
+	NumTx             uint32
+	NumRegTx          uint32
+	TxDbIDs           []uint64
+	NumStakeTx        uint32
+	STxDbIDs          []uint64
+	Time              TimeDef               `json:"time"`
+	Nonce             uint64                `json:"nonce"`
+	VoteBits          uint16                `json:"votebits"`
+	Voters            uint16                `json:"voters"`
+	FreshStake        uint8                 `json:"freshstake"`
+	Revocations       uint8                 `json:"revocations"`
+	PoolSize          uint32                `json:"poolsize"`
+	Bits              uint32                `json:"bits"`
+	SBits             uint64                `json:"sbits"`
+	Difficulty        float64               `json:"difficulty"`
+	StakeVersion      uint32                `json:"stakeversion"`
+	PreviousHash      ChainHash             `json:"previousblockhash"`
+	ChainWork         string                `json:"chainwork"`
+	Winners           []ChainHash           `json:"winners"`
+	CoinAmounts       map[uint8]string      `json:"coin_amounts,omitempty"`
+	CoinTxStats       map[uint8]CoinTxStats `json:"coin_tx_stats,omitempty"`
+	SSFeeTotalsByCoin map[uint8]string      `json:"ssfee_totals,omitempty"`
 }
 
 type BlockDataBasic struct {

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -36,7 +36,8 @@ const (
 		chainwork TEXT, -- todo: BYTE
 		winners BYTEA[], -- remove? make a new stake table? to get TicketPoolInfo.Winners we'd need a join or second query
 		coin_amounts JSONB,
-		coin_tx_stats JSONB
+		coin_tx_stats JSONB,
+		ssfee_totals JSONB
 	);`
 
 	// Block inserts. is_valid refers to blocks that have been validated by
@@ -50,12 +51,12 @@ const (
 		numtx, num_rtx, txDbIDs, num_stx,  stxDbIDs,
 		time, nonce, vote_bits, voters,
 		fresh_stake, revocations, pool_size, bits, sbits,
-		difficulty, stake_version, previous_hash, chainwork, winners, coin_amounts, coin_tx_stats)
+		difficulty, stake_version, previous_hash, chainwork, winners, coin_amounts, coin_tx_stats, ssfee_totals)
 	VALUES ($1, $2, $3, $4, $5, $6,
 		$7, $8, $9, $10, $11,
 		$12, $13, $14, $15,
 		$16, $17, $18, $19, $20,
-		$21, $22, $23, $24, $25, $26, $27) `
+		$21, $22, $23, $24, $25, $26, $27, $28) `
 
 	// InsertBlockRow inserts a new block row without checking for unique index
 	// conflicts. This should only be used before the unique indexes are created
@@ -228,7 +229,7 @@ const (
 		SELECT blocks.hash, blocks.height, blocks.size,
 			blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
 			stats.pool_val, blocks.winners, blocks.is_valid, blocks.coin_amounts,
-			blocks.coin_tx_stats
+			blocks.coin_tx_stats, blocks.ssfee_totals
 		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
 		WHERE blocks.height = $1;`
 
@@ -236,7 +237,7 @@ const (
 		SELECT blocks.hash, blocks.height, blocks.size,
 			blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
 			stats.pool_val, blocks.winners, blocks.is_valid, blocks.coin_amounts,
-			blocks.coin_tx_stats
+			blocks.coin_tx_stats, blocks.ssfee_totals
 		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
 		WHERE blocks.height BETWEEN $1 AND $2
 		ORDER BY blocks.height;`
@@ -245,7 +246,7 @@ const (
 		SELECT blocks.hash, blocks.height, blocks.size,
 			blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
 			stats.pool_val, blocks.winners, blocks.is_valid, blocks.coin_amounts,
-			blocks.coin_tx_stats
+			blocks.coin_tx_stats, blocks.ssfee_totals
 		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
 		WHERE blocks.height BETWEEN $1 AND $2
 		ORDER BY blocks.height DESC;`
@@ -254,7 +255,7 @@ const (
 		SELECT blocks.hash, blocks.height, blocks.size,
 			blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
 			stats.pool_val, blocks.winners, blocks.is_valid, blocks.coin_amounts,
-			blocks.coin_tx_stats
+			blocks.coin_tx_stats, blocks.ssfee_totals
 		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
 		WHERE blocks.height BETWEEN $1 AND $2
 			AND blocks.height %% %d = %d
@@ -264,7 +265,7 @@ const (
 		SELECT blocks.hash, blocks.height, blocks.size,
 			blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
 			stats.pool_val, blocks.winners, blocks.is_valid, blocks.coin_amounts,
-			blocks.coin_tx_stats
+			blocks.coin_tx_stats, blocks.ssfee_totals
 		FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
 		WHERE blocks.height BETWEEN $1 AND $2
 			AND blocks.height %% %d = %d
@@ -274,7 +275,7 @@ const (
 			SELECT blocks.height, blocks.size,
 				blocks.difficulty, blocks.sbits, blocks.time, stats.pool_size,
 				stats.pool_val, blocks.winners, blocks.is_mainchain, blocks.is_valid,
-				blocks.coin_amounts, blocks.coin_tx_stats
+				blocks.coin_amounts, blocks.coin_tx_stats, blocks.ssfee_totals
 			FROM blocks INNER JOIN stats ON blocks.id = stats.blocks_id
 			WHERE blocks.hash = $1;`
 

--- a/db/dcrpg/internal/schema_test.go
+++ b/db/dcrpg/internal/schema_test.go
@@ -76,6 +76,7 @@ func TestNewColumnsPresent(t *testing.T) {
 		{"votes.vote_reward TEXT", CreateVotesTable, "vote_reward TEXT"},
 		{"blocks.coin_amounts JSONB", CreateBlockTable, "coin_amounts JSONB"},
 		{"blocks.coin_tx_stats JSONB", CreateBlockTable, "coin_tx_stats JSONB"},
+		{"blocks.ssfee_totals JSONB", CreateBlockTable, "ssfee_totals JSONB"},
 	}
 	for _, tc := range checks {
 		t.Run(tc.name, func(t *testing.T) {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -5955,6 +5955,7 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	votes := make([]*exptypes.TrimmedTxInfo, 0, block.Voters)
 	revocations := make([]*exptypes.TrimmedTxInfo, 0, block.Revocations)
 	tickets := make([]*exptypes.TrimmedTxInfo, 0, block.FreshStake)
+	var stakeFees []*exptypes.TrimmedTxInfo
 
 	var treasury []*exptypes.TrimmedTxInfo
 	// treasuryActive := txhelpers.IsTreasuryActive(pgb.chainParams.Net, b.Height)
@@ -5986,6 +5987,8 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 			revocations = append(revocations, stx)
 		case stake.TxTypeTAdd, stake.TxTypeTSpend, stake.TxTypeTreasuryBase:
 			treasury = append(treasury, stx)
+		case stake.TxTypeSSFee:
+			stakeFees = append(stakeFees, stx)
 		}
 	}
 
@@ -6015,6 +6018,7 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	block.Votes = votes
 	block.Revs = revocations
 	block.Tickets = tickets
+	block.StakeFees = stakeFees
 	block.TotalMixed = totalMixed
 
 	sortTx := func(txs []*exptypes.TrimmedTxInfo) {
@@ -6028,6 +6032,7 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	sortTx(block.Votes)
 	sortTx(block.Revs)
 	sortTx(block.Tickets)
+	sortTx(block.StakeFees)
 
 	getTotalFee := func(txs []*exptypes.TrimmedTxInfo) (total dcrutil.Amount) {
 		for _, tx := range txs {
@@ -6056,7 +6061,7 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		return
 	}
 	block.TotalSent = (getTotalSent(block.Tx) + getTotalSent(block.Treasury) + getTotalSent(block.Revs) +
-		getTotalSent(block.Tickets) + getTotalSent(block.Votes)).ToCoin()
+		getTotalSent(block.Tickets) + getTotalSent(block.Votes) + getTotalSent(block.StakeFees)).ToCoin()
 	block.MiningFee = (getTotalFee(block.Tx) + getTotalFee(block.Treasury) + getTotalFee(block.Revs) +
 		getTotalFee(block.Tickets) + getTotalFee(block.Votes)).ToCoin()
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3629,7 +3629,8 @@ func insertBlock(db *sql.DB, dbBlock *dbtypes.Block, isValid, isMainchain, check
 		int64(dbBlock.SBits), dbBlock.Difficulty, int32(dbBlock.StakeVersion),
 		dbBlock.PreviousHash, dbBlock.ChainWork, dbtypes.ChainHashArray(dbBlock.Winners),
 		dbtypes.ToJSONB(dbBlock.CoinAmounts),
-		dbtypes.ToJSONB(dbBlock.CoinTxStats)).Scan(&id)
+		dbtypes.ToJSONB(dbBlock.CoinTxStats),
+		dbtypes.ToJSONB(dbBlock.SSFeeTotalsByCoin)).Scan(&id)
 	return id, err
 }
 
@@ -4377,9 +4378,11 @@ func retrieveBlockSummary(ctx context.Context, db *sql.DB, ind int64) (*apitypes
 	var timestamp dbtypes.TimeDef
 	var coinAmountsJSON []byte
 	var coinTxStatsJSON []byte
+	var ssfeeJSON []byte
 	err := db.QueryRowContext(ctx, internal.SelectBlockDataByHeight, ind).Scan(
 		&hash, &bd.Height, &bd.Size, &bd.Difficulty, &sbits, &timestamp,
-		&bd.PoolInfo.Size, &val, &winners, &isValid, &coinAmountsJSON, &coinTxStatsJSON)
+		&bd.PoolInfo.Size, &val, &winners, &isValid, &coinAmountsJSON, &coinTxStatsJSON,
+		&ssfeeJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -4394,6 +4397,7 @@ func retrieveBlockSummary(ctx context.Context, db *sql.DB, ind int64) (*apitypes
 	bd.StakeDiff = toCoin(sbits)
 	_ = json.Unmarshal(coinAmountsJSON, &bd.CoinAmounts)
 	_ = json.Unmarshal(coinTxStatsJSON, &bd.CoinTxStats)
+	_ = json.Unmarshal(ssfeeJSON, &bd.SSFeeTotalsByCoin)
 	return bd, nil
 }
 
@@ -4407,9 +4411,10 @@ func retrieveBlockSummaryByHash(ctx context.Context, db *sql.DB, hash dbtypes.Ch
 	var sbits int64
 	var coinAmountsJSON []byte
 	var coinTxStatsJSON []byte
+	var ssfeeJSON []byte
 	err := db.QueryRowContext(ctx, internal.SelectBlockDataByHash, hash).Scan(
 		&bd.Height, &bd.Size, &bd.Difficulty, &sbits, &timestamp,
-		&psize, &val, &winners, &isMainchain, &isValid, &coinAmountsJSON, &coinTxStatsJSON)
+		&psize, &val, &winners, &isMainchain, &isValid, &coinAmountsJSON, &coinTxStatsJSON, &ssfeeJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -4425,6 +4430,7 @@ func retrieveBlockSummaryByHash(ctx context.Context, db *sql.DB, hash dbtypes.Ch
 	bd.StakeDiff = toCoin(sbits)
 	_ = json.Unmarshal(coinAmountsJSON, &bd.CoinAmounts)
 	_ = json.Unmarshal(coinTxStatsJSON, &bd.CoinTxStats)
+	_ = json.Unmarshal(ssfeeJSON, &bd.SSFeeTotalsByCoin)
 	return bd, nil
 }
 
@@ -4460,9 +4466,10 @@ func retrieveBlockSummaryRange(ctx context.Context, db *sql.DB, ind0, ind1 int64
 		var hash dbtypes.ChainHash
 		var coinAmountsJSON []byte
 		var coinTxStatsJSON []byte
+		var ssfeeJSON []byte
 		err := rows.Scan(
 			&hash, &bd.Height, &bd.Size, &bd.Difficulty, &sbits, &timestamp,
-			&bd.PoolInfo.Size, &val, &winners, &isValid, &coinAmountsJSON, &coinTxStatsJSON,
+			&bd.PoolInfo.Size, &val, &winners, &isValid, &coinAmountsJSON, &coinTxStatsJSON, &ssfeeJSON,
 		)
 		if err != nil {
 			return nil, err
@@ -4478,6 +4485,7 @@ func retrieveBlockSummaryRange(ctx context.Context, db *sql.DB, ind0, ind1 int64
 		bd.StakeDiff = toCoin(sbits)
 		_ = json.Unmarshal(coinAmountsJSON, &bd.CoinAmounts)
 		_ = json.Unmarshal(coinTxStatsJSON, &bd.CoinTxStats)
+		_ = json.Unmarshal(ssfeeJSON, &bd.SSFeeTotalsByCoin)
 		blocks = append(blocks, bd)
 	}
 	if err = rows.Err(); err != nil {
@@ -4522,9 +4530,10 @@ func retrieveBlockSummaryRangeStepped(ctx context.Context, db *sql.DB, ind0, ind
 		var hash dbtypes.ChainHash
 		var coinAmountsJSON []byte
 		var coinTxStatsJSON []byte
+		var ssfeeJSON []byte
 		err := rows.Scan(
 			&hash, &bd.Height, &bd.Size, &bd.Difficulty, &sbits, &timestamp,
-			&bd.PoolInfo.Size, &val, &winners, &isValid, &coinAmountsJSON, &coinTxStatsJSON,
+			&bd.PoolInfo.Size, &val, &winners, &isValid, &coinAmountsJSON, &coinTxStatsJSON, &ssfeeJSON,
 		)
 		if err != nil {
 			return nil, err
@@ -4540,6 +4549,7 @@ func retrieveBlockSummaryRangeStepped(ctx context.Context, db *sql.DB, ind0, ind
 		bd.StakeDiff = toCoin(sbits)
 		_ = json.Unmarshal(coinAmountsJSON, &bd.CoinAmounts)
 		_ = json.Unmarshal(coinTxStatsJSON, &bd.CoinTxStats)
+		_ = json.Unmarshal(ssfeeJSON, &bd.SSFeeTotalsByCoin)
 		blocks = append(blocks, bd)
 	}
 	if err = rows.Err(); err != nil {

--- a/db/dcrpg/upgrades.go
+++ b/db/dcrpg/upgrades.go
@@ -474,6 +474,7 @@ func upgradeSchemaMultiCoin(db *sql.DB) error {
 		END $$`,
 		`ALTER TABLE blocks ADD COLUMN IF NOT EXISTS coin_amounts JSONB`,
 		`ALTER TABLE blocks ADD COLUMN IF NOT EXISTS coin_tx_stats JSONB`,
+		`ALTER TABLE blocks ADD COLUMN IF NOT EXISTS ssfee_totals JSONB`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -530,6 +530,7 @@ type BlockInfo struct {
 	Tickets               []*TrimmedTxInfo
 	Revs                  []*TrimmedTxInfo
 	Votes                 []*TrimmedTxInfo
+	StakeFees             []*TrimmedTxInfo
 	Misses                []string
 	Nonce                 uint32
 	VoteBits              uint16
@@ -557,6 +558,15 @@ type Conversion struct {
 	Index string  `json:"index"`
 }
 
+// SKAVoteReward holds per-SKA-type staker reward rates expressed as SKA atoms per VAR atom.
+type SKAVoteReward struct {
+	CoinType  uint8  `json:"coin_type"`
+	Symbol    string `json:"symbol"`
+	PerBlock  string `json:"per_block"`   // SKA/VAR ratio for last block, 18dp decimal string
+	Per30Days string `json:"per_30_days"` // 30-day average
+	PerYear   string `json:"per_year"`    // annualised average
+}
+
 // HomeInfo represents data used for the home page
 type HomeInfo struct {
 	CoinSupply            int64                    `json:"coin_supply"`
@@ -582,6 +592,7 @@ type HomeInfo struct {
 	HashRateChangeDay     float64                  `json:"hash_rate_change_day"`
 	HashRateChangeMonth   float64                  `json:"hash_rate_change_month"`
 	ExchangeRate          *Conversion              `json:"exchange_rate,omitempty"`
+	SKAVoteRewards        []SKAVoteReward          `json:"ska_vote_rewards,omitempty"`
 }
 
 // BlockSubsidy is an implementation of chainjson.GetBlockSubsidyResult

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -567,6 +567,14 @@ type SKAVoteReward struct {
 	PerYear   string `json:"per_year"`    // annualised average
 }
 
+// VoteVARReward holds the VAR staker reward rate expressed as VAR earned per
+// VAR staked (i.e. reward/ticketPrice) for last block, 30-day, and yearly.
+type VoteVARReward struct {
+	PerBlock  float64 `json:"per_block"`   // VAR/VAR for the last block
+	Per30Days float64 `json:"per_30_days"` // percentage per 30 days
+	PerYear   float64 `json:"per_year"`    // annualised percentage (ASR)
+}
+
 // HomeInfo represents data used for the home page
 type HomeInfo struct {
 	CoinSupply            int64                    `json:"coin_supply"`
@@ -592,6 +600,7 @@ type HomeInfo struct {
 	HashRateChangeDay     float64                  `json:"hash_rate_change_day"`
 	HashRateChangeMonth   float64                  `json:"hash_rate_change_month"`
 	ExchangeRate          *Conversion              `json:"exchange_rate,omitempty"`
+	VoteVARReward         VoteVARReward            `json:"vote_var_reward"`
 	SKAVoteRewards        []SKAVoteReward          `json:"ska_vote_rewards,omitempty"`
 }
 

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -20,6 +22,7 @@ import (
 	"github.com/monetarium/monetarium-node/txscript/stdscript"
 	"github.com/monetarium/monetarium-node/wire"
 
+	apitypes "github.com/monetarium/monetarium-explorer/api/types"
 	"github.com/monetarium/monetarium-explorer/blockdata"
 	"github.com/monetarium/monetarium-explorer/db/dbtypes"
 	exptypes "github.com/monetarium/monetarium-explorer/explorer/types"
@@ -50,6 +53,8 @@ type DataSource interface {
 	GetChainParams() *chaincfg.Params
 	BlockSubsidy(ctx context.Context, height int64, voters uint16) *chainjson.GetBlockSubsidyResult
 	Difficulty(ctx context.Context, timestamp int64) float64
+	Height() int64
+	GetSummaryRange(ctx context.Context, idx0, idx1 int) []*apitypes.BlockDataBasic
 }
 
 // State represents the current state of block chain.
@@ -695,6 +700,32 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 		psh.params.TargetTimePerBlock.Hours()/24)
 	//p.GeneralInfo.ASR = ASR
 
+	// Compute per-SKA vote rewards from SSFee totals in this block.
+	sbits, _ := dcrutil.NewAmount(blockData.Header.SBits)
+	ticketPriceAtoms := int64(sbits)
+	voters := int64(blockData.Header.Voters)
+	if ticketPriceAtoms > 0 && voters > 0 && len(blockData.ExtraInfo.SSFeeTotalsByCoin) > 0 {
+		blocksIn30Days := int(30 * 24 * time.Hour / psh.params.TargetTimePerBlock)
+		tip := int(psh.sourceBase.Height())
+		rewards := make([]exptypes.SKAVoteReward, 0, len(blockData.ExtraInfo.SSFeeTotalsByCoin))
+		for ct, totalStr := range blockData.ExtraInfo.SSFeeTotalsByCoin {
+			total, ok := new(big.Int).SetString(totalStr, 10)
+			if !ok {
+				continue
+			}
+			perVote := new(big.Int).Div(total, big.NewInt(voters))
+			rewards = append(rewards, exptypes.SKAVoteReward{
+				CoinType:  ct,
+				Symbol:    fmt.Sprintf("SKA-%d", ct),
+				PerBlock:  psh.formatSKAPerVAR(perVote, ticketPriceAtoms),
+				Per30Days: psh.avgSSFeeRate(ctx, ct, blocksIn30Days, tip),
+				PerYear:   psh.avgSSFeeRate(ctx, ct, blocksIn30Days*12, tip),
+			})
+		}
+		sort.Slice(rewards, func(i, j int) bool { return rewards[i].CoinType < rewards[j].CoinType })
+		p.GeneralInfo.SKAVoteRewards = rewards
+	}
+
 	p.mtx.Unlock()
 
 	// Signal to the websocket hub that a new block was received, but do not
@@ -764,4 +795,62 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	}()
 
 	return nil
+}
+
+// formatSKAPerVAR computes (skaAtoms/1e18)/(varAtoms/1e8) with 18dp precision.
+func (psh *PubSubHub) formatSKAPerVAR(skaAtoms *big.Int, varAtoms int64) string {
+	if varAtoms <= 0 || skaAtoms == nil || skaAtoms.Sign() <= 0 {
+		return "0.000000000000000000"
+	}
+	varScale := new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil)
+	resultScaled := new(big.Int).Mul(skaAtoms, varScale)
+	resultScaled.Div(resultScaled, big.NewInt(varAtoms))
+	dp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	intPart, fracPart := new(big.Int).DivMod(resultScaled, dp, new(big.Int))
+	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
+}
+
+// avgSSFeeRate returns the average SKA/VAR reward rate over the last nBlocks.
+func (psh *PubSubHub) avgSSFeeRate(ctx context.Context, coinType uint8, nBlocks, tip int) string {
+	start := tip - nBlocks + 1
+	if start < 0 {
+		start = 0
+	}
+	summaries := psh.sourceBase.GetSummaryRange(ctx, start, tip)
+	if len(summaries) == 0 {
+		return "0.000000000000000000"
+	}
+	total := new(big.Int)
+	var count int
+	for _, s := range summaries {
+		if s.SSFeeTotalsByCoin == nil {
+			continue
+		}
+		v, ok := s.SSFeeTotalsByCoin[coinType]
+		if !ok {
+			continue
+		}
+		amt, ok := new(big.Int).SetString(v, 10)
+		if !ok {
+			continue
+		}
+		ticketPriceAtoms := int64(s.StakeDiff * 1e8)
+		if ticketPriceAtoms <= 0 {
+			continue
+		}
+		voters := int64(psh.params.TicketsPerBlock)
+		perVote := new(big.Int).Div(amt, big.NewInt(voters))
+		varScale := new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil)
+		rs := new(big.Int).Mul(perVote, varScale)
+		ratio := new(big.Int).Div(rs, big.NewInt(ticketPriceAtoms))
+		total.Add(total, ratio)
+		count++
+	}
+	if count == 0 {
+		return "0.000000000000000000"
+	}
+	avg := new(big.Int).Div(total, big.NewInt(int64(count)))
+	dp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	intPart, fracPart := new(big.Int).DivMod(avg, dp, new(big.Int))
+	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
 }

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -714,12 +714,20 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 				continue
 			}
 			perVote := new(big.Int).Div(total, big.NewInt(voters))
+			start30 := tip - blocksIn30Days
+			if start30 < 0 {
+				start30 = 0
+			}
+			startYear := tip - blocksIn30Days*12
+			if startYear < 0 {
+				startYear = 0
+			}
 			rewards = append(rewards, exptypes.SKAVoteReward{
 				CoinType:  ct,
 				Symbol:    fmt.Sprintf("SKA-%d", ct),
-				PerBlock:  psh.formatSKAPerVAR(perVote, ticketPriceAtoms),
-				Per30Days: psh.avgSSFeeRate(ctx, ct, blocksIn30Days, tip),
-				PerYear:   psh.avgSSFeeRate(ctx, ct, blocksIn30Days*12, tip),
+				PerBlock:  txhelpers.FormatSKAPerVAR(perVote, ticketPriceAtoms),
+				Per30Days: txhelpers.AvgSSFeeRate(psh.sourceBase.GetSummaryRange(ctx, start30, tip), ct, psh.params.TicketsPerBlock),
+				PerYear:   txhelpers.AvgSSFeeRate(psh.sourceBase.GetSummaryRange(ctx, startYear, tip), ct, psh.params.TicketsPerBlock),
 			})
 		}
 		sort.Slice(rewards, func(i, j int) bool { return rewards[i].CoinType < rewards[j].CoinType })
@@ -795,62 +803,4 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	}()
 
 	return nil
-}
-
-// formatSKAPerVAR computes (skaAtoms/1e18)/(varAtoms/1e8) with 18dp precision.
-func (psh *PubSubHub) formatSKAPerVAR(skaAtoms *big.Int, varAtoms int64) string {
-	if varAtoms <= 0 || skaAtoms == nil || skaAtoms.Sign() <= 0 {
-		return "0.000000000000000000"
-	}
-	varScale := new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil)
-	resultScaled := new(big.Int).Mul(skaAtoms, varScale)
-	resultScaled.Div(resultScaled, big.NewInt(varAtoms))
-	dp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
-	intPart, fracPart := new(big.Int).DivMod(resultScaled, dp, new(big.Int))
-	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
-}
-
-// avgSSFeeRate returns the average SKA/VAR reward rate over the last nBlocks.
-func (psh *PubSubHub) avgSSFeeRate(ctx context.Context, coinType uint8, nBlocks, tip int) string {
-	start := tip - nBlocks + 1
-	if start < 0 {
-		start = 0
-	}
-	summaries := psh.sourceBase.GetSummaryRange(ctx, start, tip)
-	if len(summaries) == 0 {
-		return "0.000000000000000000"
-	}
-	total := new(big.Int)
-	var count int
-	for _, s := range summaries {
-		if s.SSFeeTotalsByCoin == nil {
-			continue
-		}
-		v, ok := s.SSFeeTotalsByCoin[coinType]
-		if !ok {
-			continue
-		}
-		amt, ok := new(big.Int).SetString(v, 10)
-		if !ok {
-			continue
-		}
-		ticketPriceAtoms := int64(s.StakeDiff * 1e8)
-		if ticketPriceAtoms <= 0 {
-			continue
-		}
-		voters := int64(psh.params.TicketsPerBlock)
-		perVote := new(big.Int).Div(amt, big.NewInt(voters))
-		varScale := new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil)
-		rs := new(big.Int).Mul(perVote, varScale)
-		ratio := new(big.Int).Div(rs, big.NewInt(ticketPriceAtoms))
-		total.Add(total, ratio)
-		count++
-	}
-	if count == 0 {
-		return "0.000000000000000000"
-	}
-	avg := new(big.Int).Div(total, big.NewInt(int64(count)))
-	dp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
-	intPart, fracPart := new(big.Int).DivMod(avg, dp, new(big.Int))
-	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
 }

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -686,8 +686,13 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 
 	posSubsPerVote := dcrutil.Amount(blockData.ExtraInfo.NextBlockSubsidy.PoS).ToCoin() /
 		float64(psh.params.TicketsPerBlock)
-	p.GeneralInfo.TicketReward = 100 * posSubsPerVote /
-		blockData.CurrentStakeDiff.CurrentStakeDifficulty
+	ticketRewardPct := 100 * posSubsPerVote / blockData.CurrentStakeDiff.CurrentStakeDifficulty
+	p.GeneralInfo.TicketReward = ticketRewardPct
+	p.GeneralInfo.VoteVARReward = exptypes.VoteVARReward{
+		PerBlock:  posSubsPerVote / blockData.CurrentStakeDiff.CurrentStakeDifficulty,
+		Per30Days: ticketRewardPct,
+		PerYear:   p.GeneralInfo.ASR, // ASR not recomputed in pubsub path; use last known value
+	}
 
 	// The actual reward of a ticket needs to also take into consideration the
 	// ticket maturity (time from ticket purchase until its eligible to vote)

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -707,6 +707,23 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	if ticketPriceAtoms > 0 && voters > 0 && len(blockData.ExtraInfo.SSFeeTotalsByCoin) > 0 {
 		blocksIn30Days := int(30 * 24 * time.Hour / psh.params.TargetTimePerBlock)
 		tip := int(psh.sourceBase.Height())
+		start30 := tip - blocksIn30Days
+		if start30 < 0 {
+			start30 = 0
+		}
+		startYear := tip - blocksIn30Days*12
+		if startYear < 0 {
+			startYear = 0
+		}
+		toSummaries := func(blocks []*apitypes.BlockDataBasic) []txhelpers.SSFeeSummary {
+			s := make([]txhelpers.SSFeeSummary, len(blocks))
+			for i, b := range blocks {
+				s[i] = txhelpers.SSFeeSummary{SSFeeTotalsByCoin: b.SSFeeTotalsByCoin, StakeDiff: b.StakeDiff}
+			}
+			return s
+		}
+		sum30 := toSummaries(psh.sourceBase.GetSummaryRange(ctx, start30, tip))
+		sumYear := toSummaries(psh.sourceBase.GetSummaryRange(ctx, startYear, tip))
 		rewards := make([]exptypes.SKAVoteReward, 0, len(blockData.ExtraInfo.SSFeeTotalsByCoin))
 		for ct, totalStr := range blockData.ExtraInfo.SSFeeTotalsByCoin {
 			total, ok := new(big.Int).SetString(totalStr, 10)
@@ -714,20 +731,12 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 				continue
 			}
 			perVote := new(big.Int).Div(total, big.NewInt(voters))
-			start30 := tip - blocksIn30Days
-			if start30 < 0 {
-				start30 = 0
-			}
-			startYear := tip - blocksIn30Days*12
-			if startYear < 0 {
-				startYear = 0
-			}
 			rewards = append(rewards, exptypes.SKAVoteReward{
 				CoinType:  ct,
 				Symbol:    fmt.Sprintf("SKA-%d", ct),
 				PerBlock:  txhelpers.FormatSKAPerVAR(perVote, ticketPriceAtoms),
-				Per30Days: txhelpers.AvgSSFeeRate(psh.sourceBase.GetSummaryRange(ctx, start30, tip), ct, psh.params.TicketsPerBlock),
-				PerYear:   txhelpers.AvgSSFeeRate(psh.sourceBase.GetSummaryRange(ctx, startYear, tip), ct, psh.params.TicketsPerBlock),
+				Per30Days: txhelpers.AvgSSFeeRate(sum30, ct, psh.params.TicketsPerBlock),
+				PerYear:   txhelpers.AvgSSFeeRate(sumYear, ct, psh.params.TicketsPerBlock),
 			})
 		}
 		sort.Slice(rewards, func(i, j int) bool { return rewards[i].CoinType < rewards[j].CoinType })

--- a/txhelpers/ssfee.go
+++ b/txhelpers/ssfee.go
@@ -1,0 +1,93 @@
+package txhelpers
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/monetarium/monetarium-node/blockchain/stake"
+	"github.com/monetarium/monetarium-node/wire"
+
+	apitypes "github.com/monetarium/monetarium-explorer/api/types"
+)
+
+// pre-computed constants to avoid repeated allocations.
+var (
+	ssfeeVarScale = new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil)  // 1e8
+	ssfeeDp       = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil) // 1e18
+)
+
+// BlockSSFeeTotals sums TxTypeSSFee output SKAValues per coin type for a block.
+// Returns nil if no SSFee transactions are present.
+func BlockSSFeeTotals(msgBlock *wire.MsgBlock) map[uint8]string {
+	totals := make(map[uint8]*big.Int)
+	for _, tx := range msgBlock.STransactions {
+		if stake.DetermineTxType(tx) != stake.TxTypeSSFee {
+			continue
+		}
+		for _, out := range tx.TxOut {
+			if out.CoinType.IsSKA() && out.SKAValue != nil {
+				ct := uint8(out.CoinType)
+				if totals[ct] == nil {
+					totals[ct] = new(big.Int)
+				}
+				totals[ct].Add(totals[ct], out.SKAValue)
+			}
+		}
+	}
+	if len(totals) == 0 {
+		return nil
+	}
+	result := make(map[uint8]string, len(totals))
+	for ct, v := range totals {
+		result[ct] = v.String()
+	}
+	return result
+}
+
+// FormatSKAPerVAR computes (skaAtoms/1e18) / (varAtoms/1e8) — SKA coins per
+// VAR coin — and returns a fixed-point decimal string with 18 decimal places.
+func FormatSKAPerVAR(skaAtoms *big.Int, varAtoms int64) string {
+	if varAtoms <= 0 || skaAtoms == nil || skaAtoms.Sign() <= 0 {
+		return "0.000000000000000000"
+	}
+	resultScaled := new(big.Int).Mul(skaAtoms, ssfeeVarScale)
+	resultScaled.Div(resultScaled, big.NewInt(varAtoms))
+	intPart, fracPart := new(big.Int).DivMod(resultScaled, ssfeeDp, new(big.Int))
+	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
+}
+
+// AvgSSFeeRate returns the average SKA/VAR staker reward rate over the provided
+// block summaries for the given coin type and voter count per block.
+func AvgSSFeeRate(summaries []*apitypes.BlockDataBasic, coinType uint8, ticketsPerBlock uint16) string {
+	total := new(big.Int)
+	var count int
+	voters := int64(ticketsPerBlock)
+	for _, s := range summaries {
+		if s.SSFeeTotalsByCoin == nil {
+			continue
+		}
+		v, ok := s.SSFeeTotalsByCoin[coinType]
+		if !ok {
+			continue
+		}
+		amt, ok := new(big.Int).SetString(v, 10)
+		if !ok {
+			continue
+		}
+		ticketPriceAtoms := int64(s.StakeDiff * 1e8)
+		if ticketPriceAtoms <= 0 {
+			continue
+		}
+		perVote := new(big.Int).Div(amt, big.NewInt(voters))
+		rs := new(big.Int).Mul(perVote, ssfeeVarScale)
+		ratio := new(big.Int).Div(rs, big.NewInt(ticketPriceAtoms))
+		total.Add(total, ratio)
+		count++
+	}
+	if count == 0 {
+		return "0.000000000000000000"
+	}
+	avg := new(big.Int).Div(total, big.NewInt(int64(count)))
+	intPart, fracPart := new(big.Int).DivMod(avg, ssfeeDp, new(big.Int))
+	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
+}

--- a/txhelpers/ssfee.go
+++ b/txhelpers/ssfee.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/monetarium/monetarium-node/blockchain/stake"
 	"github.com/monetarium/monetarium-node/wire"
-
-	apitypes "github.com/monetarium/monetarium-explorer/api/types"
 )
 
 // pre-computed constants to avoid repeated allocations.
@@ -15,6 +13,12 @@ var (
 	ssfeeVarScale = new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil)  // 1e8
 	ssfeeDp       = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil) // 1e18
 )
+
+// SSFeeSummary holds the per-block data needed to compute average SKA/VAR rates.
+type SSFeeSummary struct {
+	SSFeeTotalsByCoin map[uint8]string
+	StakeDiff         float64 // ticket price in VAR coins
+}
 
 // BlockSSFeeTotals sums TxTypeSSFee output SKAValues per coin type for a block.
 // Returns nil if no SSFee transactions are present.
@@ -58,7 +62,7 @@ func FormatSKAPerVAR(skaAtoms *big.Int, varAtoms int64) string {
 
 // AvgSSFeeRate returns the average SKA/VAR staker reward rate over the provided
 // block summaries for the given coin type and voter count per block.
-func AvgSSFeeRate(summaries []*apitypes.BlockDataBasic, coinType uint8, ticketsPerBlock uint16) string {
+func AvgSSFeeRate(summaries []SSFeeSummary, coinType uint8, ticketsPerBlock uint16) string {
 	total := new(big.Int)
 	var count int
 	voters := int64(ticketsPerBlock)

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -1137,6 +1137,7 @@ const (
 	TxTypeTreasurybase  string = "Treasurybase"
 	TxTypeTreasurySpend string = "Treasury Spend"
 	TxTypeTreasuryAdd   string = "Treasury Add"
+	TxTypeSSFee         string = "Stake Fee"
 )
 
 // DetermineTxTypeString returns a string representing the transaction type
@@ -1173,6 +1174,8 @@ func TxTypeToString(txType int) string {
 		return TxTypeTreasurySpend
 	case stake.TxTypeTreasuryBase:
 		return TxTypeTreasurybase
+	case stake.TxTypeSSFee:
+		return TxTypeSSFee
 	default:
 		return TxTypeRegular
 	}


### PR DESCRIPTION
## Problem

Two gaps around TxTypeSSFee (SKA stake fee distribution transactions):

1. Three stake transactions per block were silently dropped from the block detail page — the GetExplorerBlock switch had no case for stake.TxTypeSSFee, so they were 
never appended to any slice and never rendered.
2. The homepage had no "Vote SKA Reward" section — SKA staker rewards (derived from SSFee totals) were never computed or displayed.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


## Changes

### Block page — missing SSFee transactions

- txhelpers/txhelpers.go — added TxTypeSSFee = "Stake Fee" constant and case in TxTypeToString (previously fell through to "Regular")
- explorer/types/explorertypes.go — added StakeFees []*TrimmedTxInfo to BlockInfo
- db/dcrpg/pgblockchain.go — added case stake.TxTypeSSFee in GetExplorerBlock; included StakeFees in TotalSent
- cmd/dcrdata/views/block.tmpl — added "Stake Fees" table section after Revocations

### Vote SKA Reward homepage section

- api/types/apitypes.go — added SSFeeTotalsByCoin map[uint8]string to BlockDataBasic and BlockExplorerExtraInfo
- blockdata/blockdata.go — added blockSSFeeTotals helper; wired into CollectBlockInfo
- db/dbtypes/conversion.go — added blockSSFeeTotals; wired into MsgBlockToDBBlock
- db/dbtypes/types.go — added SSFeeTotalsByCoin to Block
- db/dcrpg/internal/blockstmts.go — added ssfee_totals JSONB to CREATE TABLE, insertBlockRow, and all SELECT statements
- db/dcrpg/queries.go — scan ssfee_totals in all four retrieve functions
- db/dcrpg/upgrades.go — ALTER TABLE blocks ADD COLUMN IF NOT EXISTS ssfee_totals JSONB
- db/dcrpg/internal/schema_test.go — asserts column presence in DDL
- explorer/types/explorertypes.go — added SKAVoteReward type and SKAVoteRewards []SKAVoteReward to HomeInfo
- cmd/dcrdata/internal/explorer/explorer.go — added GetSummaryRange to explorerDataSource interface; added formatSKAPerVAR and avgSSFeeRate helpers; computes 
SKAVoteRewards in Store()
- pubsub/pubsubhub.go — added Height() and GetSummaryRange() to DataSource interface; mirrors the same SKA reward computation in Store()
- cmd/dcrdata/internal/explorer/templates.go — added skaSplit template function (splits 18dp decimal into significant + trailing digits)
- cmd/dcrdata/views/home.tmpl — updated "Vote VAR Reward" label; added "Vote SKA Reward" section with skaVoteRewards and coinFillBars websocket targets
- cmd/dcrdata/public/js/controllers/homepage_controller.js — live-updates SKA vote rewards and coin fill bars on mempool/getmempooltxsResp/BLOCK_RECEIVED websocket 
events

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


## Testing

- Navigate to /block/68032b6621eab833abb6e2bd8e781947b709045b59a0a10c69c8aa3a0ce9561d — all 9 stake transactions visible (5 votes, 1 revocation, 3 stake fees)
- Homepage shows "Vote SKA Reward" section when a block containing SSFee transactions is processed
- Coin fill bars and SKA reward values update live without page reload
