### PR TITLE
feat: add PoW SKA reward display to homepage Mining section

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -766,6 +766,8 @@ type BlockExplorerExtraInfo struct {
 	CoinTxStats map[uint8]CoinTxStats `json:"coin_tx_stats,omitempty"`
 	// SSFeeTotalsByCoin holds total SKA atoms distributed via TxTypeSSFee per coin type.
 	SSFeeTotalsByCoin map[uint8]string `json:"ssfee_totals,omitempty"`
+	// SKAPoWRewards holds per-SKA-type PoW mining reward amounts (atom strings) from the block's coinbase.
+	SKAPoWRewards map[uint8]string `json:"ska_pow_rewards,omitempty"`
 }
 
 // BlockTransactionCounts contains the regular and stake transaction counts for

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -258,6 +258,11 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 		extrainfo.SSFeeTotalsByCoin = ssfee
 	}
 
+	// Extract per-SKA-type PoW mining reward amounts from the coinbase.
+	if skaRewards := blockSKAPoWRewards(msgBlock); len(skaRewards) > 0 {
+		extrainfo.SKAPoWRewards = skaRewards
+	}
+
 	return blockdata, feeInfoBlock, blockHeaderResults, extrainfo, msgBlock, err
 }
 
@@ -451,6 +456,38 @@ func blockCoinAmounts(msgBlock *wire.MsgBlock) map[uint8]string {
 		out[0] = fmt.Sprintf("%d", varTotal)
 	}
 	for k, v := range skaTotal {
+		out[k] = v.String()
+	}
+	return out
+}
+
+// blockSKAPoWRewards extracts per-SKA-type PoW mining reward amounts from the
+// coinbase transaction of a block. Only SKA outputs (CoinType 1-255) from the
+// coinbase are considered, as those represent the miner's SKA reward.
+func blockSKAPoWRewards(msgBlock *wire.MsgBlock) map[uint8]string {
+	if len(msgBlock.Transactions) == 0 {
+		return nil
+	}
+	coinbase := msgBlock.Transactions[0]
+	skaRewards := make(map[uint8]*big.Int)
+
+	for _, txout := range coinbase.TxOut {
+		if txout.CoinType.IsSKA() && txout.SKAValue != nil {
+			ct := uint8(txout.CoinType)
+			if cur, ok := skaRewards[ct]; ok {
+				cur.Add(cur, txout.SKAValue)
+			} else {
+				skaRewards[ct] = new(big.Int).Set(txout.SKAValue)
+			}
+		}
+	}
+
+	if len(skaRewards) == 0 {
+		return nil
+	}
+
+	out := make(map[uint8]string, len(skaRewards))
+	for k, v := range skaRewards {
 		out[k] = v.String()
 	}
 	return out

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -634,6 +634,20 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 		p.HomeInfo.SKAVoteRewards = rewards
 	}
 
+	// PoW SKA rewards: per-SKA-type mining reward amounts from the coinbase.
+	if len(blockData.ExtraInfo.SKAPoWRewards) > 0 {
+		powRewards := make([]types.PoWSKAReward, 0, len(blockData.ExtraInfo.SKAPoWRewards))
+		for ct, amountStr := range blockData.ExtraInfo.SKAPoWRewards {
+			powRewards = append(powRewards, types.PoWSKAReward{
+				CoinType: ct,
+				Symbol:   fmt.Sprintf("SKA-%d", ct),
+				Amount:   amountStr,
+			})
+		}
+		sort.Slice(powRewards, func(i, j int) bool { return powRewards[i].CoinType < powRewards[j].CoinType })
+		p.HomeInfo.PoWSKARewards = powRewards
+	}
+
 	// If exchange monitoring is enabled, set the exchange rate.
 	if exp.xcBot != nil {
 		exchangeConversion := exp.xcBot.Conversion(1.0)

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -172,6 +172,58 @@ func float64Formatting(v float64, numPlaces int, useCommas bool, boldNumPlaces .
 	return []string{integer, dec[:places], dec[places:], trailingZeros}
 }
 
+// skaDecimalParts converts a SKA atom string (decimal integer string, 18 decimals)
+// to the []string format expected by the "decimalParts" template.
+// Returns [integer, decimal, trailingZeros] or with boldNumPlaces:
+// [integer, firstNdec, restDec, trailingZeros].
+func skaDecimalParts(atomStr string, useCommas bool, boldNumPlaces ...int) []string {
+	if atomStr == "" {
+		return []string{"0", "", ""}
+	}
+
+	// Parse the atom value.
+	atoms, ok := new(big.Int).SetString(atomStr, 10)
+	if !ok {
+		return []string{atomStr, "", ""}
+	}
+
+	if atoms.Sign() == 0 {
+		return []string{"0", "", ""}
+	}
+
+	// SKA has 18 decimal places.
+	skaDecimals := 18
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(skaDecimals)), nil)
+
+	intPart := new(big.Int).Div(atoms, scale)
+	fracPart := new(big.Int).Mod(atoms, scale)
+
+	integer := intPart.String()
+	dec := fmt.Sprintf("%018d", fracPart.Int64())
+
+	// Trim trailing zeros and track them separately.
+	right := strings.TrimRight(dec, "0")
+	trailingZeros := strings.Repeat("0", len(dec)-len(right))
+
+	if useCommas && intPart.Sign() > 0 {
+		integer = humanize.Comma(intPart.Int64())
+	}
+
+	if len(boldNumPlaces) == 0 {
+		return []string{integer, right, trailingZeros}
+	}
+
+	places := boldNumPlaces[0]
+	if places > len(right) {
+		places = len(right)
+	}
+	if places == 0 {
+		return []string{integer, right, trailingZeros}
+	}
+
+	return []string{integer, right[:places], right[places:], trailingZeros}
+}
+
 func amountAsDecimalPartsTrimmed(v, numPlaces int64, useCommas bool) []string {
 	// Filter numPlaces to only allow up to 8 decimal places trimming (eg. 1.12345678)
 	if numPlaces > 8 {
@@ -472,6 +524,9 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		},
 		"toFloat64Amount": func(intAmount int64) float64 {
 			return dcrutil.Amount(intAmount).ToCoin()
+		},
+		"skaDecimalParts": func(atomStr string, useCommas bool, boldNumPlaces ...int) []string {
+			return skaDecimalParts(atomStr, useCommas, boldNumPlaces...)
 		},
 		"dcrPerKbToAtomsPerByte": func(amt dcrutil.Amount) int64 {
 			return int64(math.Round(float64(amt) / 1e3))

--- a/cmd/dcrdata/views/home.tmpl
+++ b/cmd/dcrdata/views/home.tmpl
@@ -287,6 +287,18 @@
                             </div>
                             {{- end}}
                         </div>
+                        {{if .PoWSKARewards}}
+                        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                            <div class="fs13 text-secondary">PoW SKA Reward</div>
+                            {{range .PoWSKARewards}}
+                            <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                                <span class="pe-1">{{.Symbol}}:</span>
+                                <span>{{template "decimalParts" (skaDecimalParts .Amount true 2)}}</span>
+                                <span class="ps-1 unit lh15rem">{{.Symbol}}</span>
+                            </div>
+                            {{end}}
+                        </div>
+                        {{end}}
                         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
                             <div class="fs13 text-secondary lh1rem">Next Block Reward Reduction</div>
                             <div class="progress mt-1 mb-1">

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -575,6 +575,13 @@ type VoteVARReward struct {
 	PerYear   float64 `json:"per_year"`    // annualised percentage (ASR)
 }
 
+// PoWSKAReward holds the PoW mining reward for a single SKA coin type.
+type PoWSKAReward struct {
+	CoinType uint8  `json:"coin_type"`
+	Symbol   string `json:"symbol"`
+	Amount   string `json:"amount"` // SKA atoms as decimal string (18 decimals)
+}
+
 // HomeInfo represents data used for the home page
 type HomeInfo struct {
 	CoinSupply            int64                    `json:"coin_supply"`
@@ -602,6 +609,7 @@ type HomeInfo struct {
 	ExchangeRate          *Conversion              `json:"exchange_rate,omitempty"`
 	VoteVARReward         VoteVARReward            `json:"vote_var_reward"`
 	SKAVoteRewards        []SKAVoteReward          `json:"ska_vote_rewards,omitempty"`
+	PoWSKARewards         []PoWSKAReward           `json:"pow_ska_rewards,omitempty"`
 }
 
 // BlockSubsidy is an implementation of chainjson.GetBlockSubsidyResult


### PR DESCRIPTION
## Summary

Extend the homepage Mining section to display per-SKA-type PoW mining rewards
extracted from each block's coinbase transaction.

## Changes

| File | Change |
|---|---|
| `explorer/types/explorertypes.go` | Add `PoWSKAReward` struct and `HomeInfo.PoWSKARewards` field |
| `api/types/apitypes.go` | Add `SKAPoWRewards map[uint8]string` to `BlockExplorerExtraInfo` |
| `blockdata/blockdata.go` | Add `blockSKAPoWRewards()` — sums SKA coinbase outputs by coin type; wired into `CollectBlockInfo()` |
| `cmd/dcrdata/internal/explorer/explorer.go` | Convert `SKAPoWRewards` → sorted `[]PoWSKAReward` in `Store()` |
| `cmd/dcrdata/internal/explorer/templates.go` | Add `skaDecimalParts()` helper for 18-decimal SKA amount rendering; register in FuncMap |
| `cmd/dcrdata/views/home.tmpl` | Render "PoW SKA Reward" subsection in Mining card (hidden when no SKA rewards) |

## Data Flow
    coinbase tx SKA outputs
      → blockSKAPoWRewards()
        → BlockExplorerExtraInfo.SKAPoWRewards
          → explorerUI.Store()
            → HomeInfo.PoWSKARewards
              → home.tmpl Mining section