### PR TITLE
feat(mining): add empty state template for SKA rewards display

### DIFF
--- a/cmd/dcrdata/public/js/controllers/mining_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mining_controller.js
@@ -46,7 +46,11 @@ export default class extends Controller {
     const container = this.powSkaRewardsTarget
     container.innerHTML = ''
 
-    if (!Array.isArray(rewards) || rewards.length === 0) return
+    if (!Array.isArray(rewards) || rewards.length === 0) {
+      const emptyTmpl = document.getElementById('pow-ska-empty-template')
+      if (emptyTmpl) container.appendChild(document.importNode(emptyTmpl.content, true))
+      return
+    }
 
     rewards.forEach((r) => {
       const clone = document.importNode(tmpl.content, true)

--- a/cmd/dcrdata/views/home_mining.tmpl
+++ b/cmd/dcrdata/views/home_mining.tmpl
@@ -67,6 +67,9 @@
                 <span class="ps-1 unit lh15rem"><span class="symbol"></span> <span class="text-black-50 ms-1 fs12">per last block</span></span>
             </div>
         </template>
+        <template id="pow-ska-empty-template">
+            <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
+        </template>
         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
             <div class="fs13 text-secondary lh1rem">Next Block VAR Reward Reduction</div>
             <div class="progress mt-1 mb-1">


### PR DESCRIPTION
- Add empty state template to display when no SKA rewards are available
- Update mining controller to render empty template when rewards array is empty
- Display user-friendly message "No SKA rewards available" in empty state
- Improve UX by providing visual feedback instead of blank container

Refs #30