### PR TITLE
Fix/latest blocks txn count

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/monetarium/monetarium-node/blockchain/stake"
 	"github.com/monetarium/monetarium-node/chaincfg"
 	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
 	"github.com/monetarium/monetarium-node/cointype"
@@ -406,6 +407,10 @@ func blockCoinTxStats(msgBlock *wire.MsgBlock) map[uint8]apitypes.CoinTxStats {
 	stats := make(map[uint8]apitypes.CoinTxStats)
 	allTxs := append(msgBlock.Transactions, msgBlock.STransactions...)
 	for _, tx := range allTxs {
+		txType := txhelpers.DetermineTxType(tx)
+		if txType == stake.TxTypeSSGen || txType == stake.TxTypeSStx || txType == stake.TxTypeSSRtx {
+			continue
+		}
 		ct := uint8(cointype.CoinTypeVAR)
 		for _, txout := range tx.TxOut {
 			if txout.CoinType.IsSKA() {

--- a/cmd/dcrdata/internal/explorer/home_viewmodel.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel.go
@@ -62,6 +62,12 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 			totalTxCount = 0
 			for _, cr := range b.CoinRows {
 				totalTxCount += cr.TxCount
+			}
+			totalTxCount -= int(b.Voters) + int(b.FreshStake) + int(b.Revocations)
+			if totalTxCount < 0 {
+				totalTxCount = 0
+			}
+			for _, cr := range b.CoinRows {
 				if cr.CoinType == 0 {
 					// VAR row
 					varTxCount = cr.TxCount

--- a/cmd/dcrdata/public/js/controllers/blocklist_controller.js
+++ b/cmd/dcrdata/public/js/controllers/blocklist_controller.js
@@ -40,6 +40,9 @@ function coinRowsToSKAData(block) {
     }
   }
 
+  totalTxCount -= (block.votes || 0) + (block.tickets || 0) + (block.revocations || 0)
+  if (totalTxCount < 0) totalTxCount = 0
+
   let skaAmount = ''
   if (subRows.length === 1) {
     skaAmount = subRows[0].amount

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -5889,7 +5889,11 @@ func makeExplorerBlockBasic(data *chainjson.GetBlockVerboseResult, params *chain
 
 	total := sumOutsTxRawResult(data.RawTx) + sumOutsTxRawResult(data.RawSTx)
 
-	numReg := len(data.RawTx)
+	numAll := len(data.RawTx) + len(data.RawSTx)
+	numReg := numAll - int(data.Voters) - int(data.FreshStake) - int(data.Revocations)
+	if numReg < 0 {
+		numReg = 0
+	}
 
 	block := &exptypes.BlockBasic{
 		IndexVal:       index,
@@ -5903,7 +5907,7 @@ func makeExplorerBlockBasic(data *chainjson.GetBlockVerboseResult, params *chain
 		Transactions:   numReg,
 		FreshStake:     data.FreshStake,
 		Revocations:    uint32(data.Revocations),
-		TxCount:        uint32(data.FreshStake+data.Revocations) + uint32(numReg) + uint32(data.Voters),
+		TxCount:        uint32(numAll),
 		BlockTime:      exptypes.NewTimeDefFromUNIX(data.Time),
 		FormattedBytes: humanize.Bytes(uint64(data.Size)),
 		Total:          total,


### PR DESCRIPTION
Summary
Corrects the transaction count displayed in the Latest Blocks table to exclude stake transactions (Votes, Ticket purchases, and Revocations), as per the specification in MAIN_MANIFEST.md §3.1.1.2 and §3.3.
Changes
- Backend (blockdata/blockdata.go): Updated blockCoinTxStats to filter out stake transaction types from the per-coin transaction aggregation.
- Database (db/dcrpg/pgblockchain.go): Modified makeExplorerBlockBasic to calculate the regular transaction count by subtracting stake transactions from the total block transaction count.
- View Model (cmd/dcrdata/internal/explorer/home_viewmodel.go): Added subtraction of stake transaction counts when calculating the total transactions from CoinRows to ensure consistency.
- Frontend (cmd/dcrdata/public/js/controllers/blocklist_controller.js): Updated the WebSocket block processing logic to subtract stake transactions, ensuring live updates match the initial page load.