### PR TITLE
feat(home): reorganize mining and voting card layouts for improved UX

### DIFF
--- a/cmd/dcrdata/views/home_mining.tmpl
+++ b/cmd/dcrdata/views/home_mining.tmpl
@@ -26,6 +26,7 @@
                 <span data-mining-target="hashrateDelta">{{template "fmtPercentage" .HashRateChangeMonth}}</span> in past 30 days
             </div>
         </div>
+        {{/* Row 2 left: PoW VAR Reward */}}
         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
             <div class="fs13 text-secondary">PoW VAR Reward</div>
             <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
@@ -38,38 +39,7 @@
             </div>
             {{- end}}
         </div>
-        {{if .PoWSKARewards}}
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">PoW SKA Reward</div>
-            <div data-mining-target="powSkaRewards">
-            {{range .PoWSKARewards}}
-            <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                <span>{{template "decimalParts" (skaDecimalParts .Amount true 2)}}</span>
-                <span class="ps-1 unit lh15rem">{{.Symbol}} <span class="text-black-50 ms-1 fs12">per last block</span></span>
-            </div>
-            {{end}}
-            </div>
-        </div>
-        {{else}}
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">PoW SKA Reward</div>
-            <div data-mining-target="powSkaRewards">
-                <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
-            </div>
-        </div>
-        {{end}}
-        {{/* Template for JS live-update cloning */}}
-        <template id="pow-ska-reward-template">
-            <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                <div class="decimal-parts d-inline-block">
-                    <span class="int"></span><span class="decimal"></span><span class="decimal trailing-zeroes"></span>
-                </div>
-                <span class="ps-1 unit lh15rem"><span class="symbol"></span> <span class="text-black-50 ms-1 fs12">per last block</span></span>
-            </div>
-        </template>
-        <template id="pow-ska-empty-template">
-            <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
-        </template>
+        {{/* Row 2 right: Next Block VAR Reward Reduction (swapped from below) */}}
         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
             <div class="fs13 text-secondary lh1rem">Next Block VAR Reward Reduction</div>
             <div class="progress mt-1 mb-1">
@@ -96,6 +66,39 @@
                 </span>
             </div>
         </div>
+        {{/* Row 3: PoW SKA Reward (moved below, grows as new SKA types are emitted) */}}
+        {{if .PoWSKARewards}}
+        <div class="col-24 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+            <div class="fs13 text-secondary">PoW SKA Reward</div>
+            <div data-mining-target="powSkaRewards">
+            {{range .PoWSKARewards}}
+            <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                <span>{{template "decimalParts" (skaDecimalParts .Amount true 2)}}</span>
+                <span class="ps-1 unit lh15rem">{{.Symbol}} <span class="text-black-50 ms-1 fs12">per last block</span></span>
+            </div>
+            {{end}}
+            </div>
+        </div>
+        {{else}}
+        <div class="col-24 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+            <div class="fs13 text-secondary">PoW SKA Reward</div>
+            <div data-mining-target="powSkaRewards">
+                <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
+            </div>
+        </div>
+        {{end}}
+        {{/* Templates for JS live-update cloning */}}
+        <template id="pow-ska-reward-template">
+            <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+                <div class="decimal-parts d-inline-block">
+                    <span class="int"></span><span class="decimal"></span><span class="decimal trailing-zeroes"></span>
+                </div>
+                <span class="ps-1 unit lh15rem"><span class="symbol"></span> <span class="text-black-50 ms-1 fs12">per last block</span></span>
+            </div>
+        </template>
+        <template id="pow-ska-empty-template">
+            <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
+        </template>
     </div>
 </div> <!-- end mining card -->
 {{- end}}

--- a/cmd/dcrdata/views/home_voting.tmpl
+++ b/cmd/dcrdata/views/home_voting.tmpl
@@ -22,19 +22,7 @@
             </div>
             {{- end}}
         </div>
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">Next Ticket Price</div>
-            <div class="mono d-flex align-items-baseline lh1rem pt-1 pb-1">
-                <span class="fs22">~</span><span class="fs24 d-flex" data-voting-target="nextExpectedSdiff">{{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 2 false)}}</span>
-                <span class="ps-1 unit lh15rem">VAR</span>
-            </div>
-            <div class="d-flex lh1rem fs12 text-black-50">
-                <span>min:&nbsp;</span>
-                <span class="d-flex" data-voting-target="nextExpectedMin">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}}</span>
-                <span>&nbsp;&mdash;&nbsp;max:&nbsp;</span>
-                <span class="d-flex" data-voting-target="nextExpectedMax">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}</span>
-            </div>
-        </div>
+        {{/* Row 1 right: Ticket Pool Size (swapped from row 3) */}}
         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
             <div class="d-block fs13 text-secondary"><a href="/charts?chart=ticket-pool-size">Ticket Pool Size</a></div>
             <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
@@ -48,6 +36,21 @@
                 target
             </div>
         </div>
+        {{/* Row 2 left: Next Ticket Price (swapped from row 1) */}}
+        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+            <div class="fs13 text-secondary">Next Ticket Price</div>
+            <div class="mono d-flex align-items-baseline lh1rem pt-1 pb-1">
+                <span class="fs22">~</span><span class="fs24 d-flex" data-voting-target="nextExpectedSdiff">{{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 2 false)}}</span>
+                <span class="ps-1 unit lh15rem">VAR</span>
+            </div>
+            <div class="d-flex lh1rem fs12 text-black-50">
+                <span>min:&nbsp;</span>
+                <span class="d-flex" data-voting-target="nextExpectedMin">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}}</span>
+                <span>&nbsp;&mdash;&nbsp;max:&nbsp;</span>
+                <span class="d-flex" data-voting-target="nextExpectedMax">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}</span>
+            </div>
+        </div>
+        {{/* Row 2 right: Next Ticket Price Change indicator */}}
         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
             <div class="fs13 text-secondary">Next Ticket Price Change</div>
             <div class="progress mt-1 mb-1">
@@ -69,7 +72,8 @@
                 </span>
             </div>
         </div>
-        <div class="col-24 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+        {{/* Row 3 left: Vote VAR Reward */}}
+        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
             <div class="fs13 text-secondary">Vote VAR Reward</div>
             <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
                 <span data-voting-target="bsubsidyPos">
@@ -81,6 +85,19 @@
                 <span data-voting-target="ticketReward">{{printf "%.2f" $page.Info.VoteVARReward.Per30Days}}%</span> per 30 days
             </div>
             <div class="fs12 lh1rem text-black-50">{{printf "%.2f" $page.Info.VoteVARReward.PerYear}}% per year</div>
+        </div>
+        {{/* Row 3 right: Total Staked VAR (moved from bottom-left, now below Next Ticket Price Change) */}}
+        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+            <div class="fs13 text-secondary"><a href="/charts?chart=stake-participation">Total Staked VAR</a></div>
+            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                <span data-voting-target="poolValue">
+                    {{template "decimalParts" (float64AsDecimalParts .PoolInfo.Value 0 true)}}
+                </span>
+                <span class="ps-1 unit lh15rem">VAR</span>
+            </div>
+            <div class="fs12 lh1rem text-black-50">
+                <span data-voting-target="poolSizePct">{{printf "%.2f" .PoolInfo.Percentage}}</span> % of circulating supply
+            </div>
         </div>
         <!-- Vote SKA Reward subsection -->
         <div class="col-24 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
@@ -112,18 +129,6 @@
                 <div class="fs12 lh1rem text-black-50" data-field="per30d"></div>
                 <div class="fs12 lh1rem text-black-50" data-field="peryear"></div>
             </template>
-        </div>
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary"><a href="/charts?chart=stake-participation">Total Staked VAR</a></div>
-            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                <span data-voting-target="poolValue">
-                    {{template "decimalParts" (float64AsDecimalParts .PoolInfo.Value 0 true)}}
-                </span>
-                <span class="ps-1 unit lh15rem">VAR</span>
-            </div>
-            <div class="fs12 lh1rem text-black-50">
-                <span data-voting-target="poolSizePct">{{printf "%.2f" .PoolInfo.Percentage}}</span> % of circulating supply
-            </div>
         </div>
     </div>
 </div> <!-- end voting card -->


### PR DESCRIPTION
- Reorder mining card sections: move "Next Block VAR Reward Reduction" above "PoW SKA Reward" for better visual hierarchy
- Update PoW SKA Reward container from col-12 to col-24 for full-width display when multiple SKA types are emitted
- Add clarifying comments throughout templates to document section purposes and layout changes
- Reorganize voting card: swap "Ticket Pool Size" and "Next Ticket Price" positions for logical flow
- Update voting card grid layout from col-12 to col-24 for Vote VAR Reward section
- Add section comments in voting template to identify row positions and swapped elements
- Improve template maintainability with descriptive comments for JS live-update cloning sections
Closes #89 #90