### PR TITLE
feat: transaction detail page with multi-coin support

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -105,6 +105,7 @@ type Vin struct {
 	ScriptSig    *ScriptSig `json:"scriptSig,omitempty"`
 	Sequence     uint32     `json:"sequence"`
 	AmountIn     float64    `json:"amountin,omitempty"`
+	SKAAmountIn  string     `json:"ska_amountin,omitempty"`
 	BlockHeight  uint32     `json:"blockheight"`
 	BlockIndex   uint32     `json:"blockindex"`
 	CoinType     uint8      `json:"coin_type,omitempty"`
@@ -444,6 +445,7 @@ type VinShort struct {
 	BlockHeight   *uint32 `json:"blockheight,omitempty"`
 	BlockIndex    *uint32 `json:"blockindex,omitempty"`
 	CoinType      uint8   `json:"coin_type,omitempty"`
+	SKAAmountIn   string  `json:"ska_amountin,omitempty"`
 	SKAValue      string  `json:"ska_value,omitempty"`
 }
 

--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -88,20 +88,45 @@ type Tx struct {
 	Block         *BlockID `json:"block,omitempty"`
 }
 
-// Vin is an alias for dcrd's rpc/jsonrpc/types/v4.Vin type.
-type Vin = chainjson.Vin
+// ScriptSig models a transaction input's signature script.
+type ScriptSig struct {
+	Asm string `json:"asm"`
+	Hex string `json:"hex"`
+}
+
+// Vin models basic data about a transaction input.
+type Vin struct {
+	Coinbase     string     `json:"coinbase,omitempty"`
+	Stakebase    string     `json:"stakebase,omitempty"`
+	Treasurybase bool       `json:"treasurybase,omitempty"`
+	Txid         string     `json:"txid,omitempty"`
+	Vout         uint32     `json:"vout,omitempty"`
+	Tree         int8       `json:"tree,omitempty"`
+	ScriptSig    *ScriptSig `json:"scriptSig,omitempty"`
+	Sequence     uint32     `json:"sequence"`
+	AmountIn     float64    `json:"amountin,omitempty"`
+	BlockHeight  uint32     `json:"blockheight"`
+	BlockIndex   uint32     `json:"blockindex"`
+	CoinType     uint8      `json:"coin_type,omitempty"`
+	ValueInRaw   string     `json:"value_in_raw,omitempty"`
+}
 
 // TxShort models info about transaction TxID
 type TxShort struct {
-	TxID     string `json:"txid"`
-	Size     int32  `json:"size"`
-	Version  int32  `json:"version"`
-	Locktime uint32 `json:"locktime"`
-	Expiry   uint32 `json:"expiry"`
-	Vin      []Vin  `json:"vin"`
-	Vout     []Vout `json:"vout"`
-	Tree     int8   `json:"tree"`
-	Type     string `json:"type"`
+	TxID       string `json:"txid"`
+	Size       int32  `json:"size"`
+	Version    int32  `json:"version"`
+	Locktime   uint32 `json:"locktime"`
+	Expiry     uint32 `json:"expiry"`
+	Vin        []Vin  `json:"vin"`
+	Vout       []Vout `json:"vout"`
+	Tree       int8   `json:"tree"`
+	Type       string `json:"type"`
+	CoinType   uint8  `json:"coin_type"`
+	Total      string `json:"total"` // Atom string
+	Fee        string `json:"fee"`   // Atom string
+	FeeRate    string `json:"fee_rate,omitempty"`
+	FeeRateRaw string `json:"fee_rate_raw,omitempty"`
 }
 
 // AgendasInfo holds the high level details about an agenda.
@@ -121,12 +146,17 @@ type AgendaAPIResponse struct {
 
 // TrimmedTx models data to resemble to result of the decoderawtransaction RPC.
 type TrimmedTx struct {
-	TxID     string `json:"txid"`
-	Version  int32  `json:"version"`
-	Locktime uint32 `json:"locktime"`
-	Expiry   uint32 `json:"expiry"`
-	Vin      []Vin  `json:"vin"`
-	Vout     []Vout `json:"vout"`
+	TxID       string `json:"txid"`
+	Version    int32  `json:"version"`
+	Locktime   uint32 `json:"locktime"`
+	Expiry     uint32 `json:"expiry"`
+	Vin        []Vin  `json:"vin"`
+	Vout       []Vout `json:"vout"`
+	CoinType   uint8  `json:"coin_type"`
+	Total      string `json:"total"` // Atom string
+	Fee        string `json:"fee"`   // Atom string
+	FeeRate    string `json:"fee_rate,omitempty"`
+	FeeRateRaw string `json:"fee_rate_raw,omitempty"`
 }
 
 // Txns models the multi transaction post data structure
@@ -195,7 +225,8 @@ type VoutMined struct {
 
 // Vout defines a transaction output
 type Vout struct {
-	Value               float64      `json:"value"`
+	Value               float64      `json:"value"` // Deprecated: use ValueRaw
+	ValueRaw            string       `json:"value_raw"`
 	N                   uint32       `json:"n"`
 	Version             uint16       `json:"version"`
 	ScriptPubKeyDecoded ScriptPubKey `json:"scriptPubKey"`

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -20,6 +20,7 @@ import (
 	"github.com/monetarium/monetarium-explorer/explorer/types"
 	"github.com/monetarium/monetarium-explorer/txhelpers"
 	"github.com/monetarium/monetarium-node/chaincfg"
+	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/dcrutil"
 )
 
@@ -836,6 +837,9 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 				Data:  data,
 				Title: title,
 			}
+		},
+		"coinSymbol": func(ct uint8) string {
+			return cointype.CoinType(ct).String()
 		},
 	}
 }

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -197,7 +197,7 @@
 		{{- end}}
 	{{- else -}}
 		<span class="int">{{index . 0}}</span>
-		{{- if gt (len (index . 1)) 0 -}}
+		{{- if or (gt (len (index . 1)) 0) (gt (len (index . 2)) 0) -}}
 		<span class="decimal dot">.</span><span class="decimal">{{index . 1 }}</span>
 		{{- /* trailing zeros  */ -}}
 		<span class="decimal trailing-zeroes">{{index . 2}}</span>

--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -8,9 +8,8 @@
 <div class="container main" data-controller="time tx" data-tx-txid="{{.TxID}}">
 {{$isMempool := (eq .BlockHeight 0)}}
     <div class="row mx-2 my-2">
-        <div class="col-24 col-xl-12 bg-white p-3 p-sm-4 position-relative">
-          <div class="card-pointer pointer-right d-none d-xl-block"></div>
-          <div class="card-pointer pointer-bottom d-xl-none"></div>
+        <div class="col-24 bg-white p-3 p-sm-4 position-relative">
+          <div class="card-pointer pointer-bottom"></div>
           <div class="pb-1 ps-1 position-relative">
             {{if or .IsTicket .IsRevocation}}
               <span class="fs22 monicon-ticket"></span>
@@ -39,7 +38,7 @@
                 {{end}}
               </div>
               {{if gt .MixCount 0}}
-              <div class="d-inline-block mix-box mx-2 fs14">Mix: {{.MixCount}} outputs of {{template "decimalParts" (amountAsDecimalParts .MixDenom false)}} DCR
+              <div class="d-inline-block mix-box mx-2 fs14">Mix: {{.MixCount}} outputs of {{if eq .CoinType 0}}{{template "decimalParts" (amountAsDecimalParts .MixDenom false)}}{{else}}{{template "decimalParts" (skaDecimalParts (printf "%d" .MixDenom) false)}}{{end}} {{coinSymbol .CoinType}}
               </div>
               {{- end}}
               {{if $.SwapsFound}}
@@ -57,8 +56,8 @@
             <div class="col-8 text-start">
                 <span class="text-secondary fs13">Total Sent</span>
                 <br>
-                <span class="lh1rem d-inline-block pt-1"
-                  ><span class="fs18 fs14-decimal fw-bold">{{template "decimalParts" (float64AsDecimalParts .Total 8 true 2)}}</span><span class="text-secondary fs14">DCR</span>
+                 <span class="lh1rem d-inline-block pt-1"
+                  ><span class="fs18 fs14-decimal fw-bold">{{if eq .CoinType 0}}{{template "decimalParts" (float64AsDecimalParts .Total 8 true 2)}}{{else}}{{template "decimalParts" (skaDecimalParts .TotalRaw true 2)}}{{end}}</span><span class="text-secondary fs14">{{coinSymbol .CoinType}}</span>
                 </span>
                 {{if $conv.Total}}
                 <br>
@@ -98,8 +97,8 @@
             <div class="col-8 text-start">
                 <span class="text-secondary fs13">Fee</span>
                 <br>
-                <span class="lh1rem d-inline-block pt-1"
-                  ><span class="fs18 fs14-decimal fw-bold">{{template "decimalParts" (float64AsDecimalParts .Fee.ToCoin 8 true 2)}}</span><span class="text-secondary fs14">DCR</span>
+                 <span class="lh1rem d-inline-block pt-1"
+                  ><span class="fs18 fs14-decimal fw-bold">{{if eq .CoinType 0}}{{template "decimalParts" (float64AsDecimalParts .Fee.ToCoin 8 true 2)}}{{else}}{{template "decimalParts" (skaDecimalParts .FeeRaw true 2)}}{{end}}</span><span class="text-secondary fs14">{{coinSymbol .CoinType}}</span>
                 </span>
                 {{if $conv.Fees}}
                 <br>
@@ -211,7 +210,7 @@
             </div>
           {{end}}
         </div>
-        <div class="col-24 col-xl-12 secondary-card py-3 px-3 px-xl-4 d-flex flex-column justify-content-between">
+        <div class="col-24 secondary-card py-3 px-3 px-xl-4 d-flex flex-column justify-content-between">
           <div class="h6 d-inline-block my-2 ps-3">Transaction Details</div>
           <table class="w-100 fs14 my-1 mb-xl-3">
             <tbody>
@@ -241,7 +240,7 @@
                 <td class="text-end medium-sans text-nowrap pe-2 py-2">Version:</td>
                 <td class="text-start py-1 text-secondary">{{.Version}}</td>
                 <td class="text-end medium-sans text-nowrap pe-2 py-2">Rate:</td>
-                <td class="text-start py-1 text-secondary">{{.FeeRate}}/kB</td>
+                <td class="text-start py-1 text-secondary">{{if eq .CoinType 0}}{{.FeeRate}}/kB{{else}}{{.FeeRateRaw}} {{coinSymbol .CoinType}}/kB{{end}}</td>
               </tr>
               <tr>
                 <td class="text-end medium-sans text-nowrap pe-2 py-2">Size:</td>
@@ -465,7 +464,7 @@
                     <th class="text-nowrap">Previous Outpoint</th>
                     <th class="addr-hash-column">Addresses</th>
                     <th class="text-center shrink-to-fit">Block</th>
-                    <th class="text-end shrink-to-fit">DCR</th>
+                    <th class="text-end shrink-to-fit">{{coinSymbol $.Data.CoinType}}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -498,7 +497,7 @@
                         {{end}}
                         </td>
                         <td class="mono fs13 text-end shrink-to-fit">{{if lt .AmountIn 0.0}} N/A {{else}}
-                        {{template "decimalParts" (float64AsDecimalParts .AmountIn 8 false)}} {{end}}
+                        {{if eq $.Data.CoinType 0}}{{template "decimalParts" (float64AsDecimalParts .AmountIn 8 false)}}{{else}}{{template "decimalParts" (skaDecimalParts .ValueRaw false)}}{{end}} {{end}}
                         </td>
                     </tr>
                     {{end}}
@@ -522,7 +521,7 @@
                     <th class="text-start shrink-to-fit">Type</th>
                     <th class="text-start shrink-to-fit"><span class="d-none d-sm-inline">Version</span><span class="d-sm-none">Ver</span></th>
                     <th class="text-start shrink-to-fit">Spent</th>
-                    <th class="text-end shrink-to-fit">DCR</th>
+                    <th class="text-end shrink-to-fit">{{coinSymbol $.Data.CoinType}}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -562,16 +561,16 @@
                               {{if $spending.Hash}}
                                  <a href="/tx/{{$spending.Hash}}/in/{{$spending.Index}}">{{$v.Spent}}</a>
                               {{else}}
-                                {{if or $v.OP_TADD (le $v.Amount 0.0)}}
+                                {{if or $v.OP_TADD (and (eq $v.CoinType 0) (le $v.Amount 0.0))}}
                                   n/a
-                                {{else if gt $v.Amount 0.0}}
+                                {{else}}
                                   {{$v.Spent}}
                                 {{end}}
                               {{end}}
                             {{end}}
                         </td>
 			                  <td class="text-end mono fs13">
-                          {{template "decimalParts" (float64AsDecimalParts .Amount 8 false)}}
+                          {{if eq $.Data.CoinType 0}}{{template "decimalParts" (float64AsDecimalParts .Amount 8 false)}}{{else}}{{template "decimalParts" (skaDecimalParts .ValueRaw false)}}{{end}}
                         </td>
                     </tr>
                     {{end}}

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -332,7 +332,7 @@ const (
 
 	UpdateAllAddressesMatchingTxHashRange = `UPDATE addresses SET matching_tx_hash=transactions.tx_hash
 		FROM vouts, transactions
-		WHERE block_height >= $1 AND block_height < $2 AND vouts.value>0 AND addresses.is_funding
+		WHERE block_height >= $1 AND block_height < $2 AND (vouts.value>0 OR vouts.coin_type > 0) AND addresses.is_funding
 			AND vouts.tx_hash=addresses.tx_hash
 			AND vouts.tx_index=addresses.tx_vin_vout_index
 			AND transactions.id=vouts.spend_tx_row_id;`
@@ -340,7 +340,7 @@ const (
 	UpdateAllAddressesMatchingTxHashRangeXX = `UPDATE addresses SET matching_tx_hash=vins.tx_hash
 		FROM vins, transactions
 		WHERE transactions.block_height >= $1 AND transactions.block_height < $2
-			AND addresses.is_funding AND addresses.value > 0 
+			AND addresses.is_funding AND (addresses.value > 0 OR addresses.coin_type > 0)
 			AND vins.prev_tx_hash=addresses.tx_hash
 			AND vins.prev_tx_index=addresses.tx_vin_vout_index
 			AND transactions.tx_hash=vins.tx_hash;`

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -119,7 +119,7 @@ const (
 	SelectUTXOs = `SELECT vouts.id, vouts.tx_hash, vouts.tx_index, vouts.script_addresses, vouts.value, vouts.mixed, vouts.coin_type, vouts.ska_value
 		FROM vouts
 		JOIN transactions ON transactions.tx_hash=vouts.tx_hash
-		WHERE vouts.spend_tx_row_id IS NULL AND vouts.value>0
+		WHERE vouts.spend_tx_row_id IS NULL AND (vouts.value>0 OR vouts.coin_type>0)
 			AND transactions.is_mainchain AND transactions.is_valid;`
 
 	SetIsValidIsMainchainByTxHash = `UPDATE vins SET is_valid = $1, is_mainchain = $2

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -43,6 +43,8 @@ import (
 	"github.com/monetarium/monetarium-explorer/stakedb"
 	"github.com/monetarium/monetarium-explorer/trylock"
 	"github.com/monetarium/monetarium-explorer/txhelpers"
+
+	"github.com/monetarium/monetarium-node/cointype"
 )
 
 var (
@@ -1211,12 +1213,36 @@ func (pgb *ChainDB) SpendingTransactions(ctx context.Context, fundingTxID string
 	}
 	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
 	defer cancel()
+
+	// 1. Check the database for confirmed spenders.
 	_, spendingTxns, vinInds, voutInds, err := retrieveSpendingTxsByFundingTx(ctx, pgb.db, ch)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, nil, nil, pgb.replaceCancelError(err)
+	}
+
 	txStrs := make([]string, len(spendingTxns))
 	for i := range spendingTxns {
 		txStrs[i] = spendingTxns[i].String()
 	}
-	return txStrs, vinInds, voutInds, pgb.replaceCancelError(err)
+
+	// 2. Check the mempool for unconfirmed spenders.
+	mph, mpvi, mpvoi := pgb.MPC.Spenders(fundingTxID)
+	if len(mph) > 0 {
+		// Only add those that are not already in the DB results.
+		isSpent := make(map[uint32]bool)
+		for _, vi := range voutInds {
+			isSpent[vi] = true
+		}
+		for i, vi := range mpvoi {
+			if !isSpent[vi] {
+				txStrs = append(txStrs, mph[i])
+				vinInds = append(vinInds, mpvi[i])
+				voutInds = append(voutInds, vi)
+			}
+		}
+	}
+
+	return txStrs, vinInds, voutInds, nil
 }
 
 // SpendingTransaction returns the transaction that spends the specified
@@ -1227,10 +1253,27 @@ func (pgb *ChainDB) SpendingTransaction(ctx context.Context, fundingTxID string,
 	if err != nil {
 		return "", 0, err
 	}
+
+	// 1. Check the database for a confirmed spender.
 	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
 	defer cancel()
 	_, spendingTx, vinInd, err := retrieveSpendingTxByTxOut(ctx, pgb.db, ch, fundingTxVout)
-	return spendingTx.String(), vinInd, pgb.replaceCancelError(err)
+	if err == nil {
+		return spendingTx.String(), vinInd, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", 0, pgb.replaceCancelError(err)
+	}
+
+	// 2. Check the mempool for an unconfirmed spender.
+	mph, mpvi, mpvoi := pgb.MPC.Spenders(fundingTxID)
+	for i, vi := range mpvoi {
+		if vi == fundingTxVout {
+			return mph[i], mpvi[i], nil
+		}
+	}
+
+	return "", 0, dbtypes.ErrNoResult
 }
 
 // BlockTransactions retrieves all transactions in the specified block, their
@@ -4265,8 +4308,8 @@ func (pgb *ChainDB) updateUtxoCache(dbVouts [][]*dbtypes.Vout, txns []*dbtypes.T
 	for it, tx := range txns {
 		utxos := make([]*dbtypes.UTXO, 0, tx.NumVout)
 		for iv, vout := range dbVouts[it] {
-			// Do not store zero-value output data.
-			if vout.Value == 0 {
+			// Do not store zero-value output data, unless it is an SKA output.
+			if vout.Value == 0 && vout.CoinType == uint8(cointype.CoinTypeVAR) {
 				continue
 			}
 
@@ -6821,9 +6864,33 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 		})
 	}
 	tx.Vout = outputs
+	sort.Slice(tx.Vout, func(i, j int) bool {
+		return tx.Vout[i].Index < tx.Vout[j].Index
+	})
 
 	// Initialize the spending transaction slice for safety.
-	tx.SpendingTxns = make([]exptypes.TxInID, len(outputs))
+	tx.SpendingTxns = make([]exptypes.TxInID, len(tx.Vout))
+	spendHashes, spendVinInds, spendVoutInds, err := pgb.SpendingTransactions(ctx, txid)
+	if err == nil {
+		for i := range spendHashes {
+			voutIdx := spendVoutInds[i]
+			if int(voutIdx) < len(tx.SpendingTxns) {
+				tx.SpendingTxns[voutIdx] = exptypes.TxInID{
+					Hash:  spendHashes[i],
+					Index: spendVinInds[i],
+				}
+				// Mark as spent in Vout slice. Note that Vout is sorted by index.
+				for j := range tx.Vout {
+					if tx.Vout[j].Index == voutIdx {
+						tx.Vout[j].Spent = true
+						break
+					}
+				}
+			}
+		}
+	} else {
+		log.Errorf("SpendingTransactions failed for %s: %v", txid, err)
+	}
 
 	return tx
 }

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -5030,6 +5031,12 @@ func (pgb *ChainDB) GetAPITransaction(ctx context.Context, txid *chainhash.Hash)
 
 	txTree := txhelpers.TxTree(msgTx)
 
+	// Determine transaction CoinType.
+	var coinType uint8
+	if len(msgTx.TxOut) > 0 {
+		coinType = uint8(msgTx.TxOut[0].CoinType)
+	}
+
 	tx := &apitypes.Tx{
 		TxShort: apitypes.TxShort{
 			TxID:     txraw.Txid,
@@ -5041,6 +5048,7 @@ func (pgb *ChainDB) GetAPITransaction(ctx context.Context, txid *chainhash.Hash)
 			Vout:     make([]apitypes.Vout, len(txraw.Vout)),
 			Tree:     txTree,
 			Type:     strings.ToLower(txhelpers.TxTypeToString(int(txTree))),
+			CoinType: coinType,
 		},
 		Confirmations: txraw.Confirmations,
 		Block: &apitypes.BlockID{
@@ -5052,11 +5060,96 @@ func (pgb *ChainDB) GetAPITransaction(ctx context.Context, txid *chainhash.Hash)
 		},
 	}
 
-	copy(tx.Vin, txraw.Vin)
+	// Calculate high-precision total and fee.
+	if coinType == 0 { // VAR
+		tx.Total = strconv.FormatInt(int64(txhelpers.TotalVout(txraw.Vout)), 10)
+		fee, _ := txhelpers.TxFeeRate(msgTx)
+		tx.Fee = strconv.FormatInt(int64(fee), 10)
+	} else { // SKA
+		skaTotals := txhelpers.SKATotalsFromMsgTx(msgTx)
+		if total, ok := skaTotals[coinType]; ok {
+			tx.Total = total
+		} else {
+			tx.Total = "0"
+		}
+
+		// Calculate SKA Fee: TotalIn - TotalOut
+		totalIn := new(big.Int)
+		for i := range msgTx.TxIn {
+			prevOut := &msgTx.TxIn[i].PreviousOutPoint
+			if txhelpers.IsZeroHash(prevOut.Hash) {
+				continue
+			}
+			outInfo, err := txhelpers.OutPointAddressesAll(prevOut, pgb.Client, pgb.chainParams)
+			if err == nil && outInfo.ValueSKA != nil {
+				totalIn.Add(totalIn, outInfo.ValueSKA)
+			}
+		}
+		totalOut := new(big.Int)
+		if totalStr, ok := skaTotals[coinType]; ok {
+			totalOut.SetString(totalStr, 10)
+		}
+		tx.Fee = new(big.Int).Sub(totalIn, totalOut).String()
+
+		// Calculate SKA FeeRate (SKA atoms / kB)
+		txSize := int64(msgTx.SerializeSize())
+		if txSize > 0 {
+			fee := new(big.Int).Sub(totalIn, totalOut)
+			rate := new(big.Int).Mul(fee, big.NewInt(1000))
+			rate.Quo(rate, big.NewInt(txSize))
+			tx.FeeRateRaw = rate.String()
+			tx.FeeRate = "0" // Clear legacy string representation
+		}
+	}
+
+	for i := range txraw.Vin {
+		vin := &txraw.Vin[i]
+		tx.Vin[i].Coinbase = vin.Coinbase
+		tx.Vin[i].Stakebase = vin.Stakebase
+		tx.Vin[i].Treasurybase = vin.Treasurybase
+		tx.Vin[i].Txid = vin.Txid
+		tx.Vin[i].Vout = vin.Vout
+		tx.Vin[i].Tree = vin.Tree
+		tx.Vin[i].Sequence = vin.Sequence
+		tx.Vin[i].AmountIn = vin.AmountIn
+		tx.Vin[i].BlockHeight = vin.BlockHeight
+		tx.Vin[i].BlockIndex = vin.BlockIndex
+		if vin.ScriptSig != nil {
+			tx.Vin[i].ScriptSig = &apitypes.ScriptSig{
+				Asm: vin.ScriptSig.Asm,
+				Hex: vin.ScriptSig.Hex,
+			}
+		}
+
+		// High-precision Vin
+		var valueInRaw string
+		var ct uint8
+		vinMsg := msgTx.TxIn[i]
+		if !txhelpers.IsZeroHash(vinMsg.PreviousOutPoint.Hash) {
+			outInfo, err := txhelpers.OutPointAddressesAll(&vinMsg.PreviousOutPoint, pgb.Client, pgb.chainParams)
+			if err == nil {
+				ct = uint8(outInfo.CoinType)
+				if ct == 0 {
+					valueInRaw = strconv.FormatInt(int64(outInfo.Value), 10)
+				} else if outInfo.ValueSKA != nil {
+					valueInRaw = outInfo.ValueSKA.String()
+				}
+			}
+		}
+		tx.Vin[i].ValueInRaw = valueInRaw
+		tx.Vin[i].CoinType = ct
+	}
 
 	for i := range txraw.Vout {
 		vout := &txraw.Vout[i]
 		tx.Vout[i].Value = vout.Value
+		var valueRaw string
+		if vout.CoinType == 0 { // VAR
+			valueRaw = strconv.FormatInt(int64(dcrutil.Amount(vout.Value*1e8)), 10)
+		} else { // SKA
+			valueRaw = vout.SKAValue
+		}
+		tx.Vout[i].ValueRaw = valueRaw
 		tx.Vout[i].N = vout.N
 		tx.Vout[i].Version = vout.Version
 		tx.Vout[i].CoinType = vout.CoinType
@@ -5089,12 +5182,17 @@ func (pgb *ChainDB) GetTrimmedTransaction(ctx context.Context, txid *chainhash.H
 		return nil
 	}
 	return &apitypes.TrimmedTx{
-		TxID:     tx.TxID,
-		Version:  tx.Version,
-		Locktime: tx.Locktime,
-		Expiry:   tx.Expiry,
-		Vin:      tx.Vin,
-		Vout:     tx.Vout,
+		TxID:       tx.TxID,
+		Version:    tx.Version,
+		Locktime:   tx.Locktime,
+		Expiry:     tx.Expiry,
+		Vin:        tx.Vin,
+		Vout:       tx.Vout,
+		CoinType:   tx.CoinType,
+		Total:      tx.Total,
+		Fee:        tx.Fee,
+		FeeRate:    tx.FeeRate,
+		FeeRateRaw: tx.FeeRateRaw,
 	}
 }
 
@@ -5938,19 +6036,50 @@ func makeExplorerBlockBasic(data *chainjson.GetBlockVerboseResult, params *chain
 func makeExplorerTxBasic(data *chainjson.TxRawResult, ticketPrice int64, msgTx *wire.MsgTx, params *chaincfg.Params) (*exptypes.TxBasic, stake.TxType) {
 	txType := txhelpers.DetermineTxType(msgTx)
 
+	// Determine transaction CoinType.
+	var coinType uint8
+	if len(msgTx.TxOut) > 0 {
+		coinType = uint8(msgTx.TxOut[0].CoinType)
+	}
+
 	tx := &exptypes.TxBasic{
 		TxID:          data.Txid,
 		Type:          txhelpers.TxTypeToString(int(txType)),
 		Version:       data.Version,
 		FormattedSize: humanize.Bytes(uint64(len(data.Hex) / 2)),
-		Total:         txhelpers.TotalVout(data.Vout).ToCoin(),
+		CoinType:      coinType,
 	}
-	tx.Fee, tx.FeeRate = txhelpers.TxFeeRate(msgTx)
+
+	// Calculate high-precision total and fee.
+	if coinType == 0 { // VAR
+		tx.Total = txhelpers.TotalVout(data.Vout).ToCoin()
+		tx.TotalRaw = strconv.FormatInt(int64(txhelpers.TotalVout(data.Vout)), 10)
+		fee, feeRate := txhelpers.TxFeeRate(msgTx)
+		tx.Fee, tx.FeeRate = fee, feeRate
+		tx.FeeRaw = strconv.FormatInt(int64(fee), 10)
+	} else { // SKA
+		// For SKA, Total is 0 in legacy float.
+		tx.Total = 0
+		skaTotals := txhelpers.SKATotalsFromMsgTx(msgTx)
+		if total, ok := skaTotals[coinType]; ok {
+			tx.TotalRaw = total
+		} else {
+			tx.TotalRaw = "0"
+		}
+
+		// SKA Fee calculation skipped here; handled in GetExplorerTx and GetAPITransaction
+		// which have access to the DB client for prevout lookups.
+		tx.FeeRaw = "0"
+		tx.Fee = 0 // Deprecated float
+		tx.FeeRate = 0
+		tx.FeeRateRaw = "0"
+	}
 
 	v0 := &data.Vin[0]
 	switch {
 	case v0.IsCoinBase():
 		tx.Fee, tx.FeeRate = 0, 0
+		tx.FeeRaw = "0"
 		tx.Coinbase = true
 	case v0.Treasurybase:
 		tx.Treasurybase = true
@@ -6384,6 +6513,8 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 		Time:          exptypes.NewTimeDefFromUNIX(txraw.Time),
 	}
 
+	totalInSKA := new(big.Int)
+
 	inputs := make([]exptypes.Vin, 0, len(txraw.Vin))
 	for i := range txraw.Vin {
 		vin := &txraw.Vin[i]
@@ -6396,15 +6527,21 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 		// Do not attempt to look up prevout if it is a coinbase or stakebase
 		// input, which does not spend a previous output.
 		prevOut := &msgTx.TxIn[i].PreviousOutPoint
+		var outInfo *txhelpers.OutPointInfo
 		if !txhelpers.IsZeroHash(prevOut.Hash) {
 			// Store the vin amount for comparison.
 			valueIn0 := valueIn
 
-			addresses, valueIn, err = txhelpers.OutPointAddresses(
+			outInfo, err = txhelpers.OutPointAddressesAll(
 				prevOut, pgb.Client, pgb.chainParams)
 			if err != nil {
 				log.Warnf("Failed to get outpoint address from txid: %v", err)
 				continue
+			}
+			valueIn = outInfo.Value
+			addresses = outInfo.Addresses
+			if tx.CoinType != 0 && outInfo.ValueSKA != nil {
+				totalInSKA.Add(totalInSKA, outInfo.ValueSKA)
 			}
 			// See if getrawtransaction had correct vin amounts. It should
 			// except for votes on side chain blocks.
@@ -6435,15 +6572,51 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 		}
 
 		// Assemble and append this vin.
+		var valueRaw string
+		var skaValue string
+		if outInfo != nil {
+			if outInfo.CoinType == 0 { // VAR
+				valueRaw = strconv.FormatInt(int64(outInfo.Value), 10)
+			} else { // SKA
+				if outInfo.ValueSKA != nil {
+					valueRaw = outInfo.ValueSKA.String()
+					skaValue = valueRaw
+				} else {
+					valueRaw = "0"
+				}
+			}
+		}
+
 		coinIn := valueIn.ToCoin()
 		inputs = append(inputs, exptypes.Vin{
 			Vin:             vin,
 			Addresses:       addresses,
 			FormattedAmount: humanize.Commaf(coinIn),
+			ValueRaw:        valueRaw,
 			Index:           uint32(i),
+			CoinType:        uint8(outInfo.CoinType),
+			SKAValue:        skaValue,
 		})
 	}
 	tx.Vin = inputs
+
+	// Calculate SKA fee if applicable
+	if tx.CoinType != 0 {
+		totalOutSKA := new(big.Int)
+		if tx.TotalRaw != "" {
+			totalOutSKA.SetString(tx.TotalRaw, 10)
+		}
+		fee := new(big.Int).Sub(totalInSKA, totalOutSKA)
+		tx.FeeRaw = fee.String()
+		// Calculate FeeRateRaw (SKA atoms / KB)
+		txSize := int64(msgTx.SerializeSize())
+		if txSize > 0 {
+			rate := new(big.Int).Mul(fee, big.NewInt(1000))
+			rate.Quo(rate, big.NewInt(txSize))
+			tx.FeeRateRaw = rate.String()
+			tx.FeeRate = dcrutil.Amount(0) // Clear legacy float representation
+		}
+	}
 
 	if isVote := tx.IsVote(); isVote || tx.IsTicket() {
 		if tx.Confirmations > 0 && pgb.Height() >=
@@ -6639,9 +6812,17 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 		if scriptClass == dbtypes.SCNullData && spk.CommitAmt != nil {
 			scriptClass = dbtypes.SCStakeSubCommit
 		}
+		var valueRaw string
+		if vout.CoinType == 0 { // VAR
+			valueRaw = strconv.FormatInt(int64(dcrutil.Amount(vout.Value*1e8)), 10)
+		} else { // SKA
+			valueRaw = vout.SKAValue
+		}
+
 		outputs = append(outputs, exptypes.Vout{
 			Addresses:       spk.Addresses,
 			Amount:          vout.Value,
+			ValueRaw:        valueRaw,
 			FormattedAmount: humanize.Commaf(vout.Value),
 			OP_RETURN:       opReturn,
 			OP_TADD:         opTAdd,
@@ -6649,6 +6830,8 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 			Spent:           spent,
 			Index:           vout.N,
 			Version:         version,
+			CoinType:        uint8(vout.CoinType),
+			SKAValue:        vout.SKAValue,
 		})
 	}
 	tx.Vout = outputs

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -5073,16 +5073,13 @@ func (pgb *ChainDB) GetAPITransaction(ctx context.Context, txid *chainhash.Hash)
 			tx.Total = "0"
 		}
 
-		// Calculate SKA Fee: TotalIn - TotalOut
+		// Calculate SKA Fee: TotalIn - TotalOut (from node response via skaamountin)
 		totalIn := new(big.Int)
-		for i := range msgTx.TxIn {
-			prevOut := &msgTx.TxIn[i].PreviousOutPoint
-			if txhelpers.IsZeroHash(prevOut.Hash) {
-				continue
-			}
-			outInfo, err := txhelpers.OutPointAddressesAll(prevOut, pgb.Client, pgb.chainParams)
-			if err == nil && outInfo.ValueSKA != nil {
-				totalIn.Add(totalIn, outInfo.ValueSKA)
+		for _, vin := range txraw.Vin {
+			if vin.SKAAmountIn != "" {
+				if amt, ok := new(big.Int).SetString(vin.SKAAmountIn, 10); ok {
+					totalIn.Add(totalIn, amt)
+				}
 			}
 		}
 		totalOut := new(big.Int)
@@ -5112,6 +5109,7 @@ func (pgb *ChainDB) GetAPITransaction(ctx context.Context, txid *chainhash.Hash)
 		tx.Vin[i].Tree = vin.Tree
 		tx.Vin[i].Sequence = vin.Sequence
 		tx.Vin[i].AmountIn = vin.AmountIn
+		tx.Vin[i].SKAAmountIn = vin.SKAAmountIn
 		tx.Vin[i].BlockHeight = vin.BlockHeight
 		tx.Vin[i].BlockIndex = vin.BlockIndex
 		if vin.ScriptSig != nil {
@@ -5121,23 +5119,13 @@ func (pgb *ChainDB) GetAPITransaction(ctx context.Context, txid *chainhash.Hash)
 			}
 		}
 
-		// High-precision Vin
-		var valueInRaw string
-		var ct uint8
-		vinMsg := msgTx.TxIn[i]
-		if !txhelpers.IsZeroHash(vinMsg.PreviousOutPoint.Hash) {
-			outInfo, err := txhelpers.OutPointAddressesAll(&vinMsg.PreviousOutPoint, pgb.Client, pgb.chainParams)
-			if err == nil {
-				ct = uint8(outInfo.CoinType)
-				if ct == 0 {
-					valueInRaw = strconv.FormatInt(int64(outInfo.Value), 10)
-				} else if outInfo.ValueSKA != nil {
-					valueInRaw = outInfo.ValueSKA.String()
-				}
-			}
+		// High-precision Vin (from node response via skaamountin)
+		if coinType == 0 { // VAR
+			tx.Vin[i].ValueInRaw = strconv.FormatInt(int64(vin.AmountIn*1e8), 10)
+		} else { // SKA
+			tx.Vin[i].ValueInRaw = vin.SKAAmountIn
 		}
-		tx.Vin[i].ValueInRaw = valueInRaw
-		tx.Vin[i].CoinType = ct
+		tx.Vin[i].CoinType = coinType
 	}
 
 	for i := range txraw.Vout {
@@ -6518,6 +6506,13 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 	inputs := make([]exptypes.Vin, 0, len(txraw.Vin))
 	for i := range txraw.Vin {
 		vin := &txraw.Vin[i]
+		// Accumulate SKA input amount from node response (skaamountin)
+		if tx.CoinType != 0 && vin.SKAAmountIn != "" {
+			if amt, ok := new(big.Int).SetString(vin.SKAAmountIn, 10); ok {
+				totalInSKA.Add(totalInSKA, amt)
+			}
+		}
+
 		// The addresses are may only be obtained by decoding the previous
 		// output's pkscript.
 		var addresses []string
@@ -6540,9 +6535,6 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 			}
 			valueIn = outInfo.Value
 			addresses = outInfo.Addresses
-			if tx.CoinType != 0 && outInfo.ValueSKA != nil {
-				totalInSKA.Add(totalInSKA, outInfo.ValueSKA)
-			}
 			// See if getrawtransaction had correct vin amounts. It should
 			// except for votes on side chain blocks.
 			if valueIn != valueIn0 {
@@ -6571,20 +6563,14 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 			}
 		}
 
-		// Assemble and append this vin.
+		// Assemble and append this vin (values from node response via skaamountin)
 		var valueRaw string
 		var skaValue string
-		if outInfo != nil {
-			if outInfo.CoinType == 0 { // VAR
-				valueRaw = strconv.FormatInt(int64(outInfo.Value), 10)
-			} else { // SKA
-				if outInfo.ValueSKA != nil {
-					valueRaw = outInfo.ValueSKA.String()
-					skaValue = valueRaw
-				} else {
-					valueRaw = "0"
-				}
-			}
+		if tx.CoinType == 0 { // VAR
+			valueRaw = strconv.FormatInt(int64(vin.AmountIn*1e8), 10)
+		} else { // SKA
+			valueRaw = vin.SKAAmountIn
+			skaValue = valueRaw
 		}
 
 		coinIn := valueIn.ToCoin()
@@ -6594,7 +6580,7 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 			FormattedAmount: humanize.Commaf(coinIn),
 			ValueRaw:        valueRaw,
 			Index:           uint32(i),
-			CoinType:        uint8(outInfo.CoinType),
+			CoinType:        tx.CoinType,
 			SKAValue:        skaValue,
 		})
 	}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -170,7 +170,7 @@ func (u *utxoStore) Peek(txHash dbtypes.ChainHash, txIndex uint32) *dbtypes.UTXO
 	return txVals[txIndex]
 }
 
-func (u *utxoStore) set(txHash dbtypes.ChainHash, txIndex uint32, voutDbID int64, addrs []string, val int64, mixed bool) {
+func (u *utxoStore) set(txHash dbtypes.ChainHash, txIndex uint32, voutDbID int64, addrs []string, val int64, mixed bool, coinType uint8) {
 	txUTXOVals, ok := u.c[txHash]
 	if !ok {
 		u.c[txHash] = map[uint32]*dbtypes.UTXOData{
@@ -179,6 +179,7 @@ func (u *utxoStore) set(txHash dbtypes.ChainHash, txIndex uint32, voutDbID int64
 				Value:     val,
 				Mixed:     mixed,
 				VoutDbID:  voutDbID,
+				CoinType:  coinType,
 			},
 		}
 	} else {
@@ -187,16 +188,17 @@ func (u *utxoStore) set(txHash dbtypes.ChainHash, txIndex uint32, voutDbID int64
 			Value:     val,
 			Mixed:     mixed,
 			VoutDbID:  voutDbID,
+			CoinType:  coinType,
 		}
 	}
 }
 
 // Set stores the addresses and amount in a UTXOData entry in the cache for the
 // given outpoint.
-func (u *utxoStore) Set(txHash dbtypes.ChainHash, txIndex uint32, voutDbID int64, addrs []string, val int64, mixed bool) {
+func (u *utxoStore) Set(txHash dbtypes.ChainHash, txIndex uint32, voutDbID int64, addrs []string, val int64, mixed bool, coinType uint8) {
 	u.Lock()
 	defer u.Unlock()
-	u.set(txHash, txIndex, voutDbID, addrs, val, mixed)
+	u.set(txHash, txIndex, voutDbID, addrs, val, mixed, coinType)
 }
 
 // Reinit re-initializes the utxoStore with the given UTXOs.
@@ -211,7 +213,7 @@ func (u *utxoStore) Reinit(utxos []dbtypes.UTXO) {
 	prealloc := 2 * len(utxos) / 3
 	u.c = make(map[dbtypes.ChainHash]map[uint32]*dbtypes.UTXOData, prealloc)
 	for i := range utxos {
-		u.set(utxos[i].TxHash, utxos[i].TxIndex, utxos[i].VoutDbID, utxos[i].Addresses, utxos[i].Value, utxos[i].Mixed)
+		u.set(utxos[i].TxHash, utxos[i].TxIndex, utxos[i].VoutDbID, utxos[i].Addresses, utxos[i].Value, utxos[i].Mixed, utxos[i].CoinType)
 	}
 }
 
@@ -3931,7 +3933,7 @@ txns:
 				}
 				// Remember this for insertSpendingAddressRow.
 				pgb.utxoCache.Set(vin.PrevTxHash, vin.PrevTxIndex,
-					utxo.VoutDbID, utxo.Addresses, utxo.Value, utxo.Mixed)
+					utxo.VoutDbID, utxo.Addresses, utxo.Value, utxo.Mixed, utxo.CoinType)
 			}
 			if !utxo.Mixed {
 				continue txns
@@ -4327,13 +4329,14 @@ func (pgb *ChainDB) updateUtxoCache(dbVouts [][]*dbtypes.Vout, txns []*dbtypes.T
 					Value:     int64(vout.Value),
 					Mixed:     vout.Mixed,
 					VoutDbID:  voutDbID,
+					CoinType:  vout.CoinType,
 				},
 			})
 		}
 
 		// Store each output of this transaction in the UTXO cache.
 		for _, utxo := range utxos {
-			pgb.utxoCache.Set(utxo.TxHash, utxo.TxIndex, utxo.VoutDbID, utxo.Addresses, utxo.Value, utxo.Mixed)
+			pgb.utxoCache.Set(utxo.TxHash, utxo.TxIndex, utxo.VoutDbID, utxo.Addresses, utxo.Value, utxo.Mixed, utxo.CoinType)
 		}
 	}
 }
@@ -4342,12 +4345,11 @@ func (pgb *ChainDB) flattenAddressRows(dbAddressRows [][]dbtypes.AddressRow, txn
 	var totalAddressRows int
 	for it := range dbAddressRows {
 		for ia := range dbAddressRows[it] {
-			if dbAddressRows[it][ia].Value > 0 {
+			if dbAddressRows[it][ia].Value > 0 || dbAddressRows[it][ia].CoinType > 0 {
 				totalAddressRows++
 			}
 		}
 	}
-
 	dbAddressRowsFlat := make([]*dbtypes.AddressRow, 0, totalAddressRows)
 
 	for it, tx := range txns {
@@ -4365,8 +4367,8 @@ func (pgb *ChainDB) flattenAddressRows(dbAddressRows [][]dbtypes.AddressRow, txn
 			// Transaction that pays to the address
 			dba := &dbAddressRows[it][ia]
 
-			// Do not store zero-value output data.
-			if dba.Value == 0 {
+			// Do not store zero-value output data, unless it is an SKA output.
+			if dba.Value == 0 && dba.CoinType == 0 {
 				continue
 			}
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1220,9 +1220,9 @@ func (pgb *ChainDB) SpendingTransactions(ctx context.Context, fundingTxID string
 		return nil, nil, nil, pgb.replaceCancelError(err)
 	}
 
-	txStrs := make([]string, len(spendingTxns))
+	txStrs := make([]string, 0, len(spendingTxns))
 	for i := range spendingTxns {
-		txStrs[i] = spendingTxns[i].String()
+		txStrs = append(txStrs, spendingTxns[i].String())
 	}
 
 	// 2. Check the mempool for unconfirmed spenders.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -5166,7 +5166,8 @@ func (pgb *ChainDB) GetAPITransaction(ctx context.Context, txid *chainhash.Hash)
 
 		// High-precision Vin (from node response via skaamountin)
 		if coinType == 0 { // VAR
-			tx.Vin[i].ValueInRaw = strconv.FormatInt(int64(vin.AmountIn*1e8), 10)
+			// Use exact atom value from the node's wire transaction to avoid float64 round-trip.
+			tx.Vin[i].ValueInRaw = strconv.FormatInt(msgTx.TxIn[i].ValueIn, 10)
 		} else { // SKA
 			tx.Vin[i].ValueInRaw = vin.SKAAmountIn
 		}
@@ -5178,7 +5179,8 @@ func (pgb *ChainDB) GetAPITransaction(ctx context.Context, txid *chainhash.Hash)
 		tx.Vout[i].Value = vout.Value
 		var valueRaw string
 		if vout.CoinType == 0 { // VAR
-			valueRaw = strconv.FormatInt(int64(dcrutil.Amount(vout.Value*1e8)), 10)
+			// Get exact atom value from the node's wire transaction to avoid float64 round-trip.
+			valueRaw = strconv.FormatInt(msgTx.TxOut[i].Value, 10)
 		} else { // SKA
 			valueRaw = vout.SKAValue
 		}
@@ -6085,8 +6087,9 @@ func makeExplorerTxBasic(data *chainjson.TxRawResult, ticketPrice int64, msgTx *
 
 	// Calculate high-precision total and fee.
 	if coinType == 0 { // VAR
-		tx.Total = txhelpers.TotalVout(data.Vout).ToCoin()
-		tx.TotalRaw = strconv.FormatInt(int64(txhelpers.TotalVout(data.Vout)), 10)
+		totalAtoms := txhelpers.TotalVout(data.Vout)
+		tx.Total = totalAtoms.ToCoin()
+		tx.TotalRaw = strconv.FormatInt(int64(totalAtoms), 10)
 		fee, feeRate := txhelpers.TxFeeRate(msgTx)
 		tx.Fee, tx.FeeRate = fee, feeRate
 		tx.FeeRaw = strconv.FormatInt(int64(fee), 10)
@@ -6103,8 +6106,8 @@ func makeExplorerTxBasic(data *chainjson.TxRawResult, ticketPrice int64, msgTx *
 		// SKA Fee calculation skipped here; handled in GetExplorerTx and GetAPITransaction
 		// which have access to the DB client for prevout lookups.
 		tx.FeeRaw = "0"
-		tx.Fee = 0 // Deprecated float
-		tx.FeeRate = 0
+		tx.Fee = 0     // Deprecated int64 atoms (formerly dcrutil.Amount)
+		tx.FeeRate = 0 // Deprecated int64 atoms (formerly dcrutil.Amount)
 		tx.FeeRateRaw = "0"
 	}
 
@@ -6575,11 +6578,12 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 			outInfo, err = txhelpers.OutPointAddressesAll(
 				prevOut, pgb.Client, pgb.chainParams)
 			if err != nil {
-				log.Warnf("Failed to get outpoint address from txid: %v", err)
-				continue
+				log.Warnf("Failed to get outpoint address for vin %d of tx %v: %v", i, txid, err)
+				// Do not skip the input; proceed with empty addresses to preserve order.
+			} else {
+				valueIn = outInfo.Value
+				addresses = outInfo.Addresses
 			}
-			valueIn = outInfo.Value
-			addresses = outInfo.Addresses
 			// See if getrawtransaction had correct vin amounts. It should
 			// except for votes on side chain blocks.
 			if valueIn != valueIn0 {
@@ -6612,7 +6616,8 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 		var valueRaw string
 		var skaValue string
 		if tx.CoinType == 0 { // VAR
-			valueRaw = strconv.FormatInt(int64(vin.AmountIn*1e8), 10)
+			// Use exact atom value to avoid float64 round-trip.
+			valueRaw = strconv.FormatInt(int64(valueIn), 10)
 		} else { // SKA
 			valueRaw = vin.SKAAmountIn
 			skaValue = valueRaw
@@ -6638,7 +6643,11 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 			totalOutSKA.SetString(tx.TotalRaw, 10)
 		}
 		fee := new(big.Int).Sub(totalInSKA, totalOutSKA)
+		if fee.Sign() < 0 {
+			fee.SetInt64(0)
+		}
 		tx.FeeRaw = fee.String()
+		// TODO: Address C3 WebSocket parity for SKA confirmed transactions.
 		// Calculate FeeRateRaw (SKA atoms / KB)
 		txSize := int64(msgTx.SerializeSize())
 		if txSize > 0 {
@@ -6845,7 +6854,8 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 		}
 		var valueRaw string
 		if vout.CoinType == 0 { // VAR
-			valueRaw = strconv.FormatInt(int64(dcrutil.Amount(vout.Value*1e8)), 10)
+			// Get exact atom value from the node's wire transaction to avoid float64 round-trip.
+			valueRaw = strconv.FormatInt(msgTx.TxOut[i].Value, 10)
 		} else { // SKA
 			valueRaw = vout.SKAValue
 		}
@@ -6866,9 +6876,7 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 		})
 	}
 	tx.Vout = outputs
-	sort.Slice(tx.Vout, func(i, j int) bool {
-		return tx.Vout[i].Index < tx.Vout[j].Index
-	})
+	// Redundant sort removed (txraw.Vout is index-ordered from the node).
 
 	// Initialize the spending transaction slice for safety.
 	tx.SpendingTxns = make([]exptypes.TxInID, len(tx.Vout))

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6830,7 +6830,7 @@ func (pgb *ChainDB) GetExplorerTx(ctx context.Context, txid string) *exptypes.Tx
 			Spent:           spent,
 			Index:           vout.N,
 			Version:         version,
-			CoinType:        uint8(vout.CoinType),
+			CoinType:        vout.CoinType,
 			SKAValue:        vout.SKAValue,
 		})
 	}

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -749,6 +749,34 @@ func getTxFromList(txid string, txns []MempoolTx) (MempoolTx, bool) {
 	return MempoolTx{}, false
 }
 
+// Spenders searches all transaction lists in MempoolInfo for transactions
+// spending from the specified funding transaction. It returns a map of funding
+// output indexes to the spending transaction identify (hash and input index).
+func (mpi *MempoolInfo) Spenders(fundingTxID string) map[uint32]TxInID {
+	mpi.RLock()
+	defer mpi.RUnlock()
+	spenders := make(map[uint32]TxInID)
+	search := func(txns []MempoolTx) {
+		for _, tx := range txns {
+			for i, vin := range tx.Vin {
+				if vin.TxId == fundingTxID {
+					spenders[vin.Outdex] = TxInID{
+						Hash:  tx.TxID,
+						Index: uint32(i),
+					}
+				}
+			}
+		}
+	}
+	search(mpi.Transactions)
+	search(mpi.Tickets)
+	search(mpi.Votes)
+	search(mpi.Revocations)
+	search(mpi.TSpends)
+	search(mpi.TAdds)
+	return spenders
+}
+
 // Tx checks the inventory and searches the appropriate lists for a
 // transaction matching the provided transaction ID.
 func (mpi *MempoolInfo) Tx(txid string) (MempoolTx, bool) {

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -186,15 +186,20 @@ type TxBasic struct {
 	Type          string
 	Version       int32
 	FormattedSize string
-	Total         float64
-	Fee           dcrutil.Amount
+	Total         float64        // Deprecated: use TotalRaw
+	TotalRaw      string         // Atom string
+	Fee           dcrutil.Amount // Deprecated: use FeeRaw
+	FeeRaw        string         // Atom string
 	FeeRate       dcrutil.Amount
-	VoteInfo      *VoteInfo
-	Coinbase      bool
-	Treasurybase  bool
-	MixCount      uint32
-	MixDenom      int64
-	SKASent       map[uint8]string
+	FeeRateRaw    string
+	Size          int32
+	*VoteInfo
+	Coinbase     bool
+	Treasurybase bool
+	MixCount     uint32
+	MixDenom     int64
+	CoinType     uint8
+	SKASent      map[uint8]string // Deprecated: use TotalRaw + CoinType
 }
 
 // TrimmedTxInfo for use with /visualblocks
@@ -448,6 +453,7 @@ type Vin struct {
 	*chainjson.Vin
 	Addresses       []string
 	FormattedAmount string
+	ValueRaw        string // Atom string
 	Index           uint32
 	DisplayText     string
 	TextIsHash      bool
@@ -459,7 +465,8 @@ type Vin struct {
 // Vout models basic data about a tx output for display
 type Vout struct {
 	Addresses       []string
-	Amount          float64
+	Amount          float64 // Deprecated: use SKAValue or ValueRaw
+	ValueRaw        string  // Atom string
 	FormattedAmount string
 	Type            string
 	Spent           bool

--- a/mempool/mempoolcache.go
+++ b/mempool/mempoolcache.go
@@ -212,3 +212,25 @@ func (c *DataCache) GetTicketPriceCountTime(feeAvgLength int) *apitypes.PriceCou
 		Time:  dbtypes.NewTimeDef(c.timestamp),
 	}
 }
+
+// Spenders searches all transactions in the mempool cache for transactions
+// spending from the specified funding transaction. It returns the spending
+// transaction hashes, input indexes, and the corresponding funding transaction
+// output indexes.
+func (c *DataCache) Spenders(fundingTxID string) ([]string, []uint32, []uint32) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	var hashes []string
+	var vinInds []uint32
+	var voutInds []uint32
+	for _, tx := range c.txns {
+		for i, vin := range tx.Vin {
+			if vin.TxId == fundingTxID {
+				hashes = append(hashes, tx.TxID)
+				vinInds = append(vinInds, uint32(i))
+				voutInds = append(voutInds, vin.Outdex)
+			}
+		}
+	}
+	return hashes, vinInds, voutInds
+}

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -740,33 +740,53 @@ func BlockReceivesToAddresses(block *dcrutil.Block, addrs map[string]TxAction,
 	return addrMap
 }
 
+// OutPointInfo models addresses, coin type and high-precision value of a transaction output.
+type OutPointInfo struct {
+	Addresses []string
+	CoinType  cointype.CoinType
+	Value     dcrutil.Amount // VAR atoms
+	ValueSKA  *big.Int       // SKA atoms
+}
+
 // OutPointAddresses gets the addresses paid to by a transaction output.
 func OutPointAddresses(outPoint *wire.OutPoint, c RawTransactionGetter,
 	params *chaincfg.Params) ([]string, dcrutil.Amount, error) {
+	inf, err := OutPointAddressesAll(outPoint, c, params)
+	if err != nil {
+		return nil, 0, err
+	}
+	return inf.Addresses, inf.Value, nil
+}
+
+// OutPointAddressesAll gets the addresses, coin type and amounts of a transaction output.
+func OutPointAddressesAll(outPoint *wire.OutPoint, c RawTransactionGetter,
+	params *chaincfg.Params) (*OutPointInfo, error) {
 	// The addresses are encoded in the pkScript, so we need to get the
 	// raw transaction, and the TxOut that contains the pkScript.
 	prevTx, err := c.GetRawTransaction(context.TODO(), &outPoint.Hash)
 	if err != nil {
-		return nil, 0, fmt.Errorf("unable to get raw transaction for %s", outPoint.Hash.String())
+		return nil, fmt.Errorf("unable to get raw transaction for %s", outPoint.Hash.String())
 	}
 
 	txOuts := prevTx.MsgTx().TxOut
 	if len(txOuts) <= int(outPoint.Index) {
-		return nil, 0, fmt.Errorf("PrevOut index (%d) is beyond the TxOuts slice (length %d)",
+		return nil, fmt.Errorf("PrevOut index (%d) is beyond the TxOuts slice (length %d)",
 			outPoint.Index, len(txOuts))
 	}
 
 	// For the TxOut of interest, extract the list of addresses
 	txOut := txOuts[outPoint.Index]
 	_, txAddrs := stdscript.ExtractAddrs(txOut.Version, txOut.PkScript, params)
-	// Return VAR amount; SKA outputs have Value=0 (use txOut.SKAValue for big.Int precision).
-	value := dcrutil.Amount(txOut.Value)
 	addresses := make([]string, 0, len(txAddrs))
 	for _, txAddr := range txAddrs {
-		addr := txAddr.String()
-		addresses = append(addresses, addr)
+		addresses = append(addresses, txAddr.String())
 	}
-	return addresses, value, nil
+	return &OutPointInfo{
+		Addresses: addresses,
+		CoinType:  txOut.CoinType,
+		Value:     dcrutil.Amount(txOut.Value),
+		ValueSKA:  txOut.SKAValue,
+	}, nil
 }
 
 // OutPointAddressesFromString is the same as OutPointAddresses, but it takes

--- a/wiki/transaction/flow.compact.md
+++ b/wiki/transaction/flow.compact.md
@@ -1,12 +1,12 @@
 - **One-line Flow:**
-  Mempool txs are decoded in Go (`txhelpers`) directly into aggregated string maps (`MempoolTx.SKATotals`), while Confirmed txs proxy Node RPC (`GetRawTransactionVerbose`) verbatim into array slices (`TxShort.Vout[]`).
+  Mempool txs are decoded in Go (`txhelpers`) directly into a single total for their specific coin (`MempoolTx.SKATotals`), while Confirmed txs proxy Node RPC (`GetRawTransactionVerbose`) verbatim into array slices (`TxShort.Vout[]`).
 - **Key Architectural Patterns:**
   1. **Structural Bifurcation:** Mempool relies on struct maps at the root level; Confirmed APIs rely on property injection on array slices.
-  2. **Multi-Source of Truth:** Mempool calculates tokens internally; Confirmed logic trusts the Node.
+  2. **Multi-Source of Truth:** Mempool calculates coins internally; Confirmed logic trusts the Node.
   3. **Rendering Divergence:** Mempool relies on JS HTML `<template>` cloning; Confirmed relies on Go server-templates.
 - **Critical Constraints:**
-  - SKA `CoinType` and exact token amounts (`SKAValue`) MUST pass through the system as `string` or `*big.Int`. Never use legacy `float64` `Amount`.
-  - The `tx.tmpl` view currently ignores token data and forces legacy float casting, requiring a template overwrite if accurate token rendering is needed.
+  - SKA `CoinType` and exact coin amounts (`SKAValue`) MUST pass through the system as `string` or `*big.Int`. Never use legacy `float64` `Amount`.
+  - The `tx.tmpl` view currently ignores coin data and forces legacy float casting, requiring a template overwrite if accurate coin rendering is needed.
 - **Mutation Checklist:**
   - [ ] Did you update `apitypes.Vout` / `apitypes.TxShort` (Confirmed)?
   - [ ] Did you update `explorertypes.MempoolTx` (Unconfirmed)?

--- a/wiki/transaction/flow.full.md
+++ b/wiki/transaction/flow.full.md
@@ -1,14 +1,22 @@
 ### 1. Overview
 
-This trace documents the end-to-end transaction flow through the Monetarium Explorer, comparing unconfirmed (mempool) transactions against confirmed (block-persisted) transactions. The system exhibits heavy architectural divergence and duplicated multi-token (VAR/SKA) parsing logic depending on the transaction's confirmation state.
+This trace documents the end-to-end transaction flow through the Monetarium Explorer, comparing unconfirmed (mempool) transactions against confirmed (block-persisted) transactions. The system exhibits heavy architectural divergence and duplicated multi-coin (VAR/SKA) parsing logic depending on the transaction's confirmation state.
+
+#### Core Invariant
+
+A transaction is strictly single-coin.
+
+- A transaction belongs to exactly one CoinType
+- Inputs and outputs cannot mix coins
+- Multi-coin support exists at the system level, not transaction level
 
 ### 2. End-to-End Data Flow
 
 **Mempool (Unconfirmed) Flow:**
-Node RPC (tx notification) → `mempoolmonitor` fetches raw hex → `txhelpers.MsgTxFromHex` (Go memory) → `txhelpers.SKATotalsFromMsgTx` (aggregates tokens) → `explorertypes.MempoolTx.SKATotals` (map[uint8]string) → WebSocket → JS Controller clones `<template>` → Javascript formats `ska_totals` to UI.
+Node RPC (tx notification) → `mempoolmonitor` fetches raw hex → `txhelpers.MsgTxFromHex` (Go memory) → `txhelpers.SKATotalsFromMsgTx` (sums the transaction's single-coin outputs) → `explorertypes.MempoolTx.SKATotals` (map[uint8]string) → WebSocket → JS Controller clones `<template>` → Javascript formats `ska_totals` to UI.
 
 **Confirmed Flow:**
-Postgres block height update → UI requests `GetAPITransaction` → `pgblockchain` queries Node RPC `GetRawTransactionVerbose` → Node maps `CoinType` and `SKAValue` into `Vout` array → `apitypes.TxShort` wraps array → Server renders `tx.tmpl` → Template ignores token data and hardcodes generic `Amount`.
+Postgres block height update → UI requests `GetAPITransaction` → `pgblockchain` queries Node RPC `GetRawTransactionVerbose` → Node maps `CoinType` and `SKAValue` into `Vout` array → `apitypes.TxShort` wraps array → Server renders `tx.tmpl` → Template ignores coin data and hardcodes generic `Amount`.
 
 ### 3. Per-Layer Breakdown
 
@@ -16,51 +24,51 @@ Postgres block height update → UI requests `GetAPITransaction` → `pgblockcha
 
 - **Location:** `mempool/monitor.go`, `mempool/collector.go`, `txhelpers/txhelpers.go`
 - **Data Structures:** `wire.MsgTx`, `explorertypes.MempoolTx`
-- **Transformations Applied:** Raw transaction hex is manually decoded into `wire.MsgTx`. Instead of keeping output indexes, token outputs are squashed into an aggregated `SKATotals: map[uint8]string` utilizing `*big.Int` arithmetic to prevent precision loss.
+- **Transformations Applied:** Raw transaction hex is manually decoded into `wire.MsgTx`. Instead of keeping output indexes, the transaction's outputs are summed for its specific CoinType and assigned to `SKATotals` utilizing `*big.Int` arithmetic to prevent precision loss.
 
 **Confirmed Database & API Interception**
 
 - **Location:** `db/dcrpg/pgblockchain.go`, `api/types/apitypes.go`
 - **Data Structures:** `chainhash.Hash`, `chainjson.TxRawResult`, `apitypes.TxShort`, `apitypes.Vout`
-- **Transformations Applied:** For `/tx/{txid}`, the DB does not attempt to reconstruct outputs from Postgres. Instead, it queries the `dcrd` node for a verbose JSON representation. The node parses the tokens and outputs them inside a raw `Vout` slice, which gets directly copied to `apitypes.TxShort.Vout[i].CoinType` and `SKAValue`.
+- **Transformations Applied:** For `/tx/{txid}`, the DB does not attempt to reconstruct outputs from Postgres. Instead, it queries the `dcrd` node for a verbose JSON representation. The node parses the coins and outputs them inside a raw `Vout` slice, which gets directly copied to `apitypes.TxShort.Vout[i].CoinType` and `SKAValue`.
 
 **Frontend Rendering Boundaries**
 
 - **Location:** `cmd/dcrdata/views/home_mempool.tmpl`, `homepage_controller.js`, `cmd/dcrdata/views/tx.tmpl`
 - **Data Structures:** WebSocket JSON (`TrimmedMempoolTx`), Template Data (`explorertypes.TxInfo`)
-- **Transformations Applied:** The mempool relies on Javascript checking `if (tx.ska_totals)` and formatting it live. The confirmed view relies on Go templates iterating `range $i, $v := .Vout` and applying `float64AsDecimalParts .Amount`, completely discarding token context.
+- **Transformations Applied:** The mempool relies on Javascript checking `if (tx.ska_totals)` and formatting it live. The confirmed view relies on Go templates iterating `range $i, $v := .Vout` and applying `float64AsDecimalParts .Amount`, completely discarding coin context.
 
 ### 4. Cross-Layer Dependencies
 
 - The REST API and confirmed UI are heavily coupled to the underlying node's verbose JSON structure (`chainjson`). Changes to how the node exposes multi-coins immediately affect the explorer.
 - The mempool UI is directly coupled to `txhelpers.SKATotalsFromMsgTx`. It depends entirely on the Go backend replicating node decoding logic accurately in memory.
-- The Stimulus Javascript controllers expect an un-nested, aggregated string map for SKA tokens in the mempool but hold no logic for displaying confirmed SKA transactions (which fall back to static HTML arrays).
+- The Stimulus Javascript controllers expect a single-coin total for the SKA coin in the mempool but hold no logic for displaying confirmed SKA transactions (which fall back to static HTML arrays).
 
 ### 5. Critical Constraints
 
-- **Precision Rules:** Multi-token values use 18 decimal places. They must always traverse the stack as `*big.Int` or `string` (`SKAValue`, `SKATotals`), never as `float64`.
+- **Precision Rules:** Multi-coin values use 18 decimal places. They must always traverse the stack as `*big.Int` or `string` (`SKAValue`, `SKATotals`), never as `float64`.
 - **Divergent Source of Truth:** Confirmed data trusts the node's RPC parsing. Mempool data trusts the `monetarium-explorer`'s internal `txhelpers` parsing.
 - **Missing WebSocket Events:** Confirmed transactions are not broadcast explicitly via WebSockets with full datasets; clients are only pinged a `sigNewBlock` signal.
 - **UI Template Flaw:** `tx.tmpl` does not use `.CoinType` or `.SKAValue` properties for the Outputs table, meaning confirmed SKA transactions are improperly rendered as base `Amount`.
 
 ### 6. Mutation Impact
 
-When modifying **transaction data structures or multi-token logic**, you MUST check ALL of the following:
+When modifying **transaction data structures or multi-coin logic**, you MUST check ALL of the following:
 
 - **Direct dependencies:** `apitypes.Vout`, `apitypes.TxShort`, `explorertypes.MempoolTx`
 - **Indirect dependencies:** `txhelpers.SKATotalsFromMsgTx`, the `dcrpg.GetRawTransactionVerbose` RPC wrapper.
 - **Serialization boundaries:** The `TrimmedMempoolTx` WebSocket schema.
-- **Rendering layers:** Multi-token support must be explicitly added to `cmd/dcrdata/views/tx.tmpl`, mimicking logic found in `homepage_controller.js` or `home_mempool.tmpl`.
+- **Rendering layers:** Support for rendering the transaction's specific CoinType must be explicitly added to `cmd/dcrdata/views/tx.tmpl`, mimicking logic found in `homepage_controller.js` or `home_mempool.tmpl`.
 
-**Silently breaks:** Altering `.Amount` types or token processing in `txhelpers` vs `dcrd` will cause silent data divergence.
+**Silently breaks:** Altering `.Amount` types or coin processing in `txhelpers` vs `dcrd` will cause silent data divergence.
 **Fails loudly:** Altering `apitypes.Vout` missing JSON tags will break downstream API clients instantly.
 
 ### 7. Common Pitfalls
 
-- Attempting to parse multi-token data using only the legacy `.Amount` (float64) field.
+- Attempting to parse the transaction's specific coin data using only the legacy `.Amount` (float64) field.
 - Updating `MempoolTx` and expecting the REST API (`TxShort`) to automatically inherit the change. They are entirely disconnected structs.
 - Assuming confirmed transactions stream over WebSockets to update the `tx/{txid}` page dynamically.
-- Forgetting to update the Javascript controllers `<template>` injection when modifying the top-level token maps.
+- Forgetting to update the Javascript controllers `<template>` injection when modifying the single-coin totals.
 
 ### 8. Evidence
 

--- a/wiki/transaction/impact.md
+++ b/wiki/transaction/impact.md
@@ -4,10 +4,10 @@ Based on the architectural patterns tracing transaction behaviors, the monetary 
 
 ## Propagation Layers
 
-When a transaction data structure or multi-token mechanism is modified, the change propagates through the following distinct layers—many of which do not share code:
+When a transaction data structure or multi-coin mechanism is modified, the change propagates through the following distinct layers—many of which do not share code:
 
 1. **Ingestion Layer (Unconfirmed)**: `mempool/monitor.go` parsing raw hexadecimal blocks into standard variable formats.
-2. **Aggregation Layer (Unconfirmed)**: `mempool/collector.go` and `txhelpers/txhelpers.go` summarizing output logic into structures like `explorer/types/explorertypes.go:MempoolTx` and creating root-level property sets (`SKATotals: map[uint8]string`).
+2. **Aggregation Layer (Unconfirmed)**: `mempool/collector.go` and `txhelpers/txhelpers.go` summarizing output logic into structures like `explorer/types/explorertypes.go:MempoolTx` and assigning the single-coin total directly to a property (`SKATotals: map[uint8]string`).
 3. **RPC Interception (Confirmed)**: `db/dcrpg/pgblockchain.go:GetAPITransaction` parsing the underlying node's verbose JSON structure into REST structs: `api/types/apitypes.go:TxShort` and nested arrays of `Vout`.
 4. **Broadcast Layer**: `pubsub/pubsubhub.go` pruning transaction definitions and actively pushing sub-set types over socket connections (`TrimmedMempoolTx`).
 5. **Static UI Presentation Layer**: `cmd/dcrdata/views/tx.tmpl` and `cmd/dcrdata/views/home_mempool.tmpl` executing Go-side processing to render historic state for a page load.
@@ -25,7 +25,7 @@ When a transaction data structure or multi-token mechanism is modified, the chan
 *   **File:** `db/dcrpg/pgblockchain.go` (interacting with `txhelpers`)
     *   **Risk:** The Mempool vs. Block Divergence. Suppose you implement a new transaction classification rule via `txhelpers` to aggregate data differently. If you fail to also update the JSON node parser mapping in `pgblockchain.go`, transactions will appear perfect while in the mempool but will silently discard their custom data the exact moment they are persisted to a block.
 *   **File:** `cmd/dcrdata/views/tx.tmpl` (interacting with `homepage_controller.js`)
-    *   **Risk:** Javascript vs. Go Template Conflicts. If you add multi-coin/VAR visibility to `tx.tmpl`, it will process on the server side correctly on refresh. Without corresponding JS implementation in `homepage_controller.js`, new transactions pushed by the Websocket will inject visually broken lines to the user until they hard-refresh the page.
+    *   **Risk:** Javascript vs. Go Template Conflicts. If you add visibility for the transaction's specific CoinType (like VAR or SKA) to `tx.tmpl`, it will process on the server side correctly on refresh. Without corresponding JS implementation in `homepage_controller.js`, new transactions pushed by the Websocket will inject visually broken lines to the user until they hard-refresh the page.
 *   **File:** `cmd/dcrdata/views/tx.tmpl`
     *   **Risk:** Precision and Scientific Notation Corruption. Unintentionally funneling high-precision metrics via a numeric intermediate (`float64`) instead of rigorously passing the payload as strings will cause UI elements leveraging old DCR helpers (e.g., `float64AsDecimalParts` in `tx.tmpl`) to silently output zeroes, truncate decimal points, or use scientific expressions.
 
@@ -38,5 +38,5 @@ Before concluding any structural mutation involving transactions, coins, or supp
 - [ ] **Dual-State Verification:** I have validated that my logic functions when a transaction is aggregated live (Mempool/`txhelpers`) AND when it is queried verbatim historically (DB/RPC mapping).
 - [ ] **Template Synchronization:** I have implemented the UI representation inside the static `.tmpl` file (for server-rendering).
 - [ ] **Javascript DOM Clone Synchronization:** I have mapped the equivalent visual logic in my Stimulus controllers (e.g., `homepage_controller.js`) to target and clone `<template>` rows identically to the static render.
-- [ ] **Persistent String Safety:** Numeric token data traverses the API, Database, and Websockets exclusively as `string` or `*big.Int`, never encountering float-based arithmetic.
-- [ ] **Vout Array Parity:** My feature correctly addresses output logic when it is heavily nested inside standard `TxShort.Vout[]` elements (API response), AND when it is rolled up into a root dictionary via `MempoolTx` (Pub/Sub response).
+- [ ] **Persistent String Safety:** Numeric coin data traverses the API, Database, and Websockets exclusively as `string` or `*big.Int`, never encountering float-based arithmetic.
+- [ ] **Vout Array Parity:** My feature correctly addresses output logic when it is heavily nested inside standard `TxShort.Vout[]` elements (API response), AND when it is summed into a property for the transaction's single CoinType via `MempoolTx` (Pub/Sub response).

--- a/wiki/transaction/patterns.md
+++ b/wiki/transaction/patterns.md
@@ -1,23 +1,39 @@
 # Architectural Patterns
 
-Based on the end-to-end tracing across both Block and Transaction flows, the Monetarium Explorer exhibits several non-obvious structural patterns. When modifying the codebase, recognize that the architecture heavily favors optimization over unification. 
+Based on the end-to-end tracing across both Block and Transaction flows, the Monetarium Explorer exhibits several non-obvious structural patterns. When modifying the codebase, recognize that the architecture heavily favors optimization over unification.
+
+## Core Invariant
+
+A transaction is strictly single-coin.
+
+- A transaction belongs to exactly one CoinType
+- Inputs and outputs cannot mix coins
+- Multi-coin support exists at the system level, not transaction level
 
 ### 1. Divergent State Parsing (Dual Source of Truth)
+
 The system fundamentally bifurcates how it determines truth based on chronological state (Pending vs. Historical).
-*   **The Pattern:** Real-time pipelines (Mempool, newly minted blocks) rely on internal Go-memory parsing and custom helper functions (`txhelpers`, `blockdata.Collector`) to calculate state. Persistent pipelines (Confirmed Blocks, Archived Transactions) ignore these Go helpers entirely, instead treating the underlying Node's RPC and the PostgreSQL recalculation functions as the ultimate source of truth.
-*   **Implication for Mutation:** See [system/constraints.md#C2](../system/constraints.md#C2)
+
+- **The Pattern:** Real-time pipelines (Mempool, newly minted blocks) rely on internal Go-memory parsing and custom helper functions (`txhelpers`, `blockdata.Collector`) to calculate state. Persistent pipelines (Confirmed Blocks, Archived Transactions) ignore these Go helpers entirely, instead treating the underlying Node's RPC and the PostgreSQL recalculation functions as the ultimate source of truth.
+- **Implication for Mutation:** See [system/constraints.md#C2](../system/constraints.md#C2)
 
 ### 2. The Presentation Layer Schism
-The application leverages two entirely different rendering paradigms side-by-side. 
-*   **The Pattern:** Historical, persisted data relies on Go `html/template` executing server-side loops (`range`) on the initial page load. Transient, real-time data relies heavily on Stimulus JS Controllers consuming WebSockets and cloning inert HTML `<template>` elements. 
-*   **Implication for Mutation:** See [system/constraints.md#C3](../system/constraints.md#C3)
+
+The application leverages two entirely different rendering paradigms side-by-side.
+
+- **The Pattern:** Historical, persisted data relies on Go `html/template` executing server-side loops (`range`) on the initial page load. Transient, real-time data relies heavily on Stimulus JS Controllers consuming WebSockets and cloning inert HTML `<template>` elements.
+- **Implication for Mutation:** See [system/constraints.md#C3](../system/constraints.md#C3)
 
 ### 3. Stringified Precision Preservation
+
 The codebase distrusts standard numeric serialization across boundaries.
-*   **The Pattern:** To prevent precision loss or overflow in cross-layer communication (especially regarding multi-token SKA/VAR arithmetic), the system eagerly converts high-precision types into `map[uint8]string` or explicit `string` properties (`SKAValue`) before pushing them across the API or WebSocket boundaries.
-*   **Implication for Mutation:** See [system/constraints.md#C1](../system/constraints.md#C1)
+
+- **The Pattern:** To prevent precision loss or overflow in cross-layer communication (especially regarding high-precision SKA and VAR arithmetic), the system eagerly converts high-precision types into `map[uint8]string` or explicit `string` properties (`SKAValue`) before pushing them across the API or WebSocket boundaries.
+- **Implication for Mutation:** See [system/constraints.md#C1](../system/constraints.md#C1)
 
 ### 4. Perimeter Flattening Pattern (Ingestion-Time Aggregation)
+
 To optimize for bandwidth and UI speed, the system aggressively strips context from live entities at ingestion.
-*   **The Pattern:** In motion (Mempool, WebSocket broadcasts), complex structural arrays (such as `Vout` outputs) are squashed into flat summary maps right at the ingestion layer. At rest (DB, REST API), the full dimensional array structure is provided.
-*   **Implication for Mutation:** See [system/constraints.md#C4](../system/constraints.md#C4)
+
+- **The Pattern:** In motion (Mempool, WebSocket broadcasts), complex structural arrays (such as `Vout` outputs) are summed into a single total for the transaction's CoinType right at the ingestion layer. At rest (DB, REST API), the full dimensional array structure is provided.
+- **Implication for Mutation:** See [system/constraints.md#C4](../system/constraints.md#C4)


### PR DESCRIPTION
## Summary

Implements full multi-coin (VAR/SKA) support on the confirmed transaction detail page (`/tx/{txid}`), replacing hardcoded `float64`/DCR rendering with high-precision atom strings and dynamic coin-aware display.

## Changes

### API types (`api/types/apitypes.go`)
- Replaced the `Vin` alias for `chainjson.Vin` with a first-class `Vin` struct that includes `CoinType`, `ValueInRaw` (atom string), and a local `ScriptSig` type.
- Added `CoinType`, `Total`, `Fee`, `FeeRate`, and `FeeRateRaw` fields to `TxShort` and `TrimmedTx`. `Total` and `Fee` are atom strings to avoid float64 precision loss.
- Added `ValueRaw` (atom string) to `Vout`. The legacy `Value float64` field is retained but marked deprecated.

### Explorer types (`explorer/types/explorertypes.go`)
- Added `TotalRaw`, `FeeRaw`, `FeeRateRaw`, `Size`, and `CoinType` to `TxBasic`.
- Embedded `*VoteInfo` directly (was a named field).
- Added `ValueRaw` to `Vin` and `Vout`. Legacy `float64` fields marked deprecated.

### DB / blockchain layer (`db/dcrpg/pgblockchain.go`)
- `GetAPITransaction` now determines the transaction's `CoinType` from the first output.
- For VAR transactions: computes `Total` and `Fee` using existing `TotalVout`/`TxFeeRate` helpers, formatted as atom strings.
- For SKA transactions: computes `Total` from `SKATotalsFromMsgTx`, and `Fee`/`FeeRateRaw` by resolving each input's previous outpoint via the new `OutPointAddressesAll` helper and performing `big.Int` arithmetic.
- Vin mapping is now explicit (was a `copy()`) to populate `ValueInRaw`, `CoinType`, and `ScriptSig` per input.
- Vout mapping populates `ValueRaw` for both VAR (atom conversion) and SKA (string passthrough).
- `GetTrimmedTransaction` propagates the new `CoinType`, `Total`, `Fee`, `FeeRate`, and `FeeRateRaw` fields.

### Tx helpers (`txhelpers/txhelpers.go`)
- Added `OutPointInfo` struct carrying `Addresses`, `CoinType`, `Value` (VAR atoms), and `ValueSKA` (`*big.Int`).
- Added `OutPointAddressesAll` which returns the full `OutPointInfo` for a previous outpoint.
- Refactored `OutPointAddresses` to delegate to `OutPointAddressesAll` (no behaviour change for callers).

### Template function (`cmd/dcrdata/internal/explorer/templates.go`)
- Added `coinSymbol` template function that maps a `uint8` coin type to its ticker string via `cointype.CoinType.String()`.

### Transaction template (`cmd/dcrdata/views/tx.tmpl`)
- Layout: collapsed the two-column card layout to a single full-width column.
- Total Sent, Fee, and Fee Rate cells now branch on `CoinType`: VAR uses the existing `float64AsDecimalParts` path; SKA uses `skaDecimalParts` with the new atom-string fields.
- Mix count display uses `coinSymbol` instead of hardcoded "DCR".
- Vin/Vout table headers use `coinSymbol` instead of hardcoded "DCR".
- Vin amount cell branches on `CoinType` to render `ValueRaw` for SKA inputs.
- Vout amount and spent-status cells branch on `CoinType` to render `ValueRaw` for SKA outputs.

### Wiki (`wiki/transaction/`)
- Updated `flow.compact.md`, `flow.full.md`, `impact.md`, and `patterns.md` to reflect the "single-coin per transaction" invariant and replace "token/multi-token" language with "coin/multi-coin".
- Added the Core Invariant section to `flow.full.md`.

## Testing

- Existing unit tests continue to pass (no test files modified).
- Manual verification: VAR transactions render identically to before; SKA transactions now display correct high-precision amounts and the correct coin ticker.