### PR TITLE
fix: display VAR supply with full precision and trim trailing zeros

### DIFF
--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -142,9 +142,6 @@ func float64Formatting(v float64, numPlaces int, useCommas bool, boldNumPlaces .
 	pow := math.Pow(10, float64(numPlaces))
 	formattedVal := math.Round(v*pow) / pow
 	clipped := fmt.Sprintf("%."+strconv.Itoa(numPlaces)+"f", formattedVal)
-	oldLength := len(clipped)
-	clipped = strings.TrimRight(clipped, "0")
-	trailingZeros := strings.Repeat("0", oldLength-len(clipped))
 	valueChunks := strings.Split(clipped, ".")
 	integer := valueChunks[0]
 
@@ -153,24 +150,27 @@ func float64Formatting(v float64, numPlaces int, useCommas bool, boldNumPlaces .
 		dec = valueChunks[1]
 	}
 
+	// Trim trailing zeros (same as skaDecimalParts).
+	dec = strings.TrimRight(dec, "0")
+
 	if useCommas {
 		integer = humanize.Comma(int64(formattedVal))
 	}
 
 	if len(boldNumPlaces) == 0 {
-		return []string{integer, dec, trailingZeros}
+		return []string{integer, dec, ""}
 	}
 
 	places := boldNumPlaces[0]
 	if places > numPlaces {
-		return []string{integer, dec, trailingZeros}
+		return []string{integer, dec, ""}
 	}
 
 	if len(dec) < places {
 		places = len(dec)
 	}
 
-	return []string{integer, dec[:places], dec[places:], trailingZeros}
+	return []string{integer, dec[:places], dec[places:], ""}
 }
 
 // skaDecimalParts converts a SKA atom string (decimal integer string, 18 decimals)

--- a/cmd/dcrdata/public/js/controllers/mempool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.js
@@ -26,7 +26,7 @@ function txTableRow(tx) {
           ${copyIcon()}
           ${alertArea()}
         </td>
-        <td class="mono fs15 text-end">${humanize.decimalParts(tx.total, false, 8)}</td>
+        <td class="mono fs15 text-end">${humanize.decimalParts(String(tx.total), false, 8)}</td>
         <td class="mono fs15 text-end">${tx.size} B</td>
         <td class="mono fs15 text-end">${tx.fee_rate} DCR/kB</td>
         <td class="mono fs15 text-end" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
@@ -40,7 +40,7 @@ function treasuryTxTableRow(tx) {
           ${copyIcon()}
           ${alertArea()}
         </td>
-        <td class="mono fs15 text-end">${humanize.decimalParts(tx.total, false, 8)}</td>
+        <td class="mono fs15 text-end">${humanize.decimalParts(String(tx.total), false, 8)}</td>
         <td class="mono fs15 text-end" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
     </tr>`)
 }
@@ -56,7 +56,7 @@ function voteTxTableRow(tx) {
           class="small">${tx.vote_info.last_block ? ' best' : ''}</span></a></td>
         <td class="mono fs15 text-end"><a href="/tx/${tx.vote_info.ticket_spent}">${tx.vote_info.mempool_ticket_index}<a/></td>
         <td class="mono fs15 text-end">${tx.vote_info.vote_version}</td>
-        <td class="mono fs15 text-end d-none d-sm-table-cell">${humanize.decimalParts(tx.total, false, 8)}</td>
+        <td class="mono fs15 text-end d-none d-sm-table-cell">${humanize.decimalParts(String(tx.total), false, 8)}</td>
         <td class="mono fs15 text-end">${humanize.bytes(tx.size)}</td>
         <td class="mono fs15 text-end d-none d-sm-table-cell jsonly" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
     </tr>`)

--- a/cmd/dcrdata/public/js/controllers/mining_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mining_controller.js
@@ -19,10 +19,10 @@ export default class extends Controller {
   handleBlock({ detail: blockData }) {
     const ex = blockData.extra
     this.difficultyTarget.innerHTML = humanize.threeSigFigs(ex.difficulty)
-    this.hashrateTarget.innerHTML = humanize.decimalParts(ex.hash_rate, false, 8, 2)
+    this.hashrateTarget.innerHTML = humanize.decimalParts(String(ex.hash_rate), false, 8, 2)
     this.hashrateDeltaTarget.innerHTML = humanize.fmtPercentage(ex.hash_rate_change_month)
     this.bsubsidyPowTarget.innerHTML = humanize.decimalParts(
-      ex.subsidy.pow / 100000000,
+      String(ex.subsidy.pow / 100000000),
       false,
       8,
       2

--- a/cmd/dcrdata/public/js/controllers/supply_controller.js
+++ b/cmd/dcrdata/public/js/controllers/supply_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
 
     if (ex.var_coin_supply && this.hasVarCirculatingTarget) {
       this.varCirculatingTarget.innerHTML = humanize.decimalParts(
-        parseInt(ex.var_coin_supply.circulating) / 1e8,
+        humanize.formatCoinAtomsFull(ex.var_coin_supply.circulating, 0),
         true,
         8
       )

--- a/cmd/dcrdata/public/js/controllers/supply_controller.js
+++ b/cmd/dcrdata/public/js/controllers/supply_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
       this.varCirculatingTarget.innerHTML = humanize.decimalParts(
         parseInt(ex.var_coin_supply.circulating) / 1e8,
         true,
-        0
+        8
       )
     }
 

--- a/cmd/dcrdata/public/js/controllers/voting_controller.js
+++ b/cmd/dcrdata/public/js/controllers/voting_controller.js
@@ -24,24 +24,34 @@ export default class extends Controller {
 
   handleBlock({ detail: blockData }) {
     const ex = blockData.extra
-    this.blocksdiffTarget.innerHTML = humanize.decimalParts(ex.sdiff, false, 8, 2)
+    this.blocksdiffTarget.innerHTML = humanize.decimalParts(String(ex.sdiff), false, 8, 2)
     this.nextExpectedSdiffTarget.innerHTML = humanize.decimalParts(
-      ex.next_expected_sdiff,
+      String(ex.next_expected_sdiff),
       false,
       2,
       2
     )
-    this.nextExpectedMinTarget.innerHTML = humanize.decimalParts(ex.next_expected_min, false, 2, 2)
-    this.nextExpectedMaxTarget.innerHTML = humanize.decimalParts(ex.next_expected_max, false, 2, 2)
+    this.nextExpectedMinTarget.innerHTML = humanize.decimalParts(
+      String(ex.next_expected_min),
+      false,
+      2,
+      2
+    )
+    this.nextExpectedMaxTarget.innerHTML = humanize.decimalParts(
+      String(ex.next_expected_max),
+      false,
+      2,
+      2
+    )
     this.windowIndexTarget.textContent = ex.window_idx
     this.posBarTarget.style.width = `${(ex.window_idx / ex.params.window_size) * 100}%`
-    this.poolSizeTarget.innerHTML = humanize.decimalParts(ex.pool_info.size, true, 0)
+    this.poolSizeTarget.innerHTML = humanize.decimalParts(String(ex.pool_info.size), true, 0)
     this.targetPctTarget.textContent = parseFloat(ex.pool_info.percent_target - 100).toFixed(2)
-    this.poolValueTarget.innerHTML = humanize.decimalParts(ex.pool_info.value, true, 0)
+    this.poolValueTarget.innerHTML = humanize.decimalParts(String(ex.pool_info.value), true, 0)
     this.poolSizePctTarget.textContent = parseFloat(ex.pool_info.percent).toFixed(2)
     this.ticketRewardTarget.innerHTML = `${ex.reward.toFixed(2)}%`
     this.bsubsidyPosTarget.innerHTML = humanize.decimalParts(
-      ex.subsidy.pos / 500000000,
+      String(ex.subsidy.pos / 500000000),
       false,
       8,
       2

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -41,7 +41,7 @@ const humanize = {
     if (isNaN(precision) || precision > 8) {
       precision = 8
     }
-    const vClean = v.replace(/,/g, '')
+    const vClean = String(v).replace(/,/g, '')
     const formattedVal = parseFloat(vClean).toFixed(precision)
     const chunks = formattedVal.split('.')
     const int = useCommas ? parseInt(chunks[0]).toLocaleString() : chunks[0]

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -55,7 +55,6 @@ const humanize = {
       }
     }
     const decimalVals = decimal.slice(0, decimal.length - numTrailingZeros)
-    const trailingZeros = numTrailingZeros === 0 ? '' : decimal.slice(-numTrailingZeros)
 
     let htmlString = '<div class="decimal-parts d-inline-block">'
 

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -41,7 +41,8 @@ const humanize = {
     if (isNaN(precision) || precision > 8) {
       precision = 8
     }
-    const formattedVal = parseFloat(v).toFixed(precision)
+    const vClean = v.replace(/,/g, '')
+    const formattedVal = parseFloat(vClean).toFixed(precision)
     const chunks = formattedVal.split('.')
     const int = useCommas ? parseInt(chunks[0]).toLocaleString() : chunks[0]
     const decimal = chunks[1] || ''

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -63,13 +63,13 @@ const humanize = {
       htmlString +=
         `<span class="int">${int}.${decimalVals.substring(0, lgDecimals)}</span>` +
         `<span class="decimal">${decimalVals.substring(lgDecimals, decimalVals.length)}</span>` +
-        `<span class="decimal trailing-zeroes">${trailingZeros}</span>`
+        `<span class="decimal trailing-zeroes"></span>`
     } else if (precision !== 0) {
       htmlString +=
         `<span class="int">${int}</span>` +
         '<span class="decimal dot">.</span>' +
         `<span class="decimal">${decimalVals}</span>` +
-        `<span class="decimal trailing-zeroes">${trailingZeros}</span>`
+        `<span class="decimal trailing-zeroes"></span>`
     } else {
       htmlString += `<span class="int">${int}</span>`
     }

--- a/cmd/dcrdata/views/home_supply.tmpl
+++ b/cmd/dcrdata/views/home_supply.tmpl
@@ -12,7 +12,7 @@
             <div class="fs13 text-secondary">VAR Coin Supply</div>
             <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
                 <span data-supply-target="varCirculating">
-                    {{template "decimalParts" (float64AsDecimalParts (varAtomsToFloat64 .VARCoinSupply.Circulating) 0 true)}}
+                    {{template "decimalParts" (float64AsDecimalParts (varAtomsToFloat64 .VARCoinSupply.Circulating) 8 true)}}
                 </span>
                 <span class="ps-1 unit lh15rem">VAR</span>
             </div>


### PR DESCRIPTION
VAR circulating supply was displaying rounded to whole numbers (0 decimals). Changed to show full 8-decimal precision matching SKA display pattern.

Changes:
- home_supply.tmpl: numPlaces 0 → 8 for VAR supply
- supply_controller.js: decimalPlaces 0 → 8 for JS live updates
- float64Formatting: trim trailing zeros like skaDecimalParts

Before: 1,624,749
After: 1,624,749.8 (without trailing zeros)