### PR TITLE
Fix/pow ska rewards extraction

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -259,9 +259,9 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 		extrainfo.SSFeeTotalsByCoin = ssfee
 	}
 
-	// Extract per-SKA-type PoW mining reward amounts from the coinbase.
-	if skaRewards := BlockSKAPoWRewards(msgBlock); len(skaRewards) > 0 {
-		extrainfo.SKAPoWRewards = skaRewards
+	// Extract SKA fees from regular transactions (goes to miner as PoW reward).
+	if skaFees := BlockSKAFees(msgBlock); len(skaFees) > 0 {
+		extrainfo.SKAPoWRewards = skaFees
 	}
 
 	return blockdata, feeInfoBlock, blockHeaderResults, extrainfo, msgBlock, err
@@ -499,9 +499,65 @@ func ExtractSKARewardsFromCoinbase(coinbase *wire.MsgTx) map[uint8]string {
 // BlockSKAPoWRewards extracts per-SKA-type PoW mining reward amounts from the
 // coinbase transaction of a block. Only SKA outputs (CoinType 1-255) from the
 // coinbase are considered, as those represent the miner's SKA reward.
+// DEPRECATED: Use BlockSKAFees() instead - SKA rewards are in regular transactions, not coinbase.
 func BlockSKAPoWRewards(msgBlock *wire.MsgBlock) map[uint8]string {
 	if len(msgBlock.Transactions) == 0 {
 		return nil
 	}
 	return ExtractSKARewardsFromCoinbase(msgBlock.Transactions[0])
+}
+
+// BlockSKAFees extracts SKA transaction fees from regular (non-stake) transactions.
+// These fees are paid to the miner as PoW reward.
+// For each regular transaction, the difference between input SKA and output SKA is the fee.
+func BlockSKAFees(msgBlock *wire.MsgBlock) map[uint8]string {
+	if len(msgBlock.Transactions) == 0 {
+		return nil
+	}
+
+	skaFees := make(map[uint8]*big.Int)
+
+	// Process regular transactions (Transactions, not STransactions)
+	for _, tx := range msgBlock.Transactions {
+		var inputSKA, outputSKA big.Int
+		inputSKA.SetInt64(0)
+		outputSKA.SetInt64(0)
+
+		// Sum SKA inputs
+		for _, vin := range tx.TxIn {
+			if vin.SKAValueIn != nil {
+				inputSKA.Add(&inputSKA, vin.SKAValueIn)
+			}
+		}
+
+		// Sum SKA outputs
+		for _, txout := range tx.TxOut {
+			if txout.CoinType.IsSKA() && txout.SKAValue != nil {
+				outputSKA.Add(&outputSKA, txout.SKAValue)
+			}
+		}
+
+		// Calculate fee (input - output)
+		if inputSKA.Sign() > 0 {
+			fee := new(big.Int).Sub(&inputSKA, &outputSKA)
+			if fee.Sign() > 0 {
+				ct := uint8(1)
+				if skaFees[ct] == nil {
+					skaFees[ct] = fee
+				} else {
+					skaFees[ct].Add(skaFees[ct], fee)
+				}
+			}
+		}
+	}
+
+	if len(skaFees) == 0 {
+		return nil
+	}
+
+	out := make(map[uint8]string, len(skaFees))
+	for k, v := range skaFees {
+		out[k] = v.String()
+	}
+	return out
 }

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -468,6 +468,7 @@ func blockCoinAmounts(msgBlock *wire.MsgBlock) map[uint8]string {
 
 // ExtractSKARewardsFromCoinbase extracts per-SKA-type PoW mining reward amounts from the
 // coinbase transaction. Only SKA outputs (CoinType 1-255) from the coinbase are considered.
+// DEPRECATED: Use BlockSKAFees() instead - SKA rewards are in regular transactions, not coinbase.
 func ExtractSKARewardsFromCoinbase(coinbase *wire.MsgTx) map[uint8]string {
 	if coinbase == nil {
 		return nil
@@ -500,6 +501,7 @@ func ExtractSKARewardsFromCoinbase(coinbase *wire.MsgTx) map[uint8]string {
 // coinbase transaction of a block. Only SKA outputs (CoinType 1-255) from the
 // coinbase are considered, as those represent the miner's SKA reward.
 // DEPRECATED: Use BlockSKAFees() instead - SKA rewards are in regular transactions, not coinbase.
+// TODO: Remove in next minor version after consumers migrate to BlockSKAFees().
 func BlockSKAPoWRewards(msgBlock *wire.MsgBlock) map[uint8]string {
 	if len(msgBlock.Transactions) == 0 {
 		return nil
@@ -510,6 +512,7 @@ func BlockSKAPoWRewards(msgBlock *wire.MsgBlock) map[uint8]string {
 // BlockSKAFees extracts SKA transaction fees from regular (non-stake) transactions.
 // These fees are paid to the miner as PoW reward.
 // For each regular transaction, the difference between input SKA and output SKA is the fee.
+// Coin type is derived from outputs since transactions are single-coin.
 func BlockSKAFees(msgBlock *wire.MsgBlock) map[uint8]string {
 	if len(msgBlock.Transactions) == 0 {
 		return nil
@@ -520,8 +523,6 @@ func BlockSKAFees(msgBlock *wire.MsgBlock) map[uint8]string {
 	// Process regular transactions (Transactions, not STransactions)
 	for _, tx := range msgBlock.Transactions {
 		var inputSKA, outputSKA big.Int
-		inputSKA.SetInt64(0)
-		outputSKA.SetInt64(0)
 
 		// Sum SKA inputs
 		for _, vin := range tx.TxIn {
@@ -530,22 +531,25 @@ func BlockSKAFees(msgBlock *wire.MsgBlock) map[uint8]string {
 			}
 		}
 
-		// Sum SKA outputs
+		// Sum SKA outputs and track coin type
+		var coinType uint8
 		for _, txout := range tx.TxOut {
 			if txout.CoinType.IsSKA() && txout.SKAValue != nil {
 				outputSKA.Add(&outputSKA, txout.SKAValue)
+				if coinType == 0 {
+					coinType = uint8(txout.CoinType)
+				}
 			}
 		}
 
 		// Calculate fee (input - output)
-		if inputSKA.Sign() > 0 {
+		if inputSKA.Sign() > 0 && coinType != 0 {
 			fee := new(big.Int).Sub(&inputSKA, &outputSKA)
 			if fee.Sign() > 0 {
-				ct := uint8(1)
-				if skaFees[ct] == nil {
-					skaFees[ct] = fee
+				if skaFees[coinType] == nil {
+					skaFees[coinType] = fee
 				} else {
-					skaFees[ct].Add(skaFees[ct], fee)
+					skaFees[coinType].Add(skaFees[coinType], fee)
 				}
 			}
 		}

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -48,7 +48,7 @@ func TestBlockSKAFees_WithSKATransaction(t *testing.T) {
 
 	feeStr, ok := got[1]
 	if !ok {
-		t.Fatal("expected SKA-1 in fees map")
+		t.Fatal("expected SKA1 in fees map")
 	}
 
 	if feeStr != expected {
@@ -66,6 +66,49 @@ func TestBlockSKAFees_NoSKA(t *testing.T) {
 
 	if got != nil {
 		t.Errorf("expected nil for no SKA, got %v", got)
+	}
+}
+
+func TestBlockSKAFees_MultipleCoinTypes(t *testing.T) {
+	// Three transactions with different coin types
+	// TX1: SKA type 1, input 200, output 150 = fee 50
+	tx1 := wire.NewMsgTx()
+	tx1.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 0, nil))
+	tx1.TxIn[0].SKAValueIn = big.NewInt(200)
+	tx1.AddTxOut(wire.NewTxOut(0, nil))
+	tx1.TxOut[0].CoinType = cointype.CoinType(1)
+	tx1.TxOut[0].SKAValue = big.NewInt(150)
+
+	// TX2: SKA type 2, input 300, output 250 = fee 50
+	tx2 := wire.NewMsgTx()
+	tx2.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 0, nil))
+	tx2.TxIn[0].SKAValueIn = big.NewInt(300)
+	tx2.AddTxOut(wire.NewTxOut(0, nil))
+	tx2.TxOut[0].CoinType = cointype.CoinType(2)
+	tx2.TxOut[0].SKAValue = big.NewInt(250)
+
+	// TX3: SKA type 5, input 500, output 400 = fee 100
+	tx3 := wire.NewMsgTx()
+	tx3.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 0, nil))
+	tx3.TxIn[0].SKAValueIn = big.NewInt(500)
+	tx3.AddTxOut(wire.NewTxOut(0, nil))
+	tx3.TxOut[0].CoinType = cointype.CoinType(5)
+	tx3.TxOut[0].SKAValue = big.NewInt(400)
+
+	got := BlockSKAFees(mockBlock(tx1, tx2, tx3))
+
+	if got == nil {
+		t.Fatal("expected non-nil SKA fees")
+	}
+
+	if got[1] != "50" {
+		t.Errorf("want SKA1=50, got %v", got[1])
+	}
+	if got[2] != "50" {
+		t.Errorf("want SKA2=50, got %v", got[2])
+	}
+	if got[5] != "100" {
+		t.Errorf("want SKA5=100, got %v", got[5])
 	}
 }
 

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -15,6 +15,60 @@ func mockBlock(txs ...*wire.MsgTx) *wire.MsgBlock {
 	return blk
 }
 
+func TestBlockSKAFees_WithSKATransaction(t *testing.T) {
+	tx := wire.NewMsgTx()
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 0, nil))
+
+	// Input: 100 + 2902901089999999999900 atoms SKA
+	vin1 := wire.NewTxIn(&wire.OutPoint{}, 0, nil)
+	vin1.SKAValueIn = big.NewInt(100)
+	tx.TxIn = append(tx.TxIn, vin1)
+
+	vin2 := wire.NewTxIn(&wire.OutPoint{}, 0, nil)
+	vin2.SKAValueIn, _ = new(big.Int).SetString("2902901089999999999900", 10)
+	tx.TxIn = append(tx.TxIn, vin2)
+
+	// Output: 2901069089999999999900 + 100 atoms SKA
+	tx.AddTxOut(wire.NewTxOut(0, nil))
+	tx.TxOut[0].CoinType = cointype.CoinType(1)
+	tx.TxOut[0].SKAValue, _ = new(big.Int).SetString("2901069089999999999900", 10)
+
+	tx.AddTxOut(wire.NewTxOut(0, nil))
+	tx.TxOut[1].CoinType = cointype.CoinType(1)
+	tx.TxOut[1].SKAValue = big.NewInt(100)
+
+	got := BlockSKAFees(mockBlock(tx))
+
+	if got == nil {
+		t.Fatal("expected non-nil SKA fees")
+	}
+
+	// Expected: 1832000000000000000 atoms
+	expected := "1832000000000000000"
+
+	feeStr, ok := got[1]
+	if !ok {
+		t.Fatal("expected SKA-1 in fees map")
+	}
+
+	if feeStr != expected {
+		t.Errorf("want %s, got %s", expected, feeStr)
+	}
+}
+
+func TestBlockSKAFees_NoSKA(t *testing.T) {
+	// Transaction with no SKA inputs/outputs
+	tx := wire.NewMsgTx()
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 0, nil))
+	tx.AddTxOut(wire.NewTxOut(100000000, nil)) // DCR only
+
+	got := BlockSKAFees(mockBlock(tx))
+
+	if got != nil {
+		t.Errorf("expected nil for no SKA, got %v", got)
+	}
+}
+
 func TestBlockCoinAmounts_VAROnly(t *testing.T) {
 	tx := wire.NewMsgTx()
 	tx.AddTxOut(wire.NewTxOut(500_000_000, nil)) // 5 VAR

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -715,17 +715,19 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	}
 
 	// PoW SKA rewards: prioritize rewards from the current block (miner-centric),
-	// then fallback to previous blocks if the current one is empty.
+	// then fallback to previous blocks if current block is empty.
 	if len(newBlockData.SKAPoWRewards) > 0 {
 		powRewards := newBlockData.SKAPoWRewards
 		p.HomeInfo.PoWSKARewards = powRewards
 	} else {
 		var powRewardsMap map[uint8]string
 		if len(blockData.ExtraInfo.SKAPoWRewards) > 0 {
+			log.Infof("HOME PoW: Using ExtraInfo.SKAPoWRewards = %v", blockData.ExtraInfo.SKAPoWRewards)
 			powRewardsMap = blockData.ExtraInfo.SKAPoWRewards
 		} else {
 			// Fallback: Search backwards from the current block height.
 			currentHeight := newBlockData.Height
+			log.Infof("HOME PoW: Falling back from height %d", currentHeight)
 			for h := currentHeight - 1; h >= currentHeight-4320 && h >= 0; h-- {
 				hash, err := exp.dataSource.BlockHash(ctx, h)
 				if err != nil {

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -726,6 +726,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 		} else {
 			// Fallback: Search backwards from the current block height.
 			// Use RPC to compute SKA fees from block transaction data.
+			// NOTE: This loop makes up to 4320 RPC calls. Consider caching SKA fees
+			// in the DB to avoid repeated RPC overhead in production.
 			currentHeight := newBlockData.Height
 			for h := currentHeight - 1; h >= currentHeight-4320 && h >= 0; h-- {
 				skaFees, err := exp.dataSource.GetBlockSKAFees(ctx, h)

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -122,6 +122,7 @@ type explorerDataSource interface {
 	GetSummaryRange(ctx context.Context, idx0, idx1 int) []*apitypes.BlockDataBasic
 	VARCoinSupply(ctx context.Context) (*types.VARCoinSupply, error)
 	SKACoinSupply(ctx context.Context) ([]*types.SKACoinSupplyEntry, error)
+	GetBlockSKAFees(ctx context.Context, height int64) (map[uint8]string, error)
 }
 
 type PoliteiaBackend interface {
@@ -717,29 +718,22 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	// PoW SKA rewards: prioritize rewards from the current block (miner-centric),
 	// then fallback to previous blocks if current block is empty.
 	if len(newBlockData.SKAPoWRewards) > 0 {
-		powRewards := newBlockData.SKAPoWRewards
-		p.HomeInfo.PoWSKARewards = powRewards
+		p.HomeInfo.PoWSKARewards = newBlockData.SKAPoWRewards
 	} else {
 		var powRewardsMap map[uint8]string
 		if len(blockData.ExtraInfo.SKAPoWRewards) > 0 {
-			log.Infof("HOME PoW: Using ExtraInfo.SKAPoWRewards = %v", blockData.ExtraInfo.SKAPoWRewards)
 			powRewardsMap = blockData.ExtraInfo.SKAPoWRewards
 		} else {
 			// Fallback: Search backwards from the current block height.
+			// Use RPC to compute SKA fees from block transaction data.
 			currentHeight := newBlockData.Height
-			log.Infof("HOME PoW: Falling back from height %d", currentHeight)
 			for h := currentHeight - 1; h >= currentHeight-4320 && h >= 0; h-- {
-				hash, err := exp.dataSource.BlockHash(ctx, h)
+				skaFees, err := exp.dataSource.GetBlockSKAFees(ctx, h)
 				if err != nil {
 					continue
 				}
-				bInfo := exp.dataSource.GetExplorerBlock(ctx, hash)
-				if bInfo != nil && len(bInfo.SKAPoWRewards) > 0 {
-					// Convert []types.PoWSKAReward back to map[uint8]string for sorting/assignment.
-					powRewardsMap = make(map[uint8]string)
-					for _, r := range bInfo.SKAPoWRewards {
-						powRewardsMap[r.CoinType] = r.Amount
-					}
+				if len(skaFees) > 0 {
+					powRewardsMap = skaFees
 					break
 				}
 			}

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -166,6 +166,15 @@ func (m *mockDataSource) SKACoinSupply(ctx context.Context) ([]*explorerTypes.SK
 	return nil, nil
 }
 
+var mockGetBlockSKAFeesResult map[uint8]string
+
+func (m *mockDataSource) GetBlockSKAFees(ctx context.Context, height int64) (map[uint8]string, error) {
+	if mockGetBlockSKAFeesResult != nil {
+		return mockGetBlockSKAFeesResult, nil
+	}
+	return nil, nil
+}
+
 func TestStore_PoWSKARewardsFallback(t *testing.T) {
 	params := chaincfg.MainNetParams()
 
@@ -193,6 +202,8 @@ func TestStore_PoWSKARewardsFallback(t *testing.T) {
 	}
 
 	t.Run("ImmediateSuccess", func(t *testing.T) {
+		defer func() { mockGetBlockSKAFeesResult = nil }()
+		mockGetBlockSKAFeesResult = nil
 		exp, mockDS := setup()
 		msgBlock := &wire.MsgBlock{Header: wire.BlockHeader{}}
 		hash := msgBlock.BlockHash().String()
@@ -230,6 +241,8 @@ func TestStore_PoWSKARewardsFallback(t *testing.T) {
 	})
 
 	t.Run("FallbackSuccess", func(t *testing.T) {
+		defer func() { mockGetBlockSKAFeesResult = nil }()
+		mockGetBlockSKAFeesResult = map[uint8]string{1: "50"}
 		exp, mockDS := setup()
 		msgBlock := &wire.MsgBlock{Header: wire.BlockHeader{}}
 		hash := msgBlock.BlockHash().String()
@@ -280,6 +293,8 @@ func TestStore_PoWSKARewardsFallback(t *testing.T) {
 	})
 
 	t.Run("ExhaustiveSearch", func(t *testing.T) {
+		defer func() { mockGetBlockSKAFeesResult = nil }()
+		mockGetBlockSKAFeesResult = nil
 		exp, mockDS := setup()
 		msgBlock := &wire.MsgBlock{Header: wire.BlockHeader{}}
 		hash := msgBlock.BlockHash().String()

--- a/cmd/dcrdata/views/home_mempool.tmpl
+++ b/cmd/dcrdata/views/home_mempool.tmpl
@@ -119,7 +119,7 @@
                                     <td class="text-start">{{.Type}}</td>
                                     {{- if .SKATotals -}}
                                       {{- range $id, $amt := .SKATotals -}}
-                                    <td class="text-start text-nowrap">SKA-{{$id}}</td>
+                                    <td class="text-start text-nowrap">SKA{{$id}}</td>
                                     <td class="text-end">{{formatCoinAtoms $amt $id}}</td>
                                       {{- end -}}
                                     {{- else -}}

--- a/cmd/dcrdata/views/home_supply.tmpl
+++ b/cmd/dcrdata/views/home_supply.tmpl
@@ -26,7 +26,7 @@
                 <div class="mt-2">
                     <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
                         <span class="int">{{formatCoinAtomsFull .InCirculation .CoinType}}</span>
-                        <span class="ps-1 unit lh15rem">SKA-{{.CoinType}}</span>
+                        <span class="ps-1 unit lh15rem">SKA{{.CoinType}}</span>
                     </div>
                     <div class="fs12 lh1rem text-black-50">Issued: <span class="mono">{{formatCoinAtomsFull .TotalIssued .CoinType}}</span></div>
                     <div class="fs12 lh1rem text-black-50">Burned: <span class="mono">{{formatCoinAtomsFull .TotalBurned .CoinType}}</span></div>

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6262,68 +6262,6 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		block.PoWHash = header.PowHashV2().String()
 	}
 
-	// PoW SKA Rewards Aggregation
-	rewardsMap := make(map[uint8]*big.Int)
-	var minerAddresses = make(map[string]bool)
-
-	// 1. Identify the coinbase transaction and collect all miner addresses.
-	var coinbaseMsgTx *wire.MsgTx
-	for _, tx := range data.RawTx {
-		if msgTx, err := txhelpers.MsgTxFromHex(tx.Hex); err == nil && txhelpers.IsCoinBaseTx(msgTx) {
-			coinbaseMsgTx = msgTx
-			break
-		}
-	}
-	if coinbaseMsgTx == nil {
-		for _, tx := range data.RawSTx {
-			if msgTx, err := txhelpers.MsgTxFromHex(tx.Hex); err == nil && txhelpers.IsCoinBaseTx(msgTx) {
-				coinbaseMsgTx = msgTx
-				break
-			}
-		}
-	}
-
-	if coinbaseMsgTx != nil {
-		for _, out := range coinbaseMsgTx.TxOut {
-			_, addrs := stdscript.ExtractAddrs(out.Version, out.PkScript, pgb.chainParams)
-			for _, addr := range addrs {
-				minerAddresses[addr.String()] = true
-			}
-		}
-
-		// 2. Aggregate all SKA rewards from all block transactions that go to these miners.
-		aggregate := func(txs []chainjson.TxRawResult) {
-			for _, tx := range txs {
-				msgTx, err := txhelpers.MsgTxFromHex(tx.Hex)
-				if err != nil {
-					continue
-				}
-				for _, out := range msgTx.TxOut {
-					_, addrs := stdscript.ExtractAddrs(out.Version, out.PkScript, pgb.chainParams)
-					isMiner := false
-					for _, addr := range addrs {
-						if minerAddresses[addr.String()] {
-							isMiner = true
-							break
-						}
-					}
-					if isMiner && out.CoinType.IsSKA() && out.SKAValue != nil {
-						ct := uint8(out.CoinType)
-						if cur, ok := rewardsMap[ct]; ok {
-							cur.Add(cur, out.SKAValue)
-						} else {
-							rewardsMap[ct] = new(big.Int).Set(out.SKAValue)
-						}
-					}
-				}
-			}
-		}
-
-		aggregate(data.RawTx)
-		aggregate(data.RawSTx)
-		block.SKAPoWRewards = powRewardsFromMap(rewardsMap)
-	}
-
 	votes := make([]*exptypes.TrimmedTxInfo, 0, block.Voters)
 	revocations := make([]*exptypes.TrimmedTxInfo, 0, block.Revocations)
 	tickets := make([]*exptypes.TrimmedTxInfo, 0, block.FreshStake)

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -5022,6 +5022,20 @@ func (pgb *ChainDB) GetBlockByHash(ctx context.Context, hash string) (*wire.MsgB
 	return pgb.Client.GetBlock(ctx, blockHash)
 }
 
+// GetBlockSKAFees calculates SKA PoW fees (transaction fees) for a block by fetching
+// the raw block via RPC and computing: sum(inputs) - sum(outputs) = miner fee.
+func (pgb *ChainDB) GetBlockSKAFees(ctx context.Context, height int64) (map[uint8]string, error) {
+	hash, err := pgb.BlockHash(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+	msgBlock, err := pgb.GetBlockByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	return blockdata.BlockSKAFees(msgBlock), nil
+}
+
 // GetHeader fetches the *chainjson.GetBlockHeaderVerboseResult for a given
 // block height.
 func (pgb *ChainDB) GetHeader(idx int) *chainjson.GetBlockHeaderVerboseResult {


### PR DESCRIPTION
## Summary
- **Root cause**: SKA PoW rewards were being extracted from coinbase, but coinbase is always empty for SKA. The actual SKA fees come from regular transaction inputs minus outputs.
- **Fix**: Extract SKA fees from regular transactions in `BlockSKAFees()` (input SKA - output SKA = miner fee), and use RPC in fallback search to compute fees when cached data is unavailable.
## Changes
- Add `BlockSKAFees()` function that calculates transaction fees from regular (non-stake) transactions
- Add `GetBlockSKAFees()` method on ChainDB that uses RPC to fetch raw block and compute SKA fees
- Add fallback logic in explorer UI that searches backwards (up to 4320 blocks) using RPC to find last block with SKA transactions
## Testing
- Unit tests added for `BlockSKAFees()` covering both SKA transactions and empty blocks
- Live tested: fallback finds block 30067 with ~2 SKA fee
## Files Changed
- `blockdata/blockdata.go`: Add `BlockSKAFees()` function
- `blockdata/blockdata_test.go`: Add tests
- `cmd/dcrdata/internal/explorer/explorer.go`: Fallback logic with RPC
- `db/dcrpg/pgblockchain.go`: Add `GetBlockSKAFees()` method