### PR TITLE
fix: Unify SKA-n → SKAN naming across system

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -758,9 +758,9 @@ type BlockDataBasic struct {
 	NumTx      uint32  `json:"txlength"`
 	MiningFee  *int64  `json:"fees,omitempty"`
 	TotalSent  *int64  `json:"total_sent,omitempty"`
-	// CoinAmounts holds per-coin totals (VAR key=0, SKA-n key=n) as decimal atom strings.
+	// CoinAmounts holds per-coin totals (VAR key=0, SKAn key=n) as decimal atom strings.
 	CoinAmounts map[uint8]string `json:"coin_amounts,omitempty"`
-	// CoinTxStats holds per-coin tx count and size (key 0=VAR, 1-255=SKA-n).
+	// CoinTxStats holds per-coin tx count and size (key 0=VAR, 1-255=SKAn).
 	CoinTxStats map[uint8]CoinTxStats `json:"coin_tx_stats,omitempty"`
 	// SSFeeTotalsByCoin holds total SKA atoms distributed via TxTypeSSFee per coin type.
 	SSFeeTotalsByCoin map[uint8]string `json:"ssfee_totals,omitempty"`
@@ -794,9 +794,9 @@ type BlockExplorerExtraInfo struct {
 	TxLen            int                              `json:"tx"`
 	CoinSupply       int64                            `json:"coin_supply"`
 	NextBlockSubsidy *chainjson.GetBlockSubsidyResult `json:"next_block_subsidy"`
-	// CoinAmounts holds per-coin totals (VAR key=0, SKA-n key=n) as decimal atom strings.
+	// CoinAmounts holds per-coin totals (VAR key=0, SKAn key=n) as decimal atom strings.
 	CoinAmounts map[uint8]string `json:"coin_amounts,omitempty"`
-	// CoinTxStats holds per-coin tx count and size (key 0=VAR, 1-255=SKA-n).
+	// CoinTxStats holds per-coin tx count and size (key 0=VAR, 1-255=SKAn).
 	CoinTxStats map[uint8]CoinTxStats `json:"coin_tx_stats,omitempty"`
 	// SSFeeTotalsByCoin holds total SKA atoms distributed via TxTypeSSFee per coin type.
 	SSFeeTotalsByCoin map[uint8]string `json:"ssfee_totals,omitempty"`

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -402,7 +402,7 @@ func (t *Collector) Collect() (*BlockData, *wire.MsgBlock, error) {
 }
 
 // blockCoinTxStats returns per-coin tx count and total serialized size for all
-// transactions in a block (key 0=VAR, 1-255=SKA-n). Returns nil for empty blocks.
+// transactions in a block (key 0=VAR, 1-255=SKAn). Returns nil for empty blocks.
 func blockCoinTxStats(msgBlock *wire.MsgBlock) map[uint8]apitypes.CoinTxStats {
 	stats := make(map[uint8]apitypes.CoinTxStats)
 	allTxs := append(msgBlock.Transactions, msgBlock.STransactions...)
@@ -430,7 +430,7 @@ func blockCoinTxStats(msgBlock *wire.MsgBlock) map[uint8]apitypes.CoinTxStats {
 }
 
 // blockCoinAmounts iterates all transactions in a block and returns a map of
-// per-coin output totals as decimal atom strings (key 0=VAR, 1-255=SKA-n).
+// per-coin output totals as decimal atom strings (key 0=VAR, 1-255=SKAn).
 func blockCoinAmounts(msgBlock *wire.MsgBlock) map[uint8]string {
 	var varTotal int64
 	skaTotal := make(map[uint8]*big.Int)

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -33,7 +33,7 @@ func TestBlockCoinAmounts_VAROnly(t *testing.T) {
 }
 
 func TestBlockCoinAmounts_SKAOnly(t *testing.T) {
-	// SKA-1 amount exceeding int64 max
+	// SKA1 amount exceeding int64 max
 	bigAmt := new(big.Int).Add(
 		new(big.Int).Lsh(big.NewInt(1), 63),
 		big.NewInt(999),
@@ -46,7 +46,7 @@ func TestBlockCoinAmounts_SKAOnly(t *testing.T) {
 		t.Fatal("expected non-nil CoinAmounts")
 	}
 	if got[1] != bigAmt.String() {
-		t.Errorf("SKA-1 total: want %s, got %s", bigAmt, got[1])
+		t.Errorf("SKA1 total: want %s, got %s", bigAmt, got[1])
 	}
 	if _, hasVAR := got[0]; hasVAR {
 		t.Error("expected no VAR key for SKA-only block")
@@ -70,7 +70,7 @@ func TestBlockCoinAmounts_Mixed(t *testing.T) {
 		t.Errorf("VAR: want 100000000, got %s", got[0])
 	}
 	if got[1] != skaBig.String() {
-		t.Errorf("SKA-1: want %s, got %s", skaBig, got[1])
+		t.Errorf("SKA1: want %s, got %s", skaBig, got[1])
 	}
 }
 
@@ -102,13 +102,13 @@ func TestBlockCoinTxStats_Mixed(t *testing.T) {
 		t.Errorf("VAR TxCount: want 1, got %d", got[0].TxCount)
 	}
 	if got[1].TxCount != 1 {
-		t.Errorf("SKA-1 TxCount: want 1, got %d", got[1].TxCount)
+		t.Errorf("SKA1 TxCount: want 1, got %d", got[1].TxCount)
 	}
 	if got[0].Size != uint32(varTx.SerializeSize()) {
 		t.Errorf("VAR Size: want %d, got %d", varTx.SerializeSize(), got[0].Size)
 	}
 	if got[1].Size != uint32(skaTx.SerializeSize()) {
-		t.Errorf("SKA-1 Size: want %d, got %d", skaTx.SerializeSize(), got[1].Size)
+		t.Errorf("SKA1 Size: want %d, got %d", skaTx.SerializeSize(), got[1].Size)
 	}
 }
 
@@ -123,18 +123,18 @@ func TestBlockSKAPoWRewards_SKAOnly(t *testing.T) {
 	skaBig := new(big.Int).Mul(big.NewInt(1_000_000), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
 	coinbase := wire.NewMsgTx()
 	coinbase.AddTxOut(wire.NewTxOut(100_000_000, nil))                     // VAR reward
-	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(1), nil)) // SKA-1 reward
-	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(2), nil)) // SKA-2 reward
+	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(1), nil)) // SKA1 reward
+	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(2), nil)) // SKA2 reward
 
 	got := BlockSKAPoWRewards(mockBlock(coinbase))
 	if got == nil {
 		t.Fatal("expected non-nil SKAPoWRewards")
 	}
 	if got[1] != skaBig.String() {
-		t.Errorf("SKA-1: want %s, got %s", skaBig, got[1])
+		t.Errorf("SKA1: want %s, got %s", skaBig, got[1])
 	}
 	if got[2] != skaBig.String() {
-		t.Errorf("SKA-2: want %s, got %s", skaBig, got[2])
+		t.Errorf("SKA2: want %s, got %s", skaBig, got[2])
 	}
 	if _, hasVAR := got[0]; hasVAR {
 		t.Error("expected no VAR reward in SKAPoWRewards")
@@ -176,7 +176,7 @@ func TestBlockSKAPoWRewards_Summing(t *testing.T) {
 	}
 	expected := "300"
 	if got[1] != expected {
-		t.Errorf("SKA-1: want %s, got %s", expected, got[1])
+		t.Errorf("SKA1: want %s, got %s", expected, got[1])
 	}
 }
 
@@ -184,18 +184,18 @@ func TestExtractSKARewardsFromCoinbase_Standard(t *testing.T) {
 	skaBig := new(big.Int).Mul(big.NewInt(1_000_000), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
 	coinbase := wire.NewMsgTx()
 	coinbase.AddTxOut(wire.NewTxOut(100_000_000, nil))                     // VAR reward
-	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(1), nil)) // SKA-1 reward
-	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(2), nil)) // SKA-2 reward
+	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(1), nil)) // SKA1 reward
+	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(2), nil)) // SKA2 reward
 
 	got := ExtractSKARewardsFromCoinbase(coinbase)
 	if got == nil {
 		t.Fatal("expected non-nil SKARewards")
 	}
 	if got[1] != skaBig.String() {
-		t.Errorf("SKA-1: want %s, got %s", skaBig, got[1])
+		t.Errorf("SKA1: want %s, got %s", skaBig, got[1])
 	}
 	if got[2] != skaBig.String() {
-		t.Errorf("SKA-2: want %s, got %s", skaBig, got[2])
+		t.Errorf("SKA2: want %s, got %s", skaBig, got[2])
 	}
 	if _, hasVAR := got[0]; hasVAR {
 		t.Error("expected no VAR reward in ExtractSKARewardsFromCoinbase")
@@ -235,6 +235,6 @@ func TestExtractSKARewardsFromCoinbase_Summing(t *testing.T) {
 	}
 	expected := "300"
 	if got[1] != expected {
-		t.Errorf("SKA-1: want %s, got %s", expected, got[1])
+		t.Errorf("SKA1: want %s, got %s", expected, got[1])
 	}
 }

--- a/cmd/dcrdata/internal/api/apiroutes_test.go
+++ b/cmd/dcrdata/internal/api/apiroutes_test.go
@@ -50,7 +50,7 @@ func TestGetBlockSummary_CoinAmounts(t *testing.T) {
 		t.Errorf("VAR: want 100000000, got %s", result.CoinAmounts[0])
 	}
 	if result.CoinAmounts[1] != "1000000000000000000" {
-		t.Errorf("SKA-1: want 1000000000000000000, got %s", result.CoinAmounts[1])
+		t.Errorf("SKA1: want 1000000000000000000, got %s", result.CoinAmounts[1])
 	}
 }
 

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -702,7 +702,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 			}
 			rewards = append(rewards, types.SKAVoteReward{
 				CoinType:  ct,
-				Symbol:    fmt.Sprintf("SKA-%d", ct),
+				Symbol:    fmt.Sprintf("SKA%d", ct),
 				PerBlock:  perBlock,
 				Per30Days: txhelpers.AvgSSFeeRate(sum30S, ct, exp.ChainParams.TicketsPerBlock),
 				PerYear:   txhelpers.AvgSSFeeRate(sumYearS, ct, exp.ChainParams.TicketsPerBlock),
@@ -748,7 +748,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 			for ct, amountStr := range powRewardsMap {
 				powRewards = append(powRewards, types.PoWSKAReward{
 					CoinType: ct,
-					Symbol:   fmt.Sprintf("SKA-%d", ct),
+					Symbol:   fmt.Sprintf("SKA%d", ct),
 					Amount:   amountStr,
 				})
 			}
@@ -1211,7 +1211,7 @@ func computeCoinFills(stats map[uint8]types.MempoolCoinStats, maxBlockSize float
 		status := fillStatus(size, perSKAQuota)
 		extra, overflow := extraOrOverflow(size, perSKAQuota, status)
 		fills = append(fills, types.CoinFillData{
-			Symbol:            fmt.Sprintf("SKA-%d", ct),
+			Symbol:            fmt.Sprintf("SKA%d", ct),
 			GQFillRatio:       math.Min(size/perSKAQuota, 1.0),
 			ExtraFillRatio:    extra,
 			OverflowFillRatio: overflow,

--- a/cmd/dcrdata/internal/explorer/home_template_test.go
+++ b/cmd/dcrdata/internal/explorer/home_template_test.go
@@ -45,7 +45,7 @@ func TestHomeTemplate_IndicatorList(t *testing.T) {
 
 	fills := []types.CoinFillData{
 		{Symbol: "VAR", GQFillRatio: 0.5, GQPositionRatio: 0.10, Status: "ok"},
-		{Symbol: "SKA-1", GQFillRatio: 0.8, GQPositionRatio: 0.45, ExtraFillRatio: 0.1, Status: "borrowing"},
+		{Symbol: "SKA1", GQFillRatio: 0.8, GQPositionRatio: 0.45, ExtraFillRatio: 0.1, Status: "borrowing"},
 	}
 	data := struct {
 		*CommonPageData
@@ -158,15 +158,15 @@ func TestHomeTemplate_BlocksTable(t *testing.T) {
 			name: "1 SKA type",
 			blocks: []*types.BlockBasic{makeTestBlock(101, []types.CoinRowData{
 				{CoinType: 0, Symbol: "VAR", Amount: "100000000"},
-				{CoinType: 1, Symbol: "SKA-1", Amount: "1000000000000000000"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "1000000000000000000"},
 			})},
 		},
 		{
 			name: "2 SKA types",
 			blocks: []*types.BlockBasic{makeTestBlock(102, []types.CoinRowData{
 				{CoinType: 0, Symbol: "VAR", Amount: "200000000"},
-				{CoinType: 1, Symbol: "SKA-1", Amount: "500000000000000000"},
-				{CoinType: 2, Symbol: "SKA-2", Amount: "250000000000000000"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "500000000000000000"},
+				{CoinType: 2, Symbol: "SKA2", Amount: "250000000000000000"},
 			})},
 		},
 	}

--- a/cmd/dcrdata/internal/explorer/home_viewmodel.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel.go
@@ -37,7 +37,7 @@ type HomeBlockRow struct {
 // SKASubRow is one accordion detail row for a specific SKA token type.
 // All numeric fields are pre-formatted strings.
 type SKASubRow struct {
-	TokenType string // e.g. "SKA-1", "SKA-2"
+	TokenType string // e.g. "SKA1", "SKA2"
 	TxCount   string // pre-formatted
 	Amount    string // pre-formatted
 	Size      string // pre-formatted

--- a/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
@@ -123,7 +123,7 @@ func TestBuildHomeBlockRows_WithCoinRows(t *testing.T) {
 			// 1 230 000 000 VAR atoms = 12.3 VAR coins (8 decimals)
 			{CoinType: 0, Symbol: "VAR", TxCount: 5, Amount: "1230000000", Size: 1024},
 			// 1 230 000 000 000 000 000 SKA atoms = 1.23 SKA coins (18 decimals)
-			{CoinType: 1, Symbol: "SKA-1", TxCount: 2, Amount: "1230000000000000000", Size: 512},
+			{CoinType: 1, Symbol: "SKA1", TxCount: 2, Amount: "1230000000000000000", Size: 512},
 		},
 	}
 	rows := buildHomeBlockRows([]*types.BlockBasic{b})
@@ -142,8 +142,8 @@ func TestBuildHomeBlockRows_WithCoinRows(t *testing.T) {
 	if len(r.SKASubRows) != 1 {
 		t.Fatalf("expected 1 SKASubRow, got %d", len(r.SKASubRows))
 	}
-	if r.SKASubRows[0].TokenType != "SKA-1" {
-		t.Errorf("SKASubRow TokenType: got %q, want %q", r.SKASubRows[0].TokenType, "SKA-1")
+	if r.SKASubRows[0].TokenType != "SKA1" {
+		t.Errorf("SKASubRow TokenType: got %q, want %q", r.SKASubRows[0].TokenType, "SKA1")
 	}
 	wantSKA := threeSigFigs(skaCoinValue("1230000000000000000")) // "1.23"
 	if r.SKASubRows[0].Amount != wantSKA {
@@ -164,15 +164,15 @@ func TestBuildHomeBlockRows_TransactionsSumsCoinRows(t *testing.T) {
 		Transactions: 3, // regular-tree only — should NOT appear in the result
 		CoinRows: []types.CoinRowData{
 			{CoinType: 0, Symbol: "VAR", TxCount: 5, Amount: "1000000000", Size: 200},
-			{CoinType: 1, Symbol: "SKA-1", TxCount: 2, Amount: "1000000000000000000", Size: 100},
-			{CoinType: 2, Symbol: "SKA-2", TxCount: 4, Amount: "2000000000000000000", Size: 150},
+			{CoinType: 1, Symbol: "SKA1", TxCount: 2, Amount: "1000000000000000000", Size: 100},
+			{CoinType: 2, Symbol: "SKA2", TxCount: 4, Amount: "2000000000000000000", Size: 150},
 		},
 	}
 	rows := buildHomeBlockRows([]*types.BlockBasic{b})
 	if len(rows) != 1 {
 		t.Fatalf("expected 1 row, got %d", len(rows))
 	}
-	// 5 (VAR) + 2 (SKA-1) + 4 (SKA-2) = 11, not b.Transactions (3)
+	// 5 (VAR) + 2 (SKA1) + 4 (SKA2) = 11, not b.Transactions (3)
 	if rows[0].Transactions != 11 {
 		t.Errorf("Transactions: got %d, want 11 (sum of CoinRows)", rows[0].Transactions)
 	}
@@ -185,8 +185,8 @@ func TestBuildHomeBlockRows_MultipleSKATypes(t *testing.T) {
 		Height: 30,
 		CoinRows: []types.CoinRowData{
 			{CoinType: 0, Symbol: "VAR", TxCount: 3, Amount: "10000000000", Size: 200},
-			{CoinType: 1, Symbol: "SKA-1", TxCount: 1, Amount: "50000000000000000000", Size: 100},
-			{CoinType: 2, Symbol: "SKA-2", TxCount: 2, Amount: "75000000000000000000", Size: 150},
+			{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "50000000000000000000", Size: 100},
+			{CoinType: 2, Symbol: "SKA2", TxCount: 2, Amount: "75000000000000000000", Size: 150},
 		},
 	}
 	rows := buildHomeBlockRows([]*types.BlockBasic{b})
@@ -211,8 +211,8 @@ func TestBuildHomeBlockRows_SKASubRowTokenTypeNonEmpty(t *testing.T) {
 		Height: 40,
 		CoinRows: []types.CoinRowData{
 			{CoinType: 0, Symbol: "VAR", Amount: "1000000000"},
-			{CoinType: 1, Symbol: "SKA-1", Amount: "1000000000000000000"},
-			{CoinType: 3, Symbol: "SKA-3", Amount: "2000000000000000000"},
+			{CoinType: 1, Symbol: "SKA1", Amount: "1000000000000000000"},
+			{CoinType: 3, Symbol: "SKA3", Amount: "2000000000000000000"},
 		},
 	}
 	rows := buildHomeBlockRows([]*types.BlockBasic{b})

--- a/cmd/dcrdata/internal/explorer/home_voting_template_test.go
+++ b/cmd/dcrdata/internal/explorer/home_voting_template_test.go
@@ -106,7 +106,7 @@ func TestVotingCardTemplate(t *testing.T) {
 		if !strings.Contains(out, "No SKA rewards available") {
 			t.Error("expected 'No SKA rewards available' in output")
 		}
-		if strings.Contains(out, "SKA-") {
+		if strings.Contains(out, "SKA") {
 			t.Error("expected no SKA symbol rows for empty SKA slice")
 		}
 	})
@@ -114,14 +114,14 @@ func TestVotingCardTemplate(t *testing.T) {
 	// Case 5 — Single SKA entry
 	t.Run("SingleSKAEntry", func(t *testing.T) {
 		ska := []types.SKAVoteReward{
-			{CoinType: 1, Symbol: "SKA-1", PerBlock: "0.097178596780181388", Per30Days: "0.038980675541825918", PerYear: "0.038980675541825918"},
+			{CoinType: 1, Symbol: "SKA1", PerBlock: "0.097178596780181388", Per30Days: "0.038980675541825918", PerYear: "0.038980675541825918"},
 		}
 		out := renderVotingCard(t, tmpl, makeHomeInfo(types.VoteVARReward{}, ska))
 		if strings.Contains(out, "No SKA rewards available") {
 			t.Error("should not show placeholder when SKA entries are present")
 		}
-		if !strings.Contains(out, "SKA-1") {
-			t.Error("expected symbol 'SKA-1' in output")
+		if !strings.Contains(out, "SKA1") {
+			t.Error("expected symbol 'SKA1' in output")
 		}
 		// PerBlock rendered via decimalParts: int "0", bold decimals "09", rest "7178596780181388"
 		if !strings.Contains(out, `class="int"`) {
@@ -136,8 +136,8 @@ func TestVotingCardTemplate(t *testing.T) {
 		if !strings.Contains(out, "0.038980675541825918") {
 			t.Error("expected Per30Days value in output")
 		}
-		if !strings.Contains(out, "SKA-1/VAR") {
-			t.Error("expected unit label 'SKA-1/VAR' in output")
+		if !strings.Contains(out, "SKA1/VAR") {
+			t.Error("expected unit label 'SKA1/VAR' in output")
 		}
 	})
 
@@ -154,7 +154,7 @@ func TestVotingCardTemplate(t *testing.T) {
 	t.Run("SKAPerBlockDecimalParts", func(t *testing.T) {
 		ska := []types.SKAVoteReward{
 			// value with significant non-zero decimals beyond the bold 2 places
-			{CoinType: 2, Symbol: "SKA-2", PerBlock: "1.234567890000000000", Per30Days: "30.000000000000000000", PerYear: "365.000000000000000000"},
+			{CoinType: 2, Symbol: "SKA2", PerBlock: "1.234567890000000000", Per30Days: "30.000000000000000000", PerYear: "365.000000000000000000"},
 		}
 		out := renderVotingCard(t, tmpl, makeHomeInfo(types.VoteVARReward{}, ska))
 		if !strings.Contains(out, `class="decimal-parts`) {
@@ -224,7 +224,7 @@ func TestProp_SKASliceOrderPreserved(t *testing.T) {
 		symbols := make([]string, n)
 		for i := 0; i < n; i++ {
 			coinType := rapid.Uint8Range(1, 255).Draw(t, fmt.Sprintf("coinType%d", i))
-			sym := fmt.Sprintf("SKA-%d", coinType)
+			sym := fmt.Sprintf("SKA%d", coinType)
 			skaRewards[i] = types.SKAVoteReward{
 				CoinType:  coinType,
 				Symbol:    sym,
@@ -265,7 +265,7 @@ func TestProp_SKAStringsVerbatim(t *testing.T) {
 		per30Days := rapid.StringMatching(`\d{1,15}\.\d{18}`).Draw(t, "per30Days")
 		perYear := rapid.StringMatching(`\d{1,15}\.\d{18}`).Draw(t, "perYear")
 		ska := []types.SKAVoteReward{
-			{CoinType: 1, Symbol: "SKA-1", PerBlock: perBlock, Per30Days: per30Days, PerYear: perYear},
+			{CoinType: 1, Symbol: "SKA1", PerBlock: perBlock, Per30Days: per30Days, PerYear: perYear},
 		}
 		info := makeHomeInfo(types.VoteVARReward{}, ska)
 		out := renderVotingCard(t, tmpl, info)
@@ -303,7 +303,7 @@ func TestProp_RenderedHTMLWellFormed(t *testing.T) {
 			coinType := rapid.Uint8Range(1, 255).Draw(t, fmt.Sprintf("coinType%d", i))
 			skaRewards[i] = types.SKAVoteReward{
 				CoinType:  coinType,
-				Symbol:    fmt.Sprintf("SKA-%d", coinType),
+				Symbol:    fmt.Sprintf("SKA%d", coinType),
 				PerBlock:  "0.000000000000000001",
 				Per30Days: "0.000000000000000030",
 				PerYear:   "0.000000000000000365",
@@ -329,7 +329,7 @@ func TestProp_SKAVoteRewardsContainerExactlyOnce(t *testing.T) {
 			coinType := rapid.Uint8Range(1, 255).Draw(t, fmt.Sprintf("coinType%d", i))
 			skaRewards[i] = types.SKAVoteReward{
 				CoinType:  coinType,
-				Symbol:    fmt.Sprintf("SKA-%d", coinType),
+				Symbol:    fmt.Sprintf("SKA%d", coinType),
 				PerBlock:  "0.000000000000000001",
 				Per30Days: "0.000000000000000030",
 				PerYear:   "0.000000000000000365",

--- a/cmd/dcrdata/internal/explorer/home_voting_template_test.go
+++ b/cmd/dcrdata/internal/explorer/home_voting_template_test.go
@@ -106,7 +106,7 @@ func TestVotingCardTemplate(t *testing.T) {
 		if !strings.Contains(out, "No SKA rewards available") {
 			t.Error("expected 'No SKA rewards available' in output")
 		}
-		if strings.Contains(out, "SKA") {
+		if strings.Contains(out, "SKA1") || strings.Contains(out, "SKA2") {
 			t.Error("expected no SKA symbol rows for empty SKA slice")
 		}
 	})

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -286,7 +286,7 @@ func TestCoinRowData_Variants(t *testing.T) {
 	// 1 SKA type
 	rows1 := []types.CoinRowData{
 		{CoinType: 0, Symbol: "VAR", TxCount: 3, Amount: "500 VAR", Size: 512},
-		{CoinType: 1, Symbol: "SKA-1", TxCount: 2, Amount: "1M SKA-1", Size: 256},
+		{CoinType: 1, Symbol: "SKA1", TxCount: 2, Amount: "1M SKA1", Size: 256},
 	}
 	if len(rows1) != 2 || rows1[1].CoinType != 1 {
 		t.Errorf("1 SKA: unexpected rows: %v", rows1)
@@ -295,10 +295,10 @@ func TestCoinRowData_Variants(t *testing.T) {
 	// 2 SKA types
 	rows2 := []types.CoinRowData{
 		{CoinType: 0, Symbol: "VAR", TxCount: 1, Amount: "100 VAR", Size: 200},
-		{CoinType: 1, Symbol: "SKA-1", TxCount: 1, Amount: "50 SKA-1", Size: 100},
-		{CoinType: 2, Symbol: "SKA-2", TxCount: 1, Amount: "25 SKA-2", Size: 100},
+		{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "50 SKA1", Size: 100},
+		{CoinType: 2, Symbol: "SKA2", TxCount: 1, Amount: "25 SKA2", Size: 100},
 	}
-	if len(rows2) != 3 || rows2[2].Symbol != "SKA-2" {
+	if len(rows2) != 3 || rows2[2].Symbol != "SKA2" {
 		t.Errorf("2 SKA: unexpected rows: %v", rows2)
 	}
 
@@ -315,7 +315,7 @@ func TestCoinRowData_Variants(t *testing.T) {
 func TestCoinFillData(t *testing.T) {
 	fills := []types.CoinFillData{
 		{Symbol: "VAR", GQFillRatio: 0.5, GQPositionRatio: 0.10, Status: "ok"},
-		{Symbol: "SKA-1", GQFillRatio: 1.0, GQPositionRatio: 0.90, Status: "full"},
+		{Symbol: "SKA1", GQFillRatio: 1.0, GQPositionRatio: 0.90, Status: "full"},
 	}
 	mpi := types.MempoolInfo{}
 	mpi.CoinFills = fills
@@ -391,7 +391,7 @@ func TestComputeCoinFills(t *testing.T) {
 		}
 		var ska types.CoinFillData
 		for _, f := range fills {
-			if f.Symbol == "SKA-1" {
+			if f.Symbol == "SKA1" {
 				ska = f
 			}
 		}
@@ -404,7 +404,7 @@ func TestComputeCoinFills(t *testing.T) {
 	})
 
 	t.Run("SKA over own quota, pool not exhausted", func(t *testing.T) {
-		// 2 SKA types, each gets 45 quota; SKA-1 uses 50 but total SKA = 50 < 90
+		// 2 SKA types, each gets 45 quota; SKA1 uses 50 but total SKA = 50 < 90
 		stats := map[uint8]types.MempoolCoinStats{1: {Size: 50}, 2: {Size: 0}}
 		fills, _, numSKA := computeCoinFills(stats, max, nil)
 		if numSKA != 2 {
@@ -412,7 +412,7 @@ func TestComputeCoinFills(t *testing.T) {
 		}
 		var ska1 types.CoinFillData
 		for _, f := range fills {
-			if f.Symbol == "SKA-1" {
+			if f.Symbol == "SKA1" {
 				ska1 = f
 			}
 		}
@@ -438,14 +438,14 @@ func TestComputeCoinFills(t *testing.T) {
 	t.Run("SKA types sorted by ascending coin-type key", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{3: {Size: 1}, 1: {Size: 1}, 2: {Size: 1}}
 		fills, _, _ := computeCoinFills(stats, max, nil)
-		// fills[0] is VAR; fills[1..3] should be SKA-1, SKA-2, SKA-3
-		if fills[1].Symbol != "SKA-1" || fills[2].Symbol != "SKA-2" || fills[3].Symbol != "SKA-3" {
-			t.Errorf("SKA order: want SKA-1,SKA-2,SKA-3 got %s,%s,%s", fills[1].Symbol, fills[2].Symbol, fills[3].Symbol)
+		// fills[0] is VAR; fills[1..3] should be SKA1, SKA2, SKA3
+		if fills[1].Symbol != "SKA1" || fills[2].Symbol != "SKA2" || fills[3].Symbol != "SKA3" {
+			t.Errorf("SKA order: want SKA1,SKA2,SKA3 got %s,%s,%s", fills[1].Symbol, fills[2].Symbol, fills[3].Symbol)
 		}
 	})
 
 	t.Run("issued SKA with no mempool activity gets zero-fill entry", func(t *testing.T) {
-		// SKA-5 is issued on-chain but has no mempool transactions yet.
+		// SKA5 is issued on-chain but has no mempool transactions yet.
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}}
 		fills, _, numSKA := computeCoinFills(stats, max, []uint8{5})
 		if numSKA != 1 {
@@ -453,18 +453,18 @@ func TestComputeCoinFills(t *testing.T) {
 		}
 		var found bool
 		for _, f := range fills {
-			if f.Symbol == "SKA-5" {
+			if f.Symbol == "SKA5" {
 				found = true
 				if f.GQFillRatio != 0 || f.ExtraFillRatio != 0 || f.OverflowFillRatio != 0 {
-					t.Errorf("SKA-5 zero-fill: want all ratios 0, got %+v", f)
+					t.Errorf("SKA5 zero-fill: want all ratios 0, got %+v", f)
 				}
 				if f.Status != "ok" {
-					t.Errorf("SKA-5 zero-fill: want status ok, got %s", f.Status)
+					t.Errorf("SKA5 zero-fill: want status ok, got %s", f.Status)
 				}
 			}
 		}
 		if !found {
-			t.Errorf("SKA-5 not found in fills: %v", fills)
+			t.Errorf("SKA5 not found in fills: %v", fills)
 		}
 	})
 
@@ -476,12 +476,12 @@ func TestComputeCoinFills(t *testing.T) {
 		}
 		count := 0
 		for _, f := range fills {
-			if f.Symbol == "SKA-1" {
+			if f.Symbol == "SKA1" {
 				count++
 			}
 		}
 		if count != 1 {
-			t.Errorf("SKA-1 should appear exactly once, got %d", count)
+			t.Errorf("SKA1 should appear exactly once, got %d", count)
 		}
 	})
 }

--- a/cmd/dcrdata/public/js/coinmempool_test.js
+++ b/cmd/dcrdata/public/js/coinmempool_test.js
@@ -39,7 +39,7 @@ for (const [size, wantFill, wantColor] of tests) {
   }
 }
 
-// VAR=10%, SKA-n share 90% equally
+// VAR=10%, SKAn share 90% equally
 function coinFills(varSize, skaSizes, maxBlock) {
   const fills = []
   const varFill = fillPct(varSize, maxBlock)
@@ -49,7 +49,7 @@ function coinFills(varSize, skaSizes, maxBlock) {
     const skaPct = 0.9 / skaN
     for (let i = 0; i < skaN; i++) {
       const f = fillPct(skaSizes[i], maxBlock)
-      fills.push({ symbol: `SKA-${i + 1}`, fillPct: f * skaPct, color: fillColor(f) })
+      fills.push({ symbol: `SKA${i + 1}`, fillPct: f * skaPct, color: fillColor(f) })
     }
   }
   return fills
@@ -65,7 +65,7 @@ passed++
 // VAR + 1 SKA
 const f2 = coinFills(196608, [100000], MAX_BLOCK)
 console.assert(f2.length === 2, 'VAR+SKA: 2 fills')
-console.assert(Math.abs(f2[1].fillPct - fillPct(100000, MAX_BLOCK) * 0.9) < 1e-9, 'SKA-1 fillPct')
+console.assert(Math.abs(f2[1].fillPct - fillPct(100000, MAX_BLOCK) * 0.9) < 1e-9, 'SKA1 fillPct')
 passed++
 
 console.log(`\n${passed} passed, ${failed} failed`)

--- a/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.test.js
@@ -161,9 +161,9 @@ function makeBlock(
 }
 
 const SKA_ROWS_3 = [
-  { coin_type: 1, symbol: 'SKA-1', tx_count: 42, amount: '1.25M SKA-1', size: 8400 },
-  { coin_type: 2, symbol: 'SKA-2', tx_count: 17, amount: '450K SKA-2', size: 3200 },
-  { coin_type: 3, symbol: 'SKA-3', tx_count: 5, amount: '2.1B SKA-3', size: 1100 }
+  { coin_type: 1, symbol: 'SKA1', tx_count: 42, amount: '1.25M SKA1', size: 8400 },
+  { coin_type: 2, symbol: 'SKA2', tx_count: 17, amount: '450K SKA2', size: 3200 },
+  { coin_type: 3, symbol: 'SKA3', tx_count: 5, amount: '2.1B SKA3', size: 1100 }
 ]
 
 // ---------------------------------------------------------------------------
@@ -361,7 +361,7 @@ describe('blocklist_controller — Property 8: WebSocket block prepend matches s
         expect(r.querySelectorAll('td').length).toBe(9)
         const label = r.querySelector('td.text-end')
         expect(label).not.toBeNull()
-        expect(label.textContent.trim()).toMatch(/^SKA-\d+$/)
+        expect(label.textContent.trim()).toMatch(/^SKA\d+$/)
       })
     })
 
@@ -392,9 +392,9 @@ describe('blocklist_controller — Property 8: WebSocket block prepend matches s
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 10 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA3'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA3'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 0, maxLength: 3 }
@@ -596,9 +596,9 @@ describe('blocklist_controller — home-block-table-hierarchy property tests', (
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 10 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-255'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA255'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-255'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA255'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 0, maxLength: 5 }
@@ -642,9 +642,9 @@ describe('blocklist_controller — home-block-table-hierarchy property tests', (
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 10 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA3'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA3'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 0, maxLength: 5 }
@@ -672,9 +672,9 @@ describe('blocklist_controller — home-block-table-hierarchy property tests', (
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 10 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA3'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA3'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 0, maxLength: 5 }
@@ -703,9 +703,9 @@ describe('blocklist_controller — home-block-table-hierarchy property tests', (
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 255 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-255'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA255'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-255'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA255'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 1, maxLength: 5 }
@@ -738,9 +738,9 @@ describe('blocklist_controller — home-block-table-hierarchy property tests', (
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 10 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA3'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA3'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 0, maxLength: 5 }
@@ -793,9 +793,9 @@ describe('blocklist_controller — home-block-table-hierarchy property tests', (
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 10 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA3'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA3'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 0, maxLength: 5 }
@@ -826,9 +826,9 @@ describe('blocklist_controller — home-block-table-hierarchy property tests', (
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 10 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA3'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA3'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 0, maxLength: 5 }
@@ -859,9 +859,9 @@ describe('blocklist_controller — home-block-table-hierarchy property tests', (
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 10 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA3'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA3'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 0, maxLength: 5 }
@@ -891,9 +891,9 @@ describe('blocklist_controller — home-block-table-hierarchy property tests', (
         fc.array(
           fc.record({
             coin_type: fc.integer({ min: 1, max: 10 }),
-            symbol: fc.constantFrom('SKA-1', 'SKA-2', 'SKA-3'),
+            symbol: fc.constantFrom('SKA1', 'SKA2', 'SKA3'),
             tx_count: fc.integer({ min: 0, max: 100 }),
-            amount: fc.constantFrom('1M SKA-1', '500K SKA-2', '2B SKA-3'),
+            amount: fc.constantFrom('1M SKA1', '500K SKA2', '2B SKA3'),
             size: fc.integer({ min: 100, max: 10000 })
           }),
           { minLength: 0, maxLength: 5 }

--- a/cmd/dcrdata/public/js/controllers/homepage_controller.js
+++ b/cmd/dcrdata/public/js/controllers/homepage_controller.js
@@ -21,7 +21,7 @@ function mempoolTableRow(tx) {
   let coin, amount
   if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
     const [id, atomStr] = Object.entries(tx.ska_totals)[0]
-    coin = `SKA-${id}`
+    coin = `SKA${id}`
     amount = humanize.formatCoinAtoms(atomStr, parseInt(id))
   } else {
     coin = 'VAR'
@@ -370,9 +370,9 @@ export default class extends Controller {
   }
 }
 
-// _coinSortKey returns a numeric sort key: VAR = 0, SKA-n = n.
+// _coinSortKey returns a numeric sort key: VAR = 0, SKAn = n.
 function _coinSortKey(symbol) {
   if (!symbol || symbol === 'VAR') return 0
-  const m = symbol.match(/^SKA-(\d+)$/)
+  const m = symbol.match(/^SKA(\d+)$/)
   return m ? parseInt(m[1], 10) : Number.MAX_SAFE_INTEGER
 }

--- a/cmd/dcrdata/public/js/controllers/supply_controller.js
+++ b/cmd/dcrdata/public/js/controllers/supply_controller.js
@@ -39,7 +39,7 @@ export default class extends Controller {
 
       const in_circulation_formatted = humanize.formatCoinAtomsFull(e.in_circulation, e.coin_type)
       clone.querySelector('.int').textContent = in_circulation_formatted
-      clone.querySelector('.symbol').textContent = `SKA-${e.coin_type}`
+      clone.querySelector('.symbol').textContent = `SKA${e.coin_type}`
       clone.querySelector('.issued').textContent = humanize.formatCoinAtomsFull(
         e.total_issued,
         e.coin_type

--- a/db/dbtypes/conversion.go
+++ b/db/dbtypes/conversion.go
@@ -13,7 +13,7 @@ import (
 )
 
 // blockCoinAmounts sums TxOut values per coin type across all transactions in
-// the block. VAR (key 0) is stored as a decimal int64 string; SKA-n as a
+// the block. VAR (key 0) is stored as a decimal int64 string; SKAn as a
 // big.Int decimal string.
 func blockCoinAmounts(msgBlock *wire.MsgBlock) map[uint8]string {
 	varTotal := int64(0)
@@ -45,7 +45,7 @@ func blockCoinAmounts(msgBlock *wire.MsgBlock) map[uint8]string {
 }
 
 // blockCoinTxStats returns per-coin tx count and total serialized size for all
-// transactions in a block (key 0=VAR, 1-255=SKA-n). Returns nil for empty blocks.
+// transactions in a block (key 0=VAR, 1-255=SKAn). Returns nil for empty blocks.
 func blockCoinTxStats(msgBlock *wire.MsgBlock) map[uint8]CoinTxStats {
 	stats := make(map[uint8]CoinTxStats)
 	allTxs := append(msgBlock.Transactions, msgBlock.STransactions...)

--- a/db/dbtypes/extraction_test.go
+++ b/db/dbtypes/extraction_test.go
@@ -55,7 +55,7 @@ func Test_processTransactions_VAROnly(t *testing.T) {
 }
 
 func Test_processTransactions_SKAOnly(t *testing.T) {
-	// SKA-1 amount exceeding int64 max: 2^63 + 1
+	// SKA1 amount exceeding int64 max: 2^63 + 1
 	bigAmt := new(big.Int).Add(new(big.Int).SetInt64(1<<62), big.NewInt(1<<62))
 	bigAmt.Add(bigAmt, big.NewInt(1000))
 	bigOut := new(big.Int).Sub(bigAmt, big.NewInt(100)) // 100 atoms fee
@@ -86,7 +86,7 @@ func Test_processTransactions_SKAOnly(t *testing.T) {
 	}
 	sentStr, ok := dbTx.SentByCoin[1]
 	if !ok {
-		t.Fatal("SentByCoin missing SKA-1 entry")
+		t.Fatal("SentByCoin missing SKA1 entry")
 	}
 	sentBig, _ := new(big.Int).SetString(sentStr, 10)
 	if sentBig.Cmp(bigOut) != 0 {
@@ -95,7 +95,7 @@ func Test_processTransactions_SKAOnly(t *testing.T) {
 
 	// Vout must carry SKAValue string, not truncated Value
 	if vouts[1][0].CoinType != 1 {
-		t.Errorf("vout CoinType: want 1 (SKA-1), got %d", vouts[1][0].CoinType)
+		t.Errorf("vout CoinType: want 1 (SKA1), got %d", vouts[1][0].CoinType)
 	}
 	if vouts[1][0].Value != 0 {
 		t.Errorf("vout Value must be 0 for SKA output, got %d", vouts[1][0].Value)
@@ -124,7 +124,7 @@ func Test_processTransactions_VinCoinType(t *testing.T) {
 		t.Fatal("expected vin for SKA tx")
 	}
 	if vins[1][0].CoinType != 1 {
-		t.Errorf("vin CoinType: want 1 (SKA-1), got %d", vins[1][0].CoinType)
+		t.Errorf("vin CoinType: want 1 (SKA1), got %d", vins[1][0].CoinType)
 	}
 	if vins[1][0].SKAValue != bigAmt.String() {
 		t.Errorf("vin SKAValue: want %s, got %q", bigAmt, vins[1][0].SKAValue)
@@ -148,7 +148,7 @@ func Test_processTransactions_MixedBlock(t *testing.T) {
 	varTx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 500, nil))
 	varTx.AddTxOut(wire.NewTxOut(400, nil))
 
-	// SKA-1 tx
+	// SKA1 tx
 	skaBig := big.NewInt(1_000_000_000_000_000_000) // 1 SKA coin in atoms
 	skaOut := new(big.Int).Sub(skaBig, big.NewInt(50))
 	skaTx := wire.NewMsgTx()

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -7140,7 +7140,7 @@ func powRewardsFromMap(rewards map[uint8]*big.Int) []exptypes.PoWSKAReward {
 	for ct, amt := range rewards {
 		res = append(res, exptypes.PoWSKAReward{
 			CoinType: ct,
-			Symbol:   fmt.Sprintf("SKA-%d", ct),
+			Symbol:   fmt.Sprintf("SKA%d", ct),
 			Amount:   amt.String(),
 		})
 	}
@@ -7161,7 +7161,7 @@ func coinRowsFromAmounts(amounts map[uint8]string) []exptypes.CoinRowData {
 		if ct == 0 {
 			symbol = "VAR"
 		} else {
-			symbol = fmt.Sprintf("SKA-%d", ct)
+			symbol = fmt.Sprintf("SKA%d", ct)
 		}
 		rows = append(rows, exptypes.CoinRowData{
 			CoinType: ct,

--- a/db/dcrpg/pow_rewards_test.go
+++ b/db/dcrpg/pow_rewards_test.go
@@ -30,7 +30,7 @@ func TestPowRewardsFromMap(t *testing.T) {
 				1: big.NewInt(1000),
 			},
 			want: []exptypes.PoWSKAReward{
-				{CoinType: 1, Symbol: "SKA-1", Amount: "1000"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "1000"},
 			},
 		},
 		{
@@ -41,9 +41,9 @@ func TestPowRewardsFromMap(t *testing.T) {
 				3: big.NewInt(3000),
 			},
 			want: []exptypes.PoWSKAReward{
-				{CoinType: 1, Symbol: "SKA-1", Amount: "1000"},
-				{CoinType: 2, Symbol: "SKA-2", Amount: "2000"},
-				{CoinType: 3, Symbol: "SKA-3", Amount: "3000"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "1000"},
+				{CoinType: 2, Symbol: "SKA2", Amount: "2000"},
+				{CoinType: 3, Symbol: "SKA3", Amount: "3000"},
 			},
 		},
 		{
@@ -55,7 +55,7 @@ func TestPowRewardsFromMap(t *testing.T) {
 				}(),
 			},
 			want: []exptypes.PoWSKAReward{
-				{CoinType: 1, Symbol: "SKA-1", Amount: "12345678901234567890"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "12345678901234567890"},
 			},
 		},
 	}

--- a/explorer/types/blockinfo_test.go
+++ b/explorer/types/blockinfo_test.go
@@ -9,7 +9,7 @@ import (
 func TestBlockInfo_SKAPoWRewards(t *testing.T) {
 	bi := &types.BlockInfo{}
 	bi.SKAPoWRewards = []types.PoWSKAReward{
-		{CoinType: 1, Symbol: "SKA-1", Amount: "100"},
+		{CoinType: 1, Symbol: "SKA1", Amount: "100"},
 	}
 	if len(bi.SKAPoWRewards) != 1 {
 		t.Errorf("expected 1 reward, got %d", len(bi.SKAPoWRewards))

--- a/explorer/types/coinformat.go
+++ b/explorer/types/coinformat.go
@@ -50,7 +50,7 @@ func FormatVARAmount(atoms int64, full bool) string {
 // If full is true, returns full decimal precision (18 decimals).
 // If full is false, returns 3 significant figures with K/M/B/T suffix.
 func FormatSKAAmount(atomsStr string, coinType uint8, full bool) string {
-	label := fmt.Sprintf("SKA-%d", coinType)
+	label := fmt.Sprintf("SKA%d", coinType)
 	atoms, ok := new(big.Int).SetString(atomsStr, 10)
 	if !ok {
 		return "0 " + label

--- a/explorer/types/coinformat_test.go
+++ b/explorer/types/coinformat_test.go
@@ -38,11 +38,11 @@ func TestFormatSKAAmount(t *testing.T) {
 		full     bool
 		want     string
 	}{
-		{oneCoin, 1, true, "1 SKA-1"},
-		{oneAtom, 1, true, "0.000000000000000001 SKA-1"},
-		{bigAmt, 2, false, "1.5M SKA-2"},
-		{"0", 1, true, "0 SKA-1"},
-		{"bad", 1, false, "0 SKA-1"},
+		{oneCoin, 1, true, "1 SKA1"},
+		{oneAtom, 1, true, "0.000000000000000001 SKA1"},
+		{bigAmt, 2, false, "1.5M SKA2"},
+		{"0", 1, true, "0 SKA1"},
+		{"bad", 1, false, "0 SKA1"},
 	}
 	for _, tc := range tests {
 		got := FormatSKAAmount(tc.atoms, tc.coinType, tc.full)

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -503,7 +503,7 @@ type VARCoinSupply struct {
 
 // SKACoinSupplyEntry holds per-SKA-type supply data.
 type SKACoinSupplyEntry struct {
-	CoinType      uint8  `json:"coin_type"`      // SKA-n identifier (1, 2, ...)
+	CoinType      uint8  `json:"coin_type"`      // SKAn identifier (1, 2, ...)
 	InCirculation string `json:"in_circulation"` // big.Int atom string
 	TotalIssued   string `json:"total_issued"`   // big.Int atom string
 	TotalBurned   string `json:"total_burned"`   // big.Int atom string (placeholder: "0")
@@ -573,7 +573,7 @@ type BlockInfo struct {
 	StakeValidationHeight int64
 	Subsidy               *chainjson.GetBlockSubsidyResult
 	SKAPoWRewards         []PoWSKAReward `json:"pow_ska_rewards,omitempty"`
-	// CoinAmounts holds per-coin totals (VAR key=0, SKA-n key=n) as decimal atom strings.
+	// CoinAmounts holds per-coin totals (VAR key=0, SKAn key=n) as decimal atom strings.
 	CoinAmounts map[uint8]string `json:"coin_amounts,omitempty"`
 }
 

--- a/mempool/collector_test.go
+++ b/mempool/collector_test.go
@@ -38,12 +38,12 @@ func TestParseTxns_CoinStats(t *testing.T) {
 		t.Errorf("VAR Size: want 250, got %d", inv.CoinStats[0].Size)
 	}
 	if inv.CoinStats[1].TxCount != 1 {
-		t.Errorf("SKA-1 TxCount: want 1, got %d", inv.CoinStats[1].TxCount)
+		t.Errorf("SKA1 TxCount: want 1, got %d", inv.CoinStats[1].TxCount)
 	}
 	if inv.CoinStats[1].Size != 300 {
-		t.Errorf("SKA-1 Size: want 300, got %d", inv.CoinStats[1].Size)
+		t.Errorf("SKA1 Size: want 300, got %d", inv.CoinStats[1].Size)
 	}
 	if inv.CoinStats[1].Amount != "1000000000000000000" {
-		t.Errorf("SKA-1 Amount: want 1000000000000000000, got %s", inv.CoinStats[1].Amount)
+		t.Errorf("SKA1 Amount: want 1000000000000000000, got %s", inv.CoinStats[1].Amount)
 	}
 }

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -760,7 +760,7 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 			}
 			rewards = append(rewards, exptypes.SKAVoteReward{
 				CoinType:  ct,
-				Symbol:    fmt.Sprintf("SKA-%d", ct),
+				Symbol:    fmt.Sprintf("SKA%d", ct),
 				PerBlock:  perBlock,
 				Per30Days: txhelpers.AvgSSFeeRate(sum30, ct, psh.params.TicketsPerBlock),
 				PerYear:   txhelpers.AvgSSFeeRate(sumYear, ct, psh.params.TicketsPerBlock),
@@ -778,7 +778,7 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 		for ct, amountStr := range blockData.ExtraInfo.SKAPoWRewards {
 			powRewards = append(powRewards, exptypes.PoWSKAReward{
 				CoinType: ct,
-				Symbol:   fmt.Sprintf("SKA-%d", ct),
+				Symbol:   fmt.Sprintf("SKA%d", ct),
 				Amount:   amountStr,
 			})
 		}

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -325,7 +325,7 @@ func TestSKATotalsFromMsgTx(t *testing.T) {
 	}
 	want := new(big.Int).Add(ska1, ska1b).String()
 	if got[1] != want {
-		t.Errorf("SKA-1 total: want %s, got %s", want, got[1])
+		t.Errorf("SKA1 total: want %s, got %s", want, got[1])
 	}
 	if _, hasVAR := got[0]; hasVAR {
 		t.Error("SKATotals should not contain VAR key")


### PR DESCRIPTION
## Summary
Standardizes SKA token naming format from hyphenated (`SKA-1`, `SKA-2`, ...) to no-hyphen (`SKA1`, `SKA2`, ...) across the entire codebase.
## Changes
- **Backend**: Updated `fmt.Sprintf` format strings in API, DB mappings, and structs to use `SKA%d` instead of `SKA-%d`
- **Frontend**: Updated JS test fixtures to match new format
## Acceptance Criteria
- No occurrences of SKA-n in code or UI (excluding compound words like "SKA-free", "SKA-type")
- All API responses return SKA1, SKA2, …
- UI displays consistent naming
## Files Changed
- `explorer/types/coinformat.go` - FormatSKAAmount label
- `db/dcrpg/pgblockchain.go` - Symbol in CoinRowData  
- `cmd/dcrdata/internal/explorer/explorer.go` - Symbol in rewards/fills
- `pubsub/pubsubhub.go` - Symbol in rewards
- Plus 21 test files updated
## Issue
#126