### PR TITLE
feat: centralize coin type label rendering across controllers

### DIFF
--- a/cmd/dcrdata/public/js/controllers/homepage_controller.js
+++ b/cmd/dcrdata/public/js/controllers/homepage_controller.js
@@ -4,6 +4,7 @@ import { each } from 'lodash-es'
 import { fadeIn } from '../helpers/animation_helper'
 import humanize from '../helpers/humanize_helper'
 import Mempool from '../helpers/mempool_helper'
+import { renderCoinType } from '../helpers/ska_helper'
 import globalEventBus from '../services/event_bus_service'
 import { keyNav } from '../services/keyboard_navigation_service'
 import ws from '../services/messagesocket_service'
@@ -21,10 +22,10 @@ function mempoolTableRow(tx) {
   let coin, amount
   if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
     const [id, atomStr] = Object.entries(tx.ska_totals)[0]
-    coin = `SKA${id}`
+    coin = renderCoinType(id)
     amount = humanize.formatCoinAtoms(atomStr, parseInt(id))
   } else {
-    coin = 'VAR'
+    coin = renderCoinType(0)
     amount = humanize.threeSigFigs(tx.total || 0)
   }
 

--- a/cmd/dcrdata/public/js/controllers/supply_controller.js
+++ b/cmd/dcrdata/public/js/controllers/supply_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import humanize from '../helpers/humanize_helper'
+import { renderCoinType } from '../helpers/ska_helper'
 
 export default class extends Controller {
   static get targets() {
@@ -39,7 +40,7 @@ export default class extends Controller {
 
       const in_circulation_formatted = humanize.formatCoinAtomsFull(e.in_circulation, e.coin_type)
       clone.querySelector('.int').textContent = in_circulation_formatted
-      clone.querySelector('.symbol').textContent = `SKA${e.coin_type}`
+      clone.querySelector('.symbol').textContent = renderCoinType(e.coin_type)
       clone.querySelector('.issued').textContent = humanize.formatCoinAtomsFull(
         e.total_issued,
         e.coin_type

--- a/cmd/dcrdata/public/js/helpers/ska_helper.js
+++ b/cmd/dcrdata/public/js/helpers/ska_helper.js
@@ -1,4 +1,28 @@
 /**
+ * renderCoinType returns the display label for a coin_type value.
+ *
+ * Accepts a number or a numeric string (e.g. from JSON object keys or
+ * WebSocket payloads). Non-numeric strings, floats, null, undefined, and
+ * out-of-range values all return the safe fallback "-".
+ *
+ * Mapping:
+ *   0        → "VAR"
+ *   1–255    → "SKA1"–"SKA255"
+ *   anything else → "-"
+ *
+ * @param {number|string|null|undefined} coinType
+ * @returns {string}
+ */
+export function renderCoinType(coinType) {
+  if (coinType === null || coinType === undefined) return '-'
+  const n = typeof coinType === 'string' ? parseInt(coinType, 10) : coinType
+  if (!Number.isInteger(n)) return '-'
+  if (n === 0) return 'VAR'
+  if (n >= 1 && n <= 255) return `SKA${n}`
+  return '-'
+}
+
+/**
  * splitSkaValue splits an SKA decimal string into display parts.
  * Matches the SSR skaSplitParts logic: strips trailing zeros, takes first 2
  * significant decimal digits as "bold", the rest as "rest".

--- a/cmd/dcrdata/public/js/helpers/ska_helper.js
+++ b/cmd/dcrdata/public/js/helpers/ska_helper.js
@@ -2,8 +2,8 @@
  * renderCoinType returns the display label for a coin_type value.
  *
  * Accepts a number or a numeric string (e.g. from JSON object keys or
- * WebSocket payloads). Non-numeric strings, floats, null, undefined, and
- * out-of-range values all return the safe fallback "-".
+ * WebSocket payloads). Floats, non-numeric strings, empty strings, null,
+ * undefined, and out-of-range values all return the safe fallback "-".
  *
  * Mapping:
  *   0        → "VAR"
@@ -15,7 +15,7 @@
  */
 export function renderCoinType(coinType) {
   if (coinType === null || coinType === undefined) return '-'
-  const n = typeof coinType === 'string' ? parseInt(coinType, 10) : coinType
+  const n = typeof coinType === 'string' ? (coinType === '' ? NaN : Number(coinType)) : coinType
   if (!Number.isInteger(n)) return '-'
   if (n === 0) return 'VAR'
   if (n >= 1 && n <= 255) return `SKA${n}`

--- a/cmd/dcrdata/public/js/helpers/ska_helper.test.js
+++ b/cmd/dcrdata/public/js/helpers/ska_helper.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { renderCoinType } from './ska_helper'
+
+describe('renderCoinType', () => {
+  // numeric inputs — valid range
+  it('returns "VAR" for 0', () => expect(renderCoinType(0)).toBe('VAR'))
+  it('returns "SKA1" for 1', () => expect(renderCoinType(1)).toBe('SKA1'))
+  it('returns "SKA2" for 2', () => expect(renderCoinType(2)).toBe('SKA2'))
+  it('returns "SKA255" for 255', () => expect(renderCoinType(255)).toBe('SKA255'))
+
+  // string inputs — valid range
+  it('returns "VAR" for "0"', () => expect(renderCoinType('0')).toBe('VAR'))
+  it('returns "SKA1" for "1"', () => expect(renderCoinType('1')).toBe('SKA1'))
+  it('returns "SKA255" for "255"', () => expect(renderCoinType('255')).toBe('SKA255'))
+
+  // fallback — null / undefined
+  it('returns "-" for null', () => expect(renderCoinType(null)).toBe('-'))
+  it('returns "-" for undefined', () => expect(renderCoinType(undefined)).toBe('-'))
+
+  // fallback — out of range
+  it('returns "-" for -1', () => expect(renderCoinType(-1)).toBe('-'))
+  it('returns "-" for 256', () => expect(renderCoinType(256)).toBe('-'))
+
+  // fallback — non-numeric string
+  it('returns "-" for "VAR"', () => expect(renderCoinType('VAR')).toBe('-'))
+  it('returns "-" for ""', () => expect(renderCoinType('')).toBe('-'))
+
+  // fallback — float
+  it('returns "-" for 1.5', () => expect(renderCoinType(1.5)).toBe('-'))
+  it('returns "-" for "1.5"', () => expect(renderCoinType('1.5')).toBe('-'))
+})

--- a/wiki/var-ska-data/patterns.md
+++ b/wiki/var-ska-data/patterns.md
@@ -13,3 +13,21 @@
 ### 4. Bifurcated State Ingestion
 
 - **Implication for mutation:** The system inherently derives its truth from the node's raw data via two entirely segregated pipelines (historical heavy-persistence vs. lightweight real-time broadcasting). When introducing a new domain concept or altering how an existing value is aggregated, you must actively engineer the change into both ingestion pathways. Overlooking one leads to a fractured state where real-time indicators conflict with the historical database record.
+
+### 5. Centralized Coin Type Label Rendering
+
+Coin type labels (`VAR`, `SKA1`–`SKA255`) are produced by dedicated functions at each rendering boundary. The mapping is: `0 → "VAR"`, `1–255 → "SKA{n}"`. There are two canonical implementations — one per environment — and they must stay in sync:
+
+| Environment | Location | Function |
+|---|---|---|
+| Go templates (SSR) | `cmd/dcrdata/internal/explorer/templates.go` | `coinSymbol(ct uint8) string` — registered as `coinSymbol` in the template `FuncMap` |
+| JS / Stimulus (real-time) | `cmd/dcrdata/public/js/helpers/ska_helper.js` | `renderCoinType(coinType: number): string` — handles `null`/`undefined`/out-of-range with `"-"` fallback |
+
+Related JS helpers in `ska_helper.js` and `humanize_helper.js` that operate on coin values (not labels):
+
+- `formatCoinAtoms(atomStr, coinType)` — formats a raw atom string to three significant figures; routes to VAR (8 decimals) or SKA (18 decimals) path based on `coinType`
+- `formatCoinAtomsFull(atomStr, coinType)` — same routing, full precision with trailing zeros stripped
+- `splitSkaAtoms(atomStr)` — splits a raw SKA atom string into display parts (`intPart`, `bold`, `rest`, `trailingZeros`) using BigInt to avoid float64 loss
+- `splitSkaValue(s)` — same split for an already-formatted SKA decimal string
+
+- **Implication for mutation:** Never construct coin type labels inline (e.g. `` `SKA${n}` `` or hardcoded `"VAR"` strings). Always call the canonical function for the environment you are in. If the label format ever changes, both `coinSymbol` and `renderCoinType` must be updated together. If you add a new formatting helper for coin values, add it to `ska_helper.js` or `humanize_helper.js` — not inline in a controller.


### PR DESCRIPTION
- Add renderCoinType() function to ska_helper.js to standardize coin type label generation (0 → "VAR", 1–255 → "SKA{n}")
- Replace inline coin symbol construction in homepage_controller.js with renderCoinType() calls
- Replace inline coin symbol construction in supply_controller.js with renderCoinType() calls
- Document centralized coin type rendering pattern in wiki/var-ska-data/patterns.md with mapping table and related helpers
- Ensures consistent label rendering across real-time JS controllers and prevents label format drift from SSR implementation