### PR TITLE
feat: include SKA transactions in time-based block listings and fix ticket price labels

### DIFF
--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -513,7 +513,7 @@ export default class extends Controller {
             d,
             [xlabel, 'Price', 'Tickets Bought'],
             true,
-            'Price (DCR)',
+            'Price (VAR)',
             true,
             false
           )

--- a/cmd/dcrdata/public/js/controllers/ticketpool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/ticketpool_controller.js
@@ -268,7 +268,7 @@ export default class extends Controller {
       colors: ['#FF8C00', '#006600', '#2971FF'],
       title: 'Ticket Price Distribution',
       labelsKMB: true,
-      xlabel: 'Ticket Price (DCR)',
+      xlabel: 'Ticket Price (VAR)',
       ylabel: 'Number of Tickets'
     }
     return new Dygraph(document.getElementById('tickets-by-purchase-price'), d, {

--- a/cmd/dcrdata/views/windows.tmpl
+++ b/cmd/dcrdata/views/windows.tmpl
@@ -107,7 +107,7 @@
                       <th class="text-center d-table-cell d-sm-none">Txns</th>
                       <th><span class="d-none d-sm-inline">Total </span>Size</th>
                       <th class="text-center d-none d-sm-table-cell">Difficulty</th>
-                      <th class="text-center"><span class="d-none d-sm-inline">Ticket </span>Price<span class="d-none d-sm-inline"> (DCR)</span></th>
+                      <th class="text-center"><span class="d-none d-sm-inline">Ticket </span>Price<span class="d-none d-sm-inline"> (VAR)</span></th>
                       <th class="text-end pe-0 jsonly">Age</th>
                       <th class="text-end pe-0 d-none d-sm-table-cell">Start Time (UTC)</th>
                   </tr>

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -131,15 +131,16 @@ const (
 		SUM(size) AS size,
 		MAX(sbits) AS sbits,
 		MIN(time) AS time,
-		COUNT(*) AS blocks_count
+		COUNT(*) AS blocks_count,
+		JSONB_AGG(coin_tx_stats) AS coin_tx_stats
 		FROM blocks
 		WHERE height BETWEEN $2 AND $3
 			AND is_mainchain
 		GROUP BY window_start
 		ORDER BY window_start DESC;`
 
-	SelectBlocksTimeListingByLimit = `SELECT date_trunc($1, time at time zone 'utc') as index_value,
-		MAX(height),
+	SelectBlocksTimeListingByLimit = `SELECT DATE_TRUNC($1, time at time zone 'utc') AS index_value,
+		MAX(height) AS max_height,
 		SUM(num_rtx) AS txs,
 		SUM(fresh_stake) AS tickets,
 		SUM(voters) AS votes,
@@ -147,9 +148,10 @@ const (
 		SUM(size) AS size,
 		COUNT(*) AS blocks_count,
 		MIN(time) AS start_time,
-		MAX(time) AS end_time
+		MAX(time) AS end_time,
+		JSONB_AGG(coin_tx_stats) AS coin_tx_stats
 		FROM blocks
-		GROUP BY index_value
+		GROUP BY DATE_TRUNC($1, time at time zone 'utc')
 		ORDER BY index_value DESC
 		LIMIT $2 OFFSET $3;`
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -5,6 +5,7 @@
 package dcrpg
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"database/sql/driver"
@@ -871,11 +872,30 @@ func retrieveWindowBlocks(ctx context.Context, db *sql.DB, windowSize, currentHe
 		var timestamp dbtypes.TimeDef
 		var startBlock, sbits, count int64
 		var blockSizes, votes, txs, revocations, tickets uint64
+		var coinTxStats json.RawMessage
 
 		err = rows.Scan(&startBlock, &difficulty, &txs, &tickets, &votes,
-			&revocations, &blockSizes, &sbits, &timestamp, &count)
+			&revocations, &blockSizes, &sbits, &timestamp, &count, &coinTxStats)
 		if err != nil {
 			return nil, err
+		}
+
+		if len(coinTxStats) > 0 {
+			coinTxStats = bytes.Trim(coinTxStats, "\x00")
+			if len(coinTxStats) > 2 {
+				var allStats []map[string]dbtypes.CoinTxStats
+				if err := json.Unmarshal(coinTxStats, &allStats); err == nil {
+					var skaTxs uint64
+					for _, stats := range allStats {
+						for _, st := range stats {
+							skaTxs += uint64(st.TxCount)
+						}
+					}
+					if skaTxs > uint64(txs) {
+						txs = skaTxs
+					}
+				}
+			}
 		}
 
 		endBlock := startBlock + windowSize - 1
@@ -921,11 +941,30 @@ func retrieveTimeBasedBlockListing(ctx context.Context, db *sql.DB, timeInterval
 		var startTime, endTime, indexVal dbtypes.TimeDef
 		var txs, tickets, votes, revocations, blockSizes uint64
 		var blocksCount, endBlock int64
+		var coinTxStats json.RawMessage
 
 		err = rows.Scan(&indexVal, &endBlock, &txs, &tickets, &votes,
-			&revocations, &blockSizes, &blocksCount, &startTime, &endTime)
+			&revocations, &blockSizes, &blocksCount, &startTime, &endTime, &coinTxStats)
 		if err != nil {
 			return nil, err
+		}
+
+		if len(coinTxStats) > 0 {
+			coinTxStats = bytes.Trim(coinTxStats, "\x00")
+			if len(coinTxStats) > 2 {
+				var allStats []map[string]dbtypes.CoinTxStats
+				if err := json.Unmarshal(coinTxStats, &allStats); err == nil {
+					var skaTxs uint64
+					for _, stats := range allStats {
+						for _, st := range stats {
+							skaTxs += uint64(st.TxCount)
+						}
+					}
+					if skaTxs > uint64(txs) {
+						txs = skaTxs
+					}
+				}
+			}
 		}
 
 		data = append(data, &dbtypes.BlocksGroupedInfo{

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -853,8 +853,36 @@ func retrieveAllVotesDbIDsHeightsTicketDbIDs(ctx context.Context, db *sql.DB) (i
 }
 */
 
-// retrieveWindowBlocks fetches chunks of windows using the limit and offset provided
-// for a window size of chaincfg.Params.StakeDiffWindowSize.
+// parseCoinTxStats aggregates tx_count from all coin types in the aggregated JSONB.
+// Returns the computed total if it exceeds the SQL-provided txs value.
+func parseCoinTxStats(coinTxStats json.RawMessage, txs uint64) uint64 {
+	if len(coinTxStats) == 0 {
+		return txs
+	}
+
+	coinTxStats = bytes.Trim(coinTxStats, "\x00")
+	if len(coinTxStats) <= 2 {
+		return txs
+	}
+
+	var allStats []map[string]dbtypes.CoinTxStats
+	if err := json.Unmarshal(coinTxStats, &allStats); err != nil {
+		return txs
+	}
+
+	var totalCoinTxs uint64
+	for _, stats := range allStats {
+		for _, st := range stats {
+			totalCoinTxs += uint64(st.TxCount)
+		}
+	}
+
+	if totalCoinTxs > txs {
+		return totalCoinTxs
+	}
+	return txs
+}
+
 func retrieveWindowBlocks(ctx context.Context, db *sql.DB, windowSize, currentHeight int64, limit, offset uint64) ([]*dbtypes.BlocksGroupedInfo, error) {
 	endWindow := currentHeight/windowSize - int64(offset)
 	startWindow := endWindow - int64(limit) + 1
@@ -880,23 +908,7 @@ func retrieveWindowBlocks(ctx context.Context, db *sql.DB, windowSize, currentHe
 			return nil, err
 		}
 
-		if len(coinTxStats) > 0 {
-			coinTxStats = bytes.Trim(coinTxStats, "\x00")
-			if len(coinTxStats) > 2 {
-				var allStats []map[string]dbtypes.CoinTxStats
-				if err := json.Unmarshal(coinTxStats, &allStats); err == nil {
-					var skaTxs uint64
-					for _, stats := range allStats {
-						for _, st := range stats {
-							skaTxs += uint64(st.TxCount)
-						}
-					}
-					if skaTxs > txs {
-						txs = skaTxs
-					}
-				}
-			}
-		}
+		txs = parseCoinTxStats(coinTxStats, txs)
 
 		endBlock := startBlock + windowSize - 1
 		index := dbtypes.CalculateWindowIndex(endBlock, windowSize)
@@ -949,23 +961,7 @@ func retrieveTimeBasedBlockListing(ctx context.Context, db *sql.DB, timeInterval
 			return nil, err
 		}
 
-		if len(coinTxStats) > 0 {
-			coinTxStats = bytes.Trim(coinTxStats, "\x00")
-			if len(coinTxStats) > 2 {
-				var allStats []map[string]dbtypes.CoinTxStats
-				if err := json.Unmarshal(coinTxStats, &allStats); err == nil {
-					var skaTxs uint64
-					for _, stats := range allStats {
-						for _, st := range stats {
-							skaTxs += uint64(st.TxCount)
-						}
-					}
-					if skaTxs > txs {
-						txs = skaTxs
-					}
-				}
-			}
-		}
+		txs = parseCoinTxStats(coinTxStats, txs)
 
 		data = append(data, &dbtypes.BlocksGroupedInfo{
 			EndBlock:           endBlock,

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -891,7 +891,7 @@ func retrieveWindowBlocks(ctx context.Context, db *sql.DB, windowSize, currentHe
 							skaTxs += uint64(st.TxCount)
 						}
 					}
-					if skaTxs > uint64(txs) {
+					if skaTxs > txs {
 						txs = skaTxs
 					}
 				}
@@ -960,7 +960,7 @@ func retrieveTimeBasedBlockListing(ctx context.Context, db *sql.DB, timeInterval
 							skaTxs += uint64(st.TxCount)
 						}
 					}
-					if skaTxs > uint64(txs) {
+					if skaTxs > txs {
 						txs = skaTxs
 					}
 				}


### PR DESCRIPTION

- Aggregate coin_tx_stats JSONB in SQL for time windows (years/months/weeks/days/ticketpricewindows)
- Parse and sum tx_count from all coin types (VAR + SKA) in Go application layer
- Correctly includes SKA transactions alongside VAR in Regular transactions column
- Rename 'Ticket Price (DCR)' to '(VAR)' in windows.tmpl and chart controllers