### PR TITLE
Bugfix/homepage values representation

### DIFF
--- a/cmd/dcrdata/public/js/controllers/mining_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mining_controller.js
@@ -19,13 +19,14 @@ export default class extends Controller {
   handleBlock({ detail: blockData }) {
     const ex = blockData.extra
     this.difficultyTarget.innerHTML = humanize.threeSigFigs(ex.difficulty)
-    this.hashrateTarget.innerHTML = humanize.decimalParts(String(ex.hash_rate), false, 8, 2)
+    this.hashrateTarget.innerHTML = humanize.decimalParts(String(ex.hash_rate), false, 8, 2, true)
     this.hashrateDeltaTarget.innerHTML = humanize.fmtPercentage(ex.hash_rate_change_month)
     this.bsubsidyPowTarget.innerHTML = humanize.decimalParts(
       String(ex.subsidy.pow / 100000000),
       false,
       8,
-      2
+      2,
+      true
     )
     this.rewardIdxTarget.textContent = ex.reward_idx
     this.powBarTarget.style.width = `${(ex.reward_idx / ex.params.reward_window_size) * 100}%`

--- a/cmd/dcrdata/public/js/controllers/mining_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mining_controller.js
@@ -61,8 +61,8 @@ export default class extends Controller {
       const trailEl = clone.querySelector('.trailing-zeroes')
 
       if (intEl) intEl.textContent = bold ? `${intPart}.${bold}` : intPart
-      if (decEl) decEl.textContent = rest
-      if (trailEl) trailEl.textContent = trailingZeros
+      if (decEl) decEl.textContent = bold ? rest : ''
+      if (trailEl) trailEl.textContent = bold ? trailingZeros : ''
 
       clone.querySelectorAll('.symbol').forEach((el) => {
         el.textContent = r.symbol

--- a/cmd/dcrdata/public/js/controllers/supply_controller.js
+++ b/cmd/dcrdata/public/js/controllers/supply_controller.js
@@ -11,11 +11,10 @@ export default class extends Controller {
     const ex = blockData.extra
 
     if (ex.var_coin_supply && this.hasVarCirculatingTarget) {
-      this.varCirculatingTarget.innerHTML = humanize.decimalParts(
-        humanize.formatCoinAtomsFull(ex.var_coin_supply.circulating, 0),
-        true,
-        8
-      )
+      const raw = humanize.formatCoinAtomsFull(ex.var_coin_supply.circulating, 0)
+      const clean = raw.replace(/,/g, '')
+
+      this.varCirculatingTarget.innerHTML = humanize.decimalParts(clean, true, 8, undefined, true)
     }
 
     if (ex.ska_coin_supply && this.hasSkaCoinSupplyTarget) {

--- a/cmd/dcrdata/public/js/controllers/voting_controller.js
+++ b/cmd/dcrdata/public/js/controllers/voting_controller.js
@@ -24,37 +24,54 @@ export default class extends Controller {
 
   handleBlock({ detail: blockData }) {
     const ex = blockData.extra
-    this.blocksdiffTarget.innerHTML = humanize.decimalParts(String(ex.sdiff), false, 8, 2)
+    this.blocksdiffTarget.innerHTML = humanize.decimalParts(ex.sdiff, false, 8, 2, true)
     this.nextExpectedSdiffTarget.innerHTML = humanize.decimalParts(
-      String(ex.next_expected_sdiff),
+      ex.next_expected_sdiff,
       false,
       2,
-      2
+      2,
+      true
     )
     this.nextExpectedMinTarget.innerHTML = humanize.decimalParts(
-      String(ex.next_expected_min),
+      ex.next_expected_min,
       false,
       2,
-      2
+      2,
+      true
     )
     this.nextExpectedMaxTarget.innerHTML = humanize.decimalParts(
-      String(ex.next_expected_max),
+      ex.next_expected_max,
       false,
       2,
-      2
+      2,
+      true
     )
     this.windowIndexTarget.textContent = ex.window_idx
     this.posBarTarget.style.width = `${(ex.window_idx / ex.params.window_size) * 100}%`
-    this.poolSizeTarget.innerHTML = humanize.decimalParts(String(ex.pool_info.size), true, 0)
+    this.poolSizeTarget.innerHTML = humanize.decimalParts(
+      ex.pool_info.size,
+      true,
+      0,
+      undefined,
+      true
+    )
     this.targetPctTarget.textContent = parseFloat(ex.pool_info.percent_target - 100).toFixed(2)
-    this.poolValueTarget.innerHTML = humanize.decimalParts(String(ex.pool_info.value), true, 0)
+    this.poolValueTarget.innerHTML = humanize.decimalParts(
+      ex.pool_info.value,
+      true,
+      0,
+      undefined,
+      true
+    )
     this.poolSizePctTarget.textContent = parseFloat(ex.pool_info.percent).toFixed(2)
     this.ticketRewardTarget.innerHTML = `${ex.reward.toFixed(2)}%`
+    // IMPORTANT: no lgDecimals here → split mode (matches Go)
     this.bsubsidyPosTarget.innerHTML = humanize.decimalParts(
-      String(ex.subsidy.pos / 500000000),
+      ex.subsidy.pos / 500000000,
       false,
       8,
-      2
+      undefined,
+      true
     )
 
     if (ex.exchange_rate && this.hasConvertedStakeTarget) {

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -33,12 +33,11 @@ const humanize = {
     sign = sign + val.toFixed(2)
     return `<span class="${cssClass}">${sign} % </span>`
   },
-  decimalParts: function (v, useCommas, precision, lgDecimals) {
+  decimalParts: function (v, useCommas, precision, lgDecimals, dropTrailingZeros = false) {
     if (isNaN(precision) || precision > 8) {
       precision = 8
     }
-    const vClean = String(v).replace(/,/g, '')
-    const formattedVal = parseFloat(vClean).toFixed(precision)
+    const formattedVal = parseFloat(v).toFixed(precision)
     const chunks = formattedVal.split('.')
     const int = useCommas ? parseInt(chunks[0]).toLocaleString() : chunks[0]
     const decimal = chunks[1] || ''
@@ -53,6 +52,12 @@ const humanize = {
     }
     const decimalVals = decimal.slice(0, decimal.length - numTrailingZeros)
 
+    const trailingZeros = dropTrailingZeros
+      ? ''
+      : numTrailingZeros === 0
+        ? ''
+        : decimal.slice(-numTrailingZeros)
+
     let htmlString = '<div class="decimal-parts d-inline-block">'
 
     if (!isNaN(lgDecimals) && lgDecimals > 0) {
@@ -60,14 +65,20 @@ const humanize = {
       const restPart = decimalVals.substring(lgDecimals)
       htmlString +=
         `<span class="int">${lgPart ? `${int}.${lgPart}` : int}</span>` +
-        `<span class="decimal">${restPart}</span>` +
-        `<span class="decimal trailing-zeroes"></span>`
+        `<span class="decimal">${restPart}</span>`
+
+      if (!dropTrailingZeros) {
+        htmlString += `<span class="decimal trailing-zeroes">${trailingZeros}</span>`
+      }
     } else if (precision !== 0) {
       htmlString +=
         `<span class="int">${int}</span>` +
         '<span class="decimal dot">.</span>' +
-        `<span class="decimal">${decimalVals}</span>` +
-        `<span class="decimal trailing-zeroes"></span>`
+        `<span class="decimal">${decimalVals}</span>`
+
+      if (!dropTrailingZeros) {
+        htmlString += `<span class="decimal trailing-zeroes">${trailingZeros}</span>`
+      }
     } else {
       htmlString += `<span class="int">${int}</span>`
     }

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -56,9 +56,11 @@ const humanize = {
     let htmlString = '<div class="decimal-parts d-inline-block">'
 
     if (!isNaN(lgDecimals) && lgDecimals > 0) {
+      const lgPart = decimalVals.substring(0, lgDecimals)
+      const restPart = decimalVals.substring(lgDecimals)
       htmlString +=
-        `<span class="int">${int}.${decimalVals.substring(0, lgDecimals)}</span>` +
-        `<span class="decimal">${decimalVals.substring(lgDecimals, decimalVals.length)}</span>` +
+        `<span class="int">${lgPart ? `${int}.${lgPart}` : int}</span>` +
+        `<span class="decimal">${restPart}</span>` +
         `<span class="decimal trailing-zeroes"></span>`
     } else if (precision !== 0) {
       htmlString +=

--- a/cmd/dcrdata/views/home_supply.tmpl
+++ b/cmd/dcrdata/views/home_supply.tmpl
@@ -2,63 +2,65 @@
 {{- $conv := .Conversions -}}
 {{with .Info -}}
 <div class="bg-white mb-1 p-2 px-3 mx-1 flex-grow-1">
-    <div class="my-3 h4">
-        <span class="monicon-coin-supply d-inline-block pe-2 h4"></span>
-        Supply
+  <div class="my-3 h4">
+    <span class="monicon-coin-supply d-inline-block pe-2 h4"></span>
+    Coin Supply
+  </div>
+  <div class="row mt-1">
+    {{if .VARCoinSupply}}
+    <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+      <div class="fs13 text-secondary">VAR Coin Supply</div>
+      <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+        <span data-supply-target="varCirculating">
+          {{template "decimalParts" (float64AsDecimalParts (varAtomsToFloat64 .VARCoinSupply.Circulating) 8 true)}}
+        </span>
+        <span class="ps-1 unit lh15rem">VAR</span>
+      </div>
     </div>
-    <div class="row mt-1">
-        {{if .VARCoinSupply}}
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">VAR Coin Supply</div>
-            <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                <span data-supply-target="varCirculating">
-                    {{template "decimalParts" (float64AsDecimalParts (varAtomsToFloat64 .VARCoinSupply.Circulating) 8 true)}}
-                </span>
-                <span class="ps-1 unit lh15rem">VAR</span>
-            </div>
+    {{end}}
+    {{if .SKACoinSupply}}
+    <div class="col-24 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+      <div class="fs13 text-secondary">SKA Coins Supply</div>
+      <div data-supply-target="skaCoinSupply">
+        {{range .SKACoinSupply}}
+        <div class="mt-2">
+          <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+            <span class="int">{{formatCoinAtomsFull .InCirculation .CoinType}}</span>
+            <span class="ps-1 unit lh15rem">SKA{{.CoinType}}</span>
+          </div>
+          <div class="fs12 lh1rem text-black-50">Issued: <span class="mono">{{formatCoinAtomsFull .TotalIssued
+              .CoinType}}</span></div>
+          <div class="fs12 lh1rem text-black-50">Burned: <span class="mono">{{formatCoinAtomsFull .TotalBurned
+              .CoinType}}</span></div>
         </div>
         {{end}}
-        {{if .SKACoinSupply}}
-        <div class="col-24 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">SKA Coins Supply</div>
-            <div data-supply-target="skaCoinSupply">
-                {{range .SKACoinSupply}}
-                <div class="mt-2">
-                    <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                        <span class="int">{{formatCoinAtomsFull .InCirculation .CoinType}}</span>
-                        <span class="ps-1 unit lh15rem">SKA{{.CoinType}}</span>
-                    </div>
-                    <div class="fs12 lh1rem text-black-50">Issued: <span class="mono">{{formatCoinAtomsFull .TotalIssued .CoinType}}</span></div>
-                    <div class="fs12 lh1rem text-black-50">Burned: <span class="mono">{{formatCoinAtomsFull .TotalBurned .CoinType}}</span></div>
-                </div>
-                {{end}}
-            </div>
-        </div>
-        {{end}}
-        {{if $conv -}}
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">
-                <a class="no-underline" href="/market">Exchange Rate</a>
-            </div>
-            <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                <span class="d-inline-block" data-supply-target="exchangeRate">{{$conv.ExchangeRate.TwoDecimals}}</span>
-                <span class="ps-1 unit lh15rem">{{$conv.ExchangeRate.Index}}</span>
-            </div>
-        </div>
-        {{- end}}
+      </div>
     </div>
+    {{end}}
+    {{if $conv -}}
+    <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+      <div class="fs13 text-secondary">
+        <a class="no-underline" href="/market">Exchange Rate</a>
+      </div>
+      <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+        <span class="d-inline-block" data-supply-target="exchangeRate">{{$conv.ExchangeRate.TwoDecimals}}</span>
+        <span class="ps-1 unit lh15rem">{{$conv.ExchangeRate.Index}}</span>
+      </div>
+    </div>
+    {{- end}}
+  </div>
 </div>
 
 {{/* Template for JS live-update cloning — one SKA supply block */}}
 <template id="ska-supply-block-template">
-    <div class="mt-2">
-        <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-            <span class="int"></span>
-            <span class="ps-1 unit lh15rem"><span class="symbol"></span></span>
-        </div>
-        <div class="fs12 lh1rem text-black-50">Issued: <span class="mono issued"></span></div>
-        <div class="fs12 lh1rem text-black-50">Burned: <span class="mono burned"></span></div>
+  <div class="mt-2">
+    <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
+      <span class="int"></span>
+      <span class="ps-1 unit lh15rem"><span class="symbol"></span></span>
     </div>
+    <div class="fs12 lh1rem text-black-50">Issued: <span class="mono issued"></span></div>
+    <div class="fs12 lh1rem text-black-50">Burned: <span class="mono burned"></span></div>
+  </div>
 </template>
 
 {{- end}}


### PR DESCRIPTION
add dropTrailingZeros parameter to decimalParts function
- Add optional dropTrailingZeros parameter (default false) to decimalParts() for conditional trailing zero rendering
- Remove automatic String() conversion in decimalParts() to accept numeric values directly
- Update mining_controller to pass dropTrailingZeros=true for hashrate and PoW subsidy displays
- Update supply_controller to strip commas before passing to decimalParts() and enable dropTrailingZeros
- Update voting_controller to remove String() conversions and enable dropTrailingZeros for all numeric displays
- Add comment clarifying split mode behavior for bsubsidy_pos (no lgDecimals parameter)
- Refactor trailing zeros rendering logic to respect dropTrailingZeros flag in both split and standard modes