### PR TITLE
ci: add GitHub workflow for automated board management on PR merge

### DIFF
--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -1,0 +1,53 @@
+name: Board Automation
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop, main]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  on_merge:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close linked issues
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            const result = await github.graphql(`
+              query ($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    closingIssuesReferences(first: 50) {
+                      nodes {
+                        number
+                      }
+                    }
+                  }
+                }
+              }
+            `, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pr: prNumber
+            });
+
+            const issues = result.repository.pullRequest.closingIssuesReferences.nodes;
+
+            for (const issue of issues) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: "closed"
+              });
+            }


### PR DESCRIPTION
- Create board-automation.yml workflow triggered on pull request merge to develop and main branches
- Query linked issues from merged pull requests using GitHub GraphQL API
- Automatically close all linked issues when their associated PR is merged
- Set appropriate permissions for reading contents, writing issues, and reading pull requests
- Improve project management efficiency by eliminating manual issue closure steps