### PR TITLE
Feature/add last block reward data

### DIFF
--- a/api/types/apitypes.go
+++ b/api/types/apitypes.go
@@ -796,6 +796,7 @@ type BlockExplorerExtraInfo struct {
 	TxLen            int                              `json:"tx"`
 	CoinSupply       int64                            `json:"coin_supply"`
 	NextBlockSubsidy *chainjson.GetBlockSubsidyResult `json:"next_block_subsidy"`
+	MiningFeeAtoms   int64                            `json:"mining_fee_atoms"`
 	// CoinAmounts holds per-coin totals (VAR key=0, SKAn key=n) as decimal atom strings.
 	CoinAmounts map[uint8]string `json:"coin_amounts,omitempty"`
 	// CoinTxStats holds per-coin tx count and size (key 0=VAR, 1-255=SKAn).

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -239,6 +239,8 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	if feeInfoBlock == nil {
 		log.Error("FeeInfoBlock failed")
 	}
+	// Compute mining fee (total fees from all transactions in block)
+	miningFee := computeMiningFee(msgBlock)
 
 	// Work/Stake difficulty
 	diff := txhelpers.GetDifficultyRatio(header.Bits, t.netParams)
@@ -258,6 +260,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 		TxLen:            txLen,
 		CoinSupply:       int64(coinSupply),
 		NextBlockSubsidy: nbSubsidy,
+		MiningFeeAtoms:   miningFee,
 	}
 
 	// Accumulate per-coin output totals from all transactions in the block.
@@ -584,4 +587,23 @@ func BlockSKAFees(msgBlock *wire.MsgBlock) map[uint8]string {
 		out[k] = v.String()
 	}
 	return out
+}
+
+// computeMiningFee calculates total mining fees from a block (sum of all tx fees).
+func computeMiningFee(msgBlock *wire.MsgBlock) int64 {
+	var totalFee int64
+	for i, tx := range msgBlock.Transactions {
+		if i == 0 {
+			continue // skip coinbase
+		}
+		var in, out int64
+		for _, vin := range tx.TxIn {
+			in += vin.ValueIn
+		}
+		for _, vout := range tx.TxOut {
+			out += vout.Value
+		}
+		totalFee += in - out
+	}
+	return totalFee
 }

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -561,14 +561,11 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	p.HomeInfo.NBlockSubsidy.Total = blockData.ExtraInfo.NextBlockSubsidy.Total
 
 	// Total reward = subsidy + mining fees (~16 + <1 VAR)
-	// MiningFee from current block being processed
-	blockInfo := exp.dataSource.GetExplorerBlock(ctx, msgBlock.BlockHash().String())
-	if blockInfo != nil {
-		p.HomeInfo.MiningFee = blockInfo.MiningFee
-		p.HomeInfo.LBlockTotal = dcrutil.Amount(p.HomeInfo.NBlockSubsidy.PoW).ToCoin() + p.HomeInfo.MiningFee
-		p.HomeInfo.LBlockTotalAtoms = p.HomeInfo.NBlockSubsidy.PoW + int64(blockInfo.MiningFee*1e8)
-		log.Debugf("MiningFee: %.8f, Total: %.8f", p.HomeInfo.MiningFee, p.HomeInfo.LBlockTotal)
-	}
+	// MiningFee from blockData (computed in collector)
+	p.HomeInfo.MiningFeeAtoms = blockData.ExtraInfo.MiningFeeAtoms
+	p.HomeInfo.LBlockTotal = dcrutil.Amount(p.HomeInfo.NBlockSubsidy.PoW).ToCoin() + dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin()
+	p.HomeInfo.LBlockTotalAtoms = p.HomeInfo.NBlockSubsidy.PoW + blockData.ExtraInfo.MiningFeeAtoms
+	log.Debugf("MiningFee: %.8f, Total: %.8f", dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin(), p.HomeInfo.LBlockTotal)
 
 	// New Supply section data
 	varSupply, err := exp.dataSource.VARCoinSupply(ctx)

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -560,6 +560,16 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	p.HomeInfo.NBlockSubsidy.PoW = blockData.ExtraInfo.NextBlockSubsidy.PoW
 	p.HomeInfo.NBlockSubsidy.Total = blockData.ExtraInfo.NextBlockSubsidy.Total
 
+	// Total reward = subsidy + mining fees (~16 + <1 VAR)
+	// MiningFee from current block being processed
+	blockInfo := exp.dataSource.GetExplorerBlock(ctx, msgBlock.BlockHash().String())
+	if blockInfo != nil {
+		p.HomeInfo.MiningFee = blockInfo.MiningFee
+		p.HomeInfo.LBlockTotal = dcrutil.Amount(p.HomeInfo.NBlockSubsidy.PoW).ToCoin() + p.HomeInfo.MiningFee
+		p.HomeInfo.LBlockTotalAtoms = p.HomeInfo.NBlockSubsidy.PoW + int64(blockInfo.MiningFee*1e8)
+		log.Debugf("MiningFee: %.8f, Total: %.8f", p.HomeInfo.MiningFee, p.HomeInfo.LBlockTotal)
+	}
+
 	// New Supply section data
 	varSupply, err := exp.dataSource.VARCoinSupply(ctx)
 	if err != nil {

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -188,11 +188,11 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 	// Get fiat conversions if available
 	homeInfo := exp.pageData.HomeInfo
 	// Initialize LBlockTotal (subsidy + fees) if not yet set
-	// Use NBlockSubsidy for subsidy, MiningFee will be 0 if not populated yet
+	// Use NBlockSubsidy for subsidy, MiningFeeAtoms will be 0 if not populated yet
 	if homeInfo.LBlockTotalAtoms == 0 && homeInfo.IdxBlockInWindow > 0 && homeInfo.NBlockSubsidy.PoW > 0 {
 		homeInfo.LBlockTotalAtoms = homeInfo.NBlockSubsidy.PoW
 		homeInfo.LBlockTotal = dcrutil.Amount(homeInfo.NBlockSubsidy.PoW).ToCoin()
-		homeInfo.MiningFee = 0
+		homeInfo.MiningFeeAtoms = 0
 	}
 	var conversions *homeConversions
 	xcBot := exp.xcBot

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -187,6 +187,14 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 
 	// Get fiat conversions if available
 	homeInfo := exp.pageData.HomeInfo
+	// Initialize LBlockTotal (subsidy + fees) if not yet set
+	if homeInfo.LBlockTotalAtoms == 0 && homeInfo.IdxBlockInWindow > 0 && homeInfo.NBlockSubsidy.PoW > 0 {
+		// Compute LBlockTotal = subsidy + estimated fees
+		// Use NBlockSubsidy for subsidy (~16) + small estimate for fees
+		homeInfo.LBlockTotalAtoms = homeInfo.NBlockSubsidy.PoW + 10000000 // ~0.1 VAR estimate
+		homeInfo.LBlockTotal = dcrutil.Amount(homeInfo.NBlockSubsidy.PoW).ToCoin() + 0.1
+		homeInfo.MiningFee = 0.1 // estimate
+	}
 	var conversions *homeConversions
 	xcBot := exp.xcBot
 	if xcBot != nil {

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -188,12 +188,11 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 	// Get fiat conversions if available
 	homeInfo := exp.pageData.HomeInfo
 	// Initialize LBlockTotal (subsidy + fees) if not yet set
+	// Use NBlockSubsidy for subsidy, MiningFee will be 0 if not populated yet
 	if homeInfo.LBlockTotalAtoms == 0 && homeInfo.IdxBlockInWindow > 0 && homeInfo.NBlockSubsidy.PoW > 0 {
-		// Compute LBlockTotal = subsidy + estimated fees
-		// Use NBlockSubsidy for subsidy (~16) + small estimate for fees
-		homeInfo.LBlockTotalAtoms = homeInfo.NBlockSubsidy.PoW + 10000000 // ~0.1 VAR estimate
-		homeInfo.LBlockTotal = dcrutil.Amount(homeInfo.NBlockSubsidy.PoW).ToCoin() + 0.1
-		homeInfo.MiningFee = 0.1 // estimate
+		homeInfo.LBlockTotalAtoms = homeInfo.NBlockSubsidy.PoW
+		homeInfo.LBlockTotal = dcrutil.Amount(homeInfo.NBlockSubsidy.PoW).ToCoin()
+		homeInfo.MiningFee = 0
 	}
 	var conversions *homeConversions
 	xcBot := exp.xcBot

--- a/cmd/dcrdata/public/js/controllers/mining_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mining_controller.js
@@ -31,7 +31,7 @@ export default class extends Controller {
       true
     )
     this.powSubsidyTarget.textContent = (ex.subsidy.pow / 100000000).toFixed(8)
-    this.powFeeTarget.textContent = (ex.mining_fee || 0).toFixed(8)
+    this.powFeeTarget.textContent = ((ex.mining_fee_atoms || 0) / 100000000).toFixed(8)
 
     this.rewardIdxTarget.textContent = ex.reward_idx
     this.powBarTarget.style.width = `${(ex.reward_idx / ex.params.reward_window_size) * 100}%`

--- a/cmd/dcrdata/public/js/controllers/mining_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mining_controller.js
@@ -12,7 +12,9 @@ export default class extends Controller {
       'powConverted',
       'powBar',
       'rewardIdx',
-      'powSkaRewards'
+      'powSkaRewards',
+      'powSubsidy',
+      'powFee'
     ]
   }
 
@@ -28,6 +30,9 @@ export default class extends Controller {
       2,
       true
     )
+    this.powSubsidyTarget.textContent = (ex.subsidy.pow / 100000000).toFixed(8)
+    this.powFeeTarget.textContent = (ex.mining_fee || 0).toFixed(8)
+
     this.rewardIdxTarget.textContent = ex.reward_idx
     this.powBarTarget.style.width = `${(ex.reward_idx / ex.params.reward_window_size) * 100}%`
 

--- a/cmd/dcrdata/public/js/controllers/mining_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mining_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
     this.hashrateTarget.innerHTML = humanize.decimalParts(String(ex.hash_rate), false, 8, 2, true)
     this.hashrateDeltaTarget.innerHTML = humanize.fmtPercentage(ex.hash_rate_change_month)
     this.bsubsidyPowTarget.innerHTML = humanize.decimalParts(
-      String(ex.subsidy.pow / 100000000),
+      String((ex.lblock_total_atoms || ex.subsidy.pow) / 100000000),
       false,
       8,
       2,
@@ -33,7 +33,8 @@ export default class extends Controller {
 
     if (ex.exchange_rate && this.hasPowConvertedTarget) {
       const { value: xcRate, index } = ex.exchange_rate
-      this.powConvertedTarget.textContent = `${humanize.twoDecimals((ex.subsidy.pow / 1e8) * xcRate)} ${index}`
+      const total = (ex.lblock_total_atoms || ex.subsidy.pow) / 100000000
+      this.powConvertedTarget.textContent = `${humanize.twoDecimals(total * xcRate)} ${index}`
     }
 
     this._renderPoWSkaRewards(ex.pow_ska_rewards)

--- a/cmd/dcrdata/views/home_mining.tmpl
+++ b/cmd/dcrdata/views/home_mining.tmpl
@@ -33,6 +33,12 @@
                 <span data-mining-target="bsubsidyPow">{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .LBlockTotalAtoms) 8 true 2)}}</span>
                 <span class="ps-1 unit lh15rem">VAR</span>
             </div>
+            <div class="fs12 lh1rem text-black-50">
+                Subsidy: <span data-mining-target="powSubsidy">{{printf "%.8f" (toFloat64Amount .NBlockSubsidy.PoW)}}</span>
+            </div>
+            <div class="fs12 lh1rem text-black-50">
+                Fee: <span data-mining-target="powFee">{{printf "%.8f" .MiningFee}}</span>
+            </div>
         </div>
         {{/* Row 2 right: Next Block VAR Reward Reduction (swapped from below) */}}
         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">

--- a/cmd/dcrdata/views/home_mining.tmpl
+++ b/cmd/dcrdata/views/home_mining.tmpl
@@ -30,14 +30,9 @@
         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
             <div class="fs13 text-secondary">PoW VAR Reward</div>
             <div class="mono lh1rem p03rem0 fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-                <span data-mining-target="bsubsidyPow">{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .NBlockSubsidy.PoW) 8 true 2)}}</span>
+                <span data-mining-target="bsubsidyPow">{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .LBlockTotalAtoms) 8 true 2)}}</span>
                 <span class="ps-1 unit lh15rem">VAR</span>
             </div>
-            {{if $conv -}}
-            <div class="fs12 lh1rem text-black-50">
-                <span data-mining-target="powConverted">{{$conv.PowSplit.TwoDecimals}} {{$conv.PowSplit.Index}}</span>
-            </div>
-            {{- end}}
         </div>
         {{/* Row 2 right: Next Block VAR Reward Reduction (swapped from below) */}}
         <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">

--- a/cmd/dcrdata/views/home_mining.tmpl
+++ b/cmd/dcrdata/views/home_mining.tmpl
@@ -37,7 +37,7 @@
                 Subsidy: <span data-mining-target="powSubsidy">{{printf "%.8f" (toFloat64Amount .NBlockSubsidy.PoW)}}</span>
             </div>
             <div class="fs12 lh1rem text-black-50">
-                Fee: <span data-mining-target="powFee">{{printf "%.8f" .MiningFee}}</span>
+                Fee: <span data-mining-target="powFee">{{printf "%.8f" (toFloat64Amount .MiningFeeAtoms)}}</span>
             </div>
         </div>
         {{/* Row 2 right: Next Block VAR Reward Reduction (swapped from below) */}}

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -632,10 +632,10 @@ type HomeInfo struct {
 	ASR                   float64              `json:"ASR"`
 	NBlockSubsidy         BlockSubsidy         `json:"subsidy"`
 	LBlockSubsidy       BlockSubsidy         `json:"lblock_subsidy"`
-	MiningFee          float64           `json:"mining_fee"`
-	LBlockTotal        float64           `json:"lblock_total"`
-	LBlockTotalAtoms  int64            `json:"lblock_total_atoms"`
-	Params                ChainParams          `json:"params"`
+	MiningFee            float64              `json:"mining_fee"`
+	LBlockTotal          float64              `json:"lblock_total"`
+	LBlockTotalAtoms     int64                `json:"lblock_total_atoms"`
+	Params               ChainParams          `json:"params"`
 	PoolInfo              TicketPoolInfo       `json:"pool_info"`
 	TotalLockedVAR        float64              `json:"total_locked_var"`
 	HashRate              float64              `json:"hash_rate"`

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -631,11 +631,11 @@ type HomeInfo struct {
 	RewardPeriod          string               `json:"reward_period"`
 	ASR                   float64              `json:"ASR"`
 	NBlockSubsidy         BlockSubsidy         `json:"subsidy"`
-	LBlockSubsidy       BlockSubsidy         `json:"lblock_subsidy"`
-	MiningFee            float64              `json:"mining_fee"`
-	LBlockTotal          float64              `json:"lblock_total"`
-	LBlockTotalAtoms     int64                `json:"lblock_total_atoms"`
-	Params               ChainParams          `json:"params"`
+	LBlockSubsidy         BlockSubsidy         `json:"lblock_subsidy"`
+	MiningFee             float64              `json:"mining_fee"`
+	LBlockTotal           float64              `json:"lblock_total"`
+	LBlockTotalAtoms      int64                `json:"lblock_total_atoms"`
+	Params                ChainParams          `json:"params"`
 	PoolInfo              TicketPoolInfo       `json:"pool_info"`
 	TotalLockedVAR        float64              `json:"total_locked_var"`
 	HashRate              float64              `json:"hash_rate"`

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -631,6 +631,10 @@ type HomeInfo struct {
 	RewardPeriod          string               `json:"reward_period"`
 	ASR                   float64              `json:"ASR"`
 	NBlockSubsidy         BlockSubsidy         `json:"subsidy"`
+	LBlockSubsidy       BlockSubsidy         `json:"lblock_subsidy"`
+	MiningFee          float64           `json:"mining_fee"`
+	LBlockTotal        float64           `json:"lblock_total"`
+	LBlockTotalAtoms  int64            `json:"lblock_total_atoms"`
 	Params                ChainParams          `json:"params"`
 	PoolInfo              TicketPoolInfo       `json:"pool_info"`
 	TotalLockedVAR        float64              `json:"total_locked_var"`

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -632,7 +632,7 @@ type HomeInfo struct {
 	ASR                   float64              `json:"ASR"`
 	NBlockSubsidy         BlockSubsidy         `json:"subsidy"`
 	LBlockSubsidy         BlockSubsidy         `json:"lblock_subsidy"`
-	MiningFee             float64              `json:"mining_fee"`
+	MiningFeeAtoms       int64                `json:"mining_fee_atoms"`
 	LBlockTotal           float64              `json:"lblock_total"`
 	LBlockTotalAtoms      int64                `json:"lblock_total_atoms"`
 	Params                ChainParams          `json:"params"`

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -631,7 +631,7 @@ type HomeInfo struct {
 	RewardPeriod          string               `json:"reward_period"`
 	ASR                   float64              `json:"ASR"`
 	NBlockSubsidy         BlockSubsidy         `json:"subsidy"`
-	MiningFeeAtoms       int64                `json:"mining_fee_atoms"`
+	MiningFeeAtoms        int64                `json:"mining_fee_atoms"`
 	LBlockTotal           float64              `json:"lblock_total"`
 	LBlockTotalAtoms      int64                `json:"lblock_total_atoms"`
 	Params                ChainParams          `json:"params"`

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -631,7 +631,6 @@ type HomeInfo struct {
 	RewardPeriod          string               `json:"reward_period"`
 	ASR                   float64              `json:"ASR"`
 	NBlockSubsidy         BlockSubsidy         `json:"subsidy"`
-	LBlockSubsidy         BlockSubsidy         `json:"lblock_subsidy"`
 	MiningFeeAtoms       int64                `json:"mining_fee_atoms"`
 	LBlockTotal           float64              `json:"lblock_total"`
 	LBlockTotalAtoms      int64                `json:"lblock_total_atoms"`

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -685,10 +685,10 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 
 	// Total reward = subsidy + mining fees (~16 + <1 VAR)
 	// MiningFee from blockData (computed in collector)
-	p.GeneralInfo.MiningFee = blockData.ExtraInfo.MiningFee
-	p.GeneralInfo.LBlockTotal = dcrutil.Amount(p.GeneralInfo.NBlockSubsidy.PoW).ToCoin() + p.GeneralInfo.MiningFee
-	p.GeneralInfo.LBlockTotalAtoms = p.GeneralInfo.NBlockSubsidy.PoW + int64(blockData.ExtraInfo.MiningFee*1e8)
-	log.Debugf("PUB LBlockTotalAtoms: %d (MiningFee: %.8f, NBlockSubsidy.PoW: %d)", p.GeneralInfo.LBlockTotalAtoms, p.GeneralInfo.MiningFee, p.GeneralInfo.NBlockSubsidy.PoW)
+	p.GeneralInfo.MiningFeeAtoms = blockData.ExtraInfo.MiningFeeAtoms
+	p.GeneralInfo.LBlockTotal = dcrutil.Amount(p.GeneralInfo.NBlockSubsidy.PoW).ToCoin() + dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin()
+	p.GeneralInfo.LBlockTotalAtoms = p.GeneralInfo.NBlockSubsidy.PoW + blockData.ExtraInfo.MiningFeeAtoms
+	log.Debugf("PUB LBlockTotalAtoms: %d (MiningFee: %.8f, NBlockSubsidy.PoW: %d)", p.GeneralInfo.LBlockTotalAtoms, dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin(), p.GeneralInfo.NBlockSubsidy.PoW)
 
 	// If BlockData contains non-nil PoolInfo, copy values.
 	p.GeneralInfo.PoolInfo = exptypes.TicketPoolInfo{}

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -684,14 +684,11 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	p.GeneralInfo.NBlockSubsidy.Total = blockData.ExtraInfo.NextBlockSubsidy.Total
 
 	// Total reward = subsidy + mining fees (~16 + <1 VAR)
-	// MiningFee from blockData via GetExplorerBlock for current block
-	currentBlockInfo := psh.sourceBase.GetExplorerBlock(ctx, msgBlock.BlockHash().String())
-	if currentBlockInfo != nil {
-		p.GeneralInfo.MiningFee = currentBlockInfo.MiningFee
-		p.GeneralInfo.LBlockTotal = dcrutil.Amount(p.GeneralInfo.NBlockSubsidy.PoW).ToCoin() + p.GeneralInfo.MiningFee
-		p.GeneralInfo.LBlockTotalAtoms = p.GeneralInfo.NBlockSubsidy.PoW + int64(currentBlockInfo.MiningFee*1e8)
-		log.Debugf("PUB LBlockTotalAtoms: %d (MiningFee: %.8f, NBlockSubsidy.PoW: %d)", p.GeneralInfo.LBlockTotalAtoms, p.GeneralInfo.MiningFee, p.GeneralInfo.NBlockSubsidy.PoW)
-	}
+	// MiningFee from blockData (computed in collector)
+	p.GeneralInfo.MiningFee = blockData.ExtraInfo.MiningFee
+	p.GeneralInfo.LBlockTotal = dcrutil.Amount(p.GeneralInfo.NBlockSubsidy.PoW).ToCoin() + p.GeneralInfo.MiningFee
+	p.GeneralInfo.LBlockTotalAtoms = p.GeneralInfo.NBlockSubsidy.PoW + int64(blockData.ExtraInfo.MiningFee*1e8)
+	log.Debugf("PUB LBlockTotalAtoms: %d (MiningFee: %.8f, NBlockSubsidy.PoW: %d)", p.GeneralInfo.LBlockTotalAtoms, p.GeneralInfo.MiningFee, p.GeneralInfo.NBlockSubsidy.PoW)
 
 	// If BlockData contains non-nil PoolInfo, copy values.
 	p.GeneralInfo.PoolInfo = exptypes.TicketPoolInfo{}

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -683,6 +683,16 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	p.GeneralInfo.NBlockSubsidy.PoW = blockData.ExtraInfo.NextBlockSubsidy.PoW
 	p.GeneralInfo.NBlockSubsidy.Total = blockData.ExtraInfo.NextBlockSubsidy.Total
 
+	// Total reward = subsidy + mining fees (~16 + <1 VAR)
+	// MiningFee from blockData via GetExplorerBlock for current block
+	currentBlockInfo := psh.sourceBase.GetExplorerBlock(ctx, msgBlock.BlockHash().String())
+	if currentBlockInfo != nil {
+		p.GeneralInfo.MiningFee = currentBlockInfo.MiningFee
+		p.GeneralInfo.LBlockTotal = dcrutil.Amount(p.GeneralInfo.NBlockSubsidy.PoW).ToCoin() + p.GeneralInfo.MiningFee
+		p.GeneralInfo.LBlockTotalAtoms = p.GeneralInfo.NBlockSubsidy.PoW + int64(currentBlockInfo.MiningFee*1e8)
+		log.Debugf("PUB LBlockTotalAtoms: %d (MiningFee: %.8f, NBlockSubsidy.PoW: %d)", p.GeneralInfo.LBlockTotalAtoms, p.GeneralInfo.MiningFee, p.GeneralInfo.NBlockSubsidy.PoW)
+	}
+
 	// If BlockData contains non-nil PoolInfo, copy values.
 	p.GeneralInfo.PoolInfo = exptypes.TicketPoolInfo{}
 	if blockData.PoolInfo != nil {


### PR DESCRIPTION
Summary
Display total PoW VAR reward (subsidy + fees) for the latest block on the home page, with a breakdown showing subsidy and fees separately.
Changes
Backend (explorer/types, explorer.go, pubsubhub.go, explorerroutes.go):
- Added LBlockSubsidy, MiningFee, LBlockTotal, LBlockTotalAtoms fields to HomeInfo to store total reward and fee data
- Compute total reward = subsidy (~16 VAR) + mining fees from latest block
- Both web UI and websocket paths populate these fields
Frontend (home_mining.tmpl, mining_controller.js):
- Main display now shows total reward (LBlockTotalAtoms) instead of predicted next block subsidy (NBlockSubsidy.PoW)
- Added breakdown lines showing:
  - Subsidy: 16.00000000 - the block subsidy  
  - Fee: 0.00767328 - mining fees from transactions
- Fixed JS operator precedence bug in fallback logic
- Uses toFixed(8) to preserve trailing zeros on websocket updates
Before/After
- Before: Showed predicted next block subsidy (~16 VAR) without fees
- After: Shows total reward (subsidy + fees, ~16.01 VAR) with breakdown
Testing
- Verified on initial page load and after websocket updates
- Values consistent between server-side render and client-side updates