### PR TITLE
Feature/homepage coin format

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -653,7 +653,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	}
 	sum30 := exp.dataSource.GetSummaryRange(ctx, start30, tip)
 
-	blocksPerYear := float64(365 * 24 * time.Hour / exp.ChainParams.TargetTimePerBlock)
+	blocksPerYear := 365 * 24 * time.Hour / exp.ChainParams.TargetTimePerBlock
+	blocksPerYearBF := new(big.Float).SetPrec(256).SetInt64(int64(blocksPerYear))
 
 	coinTypes := make(map[uint8]struct{})
 	for ct, totals := range blockData.ExtraInfo.SSFeeTotalsByCoin {
@@ -729,9 +730,9 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 						// We divide by TicketsPerBlock (fixed at 5) because the total reward
 						// is distributed across all possible voting slots in the block,
 						// regardless of whether every slot was filled.
-						rewardPerTicket := new(big.Float).SetInt(totalReward)
-						rewardPerTicket.Quo(rewardPerTicket, big.NewFloat(1e18))
-						rewardPerTicket.Quo(rewardPerTicket, big.NewFloat(float64(exp.ChainParams.TicketsPerBlock)))
+						rewardPerTicket := new(big.Float).SetPrec(256).SetInt(totalReward)
+						rewardPerTicket.Quo(rewardPerTicket, new(big.Float).SetPrec(256).SetInt64(1_000_000_000_000_000_000))
+						rewardPerTicket.Quo(rewardPerTicket, new(big.Float).SetPrec(256).SetInt64(int64(exp.ChainParams.TicketsPerBlock)))
 
 						tickets := make([]txhelpers.VoteTicket, len(voteData))
 						for i, vd := range voteData {
@@ -741,7 +742,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 								PurchaseHeight: vd.PurchaseHeight,
 							}
 						}
-						perYear = txhelpers.CalculateAverageTicketAPY(tickets, rewardPerTicket, blocksPerYear)
+						perYear = txhelpers.CalculateAverageTicketAPY(tickets, rewardPerTicket, blocksPerYearBF)
 					}
 				}
 			}

--- a/cmd/dcrdata/internal/explorer/home_voting_template_test.go
+++ b/cmd/dcrdata/internal/explorer/home_voting_template_test.go
@@ -114,7 +114,7 @@ func TestVotingCardTemplate(t *testing.T) {
 	// Case 5 — Single SKA entry
 	t.Run("SingleSKAEntry", func(t *testing.T) {
 		ska := []types.SKAVoteReward{
-			{CoinType: 1, Symbol: "SKA1", PerBlock: "0.097178596780181388", Per30Days: "0.038980675541825918", PerYear: "0.038980675541825918"},
+			{CoinType: 1, Symbol: "SKA1", PerBlock: "97178596780181388", Per30Days: "38980675541825918", PerYear: "38980675541825918"},
 		}
 		out := renderVotingCard(t, tmpl, makeHomeInfo(types.VoteVARReward{}, ska))
 		if strings.Contains(out, "No SKA rewards available") {
@@ -154,7 +154,7 @@ func TestVotingCardTemplate(t *testing.T) {
 	t.Run("SKAPerBlockDecimalParts", func(t *testing.T) {
 		ska := []types.SKAVoteReward{
 			// value with significant non-zero decimals beyond the bold 2 places
-			{CoinType: 2, Symbol: "SKA2", PerBlock: "1.234567890000000000", Per30Days: "30.000000000000000000", PerYear: "365.000000000000000000"},
+			{CoinType: 2, Symbol: "SKA2", PerBlock: "1234567890000000000", Per30Days: "30000000000000000000", PerYear: "365000000000000000000"},
 		}
 		out := renderVotingCard(t, tmpl, makeHomeInfo(types.VoteVARReward{}, ska))
 		if !strings.Contains(out, `class="decimal-parts`) {
@@ -228,9 +228,9 @@ func TestProp_SKASliceOrderPreserved(t *testing.T) {
 			skaRewards[i] = types.SKAVoteReward{
 				CoinType:  coinType,
 				Symbol:    sym,
-				PerBlock:  "0.000000000000000001",
-				Per30Days: "0.000000000000000030",
-				PerYear:   "0.000000000000000365",
+				PerBlock:  "1",
+				Per30Days: "30",
+				PerYear:   "365",
 			}
 			symbols[i] = sym
 		}
@@ -257,38 +257,23 @@ func TestProp_SKASliceOrderPreserved(t *testing.T) {
 	})
 }
 
-// Feature: voting-section-frontend, Property 4: SKA pre-formatted strings are rendered verbatim
-func TestProp_SKAStringsVerbatim(t *testing.T) {
+// Feature: voting-section-frontend, Property 4: SKA atom strings are rendered as decimals
+func TestProp_SKAAtomsRendered(t *testing.T) {
 	tmpl := newVotingCardTemplates(t)
 	rapid.Check(t, func(t *rapid.T) {
-		perBlock := rapid.StringMatching(`\d{1,15}\.\d{18}`).Draw(t, "perBlock")
-		per30Days := rapid.StringMatching(`\d{1,15}\.\d{18}`).Draw(t, "per30Days")
-		perYear := rapid.StringMatching(`\d{1,15}\.\d{18}`).Draw(t, "perYear")
+		// PerBlock must be an atom string (integer string).
+		perBlock := rapid.StringMatching(`[1-9]\d{0,30}`).Draw(t, "perBlock")
+		per30Days := rapid.StringMatching(`[1-9]\d{0,30}`).Draw(t, "per30Days")
+		perYear := rapid.StringMatching(`[1-9]\d{0,30}`).Draw(t, "perYear")
 		ska := []types.SKAVoteReward{
 			{CoinType: 1, Symbol: "SKA1", PerBlock: perBlock, Per30Days: per30Days, PerYear: perYear},
 		}
 		info := makeHomeInfo(types.VoteVARReward{}, ska)
 		out := renderVotingCard(t, tmpl, info)
 
-		// PerBlock is rendered via decimalParts using skaSplitParts.
-		// Check the significant bold part and the rest both appear.
-		parts := skaSplitParts(perBlock, 2)
-		if !strings.Contains(out, parts[0]) { // integer
-			t.Errorf("expected integer part %q of PerBlock in output", parts[0])
-		}
-		if parts[1] != "" && !strings.Contains(out, parts[1]) { // bold decimals
-			t.Errorf("expected bold decimal part %q of PerBlock in output", parts[1])
-		}
-		if parts[2] != "" && !strings.Contains(out, parts[2]) { // rest decimals
-			t.Errorf("expected rest decimal part %q of PerBlock in output", parts[2])
-		}
-
-		// Per30Days and PerYear are rendered verbatim.
-		if !strings.Contains(out, per30Days) {
-			t.Errorf("expected Per30Days %q verbatim in output", per30Days)
-		}
-		if !strings.Contains(out, perYear) {
-			t.Errorf("expected PerYear %q verbatim in output", perYear)
+		// Verification: The output must contain the decimal parts div.
+		if !strings.Contains(out, `class="decimal-parts`) {
+			t.Error("expected decimal-parts div in output")
 		}
 	})
 }
@@ -304,9 +289,9 @@ func TestProp_RenderedHTMLWellFormed(t *testing.T) {
 			skaRewards[i] = types.SKAVoteReward{
 				CoinType:  coinType,
 				Symbol:    fmt.Sprintf("SKA%d", coinType),
-				PerBlock:  "0.000000000000000001",
-				Per30Days: "0.000000000000000030",
-				PerYear:   "0.000000000000000365",
+				PerBlock:  "1",
+				Per30Days: "30",
+				PerYear:   "365",
 			}
 		}
 		info := makeHomeInfo(types.VoteVARReward{PerBlock: 1.0, Per30Days: 5.0, PerYear: 60.0}, skaRewards)
@@ -330,9 +315,9 @@ func TestProp_SKAVoteRewardsContainerExactlyOnce(t *testing.T) {
 			skaRewards[i] = types.SKAVoteReward{
 				CoinType:  coinType,
 				Symbol:    fmt.Sprintf("SKA%d", coinType),
-				PerBlock:  "0.000000000000000001",
-				Per30Days: "0.000000000000000030",
-				PerYear:   "0.000000000000000365",
+				PerBlock:  "1",
+				Per30Days: "30",
+				PerYear:   "365",
 			}
 		}
 		info := makeHomeInfo(types.VoteVARReward{}, skaRewards)

--- a/cmd/dcrdata/internal/explorer/home_voting_template_test.go
+++ b/cmd/dcrdata/internal/explorer/home_voting_template_test.go
@@ -76,8 +76,8 @@ func TestVotingCardTemplate(t *testing.T) {
 		if !strings.Contains(out, "Vote VAR Reward") {
 			t.Error("expected 'Vote VAR Reward' in output")
 		}
-		if !strings.Contains(out, "Vote SKA Reward") {
-			t.Error("expected 'Vote SKA Reward' in output")
+		if !strings.Contains(out, "Vote SKA Fee Reward") {
+			t.Error("expected 'Vote SKA Fee Reward' in output")
 		}
 	})
 
@@ -95,8 +95,8 @@ func TestVotingCardTemplate(t *testing.T) {
 		if !strings.Contains(out, `data-voting-target="bsubsidyPos"`) {
 			t.Error("expected data-voting-target=\"bsubsidyPos\" in output")
 		}
-		if !strings.Contains(out, `data-voting-target="ticketReward"`) {
-			t.Error("expected data-voting-target=\"ticketReward\" in output")
+		if !strings.Contains(out, `data-voting-target="varROI"`) {
+			t.Error("expected data-voting-target=\"varROI\" in output")
 		}
 	})
 
@@ -193,14 +193,6 @@ func TestProp_VARPercentageFormatting(t *testing.T) {
 		perYear := rapid.Float64Range(0, 100).Draw(t, "perYear")
 		info := makeHomeInfo(types.VoteVARReward{Per30Days: per30Days, PerYear: perYear}, nil)
 		out := renderVotingCard(t, tmpl, info)
-
-		want30 := fmt.Sprintf("%.2f", per30Days)
-		if !strings.Contains(out, want30) {
-			t.Errorf("expected Per30Days formatted as %q in output", want30)
-		}
-		if !strings.Contains(out, "per 30 days") {
-			t.Error("expected 'per 30 days' label in output")
-		}
 
 		wantYear := fmt.Sprintf("%.2f", perYear)
 		if !strings.Contains(out, wantYear) {

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -516,36 +516,6 @@ func formattedDuration(duration time.Duration, str *periodMap) string {
 	return i(durationsec) + pl(str.s, durationsec)
 }
 
-// skaSplitParts converts a pre-formatted SKA decimal string into the 4-element
-// []string format expected by the "decimalParts" template:
-// [integer, boldDecimals, restDecimals, trailingZeros].
-// boldPlaces controls how many decimal digits are rendered at full weight
-// (matching the boldNumPlaces argument of float64Formatting). Defaults to 2.
-// Trailing zeros are separated from the significant decimal digits so the
-// "decimal trailing-zeroes" CSS class can dim them, identical to VAR rendering.
-func skaSplitParts(s string, boldPlaces int) []string {
-	dot := strings.IndexByte(s, '.')
-	if dot < 0 {
-		return []string{s, "", "", ""}
-	}
-	integer := s[:dot]
-	frac := s[dot+1:]
-
-	// Separate trailing zeros from significant decimal digits.
-	trimmed := strings.TrimRight(frac, "0")
-	trailingZeros := strings.Repeat("0", len(frac)-len(trimmed))
-
-	// Split trimmed decimals into bold prefix and dimmed rest.
-	bold := trimmed
-	rest := ""
-	if len(trimmed) > boldPlaces {
-		bold = trimmed[:boldPlaces]
-		rest = trimmed[boldPlaces:]
-	}
-
-	return []string{integer, bold, rest, trailingZeros}
-}
-
 func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 	netTheme := "theme-" + strings.ToLower(netName(params))
 	netName := netName(params)
@@ -561,7 +531,6 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"txtypeStr": func(txtype int) string {
 			return txhelpers.TxTypeToString(txtype)
 		},
-		"skaSplitParts": func(s string) []string { return skaSplitParts(s, 2) },
 		"add": func(args ...int64) int64 {
 			var sum int64
 			for _, a := range args {

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -149,7 +149,10 @@ var toInt64 = func(v interface{}) int64 {
 func float64Formatting(v float64, numPlaces int, useCommas bool, boldNumPlaces ...int) []string {
 	pow := math.Pow(10, float64(numPlaces))
 	formattedVal := math.Round(v*pow) / pow
+
+	// Always keep full precision here
 	clipped := fmt.Sprintf("%."+strconv.Itoa(numPlaces)+"f", formattedVal)
+
 	valueChunks := strings.Split(clipped, ".")
 	integer := valueChunks[0]
 
@@ -158,27 +161,59 @@ func float64Formatting(v float64, numPlaces int, useCommas bool, boldNumPlaces .
 		dec = valueChunks[1]
 	}
 
-	// Trim trailing zeros (same as skaDecimalParts).
-	dec = strings.TrimRight(dec, "0")
-
 	if useCommas {
 		integer = humanize.Comma(int64(formattedVal))
 	}
 
+	// No bold mode → trim zeros like before
 	if len(boldNumPlaces) == 0 {
-		return []string{integer, dec, ""}
+		trimmed := strings.TrimRight(dec, "0")
+		trailingZeros := dec[len(trimmed):]
+		return []string{integer, trimmed, trailingZeros}
 	}
 
 	places := boldNumPlaces[0]
 	if places > numPlaces {
-		return []string{integer, dec, ""}
+		places = numPlaces
 	}
 
-	if len(dec) < places {
-		places = len(dec)
+	// Ensure dec always has numPlaces length (it should, but just in case)
+	if len(dec) < numPlaces {
+		dec += strings.Repeat("0", numPlaces-len(dec))
 	}
 
-	return []string{integer, dec[:places], dec[places:], ""}
+	// Split into bold + rest
+	bold := dec[:places]
+	rest := dec[places:]
+
+	// Now extract trailing zeros from the "rest" part only
+	trimmedRest := strings.TrimRight(rest, "0")
+	trailingZeros := rest[len(trimmedRest):]
+
+	return []string{integer, bold, trimmedRest, trailingZeros}
+}
+
+func float64FormattingNoTrailing(
+	v float64,
+	numPlaces int,
+	useCommas bool,
+	boldNumPlaces ...int,
+) []string {
+	parts := float64Formatting(v, numPlaces, useCommas, boldNumPlaces...)
+
+	// len == 4 → bold mode
+	if len(parts) == 4 {
+		parts[3] = "" // remove trailing zeros only
+		return parts
+	}
+
+	// len == 3 → non-bold mode
+	if len(parts) == 3 {
+		parts[2] = ""
+		return parts
+	}
+
+	return parts
 }
 
 // skaDecimalParts converts a SKA atom string (decimal integer string, 18 decimals)
@@ -601,7 +636,8 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			p := (float64(i) / float64(params.SubsidyReductionInterval)) * 100
 			return p
 		},
-		"float64AsDecimalParts": float64Formatting,
+		"float64AsDecimalParts":           float64Formatting,
+		"float64AsDecimalPartsNoTrailing": float64FormattingNoTrailing,
 		"amountAsDecimalParts": func(v int64, useCommas bool) []string {
 			return float64Formatting(dcrutil.Amount(v).ToCoin(), 8, useCommas)
 		},

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -384,12 +384,15 @@ func skaCoinValue(atomStr string) float64 {
 	return v
 }
 
-// formatCoinAtomsFull converts a raw atom string to a coin string
-// with full precision (8 decimals for VAR, 18 for SKA).
-func formatCoinAtomsFull(atomStr string, coinType uint8) string {
+// formatAtomsAsCoinString converts a base-10 atomic amount string into a formatted coin value.
+// It performs exact division (no rounding) using fixed precision (8 decimals for VAR, 18 for SKA),
+// trims trailing zeros from the fractional part while keeping at least minDecimals digits,
+// and inserts thousands separators into the integer part.
+func formatAtomsAsCoinString(atomStr string, coinType uint8, minDecimals int) string {
 	if atomStr == "" {
 		return "0"
 	}
+
 	atoms := new(big.Int)
 	if _, ok := atoms.SetString(atomStr, 10); !ok {
 		return "0"
@@ -405,33 +408,46 @@ func formatCoinAtomsFull(atomStr string, coinType uint8) string {
 		divisor = skaDecimals
 	}
 
-	rat := new(big.Rat).SetFrac(atoms, divisor)
-	s := rat.FloatString(decimals)
-	if strings.Contains(s, ".") {
-		s = strings.TrimRight(s, "0")
-		s = strings.TrimRight(s, ".")
+	// integer + remainder (NO rounding)
+	intPart := new(big.Int).Div(atoms, divisor)
+	rem := new(big.Int).Mod(atoms, divisor)
+
+	// fractional part (zero-padded to full precision)
+	fracStr := rem.String()
+	if len(fracStr) < decimals {
+		fracStr = strings.Repeat("0", decimals-len(fracStr)) + fracStr
 	}
 
-	parts := strings.Split(s, ".")
-	intPartRaw := parts[0]
+	// trim trailing zeros BUT keep at least minDecimals digits
+	trimmed := strings.TrimRight(fracStr, "0")
+	if len(trimmed) < minDecimals {
+		fracStr = fracStr[:minDecimals]
+	} else {
+		fracStr = trimmed
+	}
+
+	// format integer part with commas
+	intStr := intPart.String()
 	prefix := ""
-	if len(intPartRaw) > 0 && intPartRaw[0] == '-' {
+	if strings.HasPrefix(intStr, "-") {
 		prefix = "-"
-		intPartRaw = intPartRaw[1:]
+		intStr = intStr[1:]
 	}
 
-	if len(intPartRaw) > 3 {
+	if len(intStr) > 3 {
 		var out []byte
-		for i := 0; i < len(intPartRaw); i++ {
-			if i > 0 && (len(intPartRaw)-i)%3 == 0 {
+		for i := 0; i < len(intStr); i++ {
+			if i > 0 && (len(intStr)-i)%3 == 0 {
 				out = append(out, ',')
 			}
-			out = append(out, intPartRaw[i])
+			out = append(out, intStr[i])
 		}
-		parts[0] = prefix + string(out)
+		intStr = string(out)
 	}
 
-	return strings.Join(parts, ".")
+	intStr = prefix + intStr
+
+	return intStr + "." + fracStr
 }
 
 // formatCoinAtoms converts a raw atom string to a threeSigFigs-formatted coin
@@ -616,8 +632,8 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"varAtomsToFloat64": func(atomStr string) float64 {
 			return float64(parseInt64(atomStr)) / 1e8
 		},
-		"formatCoinAtoms":     formatCoinAtoms,
-		"formatCoinAtomsFull": formatCoinAtomsFull,
+		"formatCoinAtoms":         formatCoinAtoms,
+		"formatAtomsAsCoinString": formatAtomsAsCoinString,
 		"skaDecimalParts": func(atomStr string, useCommas bool, boldNumPlaces ...int) []string {
 			return skaDecimalParts(atomStr, useCommas, boldNumPlaces...)
 		},

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -1,9 +1,13 @@
 package explorer
 
 import (
+	"html/template"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/monetarium/monetarium-explorer/explorer/types"
+	"github.com/monetarium/monetarium-node/chaincfg"
 )
 
 func TestBlockVoteBitsStr(t *testing.T) {
@@ -484,4 +488,158 @@ func TestComputeCoinFills(t *testing.T) {
 			t.Errorf("SKA1 should appear exactly once, got %d", count)
 		}
 	})
+}
+
+func TestFloat64Formatting(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      float64
+		numPlaces  int
+		useCommas  bool
+		boldPlaces []int
+		expected   []string
+	}{
+		{
+			name:       "normal value with bold",
+			value:      332.39617174,
+			numPlaces:  8,
+			useCommas:  false,
+			boldPlaces: []int{2},
+			expected:   []string{"332", "39", "617174", ""},
+		},
+		{
+			name:       "short decimal (previously broken case)",
+			value:      3.2,
+			numPlaces:  8,
+			useCommas:  false,
+			boldPlaces: []int{2},
+			expected:   []string{"3", "20", "", "000000"},
+		},
+		{
+			name:       "no bold mode",
+			value:      3.2,
+			numPlaces:  8,
+			useCommas:  false,
+			boldPlaces: nil,
+			expected:   []string{"3", "2", "0000000"},
+		},
+		{
+			name:       "integer value",
+			value:      5.0,
+			numPlaces:  8,
+			useCommas:  false,
+			boldPlaces: []int{2},
+			expected:   []string{"5", "00", "", "000000"},
+		},
+		{
+			name:       "rounding case",
+			value:      1.999999999,
+			numPlaces:  8,
+			useCommas:  false,
+			boldPlaces: []int{2},
+			expected:   []string{"2", "00", "", "000000"},
+		},
+		{
+			name:       "with commas",
+			value:      12345.67,
+			numPlaces:  8,
+			useCommas:  true,
+			boldPlaces: []int{2},
+			expected:   []string{"12,345", "67", "", "000000"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result []string
+
+			if tt.boldPlaces != nil {
+				result = float64Formatting(tt.value, tt.numPlaces, tt.useCommas, tt.boldPlaces...)
+			} else {
+				result = float64Formatting(tt.value, tt.numPlaces, tt.useCommas)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("unexpected result\nexpected: %#v\ngot:      %#v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFloat64FormattingNoTrailing(t *testing.T) {
+	got := float64FormattingNoTrailing(3.2, 8, false, 2)
+
+	expected := []string{"3", "20", "", ""}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("expected %#v, got %#v", expected, got)
+	}
+}
+func TestDecimalPartsTemplate(t *testing.T) {
+	funcMap := makeTemplateFuncMap(chaincfg.SimNetParams())
+	// Mock asset function which is used in some templates but not decimalParts
+	funcMap["asset"] = func(name string) string { return name }
+
+	// Create a template and parse the extras.tmpl file. In tests, the path
+	// is relative to the package directory.
+	tmpl, err := template.New("base").Funcs(funcMap).ParseFiles("../../views/extras.tmpl")
+	if err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{
+			name:  "User requested case: 4 parts, empty index 2",
+			input: []string{"3", "20", "", "000000"},
+			// Based on line 183-197 of extras.tmpl:
+			// len is 4.
+			// index 1 is "20" (len > 0), so it renders "{{ index . 0 }}.{{index . 1 }}" in span class="int"
+			// index 2 is "", index 3 is "000000", so the second if block IS rendered.
+			expected: `<div class="decimal-parts d-inline-block"><span class="int">3.20</span><span class="decimal"></span><span class="decimal trailing-zeroes">000000</span></div>`,
+		},
+		{
+			name:     "4 parts, non-empty index 2",
+			input:    []string{"3", "20", "1", "00000"},
+			expected: `<div class="decimal-parts d-inline-block"><span class="int">3.20</span><span class="decimal">1</span><span class="decimal trailing-zeroes">00000</span></div>`,
+		},
+		{
+			name:     "4 parts, no decimals in int span",
+			input:    []string{"3", "", "1", "00000"},
+			expected: `<div class="decimal-parts d-inline-block"><span class="int">3</span><span class="decimal">1</span><span class="decimal trailing-zeroes">00000</span></div>`,
+		},
+		{
+			name:     "3 parts, normal",
+			input:    []string{"3", "2", "0000000"},
+			expected: `<div class="decimal-parts d-inline-block"><span class="int">3</span><span class="decimal dot">.</span><span class="decimal">2</span><span class="decimal trailing-zeroes">0000000</span></div>`,
+		},
+		{
+			name:     "3 parts, only trailing zeros",
+			input:    []string{"3", "", "00000000"},
+			expected: `<div class="decimal-parts d-inline-block"><span class="int">3</span><span class="decimal dot">.</span><span class="decimal"></span><span class="decimal trailing-zeroes">00000000</span></div>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out strings.Builder
+			err := tmpl.ExecuteTemplate(&out, "decimalParts", tt.input)
+			if err != nil {
+				t.Fatalf("failed to execute template: %v", err)
+			}
+
+			got := strings.TrimSpace(out.String())
+			// Remove any internal newlines/tabs that might be present due to template formatting
+			// although the template uses {{- and -}} to control whitespace.
+			got = strings.ReplaceAll(got, "\n", "")
+			got = strings.ReplaceAll(got, "\t", "")
+
+			if got != tt.expected {
+				t.Errorf("expected:\n%s\ngot:\n%s", tt.expected, got)
+			}
+		})
+	}
 }

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -577,68 +577,216 @@ func TestFloat64FormattingNoTrailing(t *testing.T) {
 }
 func TestDecimalPartsTemplate(t *testing.T) {
 	funcMap := makeTemplateFuncMap(chaincfg.SimNetParams())
-	// Mock asset function which is used in some templates but not decimalParts
 	funcMap["asset"] = func(name string) string { return name }
 
-	// Create a template and parse the extras.tmpl file. In tests, the path
-	// is relative to the package directory.
 	tmpl, err := template.New("base").Funcs(funcMap).ParseFiles("../../views/extras.tmpl")
 	if err != nil {
 		t.Fatalf("failed to parse template: %v", err)
 	}
 
+	render := func(input []string) string {
+		var out strings.Builder
+		err := tmpl.ExecuteTemplate(&out, "decimalParts", input)
+		if err != nil {
+			t.Fatalf("failed to execute template: %v", err)
+		}
+
+		s := out.String()
+		s = strings.ReplaceAll(s, "\n", "")
+		s = strings.ReplaceAll(s, "\t", "")
+		s = strings.TrimSpace(s)
+		return s
+	}
+
 	tests := []struct {
-		name     string
-		input    []string
-		expected string
+		name  string
+		input []string
+
+		expectContains    []string
+		expectNotContains []string
 	}{
 		{
-			name:  "User requested case: 4 parts, empty index 2",
+			name:  "non-bold trailing zero NOT dimmed",
+			input: []string{"379", "7", "0"},
+			expectContains: []string{
+				">379<",
+				">7<",
+				">0<",
+			},
+			expectNotContains: []string{
+				"trailing-zeroes",
+			},
+		},
+
+		// ✅ Bold mode: trailing zeros ARE dimmed
+		{
+			name:  "bold trailing zeros dimmed",
 			input: []string{"3", "20", "", "000000"},
-			// Based on line 183-197 of extras.tmpl:
-			// len is 4.
-			// index 1 is "20" (len > 0), so it renders "{{ index . 0 }}.{{index . 1 }}" in span class="int"
-			// index 2 is "", index 3 is "000000", so the second if block IS rendered.
-			expected: `<div class="decimal-parts d-inline-block"><span class="int">3.20</span><span class="decimal"></span><span class="decimal trailing-zeroes">000000</span></div>`,
+			expectContains: []string{
+				"3.20",
+				"trailing-zeroes",
+				"000000",
+			},
 		},
+
+		// ✅ Bold with rest decimals
 		{
-			name:     "4 parts, non-empty index 2",
-			input:    []string{"3", "20", "1", "00000"},
-			expected: `<div class="decimal-parts d-inline-block"><span class="int">3.20</span><span class="decimal">1</span><span class="decimal trailing-zeroes">00000</span></div>`,
+			name:  "bold with rest decimals",
+			input: []string{"3", "20", "1", "00000"},
+			expectContains: []string{
+				"3.20",
+				">1<",
+				"trailing-zeroes",
+			},
 		},
+
+		// ✅ No decimals at all
 		{
-			name:     "4 parts, no decimals in int span",
-			input:    []string{"3", "", "1", "00000"},
-			expected: `<div class="decimal-parts d-inline-block"><span class="int">3</span><span class="decimal">1</span><span class="decimal trailing-zeroes">00000</span></div>`,
+			name:  "integer only",
+			input: []string{"3", "", ""},
+			expectContains: []string{
+				">3<",
+			},
+			expectNotContains: []string{
+				`class="decimal"`,
+				`class="decimal dot"`,
+				`trailing-zeroes`,
+			},
 		},
+
+		// ✅ Non-bold with decimals
 		{
-			name:     "3 parts, normal",
-			input:    []string{"3", "2", "0000000"},
-			expected: `<div class="decimal-parts d-inline-block"><span class="int">3</span><span class="decimal dot">.</span><span class="decimal">2</span><span class="decimal trailing-zeroes">0000000</span></div>`,
+			name:  "non-bold normal decimals",
+			input: []string{"3", "2", "0000000"},
+			expectContains: []string{
+				".",
+				">2<",
+				">0000000<",
+			},
+			expectNotContains: []string{
+				"trailing-zeroes", // 🔥 important
+			},
 		},
+
+		// 🔥 Edge: only trailing zeros
 		{
-			name:     "3 parts, only trailing zeros",
-			input:    []string{"3", "", "00000000"},
-			expected: `<div class="decimal-parts d-inline-block"><span class="int">3</span><span class="decimal dot">.</span><span class="decimal"></span><span class="decimal trailing-zeroes">00000000</span></div>`,
+			name:  "non-bold only trailing zeros",
+			input: []string{"3", "", "00000000"},
+			expectContains: []string{
+				".",
+				">00000000<",
+			},
+			expectNotContains: []string{
+				"trailing-zeroes",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var out strings.Builder
-			err := tmpl.ExecuteTemplate(&out, "decimalParts", tt.input)
-			if err != nil {
-				t.Fatalf("failed to execute template: %v", err)
+			got := render(tt.input)
+
+			for _, s := range tt.expectContains {
+				if !strings.Contains(got, s) {
+					t.Errorf("expected to contain %q\nGot: %s", s, got)
+				}
 			}
 
-			got := strings.TrimSpace(out.String())
-			// Remove any internal newlines/tabs that might be present due to template formatting
-			// although the template uses {{- and -}} to control whitespace.
-			got = strings.ReplaceAll(got, "\n", "")
-			got = strings.ReplaceAll(got, "\t", "")
+			for _, s := range tt.expectNotContains {
+				if strings.Contains(got, s) {
+					t.Errorf("expected NOT to contain %q\nGot: %s", s, got)
+				}
+			}
+		})
+	}
+}
+func TestFormatAtomsAsCoinString(t *testing.T) {
+	tests := []struct {
+		name        string
+		atomStr     string
+		coinType    uint8
+		minDecimals int
+		expected    string
+	}{
+		// VAR
+		{
+			name:        "trim but keep 2 decimals",
+			atomStr:     "123000000",
+			coinType:    0,
+			minDecimals: 2,
+			expected:    "1.23",
+		},
+		{
+			name:        "keep trailing zeros",
+			atomStr:     "120000000",
+			coinType:    0,
+			minDecimals: 2,
+			expected:    "1.20",
+		},
+		{
+			name:        "whole number",
+			atomStr:     "500000000",
+			coinType:    0,
+			minDecimals: 2,
+			expected:    "5.00",
+		},
+		{
+			name:        "no rounding",
+			atomStr:     "123456789",
+			coinType:    0,
+			minDecimals: 2,
+			expected:    "1.23456789",
+		},
 
-			if got != tt.expected {
-				t.Errorf("expected:\n%s\ngot:\n%s", tt.expected, got)
+		// SKA
+		{
+			name:        "ska trim",
+			atomStr:     "1234500000000000000",
+			coinType:    1,
+			minDecimals: 2,
+			expected:    "1.2345",
+		},
+		{
+			name:        "ska keep zeros",
+			atomStr:     "1200000000000000000",
+			coinType:    1,
+			minDecimals: 2,
+			expected:    "1.20",
+		},
+
+		// custom minDecimals
+		{
+			name:        "custom 4 decimals",
+			atomStr:     "123400000",
+			coinType:    0,
+			minDecimals: 4,
+			expected:    "1.2340",
+		},
+
+		// commas
+		{
+			name:        "commas",
+			atomStr:     "1234567890000000",
+			coinType:    0,
+			minDecimals: 2,
+			expected:    "12,345,678.90",
+		},
+
+		// edge
+		{
+			name:        "invalid",
+			atomStr:     "abc",
+			coinType:    0,
+			minDecimals: 2,
+			expected:    "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatAtomsAsCoinString(tt.atomStr, tt.coinType, tt.minDecimals)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
 			}
 		})
 	}

--- a/cmd/dcrdata/public/js/controllers/mining_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mining_controller.js
@@ -19,14 +19,13 @@ export default class extends Controller {
   handleBlock({ detail: blockData }) {
     const ex = blockData.extra
     this.difficultyTarget.innerHTML = humanize.threeSigFigs(ex.difficulty)
-    this.hashrateTarget.innerHTML = humanize.decimalParts(String(ex.hash_rate), false, 8, 2, true)
+    this.hashrateTarget.innerHTML = humanize.decimalParts(String(ex.hash_rate), false, 8, 2)
     this.hashrateDeltaTarget.innerHTML = humanize.fmtPercentage(ex.hash_rate_change_month)
     this.bsubsidyPowTarget.innerHTML = humanize.decimalParts(
       String(ex.subsidy.pow / 100000000),
       false,
       8,
-      2,
-      true
+      2
     )
     this.rewardIdxTarget.textContent = ex.reward_idx
     this.powBarTarget.style.width = `${(ex.reward_idx / ex.params.reward_window_size) * 100}%`

--- a/cmd/dcrdata/public/js/controllers/supply_controller.js
+++ b/cmd/dcrdata/public/js/controllers/supply_controller.js
@@ -11,10 +11,10 @@ export default class extends Controller {
     const ex = blockData.extra
 
     if (ex.var_coin_supply && this.hasVarCirculatingTarget) {
-      const raw = humanize.formatCoinAtomsFull(ex.var_coin_supply.circulating, 0)
+      const raw = humanize.formatAtomsAsCoinString(ex.var_coin_supply.circulating, 0, 2)
       const clean = raw.replace(/,/g, '')
 
-      this.varCirculatingTarget.innerHTML = humanize.decimalParts(clean, true, 8, undefined, true)
+      this.varCirculatingTarget.innerHTML = humanize.decimalParts(clean, true, 8, 2, true)
     }
 
     if (ex.ska_coin_supply && this.hasSkaCoinSupplyTarget) {
@@ -37,16 +37,22 @@ export default class extends Controller {
     entries.forEach((e) => {
       const clone = document.importNode(tmpl.content, true)
 
-      const in_circulation_formatted = humanize.formatCoinAtomsFull(e.in_circulation, e.coin_type)
+      const in_circulation_formatted = humanize.formatAtomsAsCoinString(
+        e.in_circulation,
+        e.coin_type,
+        2
+      )
       clone.querySelector('.int').textContent = in_circulation_formatted
       clone.querySelector('.symbol').textContent = renderCoinType(e.coin_type)
-      clone.querySelector('.issued').textContent = humanize.formatCoinAtomsFull(
+      clone.querySelector('.issued').textContent = humanize.formatAtomsAsCoinString(
         e.total_issued,
-        e.coin_type
+        e.coin_type,
+        2
       )
-      clone.querySelector('.burned').textContent = humanize.formatCoinAtomsFull(
+      clone.querySelector('.burned').textContent = humanize.formatAtomsAsCoinString(
         e.total_burned,
-        e.coin_type
+        e.coin_type,
+        2
       )
 
       container.appendChild(clone)

--- a/cmd/dcrdata/public/js/controllers/voting_controller.js
+++ b/cmd/dcrdata/public/js/controllers/voting_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import humanize from '../helpers/humanize_helper'
-import { splitSkaValue } from '../helpers/ska_helper'
+import { splitSkaAtoms } from '../helpers/ska_helper'
 
 export default class extends Controller {
   static get targets() {
@@ -99,7 +99,7 @@ export default class extends Controller {
       const decimalPartsEl = clone.querySelector('.decimal-parts')
       if (decimalPartsEl && isDash) decimalPartsEl.style.display = 'none'
 
-      const { intPart, bold, rest, trailingZeros } = splitSkaValue(s)
+      const { intPart, bold, rest, trailingZeros } = splitSkaAtoms(s)
 
       const intEl = clone.querySelector('.int')
       const decEl = clone.querySelector('.decimal:not(.trailing-zeroes)')
@@ -120,9 +120,9 @@ export default class extends Controller {
         if (field === 'unit') {
           el.textContent = isDash ? `— ${r.symbol}/Vote` : `${r.symbol}/Vote`
         } else if (field === 'per30d') {
-          el.textContent = `${r.per_30_days} ${r.symbol}/VAR per 30 days`
+          el.textContent = `${humanize.formatCoinAtomsFull(r.per_30_days, 1)} ${r.symbol}/VAR per 30 days`
         } else if (field === 'peryear') {
-          el.textContent = `${r.per_year} ${r.symbol}/VAR per year`
+          el.textContent = `${humanize.formatCoinAtomsFull(r.per_year, 1)} ${r.symbol}/VAR per year`
         }
         el.removeAttribute('data-field')
       })

--- a/cmd/dcrdata/public/js/controllers/voting_controller.js
+++ b/cmd/dcrdata/public/js/controllers/voting_controller.js
@@ -15,8 +15,10 @@ export default class extends Controller {
       'poolValue',
       'poolSizePct',
       'targetPct',
-      'ticketReward',
+      'varROI',
       'bsubsidyPos',
+      'bsubsidy',
+      'bfee',
       'convertedStake',
       'skaVoteRewards'
     ]
@@ -39,13 +41,15 @@ export default class extends Controller {
     this.targetPctTarget.textContent = parseFloat(ex.pool_info.percent_target - 100).toFixed(2)
     this.poolValueTarget.innerHTML = humanize.decimalParts(ex.pool_info.value, true, 0)
     this.poolSizePctTarget.textContent = parseFloat(ex.pool_info.percent).toFixed(2)
-    this.ticketRewardTarget.innerHTML = `${ex.reward.toFixed(2)}%`
+    this.varROITarget.textContent = ex.vote_var_reward.per_year.toFixed(2)
     this.bsubsidyPosTarget.innerHTML = humanize.decimalParts(
       ex.subsidy.pos / 500000000,
       false,
       8,
       2
     )
+    this.bsubsidyTarget.innerHTML = humanize.decimalParts(ex.subsidy.pos / 500000000, false, 8, 2)
+    this.bfeeTarget.innerHTML = humanize.decimalParts(ex.mining_fee_atoms / 500000000, false, 8, 2)
 
     if (ex.exchange_rate && this.hasConvertedStakeTarget) {
       const { value: xcRate, index } = ex.exchange_rate
@@ -66,41 +70,55 @@ export default class extends Controller {
     rewards.forEach((r) => {
       const clone = document.importNode(tmpl.content, true)
 
+      // 1. Reward per Block (main value)
       const s = r.per_block || ''
       const isDash = !s
+      const blockValueParts = splitSkaAtoms(s)
 
-      const decimalPartsEl = clone.querySelector('.decimal-parts')
-      if (decimalPartsEl && isDash) decimalPartsEl.style.display = 'none'
-
-      const { intPart, bold, rest, trailingZeros } = splitSkaAtoms(s)
-
-      const intEl = clone.querySelector('.int')
-      const decEl = clone.querySelector('.decimal:not(.trailing-zeroes)')
-      const trailEl = clone.querySelector('.trailing-zeroes')
-      const blockHeightEl = clone.querySelector('[data-block-height]')
-
-      if (intEl) intEl.textContent = bold ? `${intPart}.${bold}` : intPart
-      if (decEl) decEl.textContent = rest
-      if (trailEl) trailEl.textContent = trailingZeros
-
-      const height = r.block_height
-      if (blockHeightEl && height) {
-        blockHeightEl.href = `/block/${height}`
+      const blockDecimalPartsEl = clone.querySelector('[data-field="block-parts"]')
+      if (blockDecimalPartsEl) {
+        if (isDash) {
+          blockDecimalPartsEl.style.display = 'none'
+        } else {
+          this._fillDecimalParts(blockDecimalPartsEl, blockValueParts)
+        }
       }
 
+      const blockHeightEl = clone.querySelector('[data-block-height]')
+      if (blockHeightEl && r.block_height) {
+        blockHeightEl.href = `/block/${r.block_height}`
+      }
+
+      // 2. Annual Return
+      const py = r.per_year || ''
+      const pyParts = splitSkaAtoms(py)
+      const pyDecimalPartsEl = clone.querySelector('[data-field="peryear-parts"]')
+      if (pyDecimalPartsEl) {
+        this._fillDecimalParts(pyDecimalPartsEl, pyParts)
+      }
+
+      // 3. Units and other fields
       clone.querySelectorAll('[data-field]').forEach((el) => {
         const field = el.dataset.field
         if (field === 'unit') {
           el.textContent = isDash ? `— ${r.symbol}/Vote` : `${r.symbol}/Vote`
-        } else if (field === 'per30d') {
-          el.textContent = `${humanize.formatAtomsAsCoinString(r.per_30_days, 1, 2)} ${r.symbol}/VAR per 30 days`
-        } else if (field === 'peryear') {
-          el.textContent = `${humanize.formatAtomsAsCoinString(r.per_year, 1, 2)} ${r.symbol}/VAR per year`
+        } else if (field === 'peryear-unit') {
+          el.textContent = `${r.symbol}/VAR per year`
         }
         el.removeAttribute('data-field')
       })
 
       container.appendChild(clone)
     })
+  }
+
+  _fillDecimalParts(el, { intPart, bold, rest, trailingZeros }) {
+    const intEl = el.querySelector('.int')
+    const decEl = el.querySelector('.decimal:not(.trailing-zeroes)')
+    const trailEl = el.querySelector('.trailing-zeroes')
+
+    if (intEl) intEl.textContent = bold ? `${intPart}.${bold}` : intPart
+    if (decEl) decEl.textContent = rest
+    if (trailEl) trailEl.textContent = trailingZeros
   }
 }

--- a/cmd/dcrdata/public/js/controllers/voting_controller.js
+++ b/cmd/dcrdata/public/js/controllers/voting_controller.js
@@ -24,54 +24,27 @@ export default class extends Controller {
 
   handleBlock({ detail: blockData }) {
     const ex = blockData.extra
-    this.blocksdiffTarget.innerHTML = humanize.decimalParts(ex.sdiff, false, 8, 2, true)
+    this.blocksdiffTarget.innerHTML = humanize.decimalParts(ex.sdiff, false, 8, 2)
     this.nextExpectedSdiffTarget.innerHTML = humanize.decimalParts(
       ex.next_expected_sdiff,
       false,
       2,
-      2,
-      true
+      2
     )
-    this.nextExpectedMinTarget.innerHTML = humanize.decimalParts(
-      ex.next_expected_min,
-      false,
-      2,
-      2,
-      true
-    )
-    this.nextExpectedMaxTarget.innerHTML = humanize.decimalParts(
-      ex.next_expected_max,
-      false,
-      2,
-      2,
-      true
-    )
+    this.nextExpectedMinTarget.innerHTML = humanize.decimalParts(ex.next_expected_min, false, 2, 2)
+    this.nextExpectedMaxTarget.innerHTML = humanize.decimalParts(ex.next_expected_max, false, 2, 2)
     this.windowIndexTarget.textContent = ex.window_idx
     this.posBarTarget.style.width = `${(ex.window_idx / ex.params.window_size) * 100}%`
-    this.poolSizeTarget.innerHTML = humanize.decimalParts(
-      ex.pool_info.size,
-      true,
-      0,
-      undefined,
-      true
-    )
+    this.poolSizeTarget.innerHTML = humanize.decimalParts(ex.pool_info.size, true, 0)
     this.targetPctTarget.textContent = parseFloat(ex.pool_info.percent_target - 100).toFixed(2)
-    this.poolValueTarget.innerHTML = humanize.decimalParts(
-      ex.pool_info.value,
-      true,
-      0,
-      undefined,
-      true
-    )
+    this.poolValueTarget.innerHTML = humanize.decimalParts(ex.pool_info.value, true, 0)
     this.poolSizePctTarget.textContent = parseFloat(ex.pool_info.percent).toFixed(2)
     this.ticketRewardTarget.innerHTML = `${ex.reward.toFixed(2)}%`
-    // IMPORTANT: no lgDecimals here → split mode (matches Go)
     this.bsubsidyPosTarget.innerHTML = humanize.decimalParts(
       ex.subsidy.pos / 500000000,
       false,
       8,
-      undefined,
-      true
+      2
     )
 
     if (ex.exchange_rate && this.hasConvertedStakeTarget) {
@@ -120,9 +93,9 @@ export default class extends Controller {
         if (field === 'unit') {
           el.textContent = isDash ? `— ${r.symbol}/Vote` : `${r.symbol}/Vote`
         } else if (field === 'per30d') {
-          el.textContent = `${humanize.formatCoinAtomsFull(r.per_30_days, 1)} ${r.symbol}/VAR per 30 days`
+          el.textContent = `${humanize.formatAtomsAsCoinString(r.per_30_days, 1, 2)} ${r.symbol}/VAR per 30 days`
         } else if (field === 'peryear') {
-          el.textContent = `${humanize.formatCoinAtomsFull(r.per_year, 1)} ${r.symbol}/VAR per year`
+          el.textContent = `${humanize.formatAtomsAsCoinString(r.per_year, 1, 2)} ${r.symbol}/VAR per year`
         }
         el.removeAttribute('data-field')
       })

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -61,14 +61,22 @@ const humanize = {
     let htmlString = '<div class="decimal-parts d-inline-block">'
 
     if (!isNaN(lgDecimals) && lgDecimals > 0) {
-      const lgPart = decimalVals.substring(0, lgDecimals)
+      const lgPart = decimal.substring(0, lgDecimals)
       const restPart = decimalVals.substring(lgDecimals)
+      // trailing zeros only from the portion after lgDecimals
+      const lgTrailingZeros = dropTrailingZeros
+        ? ''
+        : (() => {
+            const after = decimal.slice(lgDecimals)
+            const trimmed = after.replace(/0+$/, '')
+            return after.length > trimmed.length ? after.slice(trimmed.length) : ''
+          })()
       htmlString +=
         `<span class="int">${lgPart ? `${int}.${lgPart}` : int}</span>` +
         `<span class="decimal">${restPart}</span>`
 
       if (!dropTrailingZeros) {
-        htmlString += `<span class="decimal trailing-zeroes">${trailingZeros}</span>`
+        htmlString += `<span class="decimal trailing-zeroes">${lgTrailingZeros}</span>`
       }
     } else if (precision !== 0) {
       htmlString +=
@@ -87,32 +95,62 @@ const humanize = {
 
     return htmlString
   },
-  // formatCoinAtomsFull converts a raw atom string to a full-precision coin
-  // string with trailing zeros stripped — matching Go's formatCoinAtomsFull.
-  // coinType 0 = VAR (8 decimal places), any other value = SKA (18 decimal places).
-  formatCoinAtomsFull: function (atomStr, coinType) {
-    if (!atomStr || atomStr === '') return '0'
+  // formatAtomsAsCoinString converts a base-10 atomic amount string into a
+  // human-readable coin string without rounding.
+  // It uses fixed precision (8 decimals for VAR, 18 for SKA), trims trailing
+  // zeros in the fractional part while preserving at least `minDecimals` digits,
+  // and inserts thousands separators into the integer part.
+  // If the input is empty or invalid, it returns "—".
+  // coinType: 0 = VAR, any other value = SKA.
+  formatAtomsAsCoinString: function (atomStr, coinType, minDecimals) {
+    if (!atomStr) return '—'
+
     let atoms
     try {
       atoms = BigInt(atomStr)
     } catch {
-      return '0'
+      return '—'
     }
 
     const decimals = coinType === 0 ? 8 : 18
-    // Build divisor as BigInt without using ** operator (avoids Math.pow coercion)
-    let divisor = 1n
-    for (let i = 0; i < decimals; i++) divisor *= 10n
-    const whole = atoms / divisor
-    const remainder = atoms % divisor
+    // Avoid BigInt ** operator — Babel transpiles it to Math.pow which rejects BigInt args.
+    const divisor = coinType === 0 ? 100000000n : 1000000000000000000n
 
-    // Pad fractional part to full decimal width, then strip trailing zeros
-    const frac = remainder.toString().padStart(decimals, '0').replace(/0+$/, '')
-    const wholeStr = whole.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    // integer + remainder (NO rounding)
+    const intPart = atoms / divisor
+    const rem = atoms % divisor
 
-    if (remainder === 0n) return wholeStr
+    // fractional part (zero-padded)
+    let fracStr = rem.toString().padStart(decimals, '0')
 
-    return `${wholeStr}.${frac}`
+    // trim trailing zeros BUT keep at least minDecimals digits
+    const trimmed = fracStr.replace(/0+$/, '')
+    if (trimmed.length < minDecimals) {
+      fracStr = fracStr.slice(0, minDecimals)
+    } else {
+      fracStr = trimmed
+    }
+
+    // format integer part with commas (faster than regex)
+    let intStr = intPart.toString()
+    let prefix = ''
+    if (intStr[0] === '-') {
+      prefix = '-'
+      intStr = intStr.slice(1)
+    }
+
+    if (intStr.length > 3) {
+      let out = ''
+      for (let i = 0; i < intStr.length; i++) {
+        if (i > 0 && (intStr.length - i) % 3 === 0) {
+          out += ','
+        }
+        out += intStr[i]
+      }
+      intStr = out
+    }
+
+    return `${prefix + intStr}.${fracStr}`
   },
   // formatCoinAtoms converts a raw atom string to a threeSigFigs-formatted coin
   // string. coinType 0 = VAR (8 decimal places), any other value = SKA (18

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.test.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.test.js
@@ -128,47 +128,61 @@ describe('humanize.skaCoinValue + threeSigFigs', () => {
     expect(humanize.threeSigFigs(humanize.skaCoinValue('1000000000000000'))).toBe('0.00100'))
 })
 
-describe('humanize.formatCoinAtomsFull', () => {
-  // VAR: coinType 0, 8 decimal places, trailing zeros stripped
-  it('returns "0" for empty string', () => expect(humanize.formatCoinAtomsFull('', 0)).toBe('0'))
-  it('returns "0" for invalid input', () =>
-    expect(humanize.formatCoinAtomsFull('notanumber', 0)).toBe('0'))
-  it('formats whole VAR amount — no decimal point', () =>
-    expect(humanize.formatCoinAtomsFull('100000000', 0)).toBe('1'))
-  it('formats VAR with decimal, trailing zeros stripped', () =>
-    expect(humanize.formatCoinAtomsFull('150000000', 0)).toBe('1.5'))
-  it('formats VAR with full 8 decimal precision', () =>
-    expect(humanize.formatCoinAtomsFull('100000001', 0)).toBe('1.00000001'))
-  it('formats VAR zero atoms as "0"', () => expect(humanize.formatCoinAtomsFull('0', 0)).toBe('0'))
-  it('formats large VAR circulating supply (151399680000000 atoms)', () =>
-    expect(humanize.formatCoinAtomsFull('151399680000000', 0)).toBe('1,513,996.8'))
+describe('humanize.formatAtomsAsCoinString', () => {
+  it('returns dash for empty or invalid input', () => {
+    expect(humanize.formatAtomsAsCoinString('', 0, 2)).toBe('—')
+    expect(humanize.formatAtomsAsCoinString(null, 0, 2)).toBe('—')
+    expect(humanize.formatAtomsAsCoinString(undefined, 0, 2)).toBe('—')
+    expect(humanize.formatAtomsAsCoinString('abc', 0, 2)).toBe('—')
+  })
 
-  // SKA: coinType != 0, 18 decimal places, trailing zeros stripped
-  it('returns "0" for empty SKA string', () =>
-    expect(humanize.formatCoinAtomsFull('', 1)).toBe('0'))
-  it('formats whole SKA amount — no decimal point', () =>
-    expect(humanize.formatCoinAtomsFull('1000000000000000000', 1)).toBe('1'))
-  it('formats SKA with trailing-zero stripping', () =>
-    expect(humanize.formatCoinAtomsFull('1500000000000000000', 1)).toBe('1.5'))
-  it('formats SKA with two significant decimals', () =>
-    expect(humanize.formatCoinAtomsFull('1840000000000000000', 1)).toBe('1.84'))
-  it('formats SKA zero atoms as "0"', () => expect(humanize.formatCoinAtomsFull('0', 1)).toBe('0'))
-  it('formats exact WS payload in_circulation value', () =>
-    expect(humanize.formatCoinAtomsFull('899999999991999840000000000000000', 1)).toBe(
-      '899,999,999,991,999.84'
-    ))
-  it('formats exact WS payload total_issued value (whole number)', () =>
-    expect(humanize.formatCoinAtomsFull('900000000000000000000000000000000', 1)).toBe(
-      '900,000,000,000,000'
-    ))
-  it('formats exact WS payload total_burned value', () =>
-    expect(humanize.formatCoinAtomsFull('8000160000000000000000', 1)).toBe('8,000.16'))
-  it('handles a single atom (10^-18)', () =>
-    expect(humanize.formatCoinAtomsFull('1', 1)).toBe('0.000000000000000001'))
-  it('strips all 18 trailing decimal zeros for whole coin', () =>
-    expect(humanize.formatCoinAtomsFull('5000000000000000000', 1)).toBe('5'))
-  it('coinType 2 uses same 18-decimal SKA rules', () =>
-    expect(humanize.formatCoinAtomsFull('1230000000000000000', 2)).toBe('1.23'))
+  // VAR (8 decimals)
+  it('formats VAR and trims trailing zeros', () => {
+    expect(humanize.formatAtomsAsCoinString('123000000', 0, 2)).toBe('1.23')
+  })
+
+  it('keeps minimum trailing zeros', () => {
+    expect(humanize.formatAtomsAsCoinString('120000000', 0, 2)).toBe('1.20')
+    expect(humanize.formatAtomsAsCoinString('500000000', 0, 2)).toBe('5.00')
+  })
+
+  it('does not round (full precision preserved)', () => {
+    expect(humanize.formatAtomsAsCoinString('123456789', 0, 2)).toBe('1.23456789')
+  })
+
+  it('trims only unnecessary zeros', () => {
+    expect(humanize.formatAtomsAsCoinString('123450000', 0, 2)).toBe('1.2345')
+  })
+
+  it('respects custom minDecimals', () => {
+    expect(humanize.formatAtomsAsCoinString('123400000', 0, 4)).toBe('1.2340')
+  })
+
+  // SKA (18 decimals)
+  it('formats SKA correctly', () => {
+    expect(humanize.formatAtomsAsCoinString('1234500000000000000', 1, 2)).toBe('1.2345')
+  })
+
+  it('keeps minimum decimals for SKA', () => {
+    expect(humanize.formatAtomsAsCoinString('1200000000000000000', 1, 2)).toBe('1.20')
+    expect(humanize.formatAtomsAsCoinString('1000000000000000000', 1, 2)).toBe('1.00')
+  })
+
+  it('handles full precision SKA values', () => {
+    expect(humanize.formatAtomsAsCoinString('123456789123456789', 1, 2)).toBe(
+      '0.123456789123456789'
+    )
+  })
+
+  // commas
+  it('adds thousands separators', () => {
+    expect(humanize.formatAtomsAsCoinString('1234567890000000', 0, 2)).toBe('12,345,678.90')
+  })
+
+  // edge cases
+  it('handles zero correctly', () => {
+    expect(humanize.formatAtomsAsCoinString('0', 0, 2)).toBe('0.00')
+  })
 })
 
 describe('humanize.bytes', () => {
@@ -200,4 +214,152 @@ describe('humanize.bytes', () => {
   // GB range
   it('formats 1000000000 as "1.0 GB"', () => expect(humanize.bytes(1000000000)).toBe('1.0 GB'))
   it('formats 10000000000 as "10 GB"', () => expect(humanize.bytes(10000000000)).toBe('10 GB'))
+})
+
+describe('humanize.decimalParts', () => {
+  // Helper: strip HTML tags so we can assert on the text content easily
+  const strip = (html) => html.replace(/<[^>]+>/g, '')
+  // Helper: extract the text of a specific span class
+  const spanText = (html, cls) => {
+    const m = html.match(new RegExp(`<span class="${cls}">(.*?)</span>`))
+    return m ? m[1] : null
+  }
+
+  // --- basic structure ---
+  it('returns a div.decimal-parts wrapper', () => {
+    const html = humanize.decimalParts(1.5, false, 2)
+    expect(html).toContain('class="decimal-parts d-inline-block"')
+  })
+
+  // --- precision clamping ---
+  it('clamps precision > 8 to 8', () => {
+    const html = humanize.decimalParts(1.123456789, false, 10)
+    // 8 decimal places rendered
+    expect(strip(html)).toContain('1')
+    expect(html).toContain('12345679') // toFixed(8) rounds
+  })
+
+  it('treats NaN precision as 8', () => {
+    const html = humanize.decimalParts(1.5, false, NaN)
+    expect(html).toContain('decimal-parts')
+  })
+
+  // --- precision === 0: integer-only branch ---
+  it('renders only int span when precision is 0', () => {
+    // toFixed(0) rounds 42.9 → "43"
+    const html = humanize.decimalParts(42.9, false, 0)
+    expect(html).toContain('<span class="int">43</span>')
+    expect(html).not.toContain('class="decimal dot"')
+    expect(html).not.toContain('class="decimal"')
+  })
+
+  // --- standard decimal branch (no lgDecimals) ---
+  it('renders int, dot, and decimal spans for a simple value', () => {
+    const html = humanize.decimalParts(1.5, false, 2)
+    expect(html).toContain('<span class="int">1</span>')
+    expect(html).toContain('<span class="decimal dot">.</span>')
+    expect(html).toContain('<span class="decimal">5</span>')
+  })
+
+  it('includes trailing-zeroes span when value has trailing zeros', () => {
+    // 1.50 → decimalVals = "5", trailingZeros = "0"
+    const html = humanize.decimalParts(1.5, false, 2)
+    expect(html).toContain('<span class="decimal trailing-zeroes">0</span>')
+  })
+
+  it('omits trailing-zeroes span when there are no trailing zeros', () => {
+    // 1.23 → no trailing zeros
+    const html = humanize.decimalParts(1.23, false, 2)
+    expect(html).toContain('<span class="decimal trailing-zeroes"></span>')
+  })
+
+  it('drops trailing-zeroes span entirely when dropTrailingZeros=true', () => {
+    const html = humanize.decimalParts(1.5, false, 2, undefined, true)
+    expect(html).not.toContain('trailing-zeroes')
+  })
+
+  it('drops trailing zeros from decimal value when dropTrailingZeros=true', () => {
+    // 1.50 with dropTrailingZeros → decimal span should show "5" not "50"
+    const html = humanize.decimalParts(1.5, false, 2, undefined, true)
+    expect(html).toContain('<span class="decimal">5</span>')
+  })
+
+  // --- comma formatting ---
+  it('formats integer part with commas when useCommas=true', () => {
+    const html = humanize.decimalParts(1234567.89, true, 2)
+    expect(html).toContain('<span class="int">1,234,567</span>')
+  })
+
+  it('does not add commas when useCommas=false', () => {
+    const html = humanize.decimalParts(1234567.89, false, 2)
+    expect(html).toContain('<span class="int">1234567</span>')
+  })
+
+  // --- lgDecimals branch ---
+  it('merges int and first lgDecimals digits into the int span', () => {
+    // v=1.23456, precision=5, lgDecimals=2
+    // decimal="23456", lgPart=decimal.substring(0,2)="23"
+    // decimalVals="23456" (no trailing zeros), restPart=decimalVals.substring(2)="456"
+    const html = humanize.decimalParts(1.23456, false, 5, 2)
+    expect(html).toContain('<span class="int">1.23</span>')
+    expect(html).toContain('<span class="decimal">456</span>')
+  })
+
+  it('preserves zeros within lgDecimals even when they are trailing zeros (original bug)', () => {
+    // 3.2 with precision=8, lgDecimals=2 → decimal="20000000"
+    // lgPart should be "20" (from full decimal), not "2" (from trimmed decimalVals)
+    // trailing zeros: "20000000" has 7 trailing zeros → trailingZeros="0000000"
+    const html = humanize.decimalParts(3.2, false, 8, 2)
+    expect(html).toContain('<span class="int">3.20</span>')
+    expect(html).toContain('<span class="decimal trailing-zeroes">000000</span>')
+  })
+
+  it('int span includes zeros up to lgDecimals even when they are trailing zeros', () => {
+    // v=1.00, precision=2, lgDecimals=2 → decimal="00" → lgPart="00" (from full decimal, not trimmed)
+    const html = humanize.decimalParts(1.0, false, 2, 2, true)
+    expect(html).toContain('<span class="int">1.00</span>')
+  })
+
+  it('includes trailing-zeroes span in lgDecimals branch when dropTrailingZeros=false', () => {
+    // v=1.2, precision=4, lgDecimals=1 → decimalVals="2", restPart="", trailingZeros="000"
+    const html = humanize.decimalParts(1.2, false, 4, 1)
+    expect(html).toContain('trailing-zeroes')
+    expect(html).toContain('000')
+  })
+
+  it('omits trailing-zeroes span in lgDecimals branch when dropTrailingZeros=true', () => {
+    const html = humanize.decimalParts(1.2, false, 4, 1, true)
+    expect(html).not.toContain('trailing-zeroes')
+  })
+
+  // --- edge cases ---
+  it('handles v=0 correctly', () => {
+    const html = humanize.decimalParts(0, false, 2)
+    expect(html).toContain('<span class="int">0</span>')
+    expect(html).toContain('<span class="decimal trailing-zeroes">00</span>')
+  })
+
+  it('handles negative values', () => {
+    const html = humanize.decimalParts(-1.5, false, 2)
+    expect(html).toContain('<span class="int">-1</span>')
+    expect(html).toContain('<span class="decimal">5</span>')
+  })
+
+  it('handles string input that parses as a float', () => {
+    const html = humanize.decimalParts('3.14', false, 2)
+    expect(html).toContain('<span class="int">3</span>')
+    expect(html).toContain('<span class="decimal">14</span>')
+  })
+
+  it('handles precision=1', () => {
+    const html = humanize.decimalParts(9.87, false, 1)
+    expect(html).toContain('<span class="int">9</span>')
+    expect(html).toContain('<span class="decimal">9</span>')
+  })
+
+  it('handles full 8-decimal precision with no trailing zeros', () => {
+    const html = humanize.decimalParts(1.23456789, false, 8)
+    expect(html).toContain('<span class="decimal">23456789</span>')
+    expect(html).toContain('<span class="decimal trailing-zeroes"></span>')
+  })
 })

--- a/cmd/dcrdata/public/js/helpers/ska_helper.js
+++ b/cmd/dcrdata/public/js/helpers/ska_helper.js
@@ -23,28 +23,8 @@ export function renderCoinType(coinType) {
 }
 
 /**
- * splitSkaValue splits an SKA decimal string into display parts.
- * Matches the SSR skaSplitParts logic: strips trailing zeros, takes first 2
- * significant decimal digits as "bold", the rest as "rest".
- *
- * @param {string} s - e.g. "0.00158359431255151000"
- * @returns {{ intPart: string, bold: string, rest: string, trailingZeros: string }}
- */
-export function splitSkaValue(s) {
-  const dot = s.indexOf('.')
-  const intPart = dot >= 0 ? s.slice(0, dot) : s
-  const frac = dot >= 0 ? s.slice(dot + 1) : ''
-  const trimmed = frac.replace(/0+$/, '')
-  const trailingZeros = frac.slice(trimmed.length)
-  const bold = trimmed.slice(0, 2)
-  const rest = trimmed.slice(2)
-  return { intPart, bold, rest, trailingZeros }
-}
-
-/**
  * splitSkaAtoms converts a raw SKA atom string (integer, 18 decimal places)
  * into display parts, using BigInt to avoid float64 precision loss.
- * Output shape matches splitSkaValue.
  *
  * @param {string} atomStr - e.g. "1583594312551510000"
  * @param {number} [boldPlaces=2] - number of leading decimal digits to bold

--- a/cmd/dcrdata/public/js/helpers/turbolinks_helper.js
+++ b/cmd/dcrdata/public/js/helpers/turbolinks_helper.js
@@ -103,6 +103,8 @@ export default class TurboQuery {
         return false
       case 'true':
         return true
+      default:
+        break
     }
     if (!isNaN(parseFloat(v)) && isFinite(v)) {
       if (String(v).includes('.')) {

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -190,7 +190,7 @@
 			{{index . 0 }}
 		{{- end -}}
 	    </span>
-		{{- if gt (len (index . 2)) 0 -}}
+		{{- if or (gt (len (index . 2)) 0) (gt (len (index . 3)) 0) -}}
 		<span class="decimal">{{ index . 2 }}</span>
 		{{- /* trailing zeros  */ -}}
 		<span class="decimal trailing-zeroes">{{ index . 3 }}</span>

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -182,28 +182,49 @@
 
 {{define "decimalParts" -}}
 <div class="decimal-parts d-inline-block">
-	{{- if eq (len .) 4 -}}
-		<span class="int">
-		{{- if gt (len (index . 1)) 0 -}}
-			{{ index . 0 }}.{{index . 1 }}
+	<span class="int">
+		{{- $int := index . 0 -}}
+		{{- if eq (len .) 4 -}}
+			{{- $bold := index . 1 -}}
+			{{- if gt (len $bold) 0 -}}
+				{{$int}}.{{$bold}}
+			{{- else -}}
+				{{$int}}
+			{{- end -}}
 		{{- else -}}
-			{{index . 0 }}
+			{{$int}}
 		{{- end -}}
-	    </span>
-		{{- if or (gt (len (index . 2)) 0) (gt (len (index . 3)) 0) -}}
-		<span class="decimal">{{ index . 2 }}</span>
-		{{- /* trailing zeros  */ -}}
-		<span class="decimal trailing-zeroes">{{ index . 3 }}</span>
-		{{- end}}
+	</span>
+
+	{{- if eq (len .) 4 -}}
+		{{- $rest := index . 2 -}}
+		{{- $trail := index . 3 -}}
+
+		{{- if gt (len $rest) 0 -}}
+			<span class="decimal">{{$rest}}</span>
+		{{- end -}}
+
+		{{- if gt (len $trail) 0 -}}
+			<span class="decimal trailing-zeroes">{{$trail}}</span>
+		{{- end -}}
+
 	{{- else -}}
-		<span class="int">{{index . 0}}</span>
-		{{- if or (gt (len (index . 1)) 0) (gt (len (index . 2)) 0) -}}
-		<span class="decimal dot">.</span><span class="decimal">{{index . 1 }}</span>
-		{{- /* trailing zeros  */ -}}
-		<span class="decimal trailing-zeroes">{{index . 2}}</span>
-		{{- end}}
+		{{- $dec := index . 1 -}}
+		{{- $trail := index . 2 -}}
+
+		{{- if or (gt (len $dec) 0) (gt (len $trail) 0) -}}
+			<span class="decimal dot">.</span>
+		{{- end -}}
+
+		{{- if gt (len $dec) 0 -}}
+			<span class="decimal">{{$dec}}</span>
+		{{- end -}}
+
+		{{- if gt (len $trail) 0 -}}
+			<span class="decimal">{{$trail}}</span> <!-- no dimming -->
+		{{- end -}}
 	{{- end -}}
-	</div>
+</div>
 {{- end}}
 
 {{define "fmtPercentage"}}

--- a/cmd/dcrdata/views/home_supply.tmpl
+++ b/cmd/dcrdata/views/home_supply.tmpl
@@ -12,7 +12,7 @@
       <div class="fs13 text-secondary">VAR Coin Supply</div>
       <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
         <span data-supply-target="varCirculating">
-          {{template "decimalParts" (float64AsDecimalParts (varAtomsToFloat64 .VARCoinSupply.Circulating) 8 true)}}
+          {{template "decimalParts" (float64AsDecimalPartsNoTrailing (varAtomsToFloat64 .VARCoinSupply.Circulating) 8 true 2)}}
         </span>
         <span class="ps-1 unit lh15rem">VAR</span>
       </div>

--- a/cmd/dcrdata/views/home_supply.tmpl
+++ b/cmd/dcrdata/views/home_supply.tmpl
@@ -25,13 +25,13 @@
         {{range .SKACoinSupply}}
         <div class="mt-2">
           <div class="mono lh1rem fs14-decimal fs24 p03rem0 d-flex align-items-baseline">
-            <span class="int">{{formatCoinAtomsFull .InCirculation .CoinType}}</span>
+            <span class="int">{{formatAtomsAsCoinString .InCirculation .CoinType 2}}</span>
             <span class="ps-1 unit lh15rem">SKA{{.CoinType}}</span>
           </div>
-          <div class="fs12 lh1rem text-black-50">Issued: <span class="mono">{{formatCoinAtomsFull .TotalIssued
-              .CoinType}}</span></div>
-          <div class="fs12 lh1rem text-black-50">Burned: <span class="mono">{{formatCoinAtomsFull .TotalBurned
-              .CoinType}}</span></div>
+          <div class="fs12 lh1rem text-black-50">Issued: <span class="mono">{{formatAtomsAsCoinString .TotalIssued
+              .CoinType 2}}</span></div>
+          <div class="fs12 lh1rem text-black-50">Burned: <span class="mono">{{formatAtomsAsCoinString .TotalBurned
+              .CoinType 2}}</span></div>
         </div>
         {{end}}
       </div>

--- a/cmd/dcrdata/views/home_voting.tmpl
+++ b/cmd/dcrdata/views/home_voting.tmpl
@@ -77,7 +77,7 @@
             <div class="fs13 text-secondary">Vote VAR Reward</div>
             <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
                 <span data-voting-target="bsubsidyPos">
-                    {{template "decimalParts" (float64AsDecimalParts $page.Info.VoteVARReward.PerBlock 8 false)}}
+                    {{template "decimalParts" (float64AsDecimalParts $page.Info.VoteVARReward.PerBlock 8 false 2)}}
                 </span>
                  <span class="ps-1 unit lh15rem fs13">VAR/Vote</span>
             </div>

--- a/cmd/dcrdata/views/home_voting.tmpl
+++ b/cmd/dcrdata/views/home_voting.tmpl
@@ -107,14 +107,14 @@
                 <a class="text-decoration-none"{{if .BlockHeight}} href="/block/{{.BlockHeight}}"{{end}}>
                     <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex flex-column flex-lg-row align-items-baseline">
                         {{if .PerBlock}}
-                        {{template "decimalParts" (skaSplitParts .PerBlock)}}
+                        {{template "decimalParts" (skaDecimalParts .PerBlock false 2)}}
                         <span class="ps-1 unit lh15rem fs13">{{.Symbol}}/Vote</span>
                         {{else}}
                         <span class="ps-1 unit lh15rem fs13">&mdash; {{.Symbol}}/Vote</span>
                         {{end}}
                     </div>
-                    <div class="fs12 lh1rem text-black-50">{{.Per30Days}} {{.Symbol}}/VAR per 30 days</div>
-                    <div class="fs12 lh1rem text-black-50">{{.PerYear}} {{.Symbol}}/VAR per year</div>
+                    <div class="fs12 lh1rem text-black-50">{{formatCoinAtomsFull .Per30Days 1}} {{.Symbol}}/VAR per 30 days</div>
+                    <div class="fs12 lh1rem text-black-50">{{formatCoinAtomsFull .PerYear 1}} {{.Symbol}}/VAR per year</div>
                 </a>
                 {{end}}{{else}}
                 <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>

--- a/cmd/dcrdata/views/home_voting.tmpl
+++ b/cmd/dcrdata/views/home_voting.tmpl
@@ -113,8 +113,8 @@
                         <span class="ps-1 unit lh15rem fs13">&mdash; {{.Symbol}}/Vote</span>
                         {{end}}
                     </div>
-                    <div class="fs12 lh1rem text-black-50">{{formatCoinAtomsFull .Per30Days 1}} {{.Symbol}}/VAR per 30 days</div>
-                    <div class="fs12 lh1rem text-black-50">{{formatCoinAtomsFull .PerYear 1}} {{.Symbol}}/VAR per year</div>
+                    <div class="fs12 lh1rem text-black-50">{{formatAtomsAsCoinString .Per30Days 1 2}} {{.Symbol}}/VAR per 30 days</div>
+                    <div class="fs12 lh1rem text-black-50">{{formatAtomsAsCoinString .PerYear 1 2}} {{.Symbol}}/VAR per year</div>
                 </a>
                 {{end}}{{else}}
                 <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>

--- a/cmd/dcrdata/views/home_voting.tmpl
+++ b/cmd/dcrdata/views/home_voting.tmpl
@@ -1,138 +1,184 @@
 {{define "voting-card"}}
-{{- $page := . -}}
-{{- $conv := $page.Conversions -}}
-{{with $page.Info -}}
-<div class="bg-white mb-1 py-2 px-3 mx-1">
-    <div class="my-3 h4">
-        <span class="monicon-ticket d-inline-block pe-2 h3"></span>
-        Voting
-    </div>
-    <div class="row mt-1">
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">
-                <a class="no-underline" href="/charts?chart=ticket-price&zoom=month">Current Ticket Price</a>
+    {{- $page := . -}}
+    {{- $conv := $page.Conversions -}}
+    {{with $page.Info -}}
+        <div class="bg-white mb-1 py-2 px-3 mx-1">
+            <div class="my-3 h4">
+                <span class="monicon-ticket d-inline-block pe-2 h3"></span>
+                Voting
             </div>
-            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                <span data-voting-target="blocksdiff">{{template "decimalParts" (float64AsDecimalParts .StakeDiff 8 false 2)}}</span>
-                <span class="ps-1 unit lh15rem">VAR</span>
-            </div>
-            {{if $conv -}}
-            <div class="fs12 lh1rem text-black-50">
-                <span data-voting-target="convertedStake">{{$conv.StakeDiff.TwoDecimals}} {{$conv.StakeDiff.Index}}</span>
-            </div>
-            {{- end}}
-        </div>
-        {{/* Row 1 right: Ticket Pool Size (swapped from row 3) */}}
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="d-block fs13 text-secondary"><a href="/charts?chart=ticket-pool-size">Ticket Pool Size</a></div>
-            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                <span data-voting-target="poolSize">
-                    {{intComma .PoolInfo.Size}}
-                </span>
-            </div>
-            <div class="fs12 lh1rem text-black-50">
-                <span data-voting-target="targetPct">{{printf "%.2f" (toAbsValue $page.PercentChange)}}</span>%
-                {{if lt $page.PercentChange 0.0}} under {{else}} over {{end -}}
-                target
-            </div>
-        </div>
-        {{/* Row 2 left: Next Ticket Price (swapped from row 1) */}}
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">Next Ticket Price</div>
-            <div class="mono d-flex align-items-baseline lh1rem pt-1 pb-1">
-                <span class="fs22">~</span><span class="fs24 d-flex" data-voting-target="nextExpectedSdiff">{{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 2 false)}}</span>
-                <span class="ps-1 unit lh15rem">VAR</span>
-            </div>
-            <div class="d-flex lh1rem fs12 text-black-50">
-                <span>min:&nbsp;</span>
-                <span class="d-flex" data-voting-target="nextExpectedMin">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}}</span>
-                <span>&nbsp;&mdash;&nbsp;max:&nbsp;</span>
-                <span class="d-flex" data-voting-target="nextExpectedMax">{{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}</span>
-            </div>
-        </div>
-        {{/* Row 2 right: Next Ticket Price Change indicator */}}
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">Next Ticket Price Change</div>
-            <div class="progress mt-1 mb-1">
-                <div
-                    class="progress-bar rounded"
-                    data-voting-target="posBar"
-                    role="progressbar"
-                    style="width: {{ticketWindowProgress .IdxBlockInWindow}}%;"
-                    aria-valuenow="{{.IdxBlockInWindow}}"
-                    aria-valuemin="0"
-                    aria-valuemax="{{.Params.WindowSize}}"
-                >
-                    <span class="nowrap ps-1">block <span data-voting-target="windowIndex">{{.IdxBlockInWindow}}</span> of {{.Params.WindowSize}}</span>
+
+            <div class="row mt-1">
+                {{/* Row 1 left: Current Ticket Price */}}
+                <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                    <div class="fs13 text-secondary">
+                        <a class="no-underline" href="/charts?chart=ticket-price&zoom=month">Current Ticket Price</a>
+                    </div>
+                    <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                        <span data-voting-target="blocksdiff">
+                            {{template "decimalParts" (float64AsDecimalParts .StakeDiff 8 false 2)}}
+                        </span>
+                        <span class="ps-1 unit lh15rem">VAR</span>
+                    </div>
+                    {{if $conv -}}
+                        <div class="fs12 lh1rem text-black-50">
+                            <span data-voting-target="convertedStake">{{$conv.StakeDiff.TwoDecimals}} {{$conv.StakeDiff.Index}}</span>
+                        </div>
+                    {{- end}}
                 </div>
-            </div>
-            <div class="fs12 lh1rem">
-                <span class="text-black-50">
-                    {{remaining .IdxBlockInWindow .Params.WindowSize .Params.BlockTime}}
-                </span>
-            </div>
-        </div>
-        {{/* Row 3 left: Vote VAR Reward */}}
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">Vote VAR Reward</div>
-            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                <span data-voting-target="bsubsidyPos">
-                    {{template "decimalParts" (float64AsDecimalParts $page.Info.VoteVARReward.PerBlock 8 false 2)}}
-                </span>
-                 <span class="ps-1 unit lh15rem fs13">VAR/Vote</span>
-            </div>
-            <div class="fs12 lh1rem text-black-50">
-                <span data-voting-target="ticketReward">{{printf "%.2f" $page.Info.VoteVARReward.Per30Days}}%</span> per 30 days
-            </div>
-            <div class="fs12 lh1rem text-black-50">{{printf "%.2f" $page.Info.VoteVARReward.PerYear}}% per year</div>
-        </div>
-        {{/* Row 3 right: Total Staked VAR (moved from bottom-left, now below Next Ticket Price Change) */}}
-        <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary"><a href="/charts?chart=stake-participation">Total Staked VAR</a></div>
-            <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                <span data-voting-target="poolValue">
-                    {{template "decimalParts" (float64AsDecimalParts .PoolInfo.Value 0 true)}}
-                </span>
-                <span class="ps-1 unit lh15rem">VAR</span>
-            </div>
-            <div class="fs12 lh1rem text-black-50">
-                <span data-voting-target="poolSizePct">{{printf "%.2f" .PoolInfo.Percentage}}</span> % of circulating supply
-            </div>
-        </div>
-        <!-- Vote SKA Reward subsection -->
-        <div class="col-24 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
-            <div class="fs13 text-secondary">Vote SKA Reward</div>
-            <div data-voting-target="skaVoteRewards">
-                {{if $page.Info.SKAVoteRewards}}{{range $page.Info.SKAVoteRewards}}
-                <a class="text-decoration-none"{{if .BlockHeight}} href="/block/{{.BlockHeight}}"{{end}}>
-                    <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex flex-column flex-lg-row align-items-baseline">
-                        {{if .PerBlock}}
-                        {{template "decimalParts" (skaDecimalParts .PerBlock false 2)}}
-                        <span class="ps-1 unit lh15rem fs13">{{.Symbol}}/Vote</span>
+
+                {{/* Row 1 right: Ticket Pool Size */}}
+                <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                    <div class="d-block fs13 text-secondary">
+                        <a href="/charts?chart=ticket-pool-size">Ticket Pool Size</a>
+                    </div>
+                    <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                        <span data-voting-target="poolSize">
+                            {{intComma .PoolInfo.Size}}
+                        </span>
+                    </div>
+                    <div class="fs12 lh1rem text-black-50">
+                        <span data-voting-target="targetPct">{{printf "%.2f" (toAbsValue $page.PercentChange)}}</span>%
+                        {{if lt $page.PercentChange 0.0}} under {{else}} over {{end -}}
+                        target
+                    </div>
+                </div>
+
+                {{/* Row 2 left: Next Ticket Price */}}
+                <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                    <div class="fs13 text-secondary">Next Ticket Price</div>
+                    <div class="mono d-flex align-items-baseline lh1rem pt-1 pb-1">
+                        <span class="fs22">~</span>
+                        <span class="fs24 d-flex" data-voting-target="nextExpectedSdiff">
+                            {{template "decimalParts" (float64AsDecimalParts .NextExpectedStakeDiff 2 false)}}
+                        </span>
+                        <span class="ps-1 unit lh15rem">VAR</span>
+                    </div>
+                    <div class="d-flex lh1rem fs12 text-black-50">
+                        <span>min:&nbsp;</span>
+                        <span class="d-flex" data-voting-target="nextExpectedMin">
+                            {{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMin 2 false)}}
+                        </span>
+                        <span>&nbsp;&mdash;&nbsp;max:&nbsp;</span>
+                        <span class="d-flex" data-voting-target="nextExpectedMax">
+                            {{template "decimalParts" (float64AsDecimalParts .NextExpectedBoundsMax 2 false)}}
+                        </span>
+                    </div>
+                </div>
+
+                {{/* Row 2 right: Next Ticket Price Change indicator */}}
+                <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                    <div class="fs13 text-secondary">Next Ticket Price Change</div>
+                    <div class="progress mt-1 mb-1">
+                        <div class="progress-bar rounded"
+                             data-voting-target="posBar"
+                             role="progressbar"
+                             style="width: {{ticketWindowProgress .IdxBlockInWindow}}%;"
+                             aria-valuenow="{{.IdxBlockInWindow}}"
+                             aria-valuemin="0"
+                             aria-valuemax="{{.Params.WindowSize}}">
+                            <span class="nowrap ps-1">
+                                block <span data-voting-target="windowIndex">{{.IdxBlockInWindow}}</span> of {{.Params.WindowSize}}
+                            </span>
+                        </div>
+                    </div>
+                    <div class="fs12 lh1rem">
+                        <span class="text-black-50">
+                            {{remaining .IdxBlockInWindow .Params.WindowSize .Params.BlockTime}}
+                        </span>
+                    </div>
+                </div>
+
+                {{/* Row 3 left: Vote VAR Reward */}}
+                <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                    <div class="fs13 text-secondary">Vote VAR Reward (most&nbsp;recent)</div>
+                    <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                        <span data-voting-target="bsubsidyPos">
+                            {{template "decimalParts" (float64AsDecimalParts $page.Info.VoteVARReward.PerBlock 8 false 2)}}
+                        </span>
+                        <span class="ps-1 unit lh15rem fs13">VAR/Vote</span>
+                    </div>
+                    <div class="fs12 lh1rem text-black-50 d-grid mt-1" style="grid-template-columns: auto 1fr; gap: 0 0.5rem;">
+                        <span class="text-start">Subsidy:</span>
+                        <span class="text-start">
+                            <span class="mono" data-voting-target="bsubsidy">{{template "decimalParts" (float64AsDecimalParts $page.Info.VoteVARReward.PerBlock 8 false 2)}}</span>
+                        </span>
+
+                        <span class="text-start">Fee:</span>
+                        <span class="text-start">
+                            <span class="mono" data-voting-target="bfee">{{template "decimalParts" (float64AsDecimalParts (divideFloat (toFloat64Amount $page.Info.MiningFeeAtoms) 5.0) 8 false 2)}}</span>
+                        </span>
+
+                        <span class="text-start">ROI:</span>
+                        <span class="text-start">
+                            <span class="mono"><span data-voting-target="varROI">{{printf "%.2f" $page.Info.VoteVARReward.PerYear}}</span>%</span> per year
+                        </span>
+                    </div>
+                </div>
+
+                {{/* Row 3 right: Total Staked VAR */}}
+                <div class="col-12 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                    <div class="fs13 text-secondary">
+                        <a href="/charts?chart=stake-participation">Total Staked VAR</a>
+                    </div>
+                    <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
+                        <span data-voting-target="poolValue">
+                            {{template "decimalParts" (float64AsDecimalParts .PoolInfo.Value 0 true)}}
+                        </span>
+                        <span class="ps-1 unit lh15rem">VAR</span>
+                    </div>
+                    <div class="fs12 lh1rem text-black-50">
+                        <span data-voting-target="poolSizePct">{{printf "%.2f" .PoolInfo.Percentage}}</span> % of circulating supply
+                    </div>
+                </div>
+
+                {{/* Full Width: Vote SKA Fee Reward */}}
+                <div class="col-24 mb-3 mb-sm-2 mb-md-3 mb-lg-3">
+                    <div class="fs13 text-secondary">Vote SKA Fee Reward (most&nbsp;recent)</div>
+                    <div data-voting-target="skaVoteRewards">
+                        {{if $page.Info.SKAVoteRewards}}
+                            {{range $page.Info.SKAVoteRewards}}
+                                <div>
+                                    <a class="text-decoration-none" {{if .BlockHeight}} href="/block/{{.BlockHeight}}"{{end}}>
+                                        <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-inline-flex flex-column flex-lg-row align-items-baseline">
+                                            {{if .PerBlock}}
+                                                {{template "decimalParts" (skaDecimalParts .PerBlock false 2)}}
+                                                <span class="ps-1 unit lh15rem fs13">{{.Symbol}}/Vote</span>
+                                            {{else}}
+                                                <span class="ps-1 unit lh15rem fs13">&mdash; {{.Symbol}}/Vote</span>
+                                            {{end}}
+                                        </div>
+                                    </a>
+                                    <div class="fs12 lh1rem text-black-50">
+                                        {{template "decimalParts" (skaDecimalParts .PerYear false 2)}} {{.Symbol}}/VAR per year
+                                    </div>
+                                </div>
+                            {{end}}
                         {{else}}
-                        <span class="ps-1 unit lh15rem fs13">&mdash; {{.Symbol}}/Vote</span>
+                            <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
                         {{end}}
                     </div>
-                    <div class="fs12 lh1rem text-black-50">{{formatAtomsAsCoinString .PerYear 1 2}} {{.Symbol}}/VAR per year</div>
-                </a>
-                {{end}}{{else}}
-                <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
-                {{end}}
-            </div>
-            {{/* Reusable template for JS live-update cloning */}}
-            <template id="ska-reward-block-template">
-                <a class="text-decoration-none" data-block-height>
-                <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-flex align-items-baseline">
-                    <div class="decimal-parts d-inline-block">
-                        <span class="int"></span><span class="decimal"></span><span class="decimal trailing-zeroes"></span>
-                    </div>
-                    <span class="ps-1 unit lh15rem fs13" data-field="unit"></span>
+
+                    <template id="ska-reward-block-template">
+                        <div>
+                            <a class="text-decoration-none" data-block-height>
+                                <div class="mono lh1rem fs14-decimal fs24 pt-1 pb-1 d-inline-flex align-items-baseline">
+                                    <div class="decimal-parts d-inline-block" data-field="block-parts">
+                                        <span class="int"></span><span class="decimal"></span><span class="decimal trailing-zeroes"></span>
+                                    </div>
+                                    <span class="ps-1 unit lh15rem fs13" data-field="unit"></span>
+                                </div>
+                            </a>
+                            <div class="fs12 lh1rem text-black-50">
+                                <div class="decimal-parts d-inline-block" data-field="peryear-parts">
+                                    <span class="int"></span><span class="decimal"></span><span class="decimal trailing-zeroes"></span>
+                                </div>
+                                <span class="ps-1" data-field="peryear-unit"></span>
+                            </div>
+                        </div>
+                    </template>
                 </div>
-                <div class="fs12 lh1rem text-black-50" data-field="peryear"></div>
-                </a>
-            </template>
-        </div>
-    </div>
-</div> <!-- end voting card -->
-{{- end}}
+            </div>
+        </div> {{/* end voting card */}}
+    {{- end}}
 {{end}}

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -596,9 +596,9 @@ type Conversion struct {
 type SKAVoteReward struct {
 	CoinType    uint8  `json:"coin_type"`
 	Symbol      string `json:"symbol"`
-	PerBlock    string `json:"per_block"`   // SKA/VAR ratio for last block, 18dp decimal string
-	Per30Days   string `json:"per_30_days"` // 30-day average
-	PerYear     string `json:"per_year"`    // annualised average
+	PerBlock    string `json:"per_block"`   // SKA/VAR ratio for last block, big.Int atom string (18dp)
+	Per30Days   string `json:"per_30_days"` // 30-day average, big.Int atom string (18dp)
+	PerYear     string `json:"per_year"`    // annualised average, big.Int atom string (18dp)
 	BlockHeight int64  `json:"block_height,omitempty"`
 }
 

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -805,10 +805,15 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 					}
 
 					if totalReward != nil {
-						blocksPerYear := float64(365 * 24 * time.Hour / psh.params.TargetTimePerBlock)
-						rewardPerTicket := new(big.Float).SetInt(totalReward)
-						rewardPerTicket.Quo(rewardPerTicket, big.NewFloat(1e18))
-						rewardPerTicket.Quo(rewardPerTicket, big.NewFloat(float64(psh.params.TicketsPerBlock)))
+						blocksPerYear := 365 * 24 * time.Hour / psh.params.TargetTimePerBlock
+						blocksPerYearBF := new(big.Float).SetPrec(256).SetInt64(int64(blocksPerYear))
+						// rewardPerTicket is the reward for a single ticket slot.
+						// We divide by TicketsPerBlock (fixed at 5) because the total reward
+						// is distributed across all possible voting slots in the block,
+						// regardless of whether every slot was filled.
+						rewardPerTicket := new(big.Float).SetPrec(256).SetInt(totalReward)
+						rewardPerTicket.Quo(rewardPerTicket, new(big.Float).SetPrec(256).SetInt64(1_000_000_000_000_000_000))
+						rewardPerTicket.Quo(rewardPerTicket, new(big.Float).SetPrec(256).SetInt64(int64(psh.params.TicketsPerBlock)))
 
 						tickets := make([]txhelpers.VoteTicket, len(voteData))
 						for i, vd := range voteData {
@@ -818,7 +823,7 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 								PurchaseHeight: vd.PurchaseHeight,
 							}
 						}
-						perYear = txhelpers.CalculateAverageTicketAPY(tickets, rewardPerTicket, blocksPerYear)
+						perYear = txhelpers.CalculateAverageTicketAPY(tickets, rewardPerTicket, blocksPerYearBF)
 					}
 				}
 			}

--- a/txhelpers/ssfee.go
+++ b/txhelpers/ssfee.go
@@ -48,13 +48,12 @@ func BlockSSFeeTotals(msgBlock *wire.MsgBlock) map[uint8]string {
 	return result
 }
 
-// FormatSKAAtoms converts SKA atoms (1e18) to a fixed-point decimal string with 18 decimal places.
+// FormatSKAAtoms converts SKA atoms (1e18) to an atom string (integer string).
 func FormatSKAAtoms(skaAtoms *big.Int) string {
 	if skaAtoms == nil || skaAtoms.Sign() <= 0 {
-		return "0.000000000000000000"
+		return "0"
 	}
-	intPart, fracPart := new(big.Int).DivMod(skaAtoms, ssfeeDp, new(big.Int))
-	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
+	return skaAtoms.String()
 }
 
 // FormatSKAPerVAR computes (skaAtoms/1e18) / (varAtoms/1e8) — SKA coins per
@@ -110,9 +109,8 @@ func AvgSSFeeRate(summaries []SSFeeSummary, coinType uint8, ticketsPerBlock uint
 		count++
 	}
 	if count == 0 {
-		return "0.000000000000000000"
+		return "0"
 	}
 	avg := new(big.Int).Div(total, big.NewInt(int64(count)))
-	intPart, fracPart := new(big.Int).DivMod(avg, ssfeeDp, new(big.Int))
-	return fmt.Sprintf("%s.%018d", intPart.String(), fracPart.Int64())
+	return avg.String()
 }

--- a/txhelpers/ssfee.go
+++ b/txhelpers/ssfee.go
@@ -166,5 +166,16 @@ func CalculateAverageTicketAPY(voteData []VoteTicket, rewardPerTicket *big.Float
 	}
 
 	avgAPY := sumAPY / float64(count)
-	return fmt.Sprintf("%.18f", avgAPY)
+
+	// Convert the APY ratio to SKA atoms (1e18) so the result is consistent
+	// with PerBlock and can be consumed by formatAtomsAsCoinString in templates.
+	atomsFloat := new(big.Float).SetPrec(128).SetFloat64(avgAPY)
+	scale := new(big.Float).SetPrec(128).SetInt(ssfeeDp) // 1e18
+	atomsFloat.Mul(atomsFloat, scale)
+
+	atomsInt, _ := atomsFloat.Int(nil)
+	if atomsInt == nil || atomsInt.Sign() <= 0 {
+		return "0"
+	}
+	return atomsInt.String()
 }

--- a/txhelpers/ssfee.go
+++ b/txhelpers/ssfee.go
@@ -113,10 +113,10 @@ type VoteTicket struct {
 }
 
 // CalculateAverageTicketAPY computes the average annual percentage yield for a set of tickets.
-// It returns the average as a decimal string with 18 decimal places.
+// It returns the average as a big.Int atom string (18dp).
 func CalculateAverageTicketAPY(voteData []VoteTicket, rewardPerTicket *big.Float, blocksPerYear float64) string {
 	if len(voteData) == 0 {
-		return "0.000000000000000000"
+		return "0"
 	}
 
 	var sumAPY float64

--- a/txhelpers/ssfee.go
+++ b/txhelpers/ssfee.go
@@ -114,50 +114,62 @@ type VoteTicket struct {
 
 // CalculateAverageTicketAPY computes the average annual percentage yield for a set of tickets.
 // It returns the average as a big.Int atom string (18dp).
-func CalculateAverageTicketAPY(voteData []VoteTicket, rewardPerTicket *big.Float, blocksPerYear float64) string {
+func CalculateAverageTicketAPY(voteData []VoteTicket, rewardPerTicket *big.Float, blocksPerYear *big.Float) string {
 	if len(voteData) == 0 {
 		return "0"
 	}
 
-	var sumAPY float64
-	var count int
+	const prec = 256
+	sumAPY := new(big.Float).SetPrec(prec)
+	count := 0
+
+	// Pre-allocate or use constants where possible
+	zero := new(big.Float).SetPrec(prec).SetInt64(0)
+	varAtomsScale := new(big.Float).SetPrec(prec).SetInt64(100_000_000)
+
+	// Pre-allocate loop variables to reduce allocations
+	price := new(big.Float).SetPrec(prec)
+	ageBF := new(big.Float).SetPrec(prec)
+	term := new(big.Float).SetPrec(prec)
+	atoms := new(big.Int)
 
 	for _, vd := range voteData {
-		price := new(big.Float)
 		if !strings.Contains(vd.TicketPrice, ".") {
 			// Atoms
-			atoms := new(big.Int)
 			if _, ok := atoms.SetString(vd.TicketPrice, 10); !ok {
 				continue
 			}
 			price.SetInt(atoms)
-			price.Quo(price, big.NewFloat(1e8))
+			price.Quo(price, varAtomsScale)
 		} else {
 			// Decimal string
 			var err error
-			price, _, err = big.ParseFloat(vd.TicketPrice, 10, 256, big.ToNearestEven)
+			var p *big.Float
+			p, _, err = big.ParseFloat(vd.TicketPrice, 10, prec, big.ToNearestEven)
 			if err != nil {
 				continue
 			}
+			price.Set(p)
 		}
 
-		if price.Cmp(big.NewFloat(0)) <= 0 {
+		if price.Cmp(zero) <= 0 {
 			continue
 		}
 
-		age := float64(vd.VoteHeight - vd.PurchaseHeight)
+		age := int64(vd.VoteHeight - vd.PurchaseHeight)
 		if age <= 0 {
 			continue
 		}
+		ageBF.SetInt64(age)
 
 		// APY_i = (BlocksPerYear * (rewardPerTicket / ticketPrice)) / age
-		term := new(big.Float).Copy(rewardPerTicket)
+		// Ensure we use high precision for rewardPerTicket and blocksPerYear copies.
+		term.Copy(rewardPerTicket)
 		term.Quo(term, price)
-		term.Mul(term, big.NewFloat(blocksPerYear))
-		term.Quo(term, big.NewFloat(age))
+		term.Mul(term, blocksPerYear)
+		term.Quo(term, ageBF)
 
-		val, _ := term.Float64()
-		sumAPY += val
+		sumAPY.Add(sumAPY, term)
 		count++
 	}
 
@@ -165,15 +177,16 @@ func CalculateAverageTicketAPY(voteData []VoteTicket, rewardPerTicket *big.Float
 		return "0"
 	}
 
-	avgAPY := sumAPY / float64(count)
+	// avgAPY = sumAPY / count
+	countBF := new(big.Float).SetPrec(prec).SetInt64(int64(count))
+	avgAPY := new(big.Float).SetPrec(prec).Quo(sumAPY, countBF)
 
 	// Convert the APY ratio to SKA atoms (1e18) so the result is consistent
 	// with PerBlock and can be consumed by formatAtomsAsCoinString in templates.
-	atomsFloat := new(big.Float).SetPrec(128).SetFloat64(avgAPY)
-	scale := new(big.Float).SetPrec(128).SetInt(ssfeeDp) // 1e18
-	atomsFloat.Mul(atomsFloat, scale)
+	scale := new(big.Float).SetPrec(prec).SetInt(ssfeeDp) // 1e18
+	avgAPY.Mul(avgAPY, scale)
 
-	atomsInt, _ := atomsFloat.Int(nil)
+	atomsInt, _ := avgAPY.Int(nil)
 	if atomsInt == nil || atomsInt.Sign() <= 0 {
 		return "0"
 	}

--- a/txhelpers/ssfee_test.go
+++ b/txhelpers/ssfee_test.go
@@ -149,7 +149,7 @@ func TestCalculateAverageTicketAPY(t *testing.T) {
 	oneReward := big.NewFloat(1.0) // 1 SKA coin per ticket
 
 	t.Run("empty vote data returns zero sentinel", func(t *testing.T) {
-		got := CalculateAverageTicketAPY(nil, oneReward, 52560)
+		got := CalculateAverageTicketAPY(nil, oneReward, big.NewFloat(52560))
 		if got != "0" {
 			t.Errorf("got %q, want \"0\"", got)
 		}
@@ -161,7 +161,7 @@ func TestCalculateAverageTicketAPY(t *testing.T) {
 			{TicketPrice: "0", VoteHeight: 100, PurchaseHeight: 90},
 			{TicketPrice: "100000000", VoteHeight: 50, PurchaseHeight: 100}, // age <= 0
 		}
-		got := CalculateAverageTicketAPY(data, oneReward, 52560)
+		got := CalculateAverageTicketAPY(data, oneReward, big.NewFloat(52560))
 		if got != "0" {
 			t.Errorf("got %q, want \"0\"", got)
 		}
@@ -172,7 +172,7 @@ func TestCalculateAverageTicketAPY(t *testing.T) {
 			// ticket price 100 VAR in atoms, held for 144 blocks
 			{TicketPrice: "10000000000", VoteHeight: 244, PurchaseHeight: 100},
 		}
-		got := CalculateAverageTicketAPY(data, oneReward, 52560)
+		got := CalculateAverageTicketAPY(data, oneReward, big.NewFloat(52560))
 		if got == "0" || got == "0.000000000000000000" {
 			t.Fatalf("expected non-zero result, got %q", got)
 		}
@@ -191,8 +191,8 @@ func TestCalculateAverageTicketAPY(t *testing.T) {
 		decimalData := []VoteTicket{
 			{TicketPrice: "100.00000000", VoteHeight: 244, PurchaseHeight: 100},
 		}
-		gotAtom := CalculateAverageTicketAPY(atomData, oneReward, 52560)
-		gotDecimal := CalculateAverageTicketAPY(decimalData, oneReward, 52560)
+		gotAtom := CalculateAverageTicketAPY(atomData, oneReward, big.NewFloat(52560))
+		gotDecimal := CalculateAverageTicketAPY(decimalData, oneReward, big.NewFloat(52560))
 		if gotAtom != gotDecimal {
 			t.Errorf("atom path %q != decimal path %q", gotAtom, gotDecimal)
 		}
@@ -205,8 +205,8 @@ func TestCalculateAverageTicketAPY(t *testing.T) {
 		lowReward := big.NewFloat(0.5)
 		highReward := big.NewFloat(2.0)
 
-		low := mustInt(CalculateAverageTicketAPY(data, lowReward, 52560))
-		high := mustInt(CalculateAverageTicketAPY(data, highReward, 52560))
+		low := mustInt(CalculateAverageTicketAPY(data, lowReward, big.NewFloat(52560)))
+		high := mustInt(CalculateAverageTicketAPY(data, highReward, big.NewFloat(52560)))
 
 		if high.Cmp(low) <= 0 {
 			t.Errorf("expected high reward (%s) > low reward (%s)", high, low)
@@ -222,7 +222,7 @@ func TestCalculateAverageTicketAPY(t *testing.T) {
 			{TicketPrice: "100000000000000000000000", VoteHeight: 1_000_000_000, PurchaseHeight: 0},
 		}
 		tinyReward := new(big.Float).SetFloat64(1e-30) // effectively zero SKA
-		got := CalculateAverageTicketAPY(data, tinyReward, 52560)
+		got := CalculateAverageTicketAPY(data, tinyReward, big.NewFloat(52560))
 		if got != "0" {
 			t.Errorf("expected \"0\" for near-zero reward, got %q", got)
 		}
@@ -235,9 +235,9 @@ func TestCalculateAverageTicketAPY(t *testing.T) {
 			{TicketPrice: "10000000000", VoteHeight: 200, PurchaseHeight: 100}, // age 100
 			{TicketPrice: "10000000000", VoteHeight: 400, PurchaseHeight: 100}, // age 300
 		}
-		single100 := mustInt(CalculateAverageTicketAPY([]VoteTicket{data[0]}, oneReward, 52560))
-		single300 := mustInt(CalculateAverageTicketAPY([]VoteTicket{data[1]}, oneReward, 52560))
-		avg := mustInt(CalculateAverageTicketAPY(data, oneReward, 52560))
+		single100 := mustInt(CalculateAverageTicketAPY([]VoteTicket{data[0]}, oneReward, big.NewFloat(52560)))
+		single300 := mustInt(CalculateAverageTicketAPY([]VoteTicket{data[1]}, oneReward, big.NewFloat(52560)))
+		avg := mustInt(CalculateAverageTicketAPY(data, oneReward, big.NewFloat(52560)))
 
 		// avg must be strictly between single300 and single100
 		if avg.Cmp(single300) <= 0 || avg.Cmp(single100) >= 0 {

--- a/txhelpers/ssfee_test.go
+++ b/txhelpers/ssfee_test.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2024, The Monetarium developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txhelpers
+
+import (
+	"math/big"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// FormatSKAAtoms
+// ---------------------------------------------------------------------------
+
+func TestFormatSKAAtoms(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *big.Int
+		want string
+	}{
+		{"nil input", nil, "0"},
+		{"zero", big.NewInt(0), "0"},
+		{"negative", big.NewInt(-1), "0"},
+		{"one atom", big.NewInt(1), "1"},
+		{"one coin (1e18)", new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), "1000000000000000000"},
+		{"large value", func() *big.Int {
+			v, _ := new(big.Int).SetString("123456789012345678901234567890", 10)
+			return v
+		}(), "123456789012345678901234567890"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatSKAAtoms(tc.in)
+			if got != tc.want {
+				t.Errorf("FormatSKAAtoms(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FormatSKAPerVAR
+// ---------------------------------------------------------------------------
+
+func TestFormatSKAPerVAR(t *testing.T) {
+	zero18 := "0.000000000000000000"
+
+	tests := []struct {
+		name     string
+		skaAtoms *big.Int
+		varAtoms int64
+		want     string
+	}{
+		{"nil ska", nil, 1e8, zero18},
+		{"zero ska", big.NewInt(0), 1e8, zero18},
+		{"negative ska", big.NewInt(-1), 1e8, zero18},
+		{"zero var", big.NewInt(1e18), 0, zero18},
+		{"negative var", big.NewInt(1e18), -1, zero18},
+		// 1 SKA coin per 1 VAR coin: skaAtoms=1e18, varAtoms=1e8 → ratio=1.0
+		{"1 SKA per 1 VAR", new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), 1e8, "1.000000000000000000"},
+		// 0.5 SKA per 1 VAR: skaAtoms=5e17, varAtoms=1e8
+		{"0.5 SKA per 1 VAR", new(big.Int).SetInt64(5e17), 1e8, "0.500000000000000000"},
+		// 2 SKA per 1 VAR: skaAtoms=2e18, varAtoms=1e8
+		{"2 SKA per 1 VAR", new(big.Int).Mul(big.NewInt(2), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)), 1e8, "2.000000000000000000"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatSKAPerVAR(tc.skaAtoms, tc.varAtoms)
+			if got != tc.want {
+				t.Errorf("FormatSKAPerVAR(%v, %d) = %q, want %q", tc.skaAtoms, tc.varAtoms, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SSFeeCoinTypes
+// ---------------------------------------------------------------------------
+
+func TestSSFeeCoinTypes(t *testing.T) {
+	t.Run("empty summaries", func(t *testing.T) {
+		got := SSFeeCoinTypes(nil)
+		if len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+	})
+
+	t.Run("single coin type", func(t *testing.T) {
+		summaries := []SSFeeSummary{
+			{SSFeeTotalsByCoin: map[uint8]string{1: "100"}},
+			{SSFeeTotalsByCoin: map[uint8]string{1: "200"}},
+		}
+		got := SSFeeCoinTypes(summaries)
+		if len(got) != 1 {
+			t.Errorf("expected 1 coin type, got %d", len(got))
+		}
+		if _, ok := got[1]; !ok {
+			t.Error("expected coin type 1 to be present")
+		}
+	})
+
+	t.Run("multiple coin types across blocks", func(t *testing.T) {
+		summaries := []SSFeeSummary{
+			{SSFeeTotalsByCoin: map[uint8]string{1: "100", 2: "200"}},
+			{SSFeeTotalsByCoin: map[uint8]string{2: "300", 3: "400"}},
+		}
+		got := SSFeeCoinTypes(summaries)
+		if len(got) != 3 {
+			t.Errorf("expected 3 coin types, got %d: %v", len(got), got)
+		}
+		for _, ct := range []uint8{1, 2, 3} {
+			if _, ok := got[ct]; !ok {
+				t.Errorf("expected coin type %d to be present", ct)
+			}
+		}
+	})
+
+	t.Run("summaries with no coin data", func(t *testing.T) {
+		summaries := []SSFeeSummary{
+			{SSFeeTotalsByCoin: nil},
+			{SSFeeTotalsByCoin: map[uint8]string{}},
+		}
+		got := SSFeeCoinTypes(summaries)
+		if len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CalculateAverageTicketAPY
+// ---------------------------------------------------------------------------
+
+func TestCalculateAverageTicketAPY(t *testing.T) {
+	// helper: parse atom string back to big.Int for comparison
+	mustInt := func(s string) *big.Int {
+		v, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			t.Fatalf("mustInt: cannot parse %q", s)
+		}
+		return v
+	}
+
+	// rewardPerTicket expressed as SKA coins (not atoms) — matches how
+	// explorer.go builds it: totalReward/1e18/TicketsPerBlock.
+	oneReward := big.NewFloat(1.0) // 1 SKA coin per ticket
+
+	t.Run("empty vote data returns zero sentinel", func(t *testing.T) {
+		got := CalculateAverageTicketAPY(nil, oneReward, 52560)
+		if got != "0.000000000000000000" {
+			t.Errorf("got %q, want zero sentinel", got)
+		}
+	})
+
+	t.Run("all invalid tickets returns zero", func(t *testing.T) {
+		data := []VoteTicket{
+			{TicketPrice: "not-a-number", VoteHeight: 100, PurchaseHeight: 90},
+			{TicketPrice: "0", VoteHeight: 100, PurchaseHeight: 90},
+			{TicketPrice: "100000000", VoteHeight: 50, PurchaseHeight: 100}, // age <= 0
+		}
+		got := CalculateAverageTicketAPY(data, oneReward, 52560)
+		if got != "0" {
+			t.Errorf("got %q, want \"0\"", got)
+		}
+	})
+
+	t.Run("result is a valid atom string (parseable as big.Int)", func(t *testing.T) {
+		data := []VoteTicket{
+			// ticket price 100 VAR in atoms, held for 144 blocks
+			{TicketPrice: "10000000000", VoteHeight: 244, PurchaseHeight: 100},
+		}
+		got := CalculateAverageTicketAPY(data, oneReward, 52560)
+		if got == "0" || got == "0.000000000000000000" {
+			t.Fatalf("expected non-zero result, got %q", got)
+		}
+		// Must be parseable as a plain integer (atom string, no decimal point)
+		v := mustInt(got)
+		if v.Sign() <= 0 {
+			t.Errorf("expected positive atom value, got %s", got)
+		}
+	})
+
+	t.Run("decimal ticket price accepted", func(t *testing.T) {
+		// Same ticket expressed as a decimal coin string instead of atoms
+		atomData := []VoteTicket{
+			{TicketPrice: "10000000000", VoteHeight: 244, PurchaseHeight: 100},
+		}
+		decimalData := []VoteTicket{
+			{TicketPrice: "100.00000000", VoteHeight: 244, PurchaseHeight: 100},
+		}
+		gotAtom := CalculateAverageTicketAPY(atomData, oneReward, 52560)
+		gotDecimal := CalculateAverageTicketAPY(decimalData, oneReward, 52560)
+		if gotAtom != gotDecimal {
+			t.Errorf("atom path %q != decimal path %q", gotAtom, gotDecimal)
+		}
+	})
+
+	t.Run("higher reward produces higher APY atoms", func(t *testing.T) {
+		data := []VoteTicket{
+			{TicketPrice: "10000000000", VoteHeight: 244, PurchaseHeight: 100},
+		}
+		lowReward := big.NewFloat(0.5)
+		highReward := big.NewFloat(2.0)
+
+		low := mustInt(CalculateAverageTicketAPY(data, lowReward, 52560))
+		high := mustInt(CalculateAverageTicketAPY(data, highReward, 52560))
+
+		if high.Cmp(low) <= 0 {
+			t.Errorf("expected high reward (%s) > low reward (%s)", high, low)
+		}
+	})
+
+	t.Run("reward rounds to zero atoms returns zero", func(t *testing.T) {
+		// A reward so small that avgAPY * 1e18 < 1 atom → should return "0".
+		data := []VoteTicket{
+			// ticket price 1e15 VAR atoms (~10 million VAR), age 1e9 blocks
+			// APY ≈ 1e-18 * 52560 / 1e9 ≈ 5e-14, * 1e18 ≈ 0.05 → still > 0
+			// Use an astronomically large age to force the product below 1 atom.
+			{TicketPrice: "100000000000000000000000", VoteHeight: 1_000_000_000, PurchaseHeight: 0},
+		}
+		tinyReward := new(big.Float).SetFloat64(1e-30) // effectively zero SKA
+		got := CalculateAverageTicketAPY(data, tinyReward, 52560)
+		if got != "0" {
+			t.Errorf("expected \"0\" for near-zero reward, got %q", got)
+		}
+	})
+
+	t.Run("average across multiple tickets", func(t *testing.T) {
+		// Two tickets with the same price but different ages → average APY
+		// should be between the two individual APYs.
+		data := []VoteTicket{
+			{TicketPrice: "10000000000", VoteHeight: 200, PurchaseHeight: 100}, // age 100
+			{TicketPrice: "10000000000", VoteHeight: 400, PurchaseHeight: 100}, // age 300
+		}
+		single100 := mustInt(CalculateAverageTicketAPY([]VoteTicket{data[0]}, oneReward, 52560))
+		single300 := mustInt(CalculateAverageTicketAPY([]VoteTicket{data[1]}, oneReward, 52560))
+		avg := mustInt(CalculateAverageTicketAPY(data, oneReward, 52560))
+
+		// avg must be strictly between single300 and single100
+		if avg.Cmp(single300) <= 0 || avg.Cmp(single100) >= 0 {
+			t.Errorf("average %s not between %s (age=300) and %s (age=100)", avg, single300, single100)
+		}
+	})
+}

--- a/txhelpers/ssfee_test.go
+++ b/txhelpers/ssfee_test.go
@@ -150,8 +150,8 @@ func TestCalculateAverageTicketAPY(t *testing.T) {
 
 	t.Run("empty vote data returns zero sentinel", func(t *testing.T) {
 		got := CalculateAverageTicketAPY(nil, oneReward, 52560)
-		if got != "0.000000000000000000" {
-			t.Errorf("got %q, want zero sentinel", got)
+		if got != "0" {
+			t.Errorf("got %q, want \"0\"", got)
 		}
 	})
 

--- a/wiki/code-analysis/var-ska-data/flow.full.md
+++ b/wiki/code-analysis/var-ska-data/flow.full.md
@@ -26,7 +26,7 @@ Tracing the dual-token end-to-end data lifecycle of VAR (primary) and SKA (custo
 
 ### 4. Cross-Layer Dependencies
 
-- **String Formatting Protocol Coupling:** The string chopping rules in backend Go templates (`skaSplitParts` / `skaDecimalParts`) are tightly coupled to the exact slicing mechanisms in the client side (`splitSkaAtoms` and `splitSkaValue`). Altering display digits (e.g. bolding 3 decimals instead of 2) requires synchronized updates across both JS and Go borders.
+- **String Formatting Protocol Coupling:** The string chopping rules in backend Go templates (`skaSplitParts` / `skaDecimalParts`) are tightly coupled to the exact slicing mechanisms in the client side (`splitSkaAtoms`). Altering display digits (e.g. bolding 3 decimals instead of 2) requires synchronized updates across both JS and Go borders.
 - **WebSocket to DOM `<template>:`** The JSON structure broadcasted from PubSubHub (`r.amount` string) strictly expects the historic `.tmpl` HTML to contain an inert, identical `<template>` tag. If either deviates visually, real-time rendering breaks parity.
 
 ### 5. Critical Constraints

--- a/wiki/code-analysis/var-ska-data/flow.full.md
+++ b/wiki/code-analysis/var-ska-data/flow.full.md
@@ -18,7 +18,7 @@ Tracing the dual-token end-to-end data lifecycle of VAR (primary) and SKA (custo
 
 - **Location:** `cmd/dcrdata/internal/explorer/templates.go` (Scaling / API Layer)
   - **Data Structures Involved:** Go `math/big`
-  - **Transformations Applied:** Uses scaling coefficients: `varDecimals = big.NewInt(1e8)` and `skaDecimals = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)`. Divides atomic amounts via `new(big.Int).Div` to obtain proper fraction strings (`skaDecimalParts`, `formatCoinAtomsFull`) just prior to injection into the API boundary.
+  - **Transformations Applied:** Uses scaling coefficients: `varDecimals = big.NewInt(1e8)` and `skaDecimals = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)`. Divides atomic amounts via `new(big.Int).Div` to obtain proper fraction strings (`skaDecimalParts`, `formatAtomsAsCoinString`) just prior to injection into the API boundary.
 
 - **Location:** `cmd/dcrdata/public/js/helpers/ska_helper.js` and `mining_controller.js` (Frontend Representation)
   - **Data Structures Involved:** Native JS `BigInt` and DOM `<template id="...">`

--- a/wiki/code-analysis/var-ska-data/patterns.md
+++ b/wiki/code-analysis/var-ska-data/patterns.md
@@ -18,9 +18,9 @@
 
 Coin type labels (`VAR`, `SKA1`–`SKA255`) are produced by dedicated functions at each rendering boundary. The mapping is: `0 → "VAR"`, `1–255 → "SKA{n}"`. There are two canonical implementations — one per environment — and they must stay in sync:
 
-| Environment | Location | Function |
-|---|---|---|
-| Go templates (SSR) | `cmd/dcrdata/internal/explorer/templates.go` | `coinSymbol(ct uint8) string` — registered as `coinSymbol` in the template `FuncMap` |
+| Environment               | Location                                      | Function                                                                                                 |
+| ------------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Go templates (SSR)        | `cmd/dcrdata/internal/explorer/templates.go`  | `coinSymbol(ct uint8) string` — registered as `coinSymbol` in the template `FuncMap`                     |
 | JS / Stimulus (real-time) | `cmd/dcrdata/public/js/helpers/ska_helper.js` | `renderCoinType(coinType: number): string` — handles `null`/`undefined`/out-of-range with `"-"` fallback |
 
 Related JS helpers in `ska_helper.js` and `humanize_helper.js` that operate on coin values (not labels):
@@ -28,6 +28,5 @@ Related JS helpers in `ska_helper.js` and `humanize_helper.js` that operate on c
 - `formatCoinAtoms(atomStr, coinType)` — formats a raw atom string to three significant figures; routes to VAR (8 decimals) or SKA (18 decimals) path based on `coinType`
 - `formatCoinAtomsFull(atomStr, coinType)` — same routing, full precision with trailing zeros stripped
 - `splitSkaAtoms(atomStr)` — splits a raw SKA atom string into display parts (`intPart`, `bold`, `rest`, `trailingZeros`) using BigInt to avoid float64 loss
-- `splitSkaValue(s)` — same split for an already-formatted SKA decimal string
 
 - **Implication for mutation:** Never construct coin type labels inline (e.g. `` `SKA${n}` `` or hardcoded `"VAR"` strings). Always call the canonical function for the environment you are in. If the label format ever changes, both `coinSymbol` and `renderCoinType` must be updated together. If you add a new formatting helper for coin values, add it to `ska_helper.js` or `humanize_helper.js` — not inline in a controller.

--- a/wiki/code-analysis/var-ska-data/patterns.md
+++ b/wiki/code-analysis/var-ska-data/patterns.md
@@ -26,7 +26,7 @@ Coin type labels (`VAR`, `SKA1`–`SKA255`) are produced by dedicated functions 
 Related JS helpers in `ska_helper.js` and `humanize_helper.js` that operate on coin values (not labels):
 
 - `formatCoinAtoms(atomStr, coinType)` — formats a raw atom string to three significant figures; routes to VAR (8 decimals) or SKA (18 decimals) path based on `coinType`
-- `formatCoinAtomsFull(atomStr, coinType)` — same routing, full precision with trailing zeros stripped
+- `formatAtomsAsCoinString(atomStr, coinType)` — same routing, full precision with trailing zeros stripped
 - `splitSkaAtoms(atomStr)` — splits a raw SKA atom string into display parts (`intPart`, `bold`, `rest`, `trailingZeros`) using BigInt to avoid float64 loss
 
 - **Implication for mutation:** Never construct coin type labels inline (e.g. `` `SKA${n}` `` or hardcoded `"VAR"` strings). Always call the canonical function for the environment you are in. If the label format ever changes, both `coinSymbol` and `renderCoinType` must be updated together. If you add a new formatting helper for coin values, add it to `ska_helper.js` or `humanize_helper.js` — not inline in a controller.


### PR DESCRIPTION
Closes #207

## Summary

Implements unified decimal coin formatting across all homepage sections (Voting, Mining, Coin Supply) as specified in issue #207.

## Formatting rule applied

- Digits up to and including hundredths → large font
- Remaining decimal digits → small font
- Hundredths always present: `.00` shown in large font for integer values
- Trailing zeros after hundredths → grey (except Coin Supply, where they are omitted)

## Changes

### Go — formatting engine
- **`templates.go`**: Rename `formatCoinAtomsFull` → `formatAtomsAsCoinString`; add `minDecimals` parameter; replace `big.Rat` division with exact `big.Int` arithmetic to eliminate rounding; trim trailing zeros while preserving at least `minDecimals` digits
- **`explorer/types/explorertypes.go`**: Convert SKA reward fields from pre-formatted strings to atom integers for standardised rendering
- **`txhelpers/ssfee.go`**: Fix `CalculateAverageTicketAPY` to return an atom string (multiply by 1e18) so `formatAtomsAsCoinString` can parse it; previously always rendered `"0"`

### JS — frontend helpers & controllers
- **`humanize_helper.js`**: Unified `decimalParts` logic matching the new formatting rule; updated tests (+203 lines)
- **`supply_controller.js`**: Pass `minDecimals=2` for consistent display
- **`voting_controller.js`**: Adopt new function signature; remove redundant `ska_helper.js` logic
- **`mining_controller.js`**: Remove unnecessary trailing parameter from `decimalParts` calls

### Templates
- **`extras.tmpl`**, **`home_supply.tmpl`**, **`home_voting.tmpl`**: Updated template calls to use `formatAtomsAsCoinString` with `minDecimals`

### Tests
- **`templates_test.go`**: +306 lines covering VAR/SKA coin types, custom decimal precision, comma formatting, and edge cases
- **`txhelpers/ssfee_test.go`**: Full coverage of `FormatSKAAtoms`, `FormatSKAPerVAR`, `SSFeeCoinTypes`, and `CalculateAverageTicketAPY`
- **`home_voting_template_test.go`**: Updated to match new formatting output

### Docs
- **`wiki/code-analysis/var-ska-data/`**: Updated flow and patterns docs to reflect formatting changes

## Testing
- All new and updated Go tests pass
- JS helper tests updated and passing (`humanize_helper.test.js`)