### PR TITLE
docs: add development workflow guide and refactor asset manifest hand…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Monetarium Explorer is a block explorer for the [Monetarium](https://monetarium.
 - [Overview](#overview)
 - [Requirements](#requirements)
 - [Building](#building)
+- [Development Workflow](#development-workflow)
 - [Contributing](#contributing)
 - [Local Testing on Testnet](#local-testing-on-testnet)
 - [Getting Started (Production)](#getting-started-production)
@@ -100,6 +101,39 @@ Mount your `monetarium-node` configuration directory (containing `rpc.cert`) to 
 ```sh
 docker run -p 7777:7777 -v ~/.monetarium:/home/explorer/.monetarium monetarium-explorer
 ```
+
+---
+
+## Development Workflow
+
+### Live reloading of CSS, JS, and HTML templates
+
+During development you can get instant feedback on frontend changes without restarting the Go server.
+
+**1. Start the webpack watcher** (from `cmd/dcrdata`):
+
+```sh
+npm run watch
+```
+
+This watches all JS and SCSS files imported from `public/index.js` and rebuilds on every save. The output hashes in `public/dist/manifest.json` are updated automatically, and the server reads that file on every request — so a hard reload in the browser is all you need to pick up CSS or JS changes.
+
+**2. Start the explorer with HTML template reloading** (from `cmd/dcrdata`):
+
+```sh
+./monetarium-explorer --reload-html
+```
+
+With `--reload-html` enabled, Go HTML templates in the `views/` folder are re-parsed on every request, so you can edit `.tmpl` files and see changes with a hard reload in the browser — no server restart required.
+
+**Summary of what requires a restart vs. what doesn't:**
+
+| Change                           | Requires restart?         |
+| -------------------------------- | ------------------------- |
+| SCSS / CSS (`npm run watch`)     | No — hard reload          |
+| JavaScript (`npm run watch`)     | No — hard reload          |
+| HTML templates (`--reload-html`) | No — hard reload          |
+| Go source code                   | Yes — rebuild and restart |
 
 ---
 

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -237,10 +237,10 @@ type explorerUI struct {
 	displaySyncStatusPage atomic.Value
 	politeiaURL           string
 
-	invsMtx  sync.RWMutex
-	invs     *types.MempoolInfo
-	premine  int64
-	manifest map[string]string
+	invsMtx           sync.RWMutex
+	invs              *types.MempoolInfo
+	premine           int64
+	assetManifestPath string
 }
 
 // AreDBsSyncing is a thread-safe way to fetch the boolean in dbsSyncing.
@@ -375,21 +375,19 @@ func New(cfg *ExplorerConfig) *explorerUI {
 
 	log.Infof("Mean Voting Blocks calculated: %d", exp.pageData.HomeInfo.Params.MeanVotingBlocks)
 
-	// Load webpack manifest for cache-busted asset URLs.
-	if cfg.AssetManifestPath != "" {
-		if manifestData, err := os.ReadFile(cfg.AssetManifestPath); err != nil {
-			log.Warnf("Could not read asset manifest: %v", err)
-		} else if err = json.Unmarshal(manifestData, &exp.manifest); err != nil {
-			log.Warnf("Could not parse asset manifest: %v", err)
-		} else {
-			log.Infof("Loaded asset manifest with %d entries", len(exp.manifest))
-		}
-	}
+	exp.assetManifestPath = cfg.AssetManifestPath
 
 	funcMap := makeTemplateFuncMap(exp.ChainParams)
 	funcMap["asset"] = func(name string) string {
-		if hashed, ok := exp.manifest[name]; ok {
-			return hashed
+		if exp.assetManifestPath != "" {
+			if manifestData, err := os.ReadFile(exp.assetManifestPath); err == nil {
+				var m map[string]string
+				if json.Unmarshal(manifestData, &m) == nil {
+					if hashed, ok := m[name]; ok {
+						return hashed
+					}
+				}
+			}
 		}
 		return "/dist/" + name
 	}


### PR DESCRIPTION
…ling

- Add "Development Workflow" section to README with live reloading instructions
- Document webpack watcher setup for CSS and JS changes with instant feedback
- Document HTML template reloading with --reload-html flag
- Add comparison table showing which changes require server restart
- Refactor asset manifest loading from initialization to lazy loading in template function
- Replace manifest field with assetManifestPath to reduce memory footprint
- Improve asset resolution to read manifest on-demand during template rendering
- Simplifies initialization logic and allows manifest updates without server restart