### PR TITLE
refactor: simplify mining fee calculation to coinbase - subsidy

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -245,8 +245,10 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	if feeInfoBlock == nil {
 		log.Error("FeeInfoBlock failed")
 	}
-	// Compute mining fee (total fees from all transactions in block)
-	miningFee := computeMiningFee(msgBlock)
+	var miningFee int64
+	if curSubsidy != nil {
+		miningFee = computeMiningFee(msgBlock, curSubsidy.PoW)
+	}
 
 	// Work/Stake difficulty
 	diff := txhelpers.GetDifficultyRatio(header.Bits, t.netParams)
@@ -597,21 +599,17 @@ func BlockSKAFees(msgBlock *wire.MsgBlock) map[uint8]string {
 	return out
 }
 
-// computeMiningFee calculates total mining fees from a block (sum of all tx fees).
-func computeMiningFee(msgBlock *wire.MsgBlock) int64 {
-	var totalFee int64
-	for i, tx := range msgBlock.Transactions {
-		if i == 0 {
-			continue // skip coinbase
-		}
-		var in, out int64
-		for _, vin := range tx.TxIn {
-			in += vin.ValueIn
-		}
-		for _, vout := range tx.TxOut {
-			out += vout.Value
-		}
-		totalFee += in - out
+// computeMiningFee calculates total mining fees from a block.
+// Formula: Mining Fee = Coinbase Output - PoW Subsidy
+// This is equivalent to summing (Inputs - Outputs) for all non-coinbase transactions,
+// but more efficient and accurate.
+func computeMiningFee(msgBlock *wire.MsgBlock, powSubsidy int64) int64 {
+	// Get coinbase output (first transaction, first output)
+	coinbaseOutput := int64(0)
+	for _, txOut := range msgBlock.Transactions[0].TxOut {
+		coinbaseOutput += txOut.Value
 	}
-	return totalFee
+	miningFee := coinbaseOutput - powSubsidy
+
+	return miningFee
 }

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -335,3 +335,80 @@ func TestExtractSKARewardsFromCoinbase_Summing(t *testing.T) {
 		t.Errorf("SKA1: want %s, got %s", expected, got[1])
 	}
 }
+
+// ---------------------------------------------------------------------------
+// computeMiningFee tests
+// ---------------------------------------------------------------------------
+
+// TestComputeMiningFee_CoinbaseEqualsSubsidy tests when coinbase equals the base subsidy.
+// This happens when there are no transaction fees in the block.
+func TestComputeMiningFee_CoinbaseEqualsSubsidy(t *testing.T) {
+	// Coinbase output = 16.00 VAR (exactly equal to subsidy)
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxOut(wire.NewTxOut(16e8, nil)) // 16 VAR = 1.6e9 atoms
+
+	block := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{coinbase},
+	}
+
+	got := computeMiningFee(block, 16e8)
+	want := int64(0)
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+// TestComputeMiningFee_CoinbaseGreaterThanSubsidy tests when coinbase is greater than subsidy.
+// This happens when there are transaction fees (positive net from txs).
+func TestComputeMiningFee_CoinbaseGreaterThanSubsidy(t *testing.T) {
+	// Block 36500: Coinbase output = 16.00731048 VAR (fee = 0.00731048 VAR)
+	// 16.00731048 VAR = 1600731048 atoms
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxOut(wire.NewTxOut(1600731048, nil))
+
+	block := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{coinbase},
+	}
+
+	got := computeMiningFee(block, 16e8)
+	want := int64(731048) // 1600731048 - 1600000000 = 731048 atoms = 0.00731048 VAR
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+// TestComputeMiningFee_CoinbaseLessThanSubsidy tests when coinbase is less than subsidy.
+// This is an edge case that can happen if fees are negative.
+func TestComputeMiningFee_CoinbaseLessThanSubsidy(t *testing.T) {
+	// Coinbase output = 15.99 VAR (less than 16 VAR subsidy)
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxOut(wire.NewTxOut(1599000000, nil)) // 15.99 VAR = 1599000000 atoms
+
+	block := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{coinbase},
+	}
+
+	got := computeMiningFee(block, 16e8)
+	want := int64(-1000000) // 1599000000 - 1600000000 = -1000000 atoms = -0.01 VAR
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+// TestComputeMiningFee_PositiveFee tests with real data from Block 36504.
+// Coinbase output = 16.01076502 VAR
+func TestComputeMiningFee_Block36504(t *testing.T) {
+	// Block 36504: Coinbase = 16.01076502 VAR = 1601076502 atoms
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxOut(wire.NewTxOut(1601076502, nil))
+
+	block := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{coinbase},
+	}
+
+	got := computeMiningFee(block, 16e8)
+	want := int64(1076502) // 1601076502 - 1600000000 = 1076502 atoms = 0.01076502 VAR
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
- Replace per-transaction fee summation with direct formula: Mining Fee = Coinbase Output - PoW Subsidy (from GetBlockSubsidy RPC)
- Require PoW subsidy from RPC - do not use fallback as subsidy changes over time (halves after block ~6000)
- If RPC fails, mining fee is not calculated (returns 0)
- Add tests for computeMiningFee covering:
  - Zero fee (coinbase = subsidy)
  - Positive fee (Block 36504 data)
  - Negative fee (edge case)
  - Real block data verification