### PR TITLE
feat: provide multi-coin data for block page template and verbose API

### DIFF
--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -585,31 +585,30 @@ func (c *appContext) getBlockVerbose(w http.ResponseWriter, r *http.Request) {
 	// Get summary for multi-coin data
 	summary := c.DataSource.GetSummaryByHash(ctx, hash, false)
 
-	// Build extended response with total_sent and fees maps
-	response := make(map[string]interface{})
+	// Build response struct with embedded verbose result
+	type verboseResponse struct {
+		*chainjson.GetBlockVerboseResult
+		TotalSent map[string]string `json:"total_sent,omitempty"`
+		Fees      map[string]string `json:"fees,omitempty"`
+	}
 
-	// Marshal the verbose result into a map
-	if b, err := json.Marshal(blockVerbose); err == nil {
-		json.Unmarshal(b, &response)
+	response := verboseResponse{
+		GetBlockVerboseResult: blockVerbose,
 	}
 
 	// Add total_sent map (coin type key -> amount string)
 	if summary != nil && summary.CoinAmounts != nil {
-		totalSent := make(map[string]string)
+		response.TotalSent = make(map[string]string)
 		for ct, amt := range summary.CoinAmounts {
 			if amt != "0" && amt != "" {
-				totalSent[fmt.Sprintf("%d", ct)] = amt
+				response.TotalSent[fmt.Sprintf("%d", ct)] = amt
 			}
-		}
-		if len(totalSent) > 0 {
-			response["total_sent"] = totalSent
 		}
 
 		// Add fees map (coin type key -> fee string)
 		if summary.MiningFee != nil && *summary.MiningFee != 0 {
-			fees := make(map[string]string)
-			fees["0"] = fmt.Sprintf("%d", *summary.MiningFee)
-			response["fees"] = fees
+			response.Fees = make(map[string]string)
+			response.Fees["0"] = fmt.Sprintf("%d", *summary.MiningFee)
 		}
 	}
 

--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -606,6 +606,7 @@ func (c *appContext) getBlockVerbose(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Add fees map (coin type key -> fee string)
+		// VAR fees from MiningFee (total VAR tx fees in block); SKA fees from SSFeeTotalsByCoin
 		response.Fees = make(map[string]string)
 
 		// VAR fees from MiningFee

--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -582,7 +582,38 @@ func (c *appContext) getBlockVerbose(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, blockVerbose, m.GetIndentCtx(r))
+	// Get summary for multi-coin data
+	summary := c.DataSource.GetSummaryByHash(ctx, hash, false)
+
+	// Build extended response with total_sent and fees maps
+	response := make(map[string]interface{})
+
+	// Marshal the verbose result into a map
+	if b, err := json.Marshal(blockVerbose); err == nil {
+		json.Unmarshal(b, &response)
+	}
+
+	// Add total_sent map (coin type key -> amount string)
+	if summary != nil && summary.CoinAmounts != nil {
+		totalSent := make(map[string]string)
+		for ct, amt := range summary.CoinAmounts {
+			if amt != "0" && amt != "" {
+				totalSent[fmt.Sprintf("%d", ct)] = amt
+			}
+		}
+		if len(totalSent) > 0 {
+			response["total_sent"] = totalSent
+		}
+
+		// Add fees map (coin type key -> fee string)
+		if summary.MiningFee != nil && *summary.MiningFee != 0 {
+			fees := make(map[string]string)
+			fees["0"] = fmt.Sprintf("%d", *summary.MiningFee)
+			response["fees"] = fees
+		}
+	}
+
+	writeJSON(w, response, m.GetIndentCtx(r))
 }
 
 func (c *appContext) getVoteInfo(w http.ResponseWriter, r *http.Request) {

--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -606,9 +606,25 @@ func (c *appContext) getBlockVerbose(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Add fees map (coin type key -> fee string)
+		response.Fees = make(map[string]string)
+
+		// VAR fees from MiningFee
 		if summary.MiningFee != nil && *summary.MiningFee != 0 {
-			response.Fees = make(map[string]string)
 			response.Fees["0"] = fmt.Sprintf("%d", *summary.MiningFee)
+		}
+
+		// SKA fees from SSFeeTotalsByCoin (stake fee distribution)
+		if summary.SSFeeTotalsByCoin != nil {
+			for ct, fee := range summary.SSFeeTotalsByCoin {
+				if fee != "0" && fee != "" {
+					response.Fees[fmt.Sprintf("%d", ct)] = fee
+				}
+			}
+		}
+
+		// Remove empty fees map
+		if len(response.Fees) == 0 {
+			response.Fees = nil
 		}
 	}
 

--- a/cmd/dcrdata/internal/api/apiroutes_test.go
+++ b/cmd/dcrdata/internal/api/apiroutes_test.go
@@ -261,6 +261,71 @@ func TestBlockVerbose_FeesMap(t *testing.T) {
 	}
 }
 
+// blockVerboseSKAFeeDS provides SSFeeTotalsByCoin for SKA fee testing.
+type blockVerboseSKAFeeDS struct {
+	blockVerboseDS
+}
+
+func (blockVerboseSKAFeeDS) GetSummaryByHash(_ context.Context, hash string, _ bool) *apitypes.BlockDataBasic {
+	fee := int64(12345678)
+	return &apitypes.BlockDataBasic{
+		Height: 100,
+		Hash:   hash,
+		CoinAmounts: map[uint8]string{
+			0: "100000000",
+			1: "1000000000000000000",
+		},
+		MiningFee: &fee,
+		SSFeeTotalsByCoin: map[uint8]string{
+			1: "500000000000000000", // SKA1: 0.5 SKA in atoms
+			2: "300000000000000000", // SKA2: 0.3 SKA in atoms
+		},
+	}
+}
+
+func TestBlockVerbose_SKAFeesFromSSFeeTotals(t *testing.T) {
+	app := &appContext{DataSource: blockVerboseSKAFeeDS{}}
+	mux := NewAPIRouter(app, "", false, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/block/100/verbose", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	fees, ok := result["fees"].(map[string]interface{})
+	if !ok {
+		t.Fatal("fees field missing or not a map")
+	}
+
+	// VAR fees should be present
+	if fees["0"] == nil {
+		t.Error("fees missing VAR (key 0)")
+	}
+
+	// SKA fees from SSFeeTotalsByCoin should be present
+	if fees["1"] == nil {
+		t.Error("fees missing SKA1 (key 1) from SSFeeTotalsByCoin")
+	}
+	if fees["1"] != "500000000000000000" {
+		t.Errorf("fees[1] = %v, want 500000000000000000", fees["1"])
+	}
+
+	if fees["2"] == nil {
+		t.Error("fees missing SKA2 (key 2) from SSFeeTotalsByCoin")
+	}
+	if fees["2"] != "300000000000000000" {
+		t.Errorf("fees[2] = %v, want 300000000000000000", fees["2"])
+	}
+}
+
 // blockVerboseZeroSKADS provides zero-value SKA for omission test.
 type blockVerboseZeroSKADS struct {
 	blockVerboseDS

--- a/cmd/dcrdata/internal/api/apiroutes_test.go
+++ b/cmd/dcrdata/internal/api/apiroutes_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	apitypes "github.com/monetarium/monetarium-explorer/api/types"
+	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
 )
 
 // blockSummaryDS overrides GetSummaryByHash to return multi-coin data.
@@ -159,5 +160,156 @@ func TestSKASupplyChart_ResponseFormat(t *testing.T) {
 		t.Error("coin-supply/1 returns 500 - should handle gracefully")
 	default:
 		t.Logf("coin-supply/1 returns %d", w.Code)
+	}
+}
+
+// blockVerboseDS provides multi-coin data for verbose endpoint tests.
+type blockVerboseDS struct {
+	noopDS
+}
+
+func (blockVerboseDS) GetBlockVerboseByHash(_ context.Context, hash string, _ bool) *chainjson.GetBlockVerboseResult {
+	return &chainjson.GetBlockVerboseResult{
+		Hash:   hash,
+		Height: 100,
+		Tx:     []string{"tx1", "tx2"},
+	}
+}
+
+func (blockVerboseDS) GetSummaryByHash(_ context.Context, hash string, _ bool) *apitypes.BlockDataBasic {
+	fee := int64(12345678) // 0.12345678 DCR in atoms
+	return &apitypes.BlockDataBasic{
+		Height: 100,
+		Hash:   hash,
+		CoinAmounts: map[uint8]string{
+			0: "100000000",           // VAR: 1 DCR
+			1: "1000000000000000000", // SKA1: 1 SKA
+			2: "2000000000000000000", // SKA2: 2 SKA
+		},
+		MiningFee: &fee,
+	}
+}
+
+func (blockVerboseDS) GetBlockHash(_ context.Context, height int64) (string, error) {
+	return "00000000000000000000000000000000000000000000000000000000000000a0", nil
+}
+
+func TestBlockVerbose_TotalSentMap(t *testing.T) {
+	app := &appContext{DataSource: blockVerboseDS{}}
+	mux := NewAPIRouter(app, "", false, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/block/100/verbose", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	totalSent, ok := result["total_sent"].(map[string]interface{})
+	if !ok {
+		t.Fatal("total_sent field missing or not a map")
+	}
+
+	// VAR (key "0") should be present
+	if totalSent["0"] == nil {
+		t.Error("total_sent missing VAR (key 0)")
+	}
+	if totalSent["0"] != "100000000" {
+		t.Errorf("total_sent[0] = %v, want 100000000", totalSent["0"])
+	}
+
+	// SKA1 (key "1") should be present
+	if totalSent["1"] == nil {
+		t.Error("total_sent missing SKA1 (key 1)")
+	}
+	if totalSent["1"] != "1000000000000000000" {
+		t.Errorf("total_sent[1] = %v, want 1000000000000000000", totalSent["1"])
+	}
+}
+
+func TestBlockVerbose_FeesMap(t *testing.T) {
+	app := &appContext{DataSource: blockVerboseDS{}}
+	mux := NewAPIRouter(app, "", false, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/block/100/verbose", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	fees, ok := result["fees"].(map[string]interface{})
+	if !ok {
+		t.Fatal("fees field missing or not a map")
+	}
+
+	// VAR fees should be present
+	if fees["0"] == nil {
+		t.Error("fees missing VAR (key 0)")
+	}
+}
+
+// blockVerboseZeroSKADS provides zero-value SKA for omission test.
+type blockVerboseZeroSKADS struct {
+	blockVerboseDS
+}
+
+func (blockVerboseZeroSKADS) GetSummaryByHash(_ context.Context, hash string, _ bool) *apitypes.BlockDataBasic {
+	return &apitypes.BlockDataBasic{
+		Height: 100,
+		Hash:   hash,
+		CoinAmounts: map[uint8]string{
+			0: "100000000",          // VAR: 1 DCR
+			1: "0",                  // SKA1: zero - should be omitted
+			2: "500000000000000000", // SKA2: non-zero
+		},
+		MiningFee: new(int64),
+	}
+}
+
+func TestBlockVerbose_OmitsZeroSKA(t *testing.T) {
+	app := &appContext{DataSource: blockVerboseZeroSKADS{}}
+	mux := NewAPIRouter(app, "", false, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/block/100/verbose", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	totalSent := result["total_sent"].(map[string]interface{})
+
+	// VAR should be present
+	if totalSent["0"] == nil {
+		t.Error("total_sent should contain VAR (key 0)")
+	}
+
+	// SKA1 (key "1") with zero value should be omitted
+	if totalSent["1"] != nil {
+		t.Error("total_sent should omit SKA1 (key 1) with zero value")
+	}
+
+	// SKA2 (key "2") with non-zero should be present
+	if totalSent["2"] == nil {
+		t.Error("total_sent should contain SKA2 (key 2) with non-zero value")
 	}
 }

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -928,11 +928,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 
 // ChartsUpdated should be called when a chart update completes.
 func (exp *explorerUI) ChartsUpdated() {
-	anonSet := exp.chartSource.AnonymitySet()
 	exp.pageData.Lock()
-	if exp.pageData.HomeInfo.CoinSupply > 0 {
-		exp.pageData.HomeInfo.MixedPercent = float64(anonSet) / float64(exp.pageData.HomeInfo.CoinSupply) * 100
-	}
+	// MixedPercent removed - was used for privacy mix tracking
 	exp.pageData.Unlock()
 }
 

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -6,6 +6,7 @@ import { isEqual } from '../helpers/chart_helper'
 import { requestJSON } from '../helpers/http'
 import humanize from '../helpers/humanize_helper'
 import { getDefault } from '../helpers/module_helper'
+import { renderCoinType, splitSkaAtomsNoTrailing } from '../helpers/ska_helper'
 import TurboQuery from '../helpers/turbolinks_helper'
 import Zoom from '../helpers/zoom_helper'
 import globalEventBus from '../services/event_bus_service'
@@ -54,6 +55,25 @@ function hasMultipleVisibility(chart) {
 function intComma(amount) {
   if (!amount) return ''
   return amount.toLocaleString(undefined, { maximumFractionDigits: 0 })
+}
+
+function skaCoinTypeFromChart(name) {
+  if (typeof name !== 'string' || !name.startsWith('coin-supply/')) return 0
+  const n = parseInt(name.slice('coin-supply/'.length), 10)
+  return Number.isInteger(n) && n >= 1 && n <= 255 ? n : 0
+}
+
+function isSKASupplyChart(name) {
+  return skaCoinTypeFromChart(name) > 0
+}
+
+function isCoinSupplyChart(name) {
+  return name === 'coin-supply' || (typeof name === 'string' && name.startsWith('coin-supply/'))
+}
+
+function formatSkaAtomsExact(atomStr) {
+  const p = splitSkaAtomsNoTrailing(atomStr, true, 0)
+  return p.rest ? `${p.intPart}.${p.rest}` : p.intPart
 }
 
 function axesToRestoreYRange(chartName, origYRange, newYRange) {
@@ -289,7 +309,6 @@ function circulationFunc(chartData) {
   const heights = chartData.h
   const times = chartData.t
   const supplies = chartData.supply
-  const anonymitySet = chartData.anonymitySet
   const isHeightAxis = chartData.axis === 'height'
   let xFunc, hFunc
   if (chartData.bin === 'day') {
@@ -305,7 +324,7 @@ function circulationFunc(chartData) {
     const height = hFunc(i)
     addDough(height)
     inflation.push(yMax)
-    return [xFunc(i), supplies[i] * atomsToDCR, null, anonymitySet[i] * atomsToDCR]
+    return [xFunc(i), supplies[i] * atomsToDCR, null]
   })
 
   const dailyBlocks = aDay / avgBlockTime
@@ -325,7 +344,7 @@ function circulationFunc(chartData) {
   for (let i = 1; i <= projection; i++) {
     addDough(h + dailyBlocks)
     x += xIncrement
-    data.push([xFunc(x), null, yMax, null])
+    data.push([xFunc(x), null, yMax])
   }
   return { data, inflation }
 }
@@ -364,7 +383,6 @@ export default class extends Controller {
       'scaleSelector',
       'ticketsPurchase',
       'ticketsPrice',
-      'anonymitySet',
       'vSelectorItem',
       'vSelector',
       'binSize',
@@ -504,7 +522,12 @@ export default class extends Controller {
     yFormatter = defaultYFormatter
     const xlabel = data.t ? 'Date' : 'Block Height'
 
-    switch (chartName) {
+    const isSKA = isSKASupplyChart(chartName)
+    const coinType = skaCoinTypeFromChart(chartName)
+    const coinLabel = isSKA ? renderCoinType(coinType) : 'VAR'
+    const switchKey = isCoinSupplyChart(chartName) ? 'coin-supply' : chartName
+
+    switch (switchKey) {
       case 'ticket-price': // price graph
         d = ticketPriceFunc(data)
         assign(
@@ -635,52 +658,62 @@ export default class extends Controller {
         )
         break
 
-      case 'coin-supply': // supply graph
+      case 'coin-supply':
+        if (isSKA) {
+          this._skaSupplyRaw = data.supply
+          const ys = data.supply.map((s) => Number(s) * 1e-18)
+          d = zip2D(data, ys)
+          assign(
+            gOptions,
+            mapDygraphOptions(
+              d,
+              [xlabel, 'Coin Supply'],
+              true,
+              `Coin Supply (${coinLabel})`,
+              true,
+              false
+            )
+          )
+          yFormatter = (div, data, i) => {
+            const raw = this._skaSupplyRaw && this._skaSupplyRaw[i]
+            const exact = raw != null ? formatSkaAtomsExact(raw) : data.series[0].y.toString()
+            div.appendChild(
+              legendEntry(
+                `${data.series[0].dashHTML} ${data.series[0].labelHTML}: ${exact} ${coinLabel}`
+              )
+            )
+          }
+          break
+        }
         d = circulationFunc(data)
         assign(
           gOptions,
           mapDygraphOptions(
             d.data,
-            [xlabel, 'Coin Supply', 'Inflation Limit', 'Mix Rate'],
+            [xlabel, 'Coin Supply', 'Inflation Limit'],
             true,
-            'Coin Supply (DCR)',
+            'Coin Supply (VAR)',
             true,
             false
           )
         )
         gOptions.y2label = 'Inflation Limit'
-        gOptions.y3label = 'Mix Rate'
-        gOptions.series = { 'Inflation Limit': { axis: 'y2' }, 'Mix Rate': { axis: 'y3' } }
-        this.visibility = [true, true, this.anonymitySetTarget.checked]
-        gOptions.visibility = this.visibility
         gOptions.series = {
           'Inflation Limit': {
             strokePattern: [5, 5],
             color: '#888',
             strokeWidth: 1.5
-          },
-          'Mix Rate': {
-            color: '#2dd8a3'
           }
         }
         gOptions.inflation = d.inflation
         yFormatter = (div, data, i) => {
-          addLegendEntryFmt(div, data.series[0], (y) => `${intComma(y)} DCR`)
-          let change = 0
+          addLegendEntryFmt(div, data.series[0], (y) => `${intComma(y)} VAR`)
           if (i < d.inflation.length) {
-            const supply = data.series[0].y
-            if (this.anonymitySetTarget.checked) {
-              const mixed = data.series[2].y
-              const mixedPercentage = ((mixed / supply) * 100).toFixed(2)
-              div.appendChild(
-                legendEntry(`${legendMarker()} Mixed: ${intComma(mixed)} DCR (${mixedPercentage}%)`)
-              )
-            }
             const predicted = d.inflation[i]
             const unminted = predicted - data.series[0].y
-            change = ((unminted / predicted) * 100).toFixed(2)
+            const change = ((unminted / predicted) * 100).toFixed(2)
             div.appendChild(
-              legendEntry(`${legendMarker()} Unminted: ${intComma(unminted)} DCR (${change}%)`)
+              legendEntry(`${legendMarker()} Unminted: ${intComma(unminted)} VAR (${change}%)`)
             )
           }
         }
@@ -769,6 +802,9 @@ export default class extends Controller {
             false
           )
         )
+        break
+      default:
+        console.warn(`plotGraph: unknown chart "${chartName}"`)
         break
     }
 
@@ -1004,18 +1040,6 @@ export default class extends Controller {
         this.ticketsPriceTarget.checked = this.visibility[0]
         this.ticketsPurchaseTarget.checked = this.visibility[1]
         break
-      case 'coin-supply':
-        if (this.visibility.length !== 3) {
-          this.visibility = [true, true, this.anonymitySetTarget.checked]
-        }
-        this.anonymitySetTarget.checked = this.visibility[2]
-        break
-      case 'privacy-participation':
-        if (this.visibility.length !== 2) {
-          this.visibility = [true, this.anonymitySetTarget.checked]
-        }
-        this.anonymitySetTarget.checked = this.visibility[1]
-        break
       default:
         return
     }
@@ -1031,12 +1055,6 @@ export default class extends Controller {
           return
         }
         this.visibility = [this.ticketsPriceTarget.checked, this.ticketsPurchaseTarget.checked]
-        break
-      case 'coin-supply':
-        this.visibility = [true, true, this.anonymitySetTarget.checked]
-        break
-      case 'privacy-participation':
-        this.visibility = [true, this.anonymitySetTarget.checked]
         break
       default:
         return

--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -473,13 +473,11 @@ body.darkBG .customcheck input:checked ~ .coin-supply {
   background-color: #2dd8a3;
 }
 
-.customcheck input:checked ~ .tickets-bought,
-.customcheck input:checked ~ .total-mixed {
+.customcheck input:checked ~ .tickets-bought {
   background-color: #066;
 }
 
-body.darkBG .customcheck input:checked ~ .tickets-bought,
-body.darkBG .customcheck input:checked ~ .total-mixed {
+body.darkBG .customcheck input:checked ~ .tickets-bought {
   background-color: #2970ff;
 }
 

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -74,12 +74,10 @@
 			<div class="row py-2">
 				<div class="col-10 col-sm-8 text-start">
 					<span class="text-secondary fs13">Total Sent</span>
-					{{range .TotalSentByCoin}}
 					<br>
 					<span class="lh1rem d-inline-block pt-1"
-						><span class="fs18 fs14-decimal fw-bold">{{.Amount}}</span><span class="text-secondary fs14"> {{.CoinType}}</span>
+						><span class="fs18 fs14-decimal fw-bold">{{template "decimalParts" (float64AsDecimalParts .TotalSent 8 true 2)}}</span><span class="text-secondary fs14"> DCR</span>
 					</span>
-					{{end}}
 					{{if $.FiatConversion}}
 					<br>
 					<span class="text-secondary fs16"
@@ -87,6 +85,10 @@
 						<span class="fs14">{{$.FiatConversion.Index}}</span>
 					</span>
 					{{end}}
+					<br>
+					<span class="lh1rem d-inline-block pt-1"
+						><span class="fs14 fs14-decimal">Mixed: {{template "decimalParts" (amountAsDecimalParts .TotalMixed true)}}</span><span class="text-secondary fs14"> DCR</span>
+					</span>
 				</div>
 				<div class="col-7 col-sm-8 text-start">
 					<span class="text-secondary fs13">Size</span>
@@ -120,7 +122,7 @@
 							><span class="d-sm-none">Tkt Price</span>: </td>
 						<td class="text-start text-secondary">{{template "decimalParts" (float64AsDecimalParts .SBits 8 false)}}</td>
 						<td class="text-end fw-bold text-nowrap pe-2">Fees: </td>
-						<td class="text-start text-secondary">{{range .FeesByCoin}}{{.Amount}} {{.CoinType}} {{end}}</td>
+						<td class="text-start text-secondary">{{printf "%.8f" .MiningFee}}</td>
 						<td class="d-none d-sm-table-cell text-end fw-bold text-nowrap pe-2">Pool Size: </td>
 						<td class="d-none d-sm-table-cell text-start text-secondary">{{.PoolSize}}</td>
 					</tr>
@@ -343,7 +345,6 @@
 					<th class="text-end">Total DCR</th>
 					<th class="text-end">Fee</th>
 					<th class="text-end">Size</th>
-					<th class="text-end">Status</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -357,7 +358,6 @@
 					</td>
 					<td class="mono fs15 text-end">{{.Fee}}</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
-					<td class="mono fs15 text-end">{{.TicketStatus}}</td>
 				</tr>
 			{{- end}}
 			</tbody>
@@ -382,9 +382,9 @@
 						<span><a class="hash" href="/tx/{{.TxID}}">{{.TxID}}</a></span>
 					</td>
 					<td class="mono fs15 text-end">
-						{{template "decimalParts" (float64AsDecimalParts .Total 8 false)}} {{.CoinType | coinSymbol}}
+						{{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}
 					</td>
-					<td class="mono fs15 text-end">{{.Fee}} {{.CoinType | coinSymbol}}</td>
+					<td class="mono fs15 text-end">{{.Fee}}</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
 				</tr>
 			{{- end}}
@@ -404,7 +404,8 @@
 			<thead>
 				<tr>
 					<th>Transaction ID</th>
-					<th class="text-end">Total</th>
+					<th class="text-end">Total DCR</th>
+					<th class="text-end">Mixed</th>
 					<th class="text-end">Fee</th>
 					<th class="text-end">Fee Rate</th>
 					<th class="text-end">Size</th>
@@ -418,7 +419,14 @@
 						<span><a class="hash" href="/tx/{{.TxID}}">{{.TxID}}</a></span>
 					</td>
 					<td class="mono fs15 text-end">
-						{{- template "decimalParts" (float64AsDecimalParts .Total 8 false) -}} {{.CoinType | coinSymbol}}
+						{{- template "decimalParts" (float64AsDecimalParts .Total 8 false) -}}
+					</td>
+					<td class="mono fs15 text-end">
+						{{ if gt .MixCount 0 -}}
+							{{.MixCount}}x {{template "decimalParts" (amountAsDecimalParts .MixDenom false)}}
+						{{ else }}
+							-
+						{{- end}}
 					</td>
 					<td class="mono fs15 text-end">{{.Fee}}</td>
 					<td class="mono fs15 text-end">{{dcrPerKbToAtomsPerByte .FeeRate}} atoms/B</td>

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -74,10 +74,12 @@
 			<div class="row py-2">
 				<div class="col-10 col-sm-8 text-start">
 					<span class="text-secondary fs13">Total Sent</span>
+					{{range .TotalSentByCoin}}
 					<br>
 					<span class="lh1rem d-inline-block pt-1"
-						><span class="fs18 fs14-decimal fw-bold">{{template "decimalParts" (float64AsDecimalParts .TotalSent 8 true 2)}}</span><span class="text-secondary fs14"> DCR</span>
+						><span class="fs18 fs14-decimal fw-bold">{{.Amount}}</span><span class="text-secondary fs14"> {{.CoinType}}</span>
 					</span>
+					{{end}}
 					{{if $.FiatConversion}}
 					<br>
 					<span class="text-secondary fs16"
@@ -85,10 +87,6 @@
 						<span class="fs14">{{$.FiatConversion.Index}}</span>
 					</span>
 					{{end}}
-					<br>
-					<span class="lh1rem d-inline-block pt-1"
-						><span class="fs14 fs14-decimal">Mixed: {{template "decimalParts" (amountAsDecimalParts .TotalMixed true)}}</span><span class="text-secondary fs14"> DCR</span>
-					</span>
 				</div>
 				<div class="col-7 col-sm-8 text-start">
 					<span class="text-secondary fs13">Size</span>
@@ -122,7 +120,7 @@
 							><span class="d-sm-none">Tkt Price</span>: </td>
 						<td class="text-start text-secondary">{{template "decimalParts" (float64AsDecimalParts .SBits 8 false)}}</td>
 						<td class="text-end fw-bold text-nowrap pe-2">Fees: </td>
-						<td class="text-start text-secondary">{{printf "%.8f" .MiningFee}}</td>
+						<td class="text-start text-secondary">{{range .FeesByCoin}}{{.Amount}} {{.CoinType}} {{end}}</td>
 						<td class="d-none d-sm-table-cell text-end fw-bold text-nowrap pe-2">Pool Size: </td>
 						<td class="d-none d-sm-table-cell text-start text-secondary">{{.PoolSize}}</td>
 					</tr>
@@ -345,6 +343,7 @@
 					<th class="text-end">Total DCR</th>
 					<th class="text-end">Fee</th>
 					<th class="text-end">Size</th>
+					<th class="text-end">Status</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -358,6 +357,7 @@
 					</td>
 					<td class="mono fs15 text-end">{{.Fee}}</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
+					<td class="mono fs15 text-end">{{.TicketStatus}}</td>
 				</tr>
 			{{- end}}
 			</tbody>
@@ -382,9 +382,9 @@
 						<span><a class="hash" href="/tx/{{.TxID}}">{{.TxID}}</a></span>
 					</td>
 					<td class="mono fs15 text-end">
-						{{template "decimalParts" (float64AsDecimalParts .Total 8 false)}}
+						{{template "decimalParts" (float64AsDecimalParts .Total 8 false)}} {{.CoinType | coinSymbol}}
 					</td>
-					<td class="mono fs15 text-end">{{.Fee}}</td>
+					<td class="mono fs15 text-end">{{.Fee}} {{.CoinType | coinSymbol}}</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
 				</tr>
 			{{- end}}
@@ -404,8 +404,7 @@
 			<thead>
 				<tr>
 					<th>Transaction ID</th>
-					<th class="text-end">Total DCR</th>
-					<th class="text-end">Mixed</th>
+					<th class="text-end">Total</th>
 					<th class="text-end">Fee</th>
 					<th class="text-end">Fee Rate</th>
 					<th class="text-end">Size</th>
@@ -419,14 +418,7 @@
 						<span><a class="hash" href="/tx/{{.TxID}}">{{.TxID}}</a></span>
 					</td>
 					<td class="mono fs15 text-end">
-						{{- template "decimalParts" (float64AsDecimalParts .Total 8 false) -}}
-					</td>
-					<td class="mono fs15 text-end">
-						{{ if gt .MixCount 0 -}}
-							{{.MixCount}}x {{template "decimalParts" (amountAsDecimalParts .MixDenom false)}}
-						{{ else }}
-							-
-						{{- end}}
+						{{- template "decimalParts" (float64AsDecimalParts .Total 8 false) -}} {{.CoinType | coinSymbol}}
 					</td>
 					<td class="mono fs15 text-end">{{.Fee}}</td>
 					<td class="mono fs15 text-end">{{dcrPerKbToAtomsPerByte .FeeRate}} atoms/B</td>

--- a/cmd/dcrdata/views/charts.tmpl
+++ b/cmd/dcrdata/views/charts.tmpl
@@ -37,8 +37,9 @@
                             <option value="blockchain-size">Blockchain Size</option>
                             <option value="tx-count">Transaction Count</option>
                             <option value="pow-difficulty">PoW Difficulty</option>
-                            <option value="coin-supply">Circulation</option>
-                            <option value="fees">Fees</option>
+                            <option value="coin-supply/0">Circulation (VAR)</option>
+                            {{range $t := .ActiveSKATypes}}<option value="coin-supply/{{$t}}">Circulation (SKA{{$t}})</option>
+                            {{end}}<option value="fees">Fees</option>
                             <option value="privacy-participation">Privacy Participation</option>
                             <option value="duration-btw-blocks">Duration Between Blocks</option>
                             <option value="chainwork">Total Work</option>
@@ -149,17 +150,6 @@
                                         data-charts-target="ticketsPurchase"
                                     >
                                     <span class="checkmark tickets-bought"></span>
-                                </label>
-                            </li>
-                            <li class="nav-item">
-                                <label class="customcheck mx-2 d-inline-flex"
-                                    data-charts-target="vSelectorItem" data-charts="coin-supply">Mixed Coins
-                                    <input
-                                        type="checkbox"
-                                        data-action="click->charts#setVisibility"
-                                        data-charts-target="anonymitySet"
-                                    >
-                                    <span class="checkmark total-mixed"></span>
                                 </label>
                             </li>
                         </ul>

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6406,6 +6406,7 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	}
 
 	// Populate per-coin amounts from the block summary (computed at collection time).
+	var skaFeeTotals map[uint8]string
 	if summary := pgb.GetSummaryByHash(ctx, hash, false); summary != nil && summary.CoinAmounts != nil {
 		block.CoinAmounts = summary.CoinAmounts
 		// Also populate CoinRows on the embedded BlockBasic so the websocket
@@ -6418,6 +6419,9 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		block.TotalSentByCoin = exptypes.TotalSentByCoinFromMap(block.CoinAmounts, issuedSKA)
 		block.RegularCoinCounts = exptypes.RegularCoinCountsFromCoinRows(
 			block.BlockBasic.CoinRows, b.Voters, b.FreshStake, b.Revocations)
+
+		// Store SKA fee totals from SSFeeTotalsByCoin (stake fee distribution)
+		skaFeeTotals = summary.SSFeeTotalsByCoin
 	}
 
 	if data.PoWHash != "" {
@@ -6570,17 +6574,21 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	block.MiningFee = (getTotalFee(block.Tx) + getTotalFee(block.Treasury) + getTotalFee(block.Revs) +
 		getTotalFee(block.Tickets) + getTotalFee(block.Votes)).ToCoin()
 
-	// Aggregate fees per coin type (VAR from MiningFee, SKA from transactions)
+	// Aggregate fees per coin type (VAR from MiningFee, SKA from SSFeeTotalsByCoin)
 	feesMap := make(map[uint8]string)
 	// VAR fees from MiningFee
 	miningFeeAtoms := int64(block.MiningFee * 1e8)
 	if miningFeeAtoms > 0 {
 		feesMap[0] = strconv.FormatInt(miningFeeAtoms, 10)
 	}
-	// SKA fees from regular transactions (FeeRaw field)
-	exptypes.AggregateFeesFromTxSlice(block.Tx, feesMap)
-	// SKA fees from stake fees (SSFee transactions)
-	exptypes.AggregateFeesFromTxSlice(block.StakeFees, feesMap)
+	// SKA fees from SSFeeTotalsByCoin (stake fee distribution)
+	if skaFeeTotals != nil {
+		for ct, fee := range skaFeeTotals {
+			if fee != "" && fee != "0" {
+				feesMap[ct] = fee
+			}
+		}
+	}
 	block.FeesByCoin = exptypes.FeesByCoinFromAmounts(feesMap)
 
 	pgb.lastExplorerBlock.Lock()

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6418,7 +6418,14 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		block.TotalSentByCoin = exptypes.TotalSentByCoinFromMap(block.CoinAmounts, issuedSKA)
 		block.RegularCoinCounts = exptypes.RegularCoinCountsFromCoinRows(
 			block.BlockBasic.CoinRows, b.Voters, b.FreshStake, b.Revocations)
-		block.FeesByCoin = exptypes.FeesByCoinFromMiningFee(block.MiningFee)
+
+		// Build fees map from MiningFee (VAR only for now; SKA fees from stake txs would need separate aggregation)
+		feesMap := make(map[uint8]string)
+		miningFeeAtoms := int64(block.MiningFee * 1e8)
+		if miningFeeAtoms > 0 {
+			feesMap[0] = strconv.FormatInt(miningFeeAtoms, 10)
+		}
+		block.FeesByCoin = exptypes.FeesByCoinFromAmounts(feesMap)
 	}
 
 	if data.PoWHash != "" {
@@ -6476,11 +6483,13 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		case stake.TxTypeTAdd, stake.TxTypeTSpend, stake.TxTypeTreasuryBase:
 			treasury = append(treasury, stx)
 		case stake.TxTypeSSFee:
+			// Set CoinType from first output
+			if len(msgTx.TxOut) > 0 {
+				stx.CoinType = uint8(msgTx.TxOut[0].CoinType)
+			}
 			stakeFees = append(stakeFees, stx)
 		}
 	}
-
-	var totalMixed int64
 
 	txs := make([]*exptypes.TrimmedTxInfo, 0, block.Transactions)
 	for i := range data.RawTx {
@@ -6492,13 +6501,18 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		}
 
 		exptx, _ := trimmedTxInfoFromMsgTx(tx, ticketPrice, msgTx, pgb.chainParams) // maybe pass tree
+
+		// Set CoinType from first output (already extracted in makeExplorerTxBasic)
+		if len(msgTx.TxOut) > 0 {
+			exptx.CoinType = uint8(msgTx.TxOut[0].CoinType)
+		}
+
 		for i := range tx.Vin {
 			if tx.Vin[i].IsCoinBase() {
 				exptx.Fee, exptx.FeeRate, exptx.Fees = 0.0, 0.0, 0.0
 			}
 		}
 		txs = append(txs, exptx)
-		totalMixed += int64(exptx.MixCount) * exptx.MixDenom
 	}
 
 	block.Tx = txs
@@ -6507,7 +6521,6 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	block.Revs = revocations
 	block.Tickets = tickets
 	block.StakeFees = stakeFees
-	block.TotalMixed = totalMixed
 
 	sortTx := func(txs []*exptypes.TrimmedTxInfo) {
 		sort.Slice(txs, func(i, j int) bool {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6418,14 +6418,6 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		block.TotalSentByCoin = exptypes.TotalSentByCoinFromMap(block.CoinAmounts, issuedSKA)
 		block.RegularCoinCounts = exptypes.RegularCoinCountsFromCoinRows(
 			block.BlockBasic.CoinRows, b.Voters, b.FreshStake, b.Revocations)
-
-		// Build fees map from MiningFee (VAR only for now; SKA fees from stake txs would need separate aggregation)
-		feesMap := make(map[uint8]string)
-		miningFeeAtoms := int64(block.MiningFee * 1e8)
-		if miningFeeAtoms > 0 {
-			feesMap[0] = strconv.FormatInt(miningFeeAtoms, 10)
-		}
-		block.FeesByCoin = exptypes.FeesByCoinFromAmounts(feesMap)
 	}
 
 	if data.PoWHash != "" {
@@ -6577,6 +6569,27 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		getTotalSent(block.Tickets) + getTotalSent(block.Votes) + getTotalSent(block.StakeFees)).ToCoin()
 	block.MiningFee = (getTotalFee(block.Tx) + getTotalFee(block.Treasury) + getTotalFee(block.Revs) +
 		getTotalFee(block.Tickets) + getTotalFee(block.Votes)).ToCoin()
+
+	// Aggregate fees per coin type (VAR from MiningFee, SKA from transactions)
+	feesMap := make(map[uint8]string)
+	// VAR fees from MiningFee
+	miningFeeAtoms := int64(block.MiningFee * 1e8)
+	if miningFeeAtoms > 0 {
+		feesMap[0] = strconv.FormatInt(miningFeeAtoms, 10)
+	}
+	// SKA fees from regular transactions (FeeRaw field)
+	for _, tx := range block.Tx {
+		if tx.CoinType != 0 && tx.FeeRaw != "" && tx.FeeRaw != "0" {
+			feesMap[tx.CoinType] = tx.FeeRaw
+		}
+	}
+	// SKA fees from stake fees (SSFee transactions)
+	for _, tx := range block.StakeFees {
+		if tx.CoinType != 0 && tx.FeeRaw != "" && tx.FeeRaw != "0" {
+			feesMap[tx.CoinType] = tx.FeeRaw
+		}
+	}
+	block.FeesByCoin = exptypes.FeesByCoinFromAmounts(feesMap)
 
 	pgb.lastExplorerBlock.Lock()
 	pgb.lastExplorerBlock.hash = hash

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6479,6 +6479,18 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		case stake.TxTypeSStx:
 			tickets = append(tickets, stx)
 		case stake.TxTypeSSRtx:
+			// Populate TicketStatus from the ticket that was revoked
+			// Get ticket hash from the first input's previous outpoint
+			if len(msgTx.TxIn) > 0 {
+				prevOut := msgTx.TxIn[0].PreviousOutPoint
+				if prevOut.Hash != zeroHash {
+					ticketHash := dbtypes.ChainHash(prevOut.Hash)
+					_, _, poolStatus, err := retrieveTicketStatusByHash(ctx, pgb.db, ticketHash)
+					if err == nil {
+						stx.TicketStatus = poolStatus.String()
+					}
+				}
+			}
 			revocations = append(revocations, stx)
 		case stake.TxTypeTAdd, stake.TxTypeTSpend, stake.TxTypeTreasuryBase:
 			treasury = append(treasury, stx)

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6578,35 +6578,9 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		feesMap[0] = strconv.FormatInt(miningFeeAtoms, 10)
 	}
 	// SKA fees from regular transactions (FeeRaw field)
-	for _, tx := range block.Tx {
-		if tx.CoinType != 0 && tx.FeeRaw != "" && tx.FeeRaw != "0" {
-			fee, err := strconv.ParseInt(tx.FeeRaw, 10, 64)
-			if err != nil {
-				continue
-			}
-			if existing, ok := feesMap[tx.CoinType]; ok {
-				if existingAmt, err := strconv.ParseInt(existing, 10, 64); err == nil {
-					fee += existingAmt
-				}
-			}
-			feesMap[tx.CoinType] = strconv.FormatInt(fee, 10)
-		}
-	}
+	exptypes.AggregateFeesFromTxSlice(block.Tx, feesMap)
 	// SKA fees from stake fees (SSFee transactions)
-	for _, tx := range block.StakeFees {
-		if tx.CoinType != 0 && tx.FeeRaw != "" && tx.FeeRaw != "0" {
-			fee, err := strconv.ParseInt(tx.FeeRaw, 10, 64)
-			if err != nil {
-				continue
-			}
-			if existing, ok := feesMap[tx.CoinType]; ok {
-				if existingAmt, err := strconv.ParseInt(existing, 10, 64); err == nil {
-					fee += existingAmt
-				}
-			}
-			feesMap[tx.CoinType] = strconv.FormatInt(fee, 10)
-		}
-	}
+	exptypes.AggregateFeesFromTxSlice(block.StakeFees, feesMap)
 	block.FeesByCoin = exptypes.FeesByCoinFromAmounts(feesMap)
 
 	pgb.lastExplorerBlock.Lock()

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1522,7 +1522,7 @@ func (pgb *ChainDB) PoolStatusForTicket(ctx context.Context, txid string) (dbtyp
 	}
 	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
 	defer cancel()
-	_, spendType, poolStatus, err := retrieveTicketStatusByHash(ctx, pgb.db, ch)
+	spendType, poolStatus, err := retrieveTicketStatusByHash(ctx, pgb.db, ch)
 	return spendType, poolStatus, pgb.replaceCancelError(err)
 }
 
@@ -6485,7 +6485,7 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 				prevOut := msgTx.TxIn[0].PreviousOutPoint
 				if prevOut.Hash != zeroHash {
 					ticketHash := dbtypes.ChainHash(prevOut.Hash)
-					_, _, poolStatus, err := retrieveTicketStatusByHash(ctx, pgb.db, ticketHash)
+					_, poolStatus, err := retrieveTicketStatusByHash(ctx, pgb.db, ticketHash)
 					if err == nil {
 						stx.TicketStatus = poolStatus.String()
 					}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6413,6 +6413,12 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		// Include all ever-emitted SKA types so zero-activity coins still appear.
 		issuedSKA := pgb.issuedSKACoinTypes(ctx)
 		block.BlockBasic.CoinRows = coinRowsFromSummary(summary, issuedSKA)
+
+		// Populate template-facing ordered slices for multi-coin display.
+		block.TotalSentByCoin = exptypes.TotalSentByCoinFromMap(block.CoinAmounts, issuedSKA)
+		block.RegularCoinCounts = exptypes.RegularCoinCountsFromCoinRows(
+			block.BlockBasic.CoinRows, b.Voters, b.FreshStake, b.Revocations)
+		block.FeesByCoin = exptypes.FeesByCoinFromMiningFee(block.MiningFee)
 	}
 
 	if data.PoWHash != "" {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1042,8 +1042,9 @@ func retrieveTicketIDByHashNoCancel(db *sql.DB, ticketHash dbtypes.ChainHash) (i
 
 // retrieveTicketStatusByHash gets the spend status and ticket pool status for
 // the given ticket hash.
-func retrieveTicketStatusByHash(ctx context.Context, db *sql.DB, ticketHash dbtypes.ChainHash) (id uint64,
+func retrieveTicketStatusByHash(ctx context.Context, db *sql.DB, ticketHash dbtypes.ChainHash) (
 	spendStatus dbtypes.TicketSpendType, poolStatus dbtypes.TicketPoolStatus, err error) {
+	var id uint64
 	err = db.QueryRowContext(ctx, internal.SelectTicketStatusByHash, ticketHash).
 		Scan(&id, &spendStatus, &poolStatus)
 	return

--- a/explorer/types/blockinfo_test.go
+++ b/explorer/types/blockinfo_test.go
@@ -17,7 +17,7 @@ func TestTotalSentByCoinFromMap(t *testing.T) {
 			coinAmounts: map[uint8]string{0: "100000000"},
 			issuedSKA:   []uint8{1, 2},
 			want: []CoinAmount{
-				{CoinType: "VAR", Amount: "100000000"},
+				{CoinType: 0, Symbol: "VAR", Amount: "100000000"},
 			},
 		},
 		{
@@ -25,8 +25,8 @@ func TestTotalSentByCoinFromMap(t *testing.T) {
 			coinAmounts: map[uint8]string{0: "100000000", 1: "1000000000000000000"},
 			issuedSKA:   []uint8{1},
 			want: []CoinAmount{
-				{CoinType: "VAR", Amount: "100000000"},
-				{CoinType: "SKA1", Amount: "1000000000000000000"},
+				{CoinType: 0, Symbol: "VAR", Amount: "100000000"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "1000000000000000000"},
 			},
 		},
 		{
@@ -34,9 +34,9 @@ func TestTotalSentByCoinFromMap(t *testing.T) {
 			coinAmounts: map[uint8]string{0: "100000000", 1: "1000000000000000000", 2: "2000000000000000000"},
 			issuedSKA:   []uint8{1, 2},
 			want: []CoinAmount{
-				{CoinType: "VAR", Amount: "100000000"},
-				{CoinType: "SKA1", Amount: "1000000000000000000"},
-				{CoinType: "SKA2", Amount: "2000000000000000000"},
+				{CoinType: 0, Symbol: "VAR", Amount: "100000000"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "1000000000000000000"},
+				{CoinType: 2, Symbol: "SKA2", Amount: "2000000000000000000"},
 			},
 		},
 		{
@@ -44,8 +44,8 @@ func TestTotalSentByCoinFromMap(t *testing.T) {
 			coinAmounts: map[uint8]string{0: "100000000", 1: "1000000000000000000", 2: "0"},
 			issuedSKA:   []uint8{1, 2},
 			want: []CoinAmount{
-				{CoinType: "VAR", Amount: "100000000"},
-				{CoinType: "SKA1", Amount: "1000000000000000000"},
+				{CoinType: 0, Symbol: "VAR", Amount: "100000000"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "1000000000000000000"},
 			},
 		},
 		{
@@ -65,7 +65,10 @@ func TestTotalSentByCoinFromMap(t *testing.T) {
 			}
 			for i := range got {
 				if got[i].CoinType != tt.want[i].CoinType {
-					t.Errorf("[%d] CoinType = %s, want %s", i, got[i].CoinType, tt.want[i].CoinType)
+					t.Errorf("[%d] CoinType = %d, want %d", i, got[i].CoinType, tt.want[i].CoinType)
+				}
+				if got[i].Symbol != tt.want[i].Symbol {
+					t.Errorf("[%d] Symbol = %s, want %s", i, got[i].Symbol, tt.want[i].Symbol)
 				}
 				if got[i].Amount != tt.want[i].Amount {
 					t.Errorf("[%d] Amount = %s, want %s", i, got[i].Amount, tt.want[i].Amount)
@@ -87,13 +90,13 @@ func TestRegularCoinCountsFromCoinRows(t *testing.T) {
 		{
 			name: "VAR only regular count",
 			coinRows: []CoinRowData{
-				{CoinType: 0, TxCount: 10}, // 10 total - 5 votes - 2 tickets - 1 rev = 2 regular
+				{CoinType: 0, TxCount: 10},
 			},
 			voters:      5,
 			freshStake:  2,
 			revocations: 1,
 			want: []CoinCount{
-				{CoinType: "VAR", Count: 2},
+				{CoinType: 0, Symbol: "VAR", Count: 2},
 			},
 		},
 		{
@@ -107,9 +110,9 @@ func TestRegularCoinCountsFromCoinRows(t *testing.T) {
 			freshStake:  2,
 			revocations: 1,
 			want: []CoinCount{
-				{CoinType: "VAR", Count: 2},
-				{CoinType: "SKA1", Count: 3},
-				{CoinType: "SKA2", Count: 2},
+				{CoinType: 0, Symbol: "VAR", Count: 2},
+				{CoinType: 1, Symbol: "SKA1", Count: 3},
+				{CoinType: 2, Symbol: "SKA2", Count: 2},
 			},
 		},
 		{
@@ -123,20 +126,20 @@ func TestRegularCoinCountsFromCoinRows(t *testing.T) {
 			freshStake:  2,
 			revocations: 1,
 			want: []CoinCount{
-				{CoinType: "VAR", Count: 2},
-				{CoinType: "SKA1", Count: 3},
+				{CoinType: 0, Symbol: "VAR", Count: 2},
+				{CoinType: 1, Symbol: "SKA1", Count: 3},
 			},
 		},
 		{
 			name: "negative regular count clamped to zero",
 			coinRows: []CoinRowData{
-				{CoinType: 0, TxCount: 3}, // 3 - 5 votes = -2, clamped to 0
+				{CoinType: 0, TxCount: 3},
 			},
 			voters:      5,
 			freshStake:  0,
 			revocations: 0,
 			want: []CoinCount{
-				{CoinType: "VAR", Count: 0},
+				{CoinType: 0, Symbol: "VAR", Count: 0},
 			},
 		},
 	}
@@ -150,7 +153,10 @@ func TestRegularCoinCountsFromCoinRows(t *testing.T) {
 			}
 			for i := range got {
 				if got[i].CoinType != tt.want[i].CoinType {
-					t.Errorf("[%d] CoinType = %s, want %s", i, got[i].CoinType, tt.want[i].CoinType)
+					t.Errorf("[%d] CoinType = %d, want %d", i, got[i].CoinType, tt.want[i].CoinType)
+				}
+				if got[i].Symbol != tt.want[i].Symbol {
+					t.Errorf("[%d] Symbol = %s, want %s", i, got[i].Symbol, tt.want[i].Symbol)
 				}
 				if got[i].Count != tt.want[i].Count {
 					t.Errorf("[%d] Count = %d, want %d", i, got[i].Count, tt.want[i].Count)
@@ -160,45 +166,51 @@ func TestRegularCoinCountsFromCoinRows(t *testing.T) {
 	}
 }
 
-func TestFeesByCoinFromMiningFee(t *testing.T) {
+func TestFeesByCoinFromAmounts(t *testing.T) {
 	tests := []struct {
-		name      string
-		miningFee float64
-		want      []CoinAmount
+		name       string
+		feeAmounts map[uint8]string
+		want       []CoinAmount
 	}{
 		{
-			name:      "positive fee",
-			miningFee: 0.12345678,
+			name:       "VAR fee only",
+			feeAmounts: map[uint8]string{0: "12345678"},
 			want: []CoinAmount{
-				{CoinType: "VAR", Amount: "12345678"}, // DCR atoms (8 decimals)
+				{CoinType: 0, Symbol: "VAR", Amount: "12345678"},
 			},
 		},
 		{
-			name:      "zero fee",
-			miningFee: 0,
+			name:       "VAR and SKA fees",
+			feeAmounts: map[uint8]string{0: "12345678", 1: "1000000000"},
 			want: []CoinAmount{
-				{CoinType: "VAR", Amount: "0"},
+				{CoinType: 0, Symbol: "VAR", Amount: "12345678"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "1000000000"},
 			},
 		},
 		{
-			name:      "large fee",
-			miningFee: 100.12345678,
+			name:       "zero fee omitted",
+			feeAmounts: map[uint8]string{0: "12345678", 1: "0"},
 			want: []CoinAmount{
-				{CoinType: "VAR", Amount: "10012345678"},
+				{CoinType: 0, Symbol: "VAR", Amount: "12345678"},
 			},
+		},
+		{
+			name:       "empty map returns nil",
+			feeAmounts: map[uint8]string{},
+			want:       nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FeesByCoinFromMiningFee(tt.miningFee)
+			got := FeesByCoinFromAmounts(tt.feeAmounts)
 			if len(got) != len(tt.want) {
 				t.Errorf("len = %d, want %d", len(got), len(tt.want))
 				return
 			}
 			for i := range got {
 				if got[i].CoinType != tt.want[i].CoinType {
-					t.Errorf("[%d] CoinType = %s, want %s", i, got[i].CoinType, tt.want[i].CoinType)
+					t.Errorf("[%d] CoinType = %d, want %d", i, got[i].CoinType, tt.want[i].CoinType)
 				}
 				if got[i].Amount != tt.want[i].Amount {
 					t.Errorf("[%d] Amount = %s, want %s", i, got[i].Amount, tt.want[i].Amount)
@@ -239,7 +251,7 @@ func TestCoinTypeFromSymbol(t *testing.T) {
 		{"SKA2", 2, true},
 		{"SKA255", 255, true},
 		{"INVALID", 0, false},
-		{"SKA0", 0, false}, // SKA0 is not valid
+		{"SKA0", 0, false},
 		{"VARX", 0, false},
 	}
 
@@ -257,7 +269,6 @@ func TestCoinTypeFromSymbol(t *testing.T) {
 }
 
 func TestCoinTypesSorted(t *testing.T) {
-	// Ensure SKA coin types are sorted in ascending order
 	types := []uint8{0, 2, 1, 255, 10}
 	sorted := make([]uint8, len(types))
 	copy(sorted, types)

--- a/explorer/types/blockinfo_test.go
+++ b/explorer/types/blockinfo_test.go
@@ -1,17 +1,273 @@
-package types_test
+package types
 
 import (
+	"sort"
 	"testing"
-
-	"github.com/monetarium/monetarium-explorer/explorer/types"
 )
 
-func TestBlockInfo_SKAPoWRewards(t *testing.T) {
-	bi := &types.BlockInfo{}
-	bi.SKAPoWRewards = []types.PoWSKAReward{
-		{CoinType: 1, Symbol: "SKA1", Amount: "100"},
+func TestTotalSentByCoinFromMap(t *testing.T) {
+	tests := []struct {
+		name        string
+		coinAmounts map[uint8]string
+		issuedSKA   []uint8
+		want        []CoinAmount
+	}{
+		{
+			name:        "VAR only",
+			coinAmounts: map[uint8]string{0: "100000000"},
+			issuedSKA:   []uint8{1, 2},
+			want: []CoinAmount{
+				{CoinType: "VAR", Amount: "100000000"},
+			},
+		},
+		{
+			name:        "VAR and SKA",
+			coinAmounts: map[uint8]string{0: "100000000", 1: "1000000000000000000"},
+			issuedSKA:   []uint8{1},
+			want: []CoinAmount{
+				{CoinType: "VAR", Amount: "100000000"},
+				{CoinType: "SKA1", Amount: "1000000000000000000"},
+			},
+		},
+		{
+			name:        "VAR and multiple SKA sorted",
+			coinAmounts: map[uint8]string{0: "100000000", 1: "1000000000000000000", 2: "2000000000000000000"},
+			issuedSKA:   []uint8{1, 2},
+			want: []CoinAmount{
+				{CoinType: "VAR", Amount: "100000000"},
+				{CoinType: "SKA1", Amount: "1000000000000000000"},
+				{CoinType: "SKA2", Amount: "2000000000000000000"},
+			},
+		},
+		{
+			name:        "VAR and SKA with zero SKA omitted",
+			coinAmounts: map[uint8]string{0: "100000000", 1: "1000000000000000000", 2: "0"},
+			issuedSKA:   []uint8{1, 2},
+			want: []CoinAmount{
+				{CoinType: "VAR", Amount: "100000000"},
+				{CoinType: "SKA1", Amount: "1000000000000000000"},
+			},
+		},
+		{
+			name:        "empty map returns empty slice",
+			coinAmounts: map[uint8]string{},
+			issuedSKA:   []uint8{1},
+			want:        []CoinAmount{},
+		},
 	}
-	if len(bi.SKAPoWRewards) != 1 {
-		t.Errorf("expected 1 reward, got %d", len(bi.SKAPoWRewards))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TotalSentByCoinFromMap(tt.coinAmounts, tt.issuedSKA)
+			if len(got) != len(tt.want) {
+				t.Errorf("len = %d, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i].CoinType != tt.want[i].CoinType {
+					t.Errorf("[%d] CoinType = %s, want %s", i, got[i].CoinType, tt.want[i].CoinType)
+				}
+				if got[i].Amount != tt.want[i].Amount {
+					t.Errorf("[%d] Amount = %s, want %s", i, got[i].Amount, tt.want[i].Amount)
+				}
+			}
+		})
+	}
+}
+
+func TestRegularCoinCountsFromCoinRows(t *testing.T) {
+	tests := []struct {
+		name        string
+		coinRows    []CoinRowData
+		voters      uint16
+		freshStake  uint8
+		revocations uint32
+		want        []CoinCount
+	}{
+		{
+			name: "VAR only regular count",
+			coinRows: []CoinRowData{
+				{CoinType: 0, TxCount: 10}, // 10 total - 5 votes - 2 tickets - 1 rev = 2 regular
+			},
+			voters:      5,
+			freshStake:  2,
+			revocations: 1,
+			want: []CoinCount{
+				{CoinType: "VAR", Count: 2},
+			},
+		},
+		{
+			name: "VAR and SKA counts",
+			coinRows: []CoinRowData{
+				{CoinType: 0, TxCount: 10},
+				{CoinType: 1, TxCount: 3},
+				{CoinType: 2, TxCount: 2},
+			},
+			voters:      5,
+			freshStake:  2,
+			revocations: 1,
+			want: []CoinCount{
+				{CoinType: "VAR", Count: 2},
+				{CoinType: "SKA1", Count: 3},
+				{CoinType: "SKA2", Count: 2},
+			},
+		},
+		{
+			name: "zero SKA count omitted",
+			coinRows: []CoinRowData{
+				{CoinType: 0, TxCount: 10},
+				{CoinType: 1, TxCount: 3},
+				{CoinType: 2, TxCount: 0},
+			},
+			voters:      5,
+			freshStake:  2,
+			revocations: 1,
+			want: []CoinCount{
+				{CoinType: "VAR", Count: 2},
+				{CoinType: "SKA1", Count: 3},
+			},
+		},
+		{
+			name: "negative regular count clamped to zero",
+			coinRows: []CoinRowData{
+				{CoinType: 0, TxCount: 3}, // 3 - 5 votes = -2, clamped to 0
+			},
+			voters:      5,
+			freshStake:  0,
+			revocations: 0,
+			want: []CoinCount{
+				{CoinType: "VAR", Count: 0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RegularCoinCountsFromCoinRows(tt.coinRows, tt.voters, tt.freshStake, tt.revocations)
+			if len(got) != len(tt.want) {
+				t.Errorf("len = %d, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i].CoinType != tt.want[i].CoinType {
+					t.Errorf("[%d] CoinType = %s, want %s", i, got[i].CoinType, tt.want[i].CoinType)
+				}
+				if got[i].Count != tt.want[i].Count {
+					t.Errorf("[%d] Count = %d, want %d", i, got[i].Count, tt.want[i].Count)
+				}
+			}
+		})
+	}
+}
+
+func TestFeesByCoinFromMiningFee(t *testing.T) {
+	tests := []struct {
+		name      string
+		miningFee float64
+		want      []CoinAmount
+	}{
+		{
+			name:      "positive fee",
+			miningFee: 0.12345678,
+			want: []CoinAmount{
+				{CoinType: "VAR", Amount: "12345678"}, // DCR atoms (8 decimals)
+			},
+		},
+		{
+			name:      "zero fee",
+			miningFee: 0,
+			want: []CoinAmount{
+				{CoinType: "VAR", Amount: "0"},
+			},
+		},
+		{
+			name:      "large fee",
+			miningFee: 100.12345678,
+			want: []CoinAmount{
+				{CoinType: "VAR", Amount: "10012345678"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FeesByCoinFromMiningFee(tt.miningFee)
+			if len(got) != len(tt.want) {
+				t.Errorf("len = %d, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i].CoinType != tt.want[i].CoinType {
+					t.Errorf("[%d] CoinType = %s, want %s", i, got[i].CoinType, tt.want[i].CoinType)
+				}
+				if got[i].Amount != tt.want[i].Amount {
+					t.Errorf("[%d] Amount = %s, want %s", i, got[i].Amount, tt.want[i].Amount)
+				}
+			}
+		})
+	}
+}
+
+func TestCoinTypeSymbol(t *testing.T) {
+	tests := []struct {
+		coinType uint8
+		want     string
+	}{
+		{0, "VAR"},
+		{1, "SKA1"},
+		{2, "SKA2"},
+		{255, "SKA255"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := CoinTypeSymbol(tt.coinType); got != tt.want {
+				t.Errorf("CoinTypeSymbol(%d) = %s, want %s", tt.coinType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCoinTypeFromSymbol(t *testing.T) {
+	tests := []struct {
+		symbol   string
+		wantCoin uint8
+		wantOk   bool
+	}{
+		{"VAR", 0, true},
+		{"SKA1", 1, true},
+		{"SKA2", 2, true},
+		{"SKA255", 255, true},
+		{"INVALID", 0, false},
+		{"SKA0", 0, false}, // SKA0 is not valid
+		{"VARX", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.symbol, func(t *testing.T) {
+			got, ok := CoinTypeFromSymbol(tt.symbol)
+			if ok != tt.wantOk {
+				t.Errorf("CoinTypeFromSymbol(%s) ok = %v, want %v", tt.symbol, ok, tt.wantOk)
+			}
+			if got != tt.wantCoin {
+				t.Errorf("CoinTypeFromSymbol(%s) = %d, want %d", tt.symbol, got, tt.wantCoin)
+			}
+		})
+	}
+}
+
+func TestCoinTypesSorted(t *testing.T) {
+	// Ensure SKA coin types are sorted in ascending order
+	types := []uint8{0, 2, 1, 255, 10}
+	sorted := make([]uint8, len(types))
+	copy(sorted, types)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i] < sorted[j]
+	})
+	want := []uint8{0, 1, 2, 10, 255}
+	for i := range sorted {
+		if sorted[i] != want[i] {
+			t.Errorf("sorted[%d] = %d, want %d", i, sorted[i], want[i])
+		}
 	}
 }

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -170,6 +171,133 @@ func (b *BlockBasic) FlattenCoinRows() {
 	}
 }
 
+// CoinTypeSymbol returns the display symbol for a coin type.
+func CoinTypeSymbol(coinType uint8) string {
+	if coinType == 0 {
+		return "VAR"
+	}
+	return fmt.Sprintf("SKA%d", coinType)
+}
+
+// CoinTypeFromSymbol converts a display symbol back to coin type.
+// Returns (0, false) for invalid symbols.
+func CoinTypeFromSymbol(symbol string) (uint8, bool) {
+	if symbol == "VAR" {
+		return 0, true
+	}
+	if len(symbol) > 3 && symbol[:3] == "SKA" {
+		var n int
+		if _, err := fmt.Sscanf(symbol[3:], "%d", &n); err == nil {
+			if n >= 1 && n <= 255 {
+				return uint8(n), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// TotalSentByCoinFromMap converts a coin amount map to an ordered slice.
+// VAR (0) is first, then SKA types in ascending order, zero-value SKA omitted.
+func TotalSentByCoinFromMap(coinAmounts map[uint8]string, issuedSKA []uint8) []CoinAmount {
+	if len(coinAmounts) == 0 {
+		return nil
+	}
+
+	var result []CoinAmount
+
+	// Add VAR first if present
+	if amt, ok := coinAmounts[0]; ok {
+		result = append(result, CoinAmount{CoinType: "VAR", Amount: amt})
+	}
+
+	// Collect and sort SKA types
+	var skaTypes []uint8
+	if len(issuedSKA) > 0 {
+		skaTypes = make([]uint8, len(issuedSKA))
+		copy(skaTypes, issuedSKA)
+	} else {
+		// If no issuedSKA provided, derive from map keys
+		for ct := range coinAmounts {
+			if ct != 0 {
+				skaTypes = append(skaTypes, ct)
+			}
+		}
+	}
+	sort.Slice(skaTypes, func(i, j int) bool { return skaTypes[i] < skaTypes[j] })
+
+	// Add SKA types in sorted order, omitting zero values
+	for _, ct := range skaTypes {
+		if amt, ok := coinAmounts[ct]; ok && amt != "0" && amt != "" {
+			result = append(result, CoinAmount{CoinType: CoinTypeSymbol(ct), Amount: amt})
+		}
+	}
+
+	return result
+}
+
+// RegularCoinCountsFromCoinRows computes regular transaction counts per coin type.
+// Regular = Total TxCount - Votes - Tickets - Revocations
+func RegularCoinCountsFromCoinRows(rows []CoinRowData, voters uint16, freshStake uint8, revocations uint32) []CoinCount {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	// Build map for quick lookup
+	rowMap := make(map[uint8]CoinRowData)
+	for _, r := range rows {
+		rowMap[r.CoinType] = r
+	}
+
+	// Get sorted coin types present in rows
+	var coinTypes []uint8
+	for ct := range rowMap {
+		coinTypes = append(coinTypes, ct)
+	}
+	sort.Slice(coinTypes, func(i, j int) bool { return coinTypes[i] < coinTypes[j] })
+
+	var result []CoinAmount
+
+	for _, ct := range coinTypes {
+		row := rowMap[ct]
+		var regular int
+		if ct == 0 {
+			// VAR regular txs = total - votes - tickets - revocations
+			regular = row.TxCount - int(voters) - int(freshStake) - int(revocations)
+			if regular < 0 {
+				regular = 0
+			}
+		} else {
+			// SKA txs are not reduced by votes/tickets/revocations
+			regular = row.TxCount
+		}
+		// Skip zero-count SKA entries
+		if ct != 0 && regular == 0 {
+			continue
+		}
+		result = append(result, CoinAmount{CoinType: CoinTypeSymbol(ct), Amount: fmt.Sprintf("%d", regular)})
+	}
+
+	// Convert []CoinAmount to []CoinCount
+	countResult := make([]CoinCount, len(result))
+	for i, ca := range result {
+		var cnt int
+		fmt.Sscanf(ca.Amount, "%d", &cnt)
+		countResult[i] = CoinCount{CoinType: ca.CoinType, Count: cnt}
+	}
+
+	return countResult
+}
+
+// FeesByCoinFromMiningFee creates a fees slice from the VAR mining fee.
+// For now, only VAR fees are supported; SKA fees may be added later.
+func FeesByCoinFromMiningFee(miningFee float64) []CoinAmount {
+	// Convert DCR float to atoms (8 decimal places)
+	atoms := int64(miningFee * 1e8)
+	return []CoinAmount{
+		{CoinType: "VAR", Amount: fmt.Sprintf("%d", atoms)},
+	}
+}
+
 // WebBasicBlock is used for quick DB data without rpc calls
 type WebBasicBlock struct {
 	Height      uint32   `json:"height"`
@@ -210,10 +338,12 @@ type TxBasic struct {
 // TrimmedTxInfo for use with /visualblocks
 type TrimmedTxInfo struct {
 	*TxBasic
-	Fees      float64
-	VinCount  int
-	VoutCount int
-	VoteValid bool
+	Fees         float64
+	VinCount     int
+	VoutCount    int
+	VoteValid    bool
+	CoinType     uint8  // 0=VAR, 1-255=SKAn for stake fees; for revocations, set when processing
+	TicketStatus string // Pool status for revocations: "voted", "missed", "expired"
 }
 
 // TxInfo models data needed for display on the tx page
@@ -584,6 +714,28 @@ type BlockInfo struct {
 	SKAPoWRewards         []PoWSKAReward `json:"pow_ska_rewards,omitempty"`
 	// CoinAmounts holds per-coin totals (VAR key=0, SKAn key=n) as decimal atom strings.
 	CoinAmounts map[uint8]string `json:"coin_amounts,omitempty"`
+	// TotalSentByCoin is an ordered slice of total sent amounts per coin type,
+	// for template rendering. VAR (0) first, then SKA types in ascending order,
+	// with zero-value SKA entries omitted.
+	TotalSentByCoin []CoinAmount `json:"-"`
+	// RegularCoinCounts is an ordered slice of regular transaction counts per coin type,
+	// for template rendering. Same ordering as TotalSentByCoin.
+	RegularCoinCounts []CoinCount `json:"-"`
+	// FeesByCoin is an ordered slice of fees per coin type, for template rendering.
+	// Same ordering as TotalSentByCoin.
+	FeesByCoin []CoinAmount `json:"-"`
+}
+
+// CoinAmount represents an amount for a specific coin type.
+type CoinAmount struct {
+	CoinType string `json:"coin_type"` // "VAR", "SKA1", etc.
+	Amount   string `json:"amount"`    // big.Int atom string (18 decimal places for SKA)
+}
+
+// CoinCount represents a transaction count for a specific coin type.
+type CoinCount struct {
+	CoinType string `json:"coin_type"`
+	Count    int    `json:"count"`
 }
 
 // Conversion is a representation of some amount of DCR in another index.

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -280,6 +280,9 @@ func RegularCoinCountsFromCoinRows(rows []CoinRowData, voters uint16, freshStake
 }
 
 // FeesByCoinFromAmounts creates an ordered fee slice from a map of coin type -> fee atoms.
+// VAR (0) fees come from MiningFee (sum of all VAR tx fees in the block).
+// SKA fees come from SSFeeTotalsByCoin (total SKA atoms distributed via TxTypeSSFee per coin type,
+// i.e., fees collected from SKA outputs being spent in the block).
 // VAR (0) is first, then SKA types in ascending order, zero-value SKA omitted.
 func FeesByCoinFromAmounts(feeAmounts map[uint8]string) []CoinAmount {
 	if len(feeAmounts) == 0 {
@@ -735,6 +738,8 @@ type BlockInfo struct {
 	// for template rendering. Same ordering as TotalSentByCoin.
 	RegularCoinCounts []CoinCount `json:"-"`
 	// FeesByCoin is an ordered slice of fees per coin type, for template rendering.
+	// VAR fees are total transaction fees in the block; SKA fees are SSFee distribution amounts
+	// (total SKA atoms distributed via TxTypeSSFee per coin type, i.e., fees collected from SKA outputs).
 	// Same ordering as TotalSentByCoin.
 	FeesByCoin []CoinAmount `json:"-"`
 }

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -279,27 +279,6 @@ func RegularCoinCountsFromCoinRows(rows []CoinRowData, voters uint16, freshStake
 	return result
 }
 
-// AggregateFeesFromTxSlice aggregates SKA fees from a slice of transactions into a fee map.
-// VAR fees (coinType 0) are skipped since they're handled separately via MiningFee.
-// Non-zero, non-empty FeeRaw values are summed per coin type.
-func AggregateFeesFromTxSlice(txs []*TrimmedTxInfo, fees map[uint8]string) {
-	for _, tx := range txs {
-		if tx.CoinType == 0 || tx.FeeRaw == "" || tx.FeeRaw == "0" {
-			continue
-		}
-		fee, err := strconv.ParseInt(tx.FeeRaw, 10, 64)
-		if err != nil {
-			continue
-		}
-		if existing, ok := fees[tx.CoinType]; ok {
-			if existingAmt, err := strconv.ParseInt(existing, 10, 64); err == nil {
-				fee += existingAmt
-			}
-		}
-		fees[tx.CoinType] = strconv.FormatInt(fee, 10)
-	}
-}
-
 // FeesByCoinFromMiningFee creates a fees slice from the VAR mining fee.
 // For now, only VAR fees are supported; SKA fees may be added later.
 // FeesByCoinFromAmounts creates an ordered fee slice from a map of coin type -> fee atoms.

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -279,8 +279,6 @@ func RegularCoinCountsFromCoinRows(rows []CoinRowData, voters uint16, freshStake
 	return result
 }
 
-// FeesByCoinFromMiningFee creates a fees slice from the VAR mining fee.
-// For now, only VAR fees are supported; SKA fees may be added later.
 // FeesByCoinFromAmounts creates an ordered fee slice from a map of coin type -> fee atoms.
 // VAR (0) is first, then SKA types in ascending order, zero-value SKA omitted.
 func FeesByCoinFromAmounts(feeAmounts map[uint8]string) []CoinAmount {

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -186,11 +187,9 @@ func CoinTypeFromSymbol(symbol string) (uint8, bool) {
 		return 0, true
 	}
 	if len(symbol) > 3 && symbol[:3] == "SKA" {
-		var n int
-		if _, err := fmt.Sscanf(symbol[3:], "%d", &n); err == nil {
-			if n >= 1 && n <= 255 {
-				return uint8(n), true
-			}
+		n, err := strconv.Atoi(symbol[3:])
+		if err == nil && n >= 1 && n <= 255 {
+			return uint8(n), true
 		}
 	}
 	return 0, false
@@ -207,7 +206,7 @@ func TotalSentByCoinFromMap(coinAmounts map[uint8]string, issuedSKA []uint8) []C
 
 	// Add VAR first if present
 	if amt, ok := coinAmounts[0]; ok {
-		result = append(result, CoinAmount{CoinType: "VAR", Amount: amt})
+		result = append(result, CoinAmount{CoinType: 0, Symbol: "VAR", Amount: amt})
 	}
 
 	// Collect and sort SKA types
@@ -228,7 +227,7 @@ func TotalSentByCoinFromMap(coinAmounts map[uint8]string, issuedSKA []uint8) []C
 	// Add SKA types in sorted order, omitting zero values
 	for _, ct := range skaTypes {
 		if amt, ok := coinAmounts[ct]; ok && amt != "0" && amt != "" {
-			result = append(result, CoinAmount{CoinType: CoinTypeSymbol(ct), Amount: amt})
+			result = append(result, CoinAmount{CoinType: ct, Symbol: CoinTypeSymbol(ct), Amount: amt})
 		}
 	}
 
@@ -255,7 +254,7 @@ func RegularCoinCountsFromCoinRows(rows []CoinRowData, voters uint16, freshStake
 	}
 	sort.Slice(coinTypes, func(i, j int) bool { return coinTypes[i] < coinTypes[j] })
 
-	var result []CoinAmount
+	var result []CoinCount
 
 	for _, ct := range coinTypes {
 		row := rowMap[ct]
@@ -274,28 +273,45 @@ func RegularCoinCountsFromCoinRows(rows []CoinRowData, voters uint16, freshStake
 		if ct != 0 && regular == 0 {
 			continue
 		}
-		result = append(result, CoinAmount{CoinType: CoinTypeSymbol(ct), Amount: fmt.Sprintf("%d", regular)})
+		result = append(result, CoinCount{CoinType: ct, Symbol: CoinTypeSymbol(ct), Count: regular})
 	}
 
-	// Convert []CoinAmount to []CoinCount
-	countResult := make([]CoinCount, len(result))
-	for i, ca := range result {
-		var cnt int
-		fmt.Sscanf(ca.Amount, "%d", &cnt)
-		countResult[i] = CoinCount{CoinType: ca.CoinType, Count: cnt}
-	}
-
-	return countResult
+	return result
 }
 
 // FeesByCoinFromMiningFee creates a fees slice from the VAR mining fee.
 // For now, only VAR fees are supported; SKA fees may be added later.
-func FeesByCoinFromMiningFee(miningFee float64) []CoinAmount {
-	// Convert DCR float to atoms (8 decimal places)
-	atoms := int64(miningFee * 1e8)
-	return []CoinAmount{
-		{CoinType: "VAR", Amount: fmt.Sprintf("%d", atoms)},
+// FeesByCoinFromAmounts creates an ordered fee slice from a map of coin type -> fee atoms.
+// VAR (0) is first, then SKA types in ascending order, zero-value SKA omitted.
+func FeesByCoinFromAmounts(feeAmounts map[uint8]string) []CoinAmount {
+	if len(feeAmounts) == 0 {
+		return nil
 	}
+
+	var result []CoinAmount
+
+	// Add VAR first if present and non-zero
+	if amt, ok := feeAmounts[0]; ok && amt != "0" && amt != "" {
+		result = append(result, CoinAmount{CoinType: 0, Symbol: "VAR", Amount: amt})
+	}
+
+	// Collect and sort SKA types
+	var skaTypes []uint8
+	for ct := range feeAmounts {
+		if ct != 0 {
+			skaTypes = append(skaTypes, ct)
+		}
+	}
+	sort.Slice(skaTypes, func(i, j int) bool { return skaTypes[i] < skaTypes[j] })
+
+	// Add SKA types in sorted order, omitting zero values
+	for _, ct := range skaTypes {
+		if amt, ok := feeAmounts[ct]; ok && amt != "0" && amt != "" {
+			result = append(result, CoinAmount{CoinType: ct, Symbol: CoinTypeSymbol(ct), Amount: amt})
+		}
+	}
+
+	return result
 }
 
 // WebBasicBlock is used for quick DB data without rpc calls
@@ -728,13 +744,15 @@ type BlockInfo struct {
 
 // CoinAmount represents an amount for a specific coin type.
 type CoinAmount struct {
-	CoinType string `json:"coin_type"` // "VAR", "SKA1", etc.
-	Amount   string `json:"amount"`    // big.Int atom string (18 decimal places for SKA)
+	CoinType uint8  `json:"coin_type"`        // 0=VAR, 1-255=SKAn
+	Symbol   string `json:"symbol,omitempty"` // Display label: "VAR", "SKA1", etc. (optional, for templates)
+	Amount   string `json:"amount"`           // big.Int atom string (18 decimal places for SKA)
 }
 
 // CoinCount represents a transaction count for a specific coin type.
 type CoinCount struct {
-	CoinType string `json:"coin_type"`
+	CoinType uint8  `json:"coin_type"`        // 0=VAR, 1-255=SKAn
+	Symbol   string `json:"symbol,omitempty"` // Display label (optional)
 	Count    int    `json:"count"`
 }
 

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -213,8 +213,8 @@ func TotalSentByCoinFromMap(coinAmounts map[uint8]string, issuedSKA []uint8) []C
 	// Collect and sort SKA types
 	var skaTypes []uint8
 	if len(issuedSKA) > 0 {
-		skaTypes = make([]uint8, len(issuedSKA))
-		copy(skaTypes, issuedSKA)
+		skaTypes = make([]uint8, 0, len(issuedSKA))
+		skaTypes = append(skaTypes, issuedSKA...)
 	} else {
 		// If no issuedSKA provided, derive from map keys
 		for ct := range coinAmounts {

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -745,7 +745,6 @@ type BlockInfo struct {
 	NextHash              string
 	TotalSent             float64
 	MiningFee             float64
-	TotalMixed            int64
 	StakeValidationHeight int64
 	Subsidy               *chainjson.GetBlockSubsidyResult
 	SKAPoWRewards         []PoWSKAReward `json:"pow_ska_rewards,omitempty"`
@@ -812,7 +811,6 @@ type PoWSKAReward struct {
 // HomeInfo represents data used for the home page
 type HomeInfo struct {
 	CoinSupply            int64                `json:"coin_supply"`
-	MixedPercent          float64              `json:"mixed_percent"`
 	StakeDiff             float64              `json:"sdiff"`
 	NextExpectedStakeDiff float64              `json:"next_expected_sdiff"`
 	NextExpectedBoundsMin float64              `json:"next_expected_min"`

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -279,6 +279,27 @@ func RegularCoinCountsFromCoinRows(rows []CoinRowData, voters uint16, freshStake
 	return result
 }
 
+// AggregateFeesFromTxSlice aggregates SKA fees from a slice of transactions into a fee map.
+// VAR fees (coinType 0) are skipped since they're handled separately via MiningFee.
+// Non-zero, non-empty FeeRaw values are summed per coin type.
+func AggregateFeesFromTxSlice(txs []*TrimmedTxInfo, fees map[uint8]string) {
+	for _, tx := range txs {
+		if tx.CoinType == 0 || tx.FeeRaw == "" || tx.FeeRaw == "0" {
+			continue
+		}
+		fee, err := strconv.ParseInt(tx.FeeRaw, 10, 64)
+		if err != nil {
+			continue
+		}
+		if existing, ok := fees[tx.CoinType]; ok {
+			if existingAmt, err := strconv.ParseInt(existing, 10, 64); err == nil {
+				fee += existingAmt
+			}
+		}
+		fees[tx.CoinType] = strconv.FormatInt(fee, 10)
+	}
+}
+
 // FeesByCoinFromMiningFee creates a fees slice from the VAR mining fee.
 // For now, only VAR fees are supported; SKA fees may be added later.
 // FeesByCoinFromAmounts creates an ordered fee slice from a map of coin type -> fee atoms.


### PR DESCRIPTION
- Add CoinAmount, CoinCount types and TotalSentByCoin, RegularCoinCounts, FeesByCoin fields to BlockInfo
- Add CoinType, TicketStatus fields to TrimmedTxInfo for stake fees and revocation rows
- Add helper functions for ordered slice generation (VAR first, SKA sorted, zero omitted)
- Update GetExplorerBlock to populate new template-facing fields from block summary
- Extend /api/block/{height}/verbose with total_sent and fees map objects
- Update block template: TotalSent iterates coins, Fees shows coin type, Revocations add Status column, StakeFees add coin type, Transactions remove Mixed column
- Add unit tests for ordered slice generation and API tests for verbose endpoint