### PR TITLE
wiki: add address page multi-coin spec

### DIFF
--- a/wiki/code-analysis/address/charts.impact.md
+++ b/wiki/code-analysis/address/charts.impact.md
@@ -1,0 +1,362 @@
+### Mutation Impact: Address Page Charts Card
+
+Change-surface reference for the right-top "charts" card on `/address/{address}`. Companion to `wiki/code-analysis/address/flow.compact.md` and `flow.full.md`; covers only the chart UI, its API endpoints, the DB query path, and URL state. Summary card and transactions table are out of scope.
+
+---
+
+## 1. Scope
+
+Template region (the right-top card):
+- `cmd/dcrdata/views/address.tmpl:113-183` — the `<div class="col-24 col-xl-13 secondary-card p-2">` block.
+  - Fullscreen mount: `address.tmpl:17-19` (`fullscreen` + `bigchart` targets) — outside the card but driven by `toggleExpand` on the card's `expando`.
+  - Container `data-controller="address newblock"` and the per-page payload attributes are at `address.tmpl:10-16` (read by `connect()`).
+
+Frontend controller sections (`cmd/dcrdata/public/js/controllers/address_controller.js`):
+- Module-level chart helpers: `txTypesFunc` (18-28), `amountFlowProcessor` (30-53), `formatter` / `customizedFormatter` (55-87), `createOptions` / `commonOptions` / `typesGraphOptions` / `amountFlowGraphOptions` / `balanceGraphOptions` (97-148).
+- Targets used on this card: `options`, `flow`, `zoom`, `interval`, `chartbox`, `noconfirms`, `chart`, `chartLoader`, `expando`, `littlechart`, `bigchart`, `fullscreen` (declared in the `targets` list at 153-191).
+- Lifecycle: `connect` (194-254), `disconnect` (256-262), `bindElements` (274-282), `initializeChart` (265-272).
+- Chart state machine: `drawGraph` (473-494), `fetchGraphData` (496-527), `processData` (529-546), `popChartCache` (548-589), `noDataAvailable` (591-595).
+- Validation/state writes: `validChartType` (597-599), `validGraphInterval` (601-608), `validateZoom` (610-618), `setChartType` (721-726), `setIntervalButton` (702-709), `setSelectedZoom` (728-736), `setButtonVisibility` (758-772).
+- UI event handlers: `changeGraph` (620-624), `changeBin` (626-633), `setGraphQuery` (635-637), `updateFlow` (639-657), `setFlowChecks` (659-664), `onZoom` (666-681), `setZoom` (683-692), Dygraph callbacks `_drawCallback` (738-747) and `_zoomCallback` (749-756), fullscreen `toggleExpand` (830-841), `putChartBack` (843-850), `exitFullscreen` (852-855).
+- Getters: `chartType` (857-859), `activeZoomDuration` (869-871), `activeZoomKey` (873-877), `chartDuration` (879-881), `activeBin` (883-885), `flow` (887-893), `getBin` (694-700).
+- Dygraph wrapper: `createGraph` (433-435).
+- Dygraph lazy load: `Dygraph = await getDefault(import('../vendor/dygraphs.min.js'))` at 248-250.
+
+Backend chart routes and handlers (chart side only):
+- `cmd/dcrdata/internal/api/apirouter.go:185-186` — `/api/address/{address}/types/{chartgrouping}` and `/api/address/{address}/amountflow/{chartgrouping}`.
+- `cmd/dcrdata/internal/api/apiroutes.go:1777-1811` (`getAddressTxTypesData`), `:1813-1846` (`getAddressTxAmountFlowData`).
+- `DataSource.TxHistoryData` interface entry: `apiroutes.go:65-66`.
+- Mock: `cmd/dcrdata/internal/api/noop_ds_test.go:40-42`.
+
+Backend DB path:
+- `db/dcrpg/pgblockchain.go:3112-3182` (`(*ChainDB).TxHistoryData` — cache lookup + dispatch).
+- `db/dcrpg/queries.go:1909-1939` (`retrieveTxHistoryByType`), `:1946-1952` (`retrieveTxHistoryByAmountFlow`), `:4139-4164` (`parseRowsSentReceived`), `:4135-4137` (`toCoin` helper).
+- `db/dcrpg/internal/addrstmts.go:312-329` (raw SQL for both kinds), `:417-425` (`MakeSelectAddressTxTypesByAddress`, `MakeSelectAddressAmountFlowByAddress`).
+- Cache: `db/cache/addresscache.go:460-482` (`(*AddressCacheItem).HistoryChart`), `:854-868` (`(*AddressCache).HistoryChart`), `:1120-1166` (`StoreHistoryChart`). Cache buckets keyed by `dbtypes.HistoryChart` × `dbtypes.TimeBasedGrouping`.
+- Types: `db/dbtypes/types.go:855-862` (`HistoryChart`/`TxsType`/`AmountFlow`), `:745-770` (`TimeBasedGrouping` + `TimeIntervals`), `:822-862` (`TimeBasedGroupings`/`TimeGroupingFromStr`), `:2030-2040` (`ChartsData`).
+
+---
+
+## 2. Backend touch points
+
+**Chart route registration** — `cmd/dcrdata/internal/api/apirouter.go:185-186`:
+```
+re.With(m.ChartGroupingCtx).Get("/types/{chartgrouping}", app.getAddressTxTypesData)
+re.With(m.ChartGroupingCtx).Get("/amountflow/{chartgrouping}", app.getAddressTxAmountFlowData)
+```
+Both inherit `m.AddressPathCtxN(1)` from the enclosing group (apirouter.go:181-198) so they accept exactly one address (rejects multi-address `,`-separated input). `m.ChartGroupingCtx` (`internal/middleware/apimiddleware.go:817+`) extracts `chartgrouping` URL segment.
+
+There is **no `balance` route**. The "balance" chart kind is a frontend-only derivation: `address_controller.js:519` rewrites `chart === 'balance'` to URL key `amountflow` before fetching, then `amountFlowProcessor` (30-53) runs both `flow` and `balance` series from a single response.
+
+**Handler entry points**:
+- `getAddressTxTypesData` (apiroutes.go:1777) — calls `TxHistoryData(ctx, addr, dbtypes.TxsType, interval)`.
+- `getAddressTxAmountFlowData` (apiroutes.go:1813) — calls `TxHistoryData(ctx, addr, dbtypes.AmountFlow, interval)`.
+
+Both pin the address parameter at index 0 (`addresses[0]`) after the `len(addresses) > 1` reject (lines 1781-1785 / 1817-1821), translate `chartgrouping` to `dbtypes.TimeBasedGrouping` via `TimeGroupingFromStr` (1793/1828), reject `UnknownGrouping`, and pass `dbtypes.IsTimeoutErr` failures through as HTTP 503. JSON serialization is plain `writeJSON(w, data, m.GetIndentCtx(r))`.
+
+**`TxHistoryData` signature** — `db/dcrpg/pgblockchain.go:3114-3115`:
+```
+func (pgb *ChainDB) TxHistoryData(ctx context.Context, address string,
+    addrChart dbtypes.HistoryChart,
+    chartGroupings dbtypes.TimeBasedGrouping) (cd *dbtypes.ChartsData, err error)
+```
+**No `CoinType` parameter.** This is the central multi-coin gap (see §6).
+
+Call sites:
+- `cmd/dcrdata/internal/api/apiroutes.go:1798` (`TxsType`), `:1833` (`AmountFlow`).
+- Recursive self-call inside the `CacheLocks.bal.TryLock` busy-wait: `pgblockchain.go:3150`.
+
+Interface declaration: `apiroutes.go:65-66` (`DataSource.TxHistoryData`).
+
+Mock: `noop_ds_test.go:40-42` (returns `nil, nil`). Any signature change here cascades.
+
+**`db/cache` interaction** (`db/cache/addresscache.go`):
+- Pre-DB lookup at `pgblockchain.go:3128`: `pgb.AddressCache.HistoryChart(address, addrChart, chartGroupings)`. If cache hit and `validBlock != nil`, returns immediately.
+- Per-address singleflight: `pgb.CacheLocks.bal.TryLock(address)` (3139). Concurrent callers wait on a channel; the winner runs the query.
+- Post-query store: `pgb.AddressCache.StoreHistoryChart(...)` (3179).
+- Cache shape: `AddressCacheItem.history` holds `TypeByInterval[grouping]` and `AmtFlowByInterval[grouping]` slots — two `[NumIntervals]*ChartsData` arrays per address. (`addresscache.go:471-481`, `:1156-1163`.)
+- **No coin-type dimension** in the cache key. Adding per-coin data requires either a new dimension (e.g. `[NumIntervals]*ChartsData[CoinType]`) or a separate cache map.
+
+**SQL queries** — `db/dcrpg/internal/addrstmts.go`:
+- `selectAddressTxTypesByAddress` (312-321) — `COUNT(...)` of regular-tx funding/spending and `tx_type = 1/2/3` (SSTx/SSGen/SSRtx) over `addresses` rows for the given address. **Does not filter by `coin_type`** and **does not reference `ska_value`**. Counts are coin-agnostic; tickets/votes/revocations are inherently VAR-only on Decred-derived consensus, so this row is structurally a count of "all txs (mostly VAR)".
+- `selectAddressAmountFlowByAddress` (323-329) — `SUM(value)` from the `addresses` table partitioned by `is_funding`. **`addresses.value` is `INT8` and stores VAR atoms only** (`addrstmts.go:21`). The `ska_value TEXT` column at line 23 exists in the schema but is **not summed** here.
+
+**`ChartsData` struct fields populated per kind** — `db/dbtypes/types.go:2030-2040`:
+```
+type ChartsData struct {
+    Time        []TimeDef `json:"time,omitempty"`
+    SentRtx     []uint64  `json:"sentRtx,omitempty"`
+    ReceivedRtx []uint64  `json:"receivedRtx,omitempty"`
+    Tickets     []uint32  `json:"tickets,omitempty"`
+    Votes       []uint32  `json:"votes,omitempty"`
+    RevokeTx    []uint32  `json:"revokeTx,omitempty"`
+    Received    []float64 `json:"received,omitempty"`
+    Sent        []float64 `json:"sent,omitempty"`
+    Net         []float64 `json:"net,omitempty"`
+}
+```
+- **`types`**: populates `Time`, `SentRtx`, `ReceivedRtx`, `Tickets`, `Votes`, `RevokeTx` (queries.go:1927-1932). Counts are `uint64` / `uint32`, no atomic precision concern.
+- **`amountflow`**: populates `Time`, `Received`, `Sent`, `Net` via `parseRowsSentReceived` (queries.go:4139-4163). `received`/`sent` come back as `uint64` then run through `toCoin = float64(amt) / 1e8` (queries.go:4135-4137). `Net = toCoin(received - sent)`. **Float64 boundary, hard-coded `1e-8` (VAR scale).**
+- **No `Balance` field on the wire.** The frontend computes balance by integrating `amountflow` (`amountFlowProcessor` lines 30-53).
+
+---
+
+## 3. Per-chart-kind behavior
+
+### 3.1 `balance`
+- **Wire**: not a backend kind. `address_controller.js:519` rewrites the URL chart segment to `amountflow` before calling `/api/address/{addr}/amountflow/{bin}`.
+- **Data source**: same response as `amountflow` (`Received`, `Sent`, `Net` `[]float64`).
+- **Frontend transform**: `amountFlowProcessor` (30-53) walks `d.net[i]` and accumulates a running JS `Number` `balance += v` (line 42). Both flow and balance series are cached in `retrievedData` (line 540-541).
+- **Coin-type assumption**: implicitly VAR-only. The accumulator is a JS `Number` and the source is float64 already lossy at the API boundary. SKA cannot pass through this without precision loss.
+- **Status**: implicitly VAR-only end-to-end. The float64-everywhere assumption (`1e-8` scaling, `Number` accumulator, `digitsAfterDecimal: 8`) makes this incompatible with SKA without a parallel pipeline.
+
+### 3.2 `types` (Tx Type)
+- **Wire**: `GET /api/address/{addr}/types/{bin}` → `TxHistoryData(.., TxsType, ..)` → `retrieveTxHistoryByType` → JSON with `time`, `sentRtx`, `receivedRtx`, `tickets`, `votes`, `revokeTx`.
+- **DB query**: `selectAddressTxTypesByAddress` (`addrstmts.go:312-321`) — counts only, partitioned by `tx_type`. **Not filtered by `coin_type`.**
+- **Fields populated**: see §2 above.
+- **Frontend transform**: `txTypesFunc` (`address_controller.js:18-28`) maps to a Dygraph 6-column row (`Date`, `sentRtx`, `receivedRtx`, `tickets`, `votes`, `revokeTx`).
+- **Coin-type assumption**: tickets / votes / revocations are stake-tree primitives that exist only in VAR (per `CLAUDE.md` — SKA txs are pure value transfers, no ticket purchases). So `Tickets`/`Votes`/`RevokeTx` series are **structurally VAR-only**. `SentRtx`/`ReceivedRtx` are the only series that could meaningfully aggregate across coin types — and currently they do, silently mixing VAR and SKA tx counts when the same address holds both.
+- **Status**: coin-agnostic for regular-tx counts (VAR + SKA mixed); structurally VAR-only for stake-tree counts. With the multi-coin model, when interpreting "Tx Type" for a non-VAR coin, three of the five series are always zero.
+
+### 3.3 `amountflow` (Sent/Received)
+- **Wire**: `GET /api/address/{addr}/amountflow/{bin}` → `TxHistoryData(.., AmountFlow, ..)` → `retrieveTxHistoryByAmountFlow` → `parseRowsSentReceived` → JSON with `time`, `received`, `sent`, `net`.
+- **DB query**: `selectAddressAmountFlowByAddress` (`addrstmts.go:323-329`) — sums `addresses.value` partitioned by `is_funding`.
+- **Fields populated**: `Time`, `Received`, `Sent`, `Net` `[]float64`.
+- **Frontend transform**: `amountFlowProcessor` (30-53) emits `[Date, received, sent, netReceived, netSent]` rows (lines 41) and the parallel balance series (43).
+- **Coin-type assumption**: **implicitly VAR-only** at three layers:
+  1. `addresses.value INT8` is the VAR atom column; `ska_value TEXT` is ignored by the SUM.
+  2. `parseRowsSentReceived` scans into `uint64`, divides by `1e8` (`toCoin`).
+  3. JSON shape uses `[]float64`.
+  Result: for a SKA address, the sums are 0 (no VAR rows) regardless of how many SKA atoms moved. There is no "mixed coin" failure mode for `amountflow` because it only ever reads VAR; it just silently shows all-zero for SKA.
+
+---
+
+## 4. Template touch points
+
+`cmd/dcrdata/views/address.tmpl` — every Stimulus target / button / option on this card:
+
+Container payload (read by controller `connect`):
+- `address.tmpl:11` `data-controller="address newblock"` (co-mounted; `newblock` may mutate `txnCount` outside the chart card).
+- `:13` `data-address-dcraddress="{{.Address}}"` — used in `fetchGraphData` URL (`/api/address/${ctrl.dcrAddress}/...`).
+- `:14` `data-address-txn-count="{{$TxnCount}}"` — read in `connect()` for `paginationParams.count` (228); not used for chart logic.
+- `:15` `data-address-balance="{{toFloat64Amount .Balance.TotalUnspent}}"` — read into `ctrl.balance` (230) but **not actually used by chart code** (no usages elsewhere in the controller).
+
+Fullscreen mount (driven by chart's `expando`):
+- `:17-19` `data-address-target="fullscreen"` and inner `data-address-target="bigchart"`. `toggleExpand` (830) appends/removes `chartbox` to/from these.
+
+Card region:
+- `:113` `<div class="col-24 col-xl-13 secondary-card p-2">` — outer card.
+- `:117` `data-address-target="littlechart"` — home for `chartbox` when not in fullscreen (used by `putChartBack` line 847).
+- `:118` `data-address-target="chartbox"` — the movable chart subtree.
+- `:120` `data-address-target="chartLoader"` — loader spinner element.
+
+Chart-kind dropdown:
+- `:123-131` `<select data-address-target="options" data-action="change->address#changeGraph">`
+  - `:128` `<option name="balance" value="balance">Balance</option>`
+  - `:129` `<option name="types" value="types">Tx Type</option>`
+  - `:130` `<option name="amountflow" value="amountflow">Sent/Received</option>`
+- `<option value>` strings double as TurboQuery `chart=` values **and** must match the URL-segment derivation logic at `address_controller.js:519` (`chart === 'balance' ? 'amountflow' : chart`) and the route registrations at `apirouter.go:185-186`. Adding/renaming any value requires touching all three.
+- The `name` attribute is read by `validChartType` via `optionsTarget.namedItem(chart)` (`address_controller.js:598`).
+
+Zoom buttons:
+- `:133-145` `<div data-address-target="zoom" data-action="click->address#onZoom">` + label "Zoom".
+- Buttons by `name`: `all` (`data-fixed="1"`, default `btn-selected`), `year`, `month`, `week`, `day`. These names key into `zoomMap` in `helpers/zoom_helper.js:4-10`.
+
+Group-By buttons:
+- `:146-159` `<div data-address-target="interval" data-action="click->address#changeBin">` with `data-txcount="{{$TxnCount}}"` (`:149`) — note: `data-txcount` is **decorative HTML only**; no JS reads it (group-by visibility comes from `setButtonVisibility` based on `chartDuration` vs `Zoom.mapValue(button.name)`).
+- Buttons by `name`: `year`, `month` (default `btn-selected`), `week`, `day` (`data-fixed="1"`), `all` (label "Block", `data-fixed="1"`). Note the **label / value mismatch on the last button**: text is "Block", value is `all`. The `bin` URL value can be `all` and means "Block" axis.
+
+Flow checkboxes (only relevant for `amountflow`):
+- `:160-174` `<div data-address-target="flow" data-action="change->address#updateFlow">` — initially `d-hide`-friendly (Bootstrap `d-hide` toggled by `popChartCache`).
+- Checkbox values are bitmask flags: `Sent=2`, `Received=1` (default checked), `Net=4`. Encoded as a base-10 bitmap in URL (`?flow=`).
+- `updateFlow` (line 639) maps the bitmap to Dygraph series visibility for indices 0/1/2/3.
+
+Chart canvas + loader:
+- `:176-180` chart wrapper div with the `address_chart` class.
+  - `:177` `data-address-target="expando"` (fullscreen toggle, `monicon-expand` class).
+  - `:178` `data-address-target="noconfirms"` (no-data placeholder).
+  - `:179` `data-address-target="chart"` — Dygraph mount point.
+
+Hard-coded labels on this card / its options:
+- `:122` `<label>Chart</label>`.
+- `:128` `Balance`, `:129` `Tx Type`, `:130` `Sent/Received` — coin-agnostic strings; no `DCR`/`VAR` tokens.
+- `:139` `<label>Zoom</label>`.
+- `:153` `<label>Group By </label>`.
+- `:158` button label `Block` (vs `name="all"`).
+- `:162-173` checkbox labels `Sent` / `Received` / `Net`.
+- **No coin labels in the template.** Coin labels live in the controller (next section).
+
+Currency labels in the *summary* card (out of scope but easy to confuse): `:48`, `:50`, `:64`, `:66`, `:77`, `:79` all hard-code `DCR`. The chart card itself has no `DCR`/`VAR` tokens.
+
+---
+
+## 5. Frontend touch points (URL contract + zoom)
+
+**TurboQuery null-template (must declare every persisted key)** — `address_controller.js:211-219`:
+```
+ctrl.settings = TurboQuery.nullTemplate([
+  'chart', 'zoom', 'bin', 'flow', 'n', 'start', 'txntype'
+])
+```
+This card owns `chart`, `zoom`, `bin`, `flow`. (`n`, `start`, `txntype` belong to the table.) New URL keys (e.g. `coin`) require a new entry here per the rule in `flow.compact.md` mutation checklist.
+
+**URL key flow (UI → settings → URL → fetch)**:
+
+| Key      | UI source                                                      | Settings write                             | URL emit                              | Fetch use                                                                         |
+|----------|----------------------------------------------------------------|--------------------------------------------|---------------------------------------|-----------------------------------------------------------------------------------|
+| `chart`  | `<select data-address-target="options">` change                | `changeGraph` (620) → `settings.chart = chartType` | `setGraphQuery` → `query.replace(settings)` (635) | `fetchGraphData` (519): `chart === 'balance' ? 'amountflow' : chart`             |
+| `bin`    | `<button>` click in `interval` set                              | `changeBin` (626): `settings.bin = target.name`   | `setGraphQuery` → `query.replace`     | `fetchGraphData` (520): `/api/address/${addr}/${chartKey}/${bin}`                |
+| `zoom`   | `onZoom` button (666), `_zoomCallback` Dygraph drag (749), `_drawCallback` Dygraph slide (738) | `setZoom` (683) writes `settings.zoom = Zoom.encode(start, end)`; callbacks at 744 / 753 do the same | `query.replace(settings)` (690 / 745 / 754) | `drawGraph` short-circuit (482-488): if only zoom changed, decode and re-apply without refetch |
+| `flow`   | `<input type=checkbox>` change in `flow`                       | `updateFlow` (639): `settings.flow = bitmap` (646) | `setGraphQuery` (647)                 | not used in fetch URL; consumed only by `setFlowChecks`/`updateFlow` for visibility bitmap |
+
+**Initial load** (`connect()`): `query.update(settings)` (233) populates from URL; `setChartType()` (234) syncs `<select>`; `setFlowChecks()` (235) syncs flow checkboxes; if `bin == null`, `getBin()` (242) reads `bin` from URL again or falls back to `activeBin` (the currently-selected interval button, default `month`).
+
+**Validation**:
+- `validChartType` (597-599) — `optionsTarget.namedItem(chart)`. Treats the option `name` attribute as the validity oracle. URL `chart` outside the three known names is silently overridden to `ctrl.chartType` (244-246).
+- `validGraphInterval` (601-608) — looks for a button with `name === bin`. Unknown `bin` falls back through `getBin()` → `activeBin` → default `month`.
+- `validateZoom` (610-618) — `Zoom.validate(activeZoomKey || settings.zoom, ctrl.xRange, binSize)`. **Clamps silently** to the new chart's `xRange` (no error). This is what hides the stale-zoom failure mode.
+
+**Stale-`?zoom=` failure mode** (per `flow.full.md §6`):
+- `changeGraph` (620-624) writes the new `chart` to settings then calls `setGraphQuery` → `query.replace(this.settings)` **without resetting `settings.zoom`**.
+- Same in `changeBin` (626-633).
+- Result: when switching from a long-history chart kind to a shorter one, `?zoom=` in the URL still encodes the prior chart's window; on the next refresh, `validateZoom` clamps it silently to the new range. The user sees a "different" zoom than they last set.
+- Decision: any change to `setGraphQuery` (635) or to `changeGraph`/`changeBin` must explicitly choose **drop / project / keep** for `settings.zoom`. The `charts_controller.js` (charts page) calls `Zoom.project(...)` for this; the address controller does not.
+
+**Group-by visibility** — `setButtonVisibility` (758-772) hides bins coarser than the current `chartDuration` (`xRange[1] - xRange[0]`) **per data range, not per tx count**. The `data-fixed="1"` attribute on `all` zoom and on `day` / `all` (Block) interval buttons exempts them. The `data-txcount="{{$TxnCount}}"` on `interval` (`address.tmpl:149`) is unread (template residue).
+
+**Cache** — `ctrl.retrievedData` (196) keyed by `${chart}-${bin}` (497). `popChartCache` (548) replays cached data without re-fetching when both keys match. Note the `processData` quirk at 538-542: an `amountflow` fetch fills both `amountflow-${bin}` and `balance-${bin}` cache entries, but a separate `balance` request still hits the URL on first switch.
+
+---
+
+## 6. Multi-coin gaps
+
+The most important section. Each gap is a precise file:line where the current pipeline assumes coin-agnostic-aggregating or single-coin-VAR.
+
+### 6.1 No `CoinType` parameter on chart endpoints
+
+- **Route**: `cmd/dcrdata/internal/api/apirouter.go:185-186` — only `{address}` and `{chartgrouping}` URL params; no coin-type segment.
+- **Handler**: `apiroutes.go:1798`, `:1833` — both call `TxHistoryData(ctx, address, dbtypes.TxsType, interval)` / `(.., AmountFlow, ..)` without coin type.
+- **DB layer signature**: `db/dcrpg/pgblockchain.go:3114-3115` — no `CoinType` argument.
+- **Cache key**: `db/cache/addresscache.go:471-481`, `:1156-1163` — keyed by (address, `HistoryChart`, `TimeBasedGrouping`); no coin-type dimension.
+- **Mock**: `cmd/dcrdata/internal/api/noop_ds_test.go:40-42` — must be updated together with the interface (`apiroutes.go:65-66`).
+- **Frontend URL builder**: `address_controller.js:519-521` — emits `/api/address/${addr}/${chartKey}/${bin}`; no coin segment.
+
+### 6.2 Float64 / `1e-8` precision on `amountflow`
+
+- **`parseRowsSentReceived`** at `db/dcrpg/queries.go:4139-4163`:
+  - Line 4144 — `var received, sent uint64` (overflows for SKA atoms).
+  - Line 4151-4157 — `items.Received = append(.., toCoin(received))`, `items.Sent = .., items.Net = toCoin(received-sent)`.
+  - `toCoin` (queries.go:4135-4137): `float64(amt) / 1e8` — VAR scale only.
+- **JSON shape**: `db/dbtypes/types.go:2037-2039` — `Received`, `Sent`, `Net` are `[]float64`.
+- **Frontend**: `address_controller.js:30-53` (`amountFlowProcessor`) — accumulates `balance` via `+=` on JS `Number`; `digitsAfterDecimal: 8` on Dygraph (commonOptions, line 101); legend format `${series.y} DCR` (line 84).
+- **Schema source**: `db/dcrpg/internal/addrstmts.go:21,23` — `value INT8` (VAR atoms) is what `selectAddressAmountFlowByAddress` sums; `ska_value TEXT` is ignored.
+
+### 6.3 Hard-coded `DCR` / VAR-implying labels in chart options
+
+Within the chart card and its controller (template currency labels in the summary card are out of scope here):
+- `address_controller.js:84` — `customizedFormatter` legend: `${series.y} DCR`. Used by `amountFlowGraphOptions` (line 132) and `balanceGraphOptions` (line 142).
+- `address_controller.js:130` — `amountFlowGraphOptions.ylabel = 'Total (DCR)'`.
+- `address_controller.js:140` — `balanceGraphOptions.ylabel = 'Balance (DCR)'`.
+- `address_controller.js:120` — `typesGraphOptions.ylabel = 'Tx Count'` (no coin label; OK).
+- **No use of `helpers/ska_helper.js`** anywhere in `address_controller.js`. `renderCoinType`, `splitSkaAtoms`, `splitSkaAtomsNoTrailing` are unused on this surface.
+
+### 6.4 Implicit aggregation across coins
+
+- `selectAddressTxTypesByAddress` (`db/dcrpg/internal/addrstmts.go:312-321`) does not filter by `coin_type`; counts mix VAR and SKA regular-tx rows. Tickets/votes/revocations are inherently VAR-only on consensus, so they remain VAR-only in aggregate but the regular-tx counts silently mix.
+- `selectAddressAmountFlowByAddress` (323-329) sums only `value` (VAR). It is *not* aggregating across coins; it is **silently dropping all SKA**. This is a different gap shape from `types`.
+
+### 6.5 `data-address-balance` is VAR-only
+
+- `address.tmpl:15` `data-address-balance="{{toFloat64Amount .Balance.TotalUnspent}}"` (lossy for SKA per `flow.compact.md C1` violation note).
+- Read into `ctrl.balance` (`address_controller.js:230`) but currently unused by chart logic — still a hidden contract that breaks if `AddressInfo.Balance` becomes per-coin.
+
+### 6.6 `flow` bitmap is single-coin-aware only
+
+- The flow checkboxes (`address.tmpl:160-174`, controller `updateFlow` 639) toggle Dygraph series visibility on a single dataset. There is no per-coin filtering concept; if the response carried multiple coin series, the bitmap couldn't address them.
+
+---
+
+## 7. Mirror pattern: SKA coin-supply
+
+Reference: `wiki/code-analysis/charts/flow.compact.md` and `flow.full.md`. Summary of the precedent for adding per-coin chart endpoints, and what would map vs. diverge.
+
+**Reuses** (the address charts can adopt directly):
+- **URL prefix namespace**. `coin-supply/{N}` (1≤N≤255) is parsed by `db/cache/charts.go:92-109` (`IsSKASupplyChart`, `SkaCoinType`) and JS `skaCoinTypeFromChart` (`charts_controller.js:60`). An address-chart equivalent could mirror this with e.g. `/api/address/{addr}/amountflow/{N}/{bin}` or `?coin=N` (see open questions §9).
+- **String-only SKA pipeline**. SQL `::text` → Go `[]string` + `*big.Int.Add` → JSON `"supply": []string` → JS `Number(s) * 1e-18` for the line, `splitSkaAtomsNoTrailing` for the legend (`charts_controller.js:661-687`). The address `amountflow` SKA equivalent must adopt the same string discipline (do not reuse `parseRowsSentReceived`'s `uint64` + `toCoin` path).
+- **`ActiveSKATypes` projection from `HomeInfo.SKACoinSupply`**. `cmd/dcrdata/internal/explorer/explorerroutes.go:1911-1932` populates `ActiveSKATypes []uint8` for the charts page. `AddressPage` (`explorerroutes.go:1534-1651`) does **not** currently project this; adding a coin selector would require it (or a per-address active-coin set, which is a different question).
+- **`renderCoinType(coinType)` for labels** (`ska_helper.js:16`). Replaces hard-coded `DCR` / `VAR` in the controller.
+- **`Zoom.project` across data-range changes** (`charts_controller.js` line 901, per `flow.full.md`). The address controller does not currently call this; adopting it would resolve the stale-zoom failure mode at the same time.
+- **Mock co-update pattern**. `noop_ds_test.go:131` is the SKA precedent for keeping an interface-method mock in sync.
+
+**Divergences** expected for address charts:
+- The coin-supply pipeline is **per-coin-type** at the chart level (one chart, one coin). `amountflow` for an address could be **per-coin** or **per-coin-stacked** or **per-coin-line** — that's a UX choice (§9). Either way the *backend* signature change is the same: add `coinType uint8` to `TxHistoryData` and pass through to a coin-aware SQL query.
+- **Cache shape diverges**. Coin-supply uses a single `ChartData.SKASupply[uint8]SKASupplyChartData` keyed only by coin type. The address cache is keyed by `(address, HistoryChart, TimeBasedGrouping)`; adding coin type produces a 4-tuple key. The cache data structure (`AddressCacheItem.history`) needs a per-coin slice or per-coin map; not a drop-in.
+- **Cumulative-vs-per-block invariants don't carry over**. SKA coin supply is cumulative per-height; address `amountflow` is per-bin (delta) with the cumulative balance computed client-side in `amountFlowProcessor`. There is **no equivalent of the "`accumulate()` for VAR / pre-cumulated for SKA" split**; both flow charts on the address page are per-bin deltas. **However**: the `balance` derived chart is a JS-side cumulative sum (`address_controller.js:42`), and that's where SKA precision will silently break — running `balance += BigDecimalString` requires `BigInt` in JS or string-arith helpers, mirroring the lesson from `splitSkaAtomsNoTrailing`.
+- **`h` field convention** for time-axis SKA responses (`charts/flow.full.md §4`) does not naturally apply: `ChartsData` uses `time` only, no block height. If the new endpoint is height-aligned (e.g., per-block bin), include `h` for parity; otherwise drop it.
+- **`coin-supply/0` legacy duality** is not relevant — there's no existing bare `amountflow` route to deprecate; the `/api/address/{addr}/amountflow/{bin}` route can either stay as VAR-only or adopt a `0` / default-coin convention.
+
+---
+
+## 8. Cross-surface dependencies
+
+**Summary card** (`address.tmpl:21-112`, out of scope but adjacent):
+- Container attributes shared with this card via the same `data-controller="address"` element:
+  - `data-address-balance` (`:15`) — read by controller (`:230`) but not used in chart code today.
+  - `data-address-txn-count` (`:14`) — read at `connect():228` for table pagination, also stamped on `txnCount` target in the table footer (`:192`).
+- The summary card uses `toFloat64Amount` / `amountAsDecimalParts` for `Balance.TotalUnspent`/`TotalSpent` (`:48,50,64,66,77,79`). When the address page goes multi-coin, both surfaces must change together — but the chart card itself doesn't read these template fields.
+
+**Transactions table** (`address.tmpl:185-297`):
+- Independent state machine; no zoom/chart dependency.
+- One subtle dependency: `data-txcount="{{$TxnCount}}"` on the chart card's `interval` set (`:149`) is the same `$TxnCount` shown on the table's `txnCount` target (`:192`). The chart card attribute is currently dead HTML in JS, but it is wired to the same template value, so renaming `TxnCount` propagates to both.
+- `newblock` co-controller (mounted on the same root, `:11`) increments `txnCount.dataset.txnCount` on `BLOCK_RECEIVED`. This affects only the table-side count; the chart card's `data-txcount` is set once at template render and not updated.
+
+**Co-mounted controllers**:
+- `data-controller="address newblock"` — `newblock` is unrelated to the chart card directly, but mutating shared `txnCount` DOM means any chart-card refactor that introduces new shared state must avoid stomping on this surface.
+
+**Fullscreen DOM movement**:
+- The `chartbox` subtree is moved between `littlechart` (in-card, `address.tmpl:117`) and `bigchart` (top-of-page, `:18`) by `toggleExpand` (830) / `putChartBack` (843). Any DOM identity assumptions across the chart card must survive being detached and re-attached.
+
+---
+
+## 9. Open product/UX questions
+
+These are decisions a spec author cannot answer from the code alone. Ordered roughly by blast radius.
+
+1. **Per-coin lines on one chart, separate chart per coin, or coin selector?**
+   - One stacked Dygraph with N series — easy to retrofit `amountflow`/`balance`, hard to label legend (`splitSkaAtomsNoTrailing` per series), bad UX with mixed-magnitude coins (one VAR series at 1e8 + one SKA series at 1e18).
+   - Selector dropdown (mirroring `coin-supply/{N}`) — clean precedent, but doubles fetches for users comparing coins.
+   - Always-stacked + a "show coins" multi-select — heaviest, but most consistent with the chart card's existing flow checkbox pattern.
+
+2. **Should `types` be VAR-only by definition?** Tickets/votes/revocations are stake-tree primitives that don't exist for SKA. Options:
+   - Hide the `Tx Type` chart for non-VAR coin selection.
+   - Show only `SentRtx` / `ReceivedRtx` series (reduce to a 2-series chart).
+   - Show all 5 with the stake series always-zero (current implicit behavior, just made explicit per coin).
+
+3. **What does `amountflow` look like for an address that holds both VAR and SKA?**
+   - "All coins" aggregated is meaningless (different scales).
+   - Default-to-VAR with a coin selector is the most direct port of the coin-supply pattern.
+   - Default-to-the-address's-primary-coin (whatever that means) requires a backend "primary coin" inference.
+
+4. **Should `?coin=` join the URL contract?** Mirroring `coin-supply/{N}` would put the coin in the path: `/api/address/{addr}/amountflow/{N}/{bin}`. Mirroring the existing flow bitmap pattern would put it in the query: `?coin=1`. The latter is cheaper (no router change) but breaks the precedent set by `apirouter.go:240-243`.
+
+5. **Where does the `balance` chart get its precision from?**
+   - The current JS-side accumulator (`balance += v`) on float64 is already lossy for very large VAR addresses (the `1e-8` `toCoin` already burned precision before JS). For SKA it's catastrophic.
+   - Options: server-side cumulative sum returned alongside `flow` (one extra column on the `amountflow` JSON), or client-side `BigInt`-based accumulator on the raw atom strings.
+
+6. **Should `data-address-balance` (`address.tmpl:15`) become per-coin?** Currently dead-but-wired to `ctrl.balance`. If multi-coin, a `data-address-balances='{"0":"...","1":"...","2":"..."}'` JSON-stringified attribute is one path; another is to drop the attribute and have the chart card read balances from a server-side payload.
+
+7. **Stale-`?zoom=` fix concurrent with multi-coin work?** The bugfix branch `bugfix/stale-zoom-param` and a multi-coin chart refactor will both touch `setGraphQuery` / `changeGraph` / `changeBin`. Decide order: a per-coin URL param will inevitably re-enter `setGraphQuery`, so it's natural to fix the stale-zoom invariant in the same pass (drop or `Zoom.project` `settings.zoom` on chart-kind change).
+
+8. **Does the chart card need an `ActiveSKATypes` projection?** The `Charts` page (`/charts`) does this from `HomeInfo.SKACoinSupply`. For an address, the more useful projection is "which coin types has *this address* ever held," which requires a new DB query (`SELECT DISTINCT coin_type FROM addresses WHERE address=$1`). Project-wide vs. per-address coin lists is a meaningful UX difference.
+
+9. **Should the Tx Type chart distinguish VAR-vs-SKA regular txs?** A 7-series chart (`SentRtx-VAR`, `ReceivedRtx-VAR`, `SentRtx-SKA`, `ReceivedRtx-SKA`, `Tickets`, `Votes`, `Revocations`) is one option. A coin-segmented dropdown is another. A per-coin-type version of the existing 5-series chart is a third.
+
+---
+
+### See also
+
+- `wiki/code-analysis/address/flow.compact.md` — TurboQuery URL ownership; stale-zoom failure mode summary.
+- `wiki/code-analysis/address/flow.full.md` — detailed per-layer breakdown that this note builds on.
+- `wiki/code-analysis/charts/flow.compact.md` and `flow.full.md` — `coin-supply/{N}` precedent for per-coin chart endpoints; SKA string-pipeline rules; `Zoom.project` pattern.
+- `wiki/core/constraints.md#C1` — numeric precision & bifurcation (currently violated on the chart card's `amountflow`/`balance` paths via `parseRowsSentReceived`'s `uint64` + `toCoin`).
+- `wiki/core/constraints.md#C7` — centralized coin-type label rendering (`renderCoinType`); currently *not* applied on this surface (`DCR`-string in `customizedFormatter` and ylabels).

--- a/wiki/code-analysis/address/summary.impact.md
+++ b/wiki/code-analysis/address/summary.impact.md
@@ -1,0 +1,277 @@
+# Address summary card — multi-coin mutation impact
+
+## TL;DR
+
+The summary card pulls from `dbtypes.AddressInfo`/`AddressBalance` (single `int64` totals, no coin-type dimension), runs every monetary value through `toFloat64Amount`/`amountAsDecimalParts` (i.e. `dcrutil.Amount.ToCoin()` — VAR-only) at `address.tmpl:15, 48, 64, 77`, and hard-codes the literal `DCR` string at `address.tmpl:48, 50, 64, 66, 77, 79`. The structural origin of the multi-coin gap is in the data layer: SQL `SelectAddressSpentUnspentCountAndValue` already groups by `coin_type` (`db/dcrpg/internal/addrstmts.go:220-232`), but `retrieveAddressBalance` (`queries.go:1484-1513`) and `ReduceAddressHistory` (`db/dbtypes/types.go:2380+`) flatten that dimension into a single `AddressBalance` — so balances from VAR (1e8 scale) and SKA (1e18 scale) are summed into one int64 today, which is silently nonsensical for any mixed address. The frontend exposes summary state via container `data-address-*` attrs at `address.tmpl:10-16` (one of which, `data-address-balance`, is currently set but unread by `address_controller.js`), and only `numUnconfirmed` and the table-region `txnCount` get live updates via `_confirmMempoolTxs`. SKA-aware helpers (`formatAtomsAsCoinString`, `skaDecimalParts`, `coinSymbol`) already exist and are used in `views/tx.tmpl` and `views/home_supply.tmpl` — those are the patterns to mirror. Five product decisions are blocking before a spec can specify structure: per-coin layout shape, row sort order, whether Received/Spent split per coin, fiat-without-SKA-price behavior, what "stake spending/income" means for non-VAR coins.
+
+## 1. Scope
+
+The "summary card" is the **left top card** in `cmd/dcrdata/views/address.tmpl`. The container that owns its data is `<div class="container main">` at line 10–16, which mounts both the `address` and `newblock` Stimulus controllers. The summary card itself is the column at line 21 (`<div class="col-24 col-xl-11 bg-white px-3 py-3 position-relative">`) and ends at line 112.
+
+DOM blocks inside that column, by sub-region:
+
+- **Address heading + clipboard + QR** — `address.tmpl:22-38` (`Address` label, `data-address-target="addr"` clipboard hash-box, QR icon and box targets).
+- **Type line** — `address.tmpl:39-41` (`{{.Type}}`).
+- **Three summary numbers (Balance / Received / Spent)** — `address.tmpl:42-86`.
+  - Balance — `address.tmpl:43-57` (number + fiat).
+  - Received — `address.tmpl:58-71` (number + outputs count).
+  - Spent — `address.tmpl:72-84` (number + inputs count).
+- **Unconfirmed / Stake spending / Stake income row** — `address.tmpl:87-103`.
+- **Dummy address notice** — `address.tmpl:107-111`.
+
+Out of scope: charts column (`address.tmpl:113-184`), transactions area (`address.tmpl:185-251`), `addressTable.tmpl`.
+
+The container `<div class="container main">` (lines 10–16) is **shared** with the table region — its `data-address-*` attributes (`offset`, `dcraddress`, `txn-count`, `balance`) are read by `address_controller.js` for both summary and table behavior, see Cross-surface dependencies (§6).
+
+## 2. Backend touch points
+
+### 2.1 Handler entry point
+
+`cmd/dcrdata/internal/explorer/explorerroutes.go:1534` — `AddressPage`.
+
+- Defines an inline payload struct `AddressPageData` at `explorerroutes.go:1538-1545` with fields `*CommonPageData`, `Data *dbtypes.AddressInfo`, `Type`, `CRLFDownload`, `FiatBalance *exchanges.Conversion`, `Pages`. The summary card reads `Data` and `FiatBalance`.
+- Calls `parseAddressParams` (`explorerroutes.go:1774`), then either short-circuits the dummy/zero address (`explorerroutes.go:1592-1602`, returns an `AddressInfo` with an empty `AddressBalance`) or calls `AddressListData` (`explorerroutes.go:1877`) which delegates to `dataSource.AddressData` (`explorerroutes.go:1881`).
+- Computes `FiatBalance` at `explorerroutes.go:1617`: `exp.xcBot.Conversion(dcrutil.Amount(addrData.Balance.TotalUnspent).ToCoin())` — passes a `float64` of "DCR coins" derived from `Balance.TotalUnspent`.
+- Renders via `templates.exec("address", pageData)` at `explorerroutes.go:1637`.
+
+The XHR sibling `AddressTable` (`explorerroutes.go:1654`) does **not** render the summary card, but it shares `parseAddressParams` and `AddressListData`, and it returns `tx_count = addrData.TxnCount + addrData.NumUnconfirmed` (line 1680). That value drives `paginationParams.count` in JS — see §6.
+
+### 2.2 Struct fields read by the summary card
+
+`db/dbtypes/types.go:2304-2346` — `AddressInfo`:
+
+- `.Address` — `address.tmpl:5,13,25` (page title, controller attr, displayed string).
+- `.Type` — `address.tmpl:40` (typed as `txhelpers.AddressType`, stringer used).
+- `.Offset` — `address.tmpl:12` (controller attr).
+- `.TxnCount` — combined with `.NumUnconfirmed` at `address.tmpl:8` into `$TxnCount`, then onto `data-address-txn-count` (line 14).
+- `.NumUnconfirmed` — `address.tmpl:8,88,90`.
+- `.IsDummyAddress` — `address.tmpl:108` (notice + suppresses table block at line 185).
+- `.Balance` — pointer to `AddressBalance`; the rest of the summary card lives in this sub-struct.
+
+`db/dbtypes/types.go:2350-2370` — `AddressBalance`:
+
+- `TotalUnspent int64` — Balance number (line 48), `data-address-balance` attr (line 15), fiat input (`explorerroutes.go:1617`).
+- `TotalSpent int64` — Spent number (line 77) and part of Received (line 63).
+- `NumSpent int64` — Spent inputs count (line 83) and part of Received outputs count (line 70).
+- `NumUnspent int64` — part of Received outputs count (line 70).
+- `FromStake float64` — Stake spending % (line 95) via `HasStakeOutputs()` gate (line 93).
+- `ToStake float64` — Stake income % (line 100) via `HasStakeInputs()` gate (line 98).
+- Methods `HasStakeOutputs` (line 2362) and `HasStakeInputs` (line 2368) used as gating conditions.
+
+### 2.3 DB query that fills `AddressBalance`
+
+`db/dcrpg/pgblockchain.go:2484` — `AddressData` invokes `AddressHistory` at line 2496, which produces `*AddressBalance` either through:
+
+- Shortcut path: `dbtypes.ReduceAddressHistory(addressRows)` at `pgblockchain.go:2445` + manual struct fill at `pgblockchain.go:2452-2460`.
+- Cache miss path: `pgb.AddressBalance(ctx, address)` at `pgblockchain.go:2468`, which delegates to `retrieveAddressBalance` (`db/dcrpg/queries.go:1453`), which runs SQL `SelectAddressSpentUnspentCountAndValue` (`db/dcrpg/internal/addrstmts.go:220`).
+
+**The SQL groups by `coin_type` (`addrstmts.go:222,230`), but `retrieveAddressBalance` discards that dimension** (`queries.go:1484-1513` — it sums `count` and `totalValue` into the single `balance.NumUnspent`/`balance.TotalUnspent`/etc. fields without keying by coin_type). Same flattening happens in `ReduceAddressHistory` (`db/dbtypes/types.go:2380` onwards): the function loops over `addrHist`, switches on `addrOut.CoinType` for VAR vs SKA but feeds them into a **single** `received`/`sent` running total (line 2392 calls `dcrutil.Amount(addrOut.Value).ToCoin()` regardless of coin type). This is the structural origin of the multi-coin gap — see §5.
+
+There is no per-coin balance map anywhere in the address pipeline. `dbtypes.AddressRow.CoinType` and `AddressRow.SKAValue` (referenced in `queries.go:1392, 1831, 2725, 2791`) carry the coin info into the rows, but it is dropped before reaching the summary card.
+
+### 2.4 `xcBot.Conversion` (FiatBalance)
+
+`exchanges/bot.go:1043-1058` — `(*ExchangeBot).Conversion(dcrVal float64) *Conversion` multiplies `xcState.Price * dcrVal` and returns `Conversion{Value, Index}`. Single price source. Today VAR-only — no SKA price model. Caller (`explorerroutes.go:1617`) passes `dcrutil.Amount(addrData.Balance.TotalUnspent).ToCoin()` — a single VAR-scale float.
+
+`exchanges/bot.go:1025-1029` — `Conversion struct { Value float64; Index string }`. Template reads `$.FiatBalance.Value` and `$.FiatBalance.Index` at `address.tmpl:55`.
+
+### 2.5 DataSource interface and mocks
+
+- Interface declaration: `cmd/dcrdata/internal/explorer/explorer.go:84-86`
+  - `AddressHistory(...) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)`
+  - `AddressData(...) (*dbtypes.AddressInfo, error)`
+  - `DevBalance(...) (*dbtypes.AddressBalance, error)`
+- Test mocks that must stay in sync:
+  - `cmd/dcrdata/internal/explorer/explorer_test.go:50-58` — `mockDataSource.AddressHistory`, `AddressData`, `DevBalance` (all return zero values).
+  - `cmd/dcrdata/internal/api/noop_ds_test.go:29-31` — `noopDS.AddressHistory` (different DataSource interface for the API layer; relevant if `AddressBalance` shape changes).
+
+Renaming or extending `AddressInfo`/`AddressBalance` requires updating both mocks plus the production type.
+
+## 3. Template touch points
+
+All paths are `cmd/dcrdata/views/address.tmpl`. `.Data` is `*dbtypes.AddressInfo`; under `with .Data`, `.Balance` is `*dbtypes.AddressBalance`; `$.FiatBalance` is the page-level `*exchanges.Conversion`.
+
+| Line | Reference                                                          | Helper(s) used                                | Notes                                                              |
+| ---- | ------------------------------------------------------------------ | --------------------------------------------- | ------------------------------------------------------------------ |
+| 5    | `.Data.Address`                                                    | —                                             | Page title via `headData`.                                         |
+| 8    | `.TxnCount`, `.NumUnconfirmed`                                     | `add`                                         | Derived `$TxnCount`.                                               |
+| 9    | `.TxnType`                                                         | —                                             | `$txType`.                                                         |
+| 12   | `.Offset`                                                          | —                                             | `data-address-offset`.                                             |
+| 13   | `.Address`                                                         | —                                             | `data-address-dcraddress`.                                         |
+| 14   | `$TxnCount`                                                        | —                                             | `data-address-txn-count`.                                          |
+| 15   | `.Balance.TotalUnspent`                                            | `toFloat64Amount`                             | `data-address-balance` — **VAR-only float**.                       |
+| 25   | `.Address`                                                         | `template "copyTextIcon"`                     | Visible address text.                                              |
+| 40   | `.Type`                                                            | —                                             | Stringer of `txhelpers.AddressType`.                               |
+| 47-48| `.Balance`, `.Balance.TotalUnspent`                                | `amountAsDecimalParts`, `template decimalParts` | **Hard-coded `DCR`** label at line 48.                             |
+| 50   | static "0" + "DCR"                                                 | —                                             | Empty-balance branch — **hard-coded `DCR`**.                       |
+| 54-55| `$.FiatBalance.Value`, `$.FiatBalance.Index`                       | `threeSigFigs`                                | Single fiat number.                                                |
+| 62-64| `.Balance.TotalSpent`, `.Balance.TotalUnspent`                     | `add`, `amountAsDecimalParts`                 | Received = spent + unspent. **Hard-coded `DCR`** at line 64.       |
+| 66   | static "0" + "DCR"                                                 | —                                             | Empty-balance branch.                                              |
+| 70   | `.Balance.NumSpent`, `.Balance.NumUnspent`                         | `add`, `intComma`                             | "outputs" count.                                                   |
+| 76-77| `.Balance.TotalSpent`                                              | `amountAsDecimalParts`, `template decimalParts` | **Hard-coded `DCR`** at line 77.                                   |
+| 79   | static "0" + "DCR"                                                 | —                                             | Empty-balance branch.                                              |
+| 83   | `.Balance.NumSpent`                                                | `intComma`                                    | "inputs" count.                                                    |
+| 88-90| `.NumUnconfirmed`                                                  | `ne`                                          | Conditional row + raw count.                                       |
+| 93-95| `.Balance.HasStakeOutputs`, `.Balance.FromStake`                   | `printf "%.1f"`, `x100`                       | Stake spending %.                                                  |
+| 98-100| `.Balance.HasStakeInputs`, `.Balance.ToStake`                     | `printf "%.1f"`, `x100`                       | Stake income %.                                                    |
+| 108  | `.IsDummyAddress`                                                  | —                                             | Notice text.                                                       |
+
+Helpers, with their definitions in `cmd/dcrdata/internal/explorer/templates.go`:
+
+- `amountAsDecimalParts` (line 652) — `dcrutil.Amount(v).ToCoin()` then `float64Formatting`. **VAR-only by construction.**
+- `toFloat64Amount` (line 655) — `dcrutil.Amount(intAmount).ToCoin()`. **VAR-only.**
+- `intComma` (line 637) — `humanize.Comma(toInt64(v))`. Coin-agnostic (counts).
+- `x100` (line 630) — float multiply. Coin-agnostic.
+- `threeSigFigs` (line 339) — formats the fiat float. Coin-agnostic but operates on the lossy fiat product.
+- `add` (line 576) — int64 sum.
+- `template "decimalParts"` — `views/extras.tmpl:176-188`, layout-only (no math).
+
+Helpers **available but unused** on this surface (already SKA-aware, declared in `templates.go`): `formatCoinAtoms` (line 661), `formatAtomsAsCoinString` (line 662), `skaDecimalParts` / `skaDecimalPartsNoTrailing` (lines 663, 666), `coinSymbol` (line 899). Multi-coin work for the summary card will route through these. Reference for the established pattern: `views/tx.tmpl:60, 101, 500, 573` shows the `{{if eq .CoinType 0}}…{{else}}…{{end}}` + `{{coinSymbol .CoinType}}` idiom that this card needs to follow.
+
+## 4. Frontend touch points
+
+All paths are `cmd/dcrdata/public/js/controllers/address_controller.js` unless noted.
+
+### 4.1 Stimulus targets within the summary card
+
+Declared in the `targets` getter (lines 153–192):
+
+- `addr` — line 156 declaration; consumed indirectly via `clipboard` controller (the `.clipboard` class triggers a separate controller; not used for state inside `address` itself).
+- `qricon` — line 165, manipulated in `showQRCode`/`hideQRCode` (lines 308, 312).
+- `qrbox` — line 167, toggled in `showQRCode`/`hideQRCode` (lines 294, 313).
+- `qrimg` — line 166, populated with `<img src="${qrCodeImg}"/>` in `showQRCode` (line 304); opacity reset in `hideQRCode` (line 314).
+- `numUnconfirmed` — line 161, mutated in `_confirmMempoolTxs` (lines 791-802) when a mempool tx confirms.
+
+Other targets in §1's container that the summary card does **not** own but coexists with: `txnCount` (line 164, declared on the table region at `address.tmpl:192`), `fullscreen`, `bigchart`, `littlechart`, `chartbox`, `expando`, etc.
+
+### 4.2 Container data attributes consumed by JS
+
+Declared on `address.tmpl:10-16`:
+
+- `data-address-offset` — read at `address_controller.js:227` (`paginationParams.offset`).
+- `data-address-dcraddress` — read at line 225 (`ctrl.dcrAddress`); also consumed by `showQRCode` (line 299) and URL builders for the table fetch (lines 321, 364, 447).
+- `data-address-txn-count` — read at line 228 (`paginationParams.count`).
+- `data-address-balance` — read at line 230 (`ctrl.balance`). **Currently set but never used elsewhere in the controller** (no further reference). Live-inert (would be silently inert if the value were SKA atoms today).
+
+### 4.3 Actions wired to the summary card
+
+- `data-action="click->address#showQRCode"` — `address.tmpl:28` → `showQRCode` (line 293). Lazy-imports `qrcode`, paints `qrimgTarget`, hides `qriconTarget`. Also calls `this.graph.resize()` (line 306) — implicit dependency on the chart column.
+- `data-action="click->address#hideQRCode"` — `address.tmpl:33` → `hideQRCode` (line 311). Symmetric reverse, also calls `this.graph.resize()`.
+
+There are **no actions** on Balance/Received/Spent/Stake-percent values — they are static after server render.
+
+### 4.4 Live updates (`newblock` controller and BLOCK_RECEIVED)
+
+- The container mounts both controllers: `data-controller="address newblock"` (`address.tmpl:11`).
+- The `newblock` controller (`public/js/controllers/newblock_controller.js`) only operates on elements with `data-newblock-target="confirmations"`. The summary card has **no** such target — so `newblock` does not touch this surface directly.
+- The `address` controller listens to `BLOCK_RECEIVED` via `globalEventBus.on('BLOCK_RECEIVED', this.confirmMempoolTxs)` at line 285. `_confirmMempoolTxs` (line 774) is the **only** path that updates summary-card DOM live:
+  - Line 788-790: increments `data-address-target="txnCount"` (table region, line 192) and re-renders its text. Note this also re-renders `$TxnCount` semantics, but only in that span — the container's `data-address-txn-count` attr is **not** updated.
+  - Line 791-802: walks `numUnconfirmed` targets, decrements the count, and hides the row when it reaches 0.
+- **Balance / Received / Spent / Stake % / FiatBalance are never updated live.** They reflect the state at SSR time and only change on a hard reload.
+
+## 5. Multi-coin gaps (most important)
+
+### 5.1 Balance number (`Balance.TotalUnspent`)
+
+- `address.tmpl:15` — `data-address-balance="{{toFloat64Amount .Balance.TotalUnspent}}"` — runs through `dcrutil.Amount.ToCoin()`. Lossy for SKA; nonsensical when the address holds both VAR and SKA atoms summed into one int64.
+- `address.tmpl:48` — `{{template "decimalParts" (amountAsDecimalParts .Balance.TotalUnspent true)}}<span ...>DCR</span>` — same lossy float64 path; **hard-coded `DCR`** label.
+- `address.tmpl:50` — empty-branch `<span ...>DCR</span>` — hard-coded label.
+- Backend cause: `db/dbtypes/types.go:2350` — `AddressBalance.TotalUnspent` is single `int64`, not a per-coin map. Filled by:
+  - `db/dcrpg/queries.go:1488-1497` — `retrieveAddressBalance` reads `coin_type` from the SQL row but discards it before summation.
+  - `db/dbtypes/types.go:2406-2407` — `ReduceAddressHistory` takes the `IsFunding && CoinType == 0` branch but still feeds `received += int64(addrOut.Value)` without segregating by coin type.
+
+### 5.2 Received (`Balance.TotalSpent + Balance.TotalUnspent`)
+
+- `address.tmpl:63-64` — `{{$received := add .Balance.TotalSpent .Balance.TotalUnspent}}` then `amountAsDecimalParts $received true` plus hard-coded `DCR`.
+- `address.tmpl:66` — empty branch hard-coded `DCR`.
+- Same root cause as 5.1: both summands are coin-agnostic int64 sums.
+- Outputs count line `address.tmpl:70` (`.Balance.NumSpent + .Balance.NumUnspent`) is coin-agnostic (counts only) — no fix needed for precision, but a multi-coin spec must decide whether the count should be per-coin too (cosmetic decision; see §7).
+
+### 5.3 Spent (`Balance.TotalSpent`)
+
+- `address.tmpl:77` — `amountAsDecimalParts .Balance.TotalSpent true` + hard-coded `DCR`.
+- `address.tmpl:79` — empty branch hard-coded `DCR`.
+- `address.tmpl:83` — `intComma .Balance.NumSpent` (count, coin-agnostic).
+- Same root cause as 5.1.
+
+### 5.4 Fiat balance
+
+- `address.tmpl:54-56` — guarded by `if $.FiatBalance`. Renders `$.FiatBalance.Value` (float64).
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:1617` — `exp.xcBot.Conversion(dcrutil.Amount(addrData.Balance.TotalUnspent).ToCoin())` — feeds the same single-coin VAR-scaled float into the conversion.
+- `exchanges/bot.go:1043-1058` — `Conversion(dcrVal float64)` is hard-wired to the single price feed (`xcState.Price`); no concept of coin-type-specific rates.
+- Multi-coin gap: there is no SKA price feed model anywhere in the bot, and the `Conversion` API takes a single float. A multi-coin fiat display requires structural changes upstream (decision needed — see §7).
+
+### 5.5 Unconfirmed count
+
+- `address.tmpl:88-91` — `if ne .NumUnconfirmed 0` and `<span class="addr-unconfirmed-count">{{.NumUnconfirmed}}</span>`.
+- Backend: `db/dcrpg/pgblockchain.go:2587-2592` — `pgb.mp.UnconfirmedTxnsForAddress(address)` returns `numUnconfirmed int64`. **No coin-type segregation** — it counts unconfirmed mempool entries against the address regardless of coin.
+- Frontend: `address_controller.js:791-802` decrements that single count when a mempool tx confirms.
+- Gap is cosmetic-only: the count itself is correct (a count is coin-agnostic), but if the spec wants per-coin breakdown, this needs a new mempool API and a new controller path.
+
+### 5.6 Stake spending / Stake income (`FromStake`, `ToStake`)
+
+- `address.tmpl:93-95` — `if .Balance.HasStakeOutputs` and `printf "%.1f" (x100 .Balance.FromStake)`.
+- `address.tmpl:98-100` — symmetric for `HasStakeInputs` / `ToStake`.
+- Backend root cause: `db/dbtypes/types.go:2356-2357` — `FromStake`/`ToStake` are float64 fractions computed in `db/dcrpg/queries.go:1518-1524` as `fromStake / totalTransfer` and `toStake / TotalSpent`, using the same coin-flattened sums (`fromStake` is accumulated at `queries.go:1511` from rows of all coin types). For an address with mixed VAR + SKA activity the ratio is meaningless because the numerator and denominator are atom sums on different decimal scales.
+- There is also a deeper conceptual gap: "stake" in dcrdata's sense was tied to the original Decred consensus stake mechanism. The Monetarium multi-coin model does not use stake outputs the same way for SKA coin types. A spec decision is needed (see §7) before this row even has a defined meaning for non-VAR coins.
+
+### 5.7 Address type line
+
+- `address.tmpl:40` — `{{.Type}}` is `txhelpers.AddressType`. Independent of coin type.
+- No multi-coin gap; informational only.
+
+### 5.8 Helpers that should replace single-coin helpers
+
+For each VAR-only helper used today, the multi-coin replacement already exists in `cmd/dcrdata/internal/explorer/templates.go`:
+
+| Today (VAR-only)                                        | Multi-coin replacement                                                                | Pattern reference        |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------ |
+| `amountAsDecimalParts` (line 652)                       | `formatAtomsAsCoinString` (line 662) or `skaDecimalParts` (line 663) for SKA branches | `views/tx.tmpl:60`       |
+| `toFloat64Amount` (line 655)                            | `varAtomsToFloat64` (line 658) for VAR-only data; for SKA, no float bridge — pass atom strings | `views/home_supply.tmpl:14` |
+| Hard-coded `DCR` text                                   | `{{coinSymbol .CoinType}}` (line 899)                                                 | `views/tx.tmpl:60, 101`  |
+
+## 6. Cross-surface dependencies
+
+- **Container element shared with table.** `<div class="container main">` at `address.tmpl:10-16` carries summary-card state (`data-address-balance`) **and** table state (`data-address-offset`, `data-address-txn-count`, `data-address-dcraddress`). Renaming any of these attrs requires updating both regions and `address_controller.js:225-230`.
+- **`$TxnCount` derivation crosses surfaces.** Defined at `address.tmpl:8` from `.TxnCount + .NumUnconfirmed`, used at line 14 (container attr — summary input), line 149 (chart `data-txcount`), line 192 (table header span — `data-address-target="txnCount"` + `data-txn-count`), and lines 196, 208, 245 (pagination gating). The same value is also returned over the wire as `tx_count` from the `/addresstable` XHR (`explorerroutes.go:1680`) and overwrites `paginationParams.count` (`address_controller.js:370`). Any change in how unconfirmed count is computed (e.g. per-coin) propagates into all three regions.
+- **`numUnconfirmed` drives both summary text and table-row decoration.** `_confirmMempoolTxs` (`address_controller.js:774-806`) walks ALL `numUnconfirmed` targets — currently only the summary-card row at `address.tmpl:89` is annotated, but the controller iterates `numUnconfirmedTargets` as if multiple rows existed. If a multi-coin design adds per-coin unconfirmed rows, each one needs the same target name and `data-count` attribute for the existing controller logic to work.
+- **`txnCount` cross-write.** `_confirmMempoolTxs` (`address_controller.js:788-790`) increments `txnCountTarget.dataset.txnCount` (table region) on confirmation. The summary card's container attr `data-address-txn-count` is **not** updated to match. This mismatch is invisible today because nothing in `address_controller.js` re-reads `data-address-txn-count` after `connect()`. A spec that adds live updates to summary numbers may want to fix this asymmetry.
+- **FiatBalance shares state with home page market data, not address state.** `xcBot` is a singleton; if a future per-coin price feed lands, it will affect every page that displays a fiat conversion (home, mempool, tx, address). Out of scope for this card but worth flagging.
+- **Dummy address branch suppresses the table** but **not** the summary card (`address.tmpl:185` gates the table). Any reorganization of `AddressInfo`/`AddressBalance` for multi-coin must keep the dummy short-circuit at `explorerroutes.go:1592-1602` producing a renderable empty `Balance`, otherwise the summary card crashes the template.
+
+## 7. Open product/UX questions
+
+These cannot be decided from code alone. Each blocks a structural decision.
+
+1. **Per-coin balances on a single address.** A Monetarium address can receive VAR and any number of SKA{n} outputs (chain invariant: tx is single-coin, but an address sees txs of many coin types). Does the summary card show:
+   - a list/expandable of one row per coin type held (like `views/home_supply.tmpl:29-39`), or
+   - a single "default" coin (VAR) with a tab/dropdown for SKA{n}, or
+   - only coins with non-zero balance?
+2. **Default sort/order of coin rows.** VAR first, then `SKA1..SKA255` ascending? Sort by balance descending? Hide zero balances?
+3. **Received / Spent semantics in the multi-coin world.** Both are aggregates today. With per-coin display: does each coin row carry its own Received and Spent, or only Balance, with Received/Spent collapsed into a transactions count? Note that the outputs-count and inputs-count lines (`address.tmpl:70, 83`) are coin-agnostic counts — keep them shared, or split per coin?
+4. **Fiat balance with no SKA price feed.** `xcBot.Conversion` only knows the VAR price. For an address with only SKA holdings: hide the fiat row, show "—", or show a "VAR equivalent only" line? Same question once SKA price feeds eventually exist: do we sum across coins for a single fiat number, or list per coin?
+5. **Stake spending / Stake income for non-VAR coins.** SKA coins do not participate in the Decred-style stake mechanism the way VAR does. Possible answers: (a) only show these rows when VAR activity exists; (b) drop the rows entirely from the multi-coin design; (c) redefine the metric per coin if SKA acquires its own stake-like flow. Backend currently produces a single ratio across all coin types — meaningless until this is decided.
+6. **Unconfirmed count: aggregate or per-coin?** Mempool count is one int64 today. UX call: show "Unconfirmed: 3" total, or "Unconfirmed: 1 VAR, 2 SKA1"? Affects mempool API shape.
+7. **Address type line vs coin type.** `txhelpers.AddressType` is independent of coin type. Confirm the type line stays a single value (it should — it's a property of the address script, not its holdings).
+8. **`data-address-balance` semantics.** Currently set but unused by JS. Drop it, or reuse it as a JSON-serialized per-coin map for future client behavior (e.g. live updates)? Decision affects whether we treat that attribute as a public contract or remove it.
+9. **Live updates.** Today only `numUnconfirmed` and the table-region `txnCount` update on `BLOCK_RECEIVED`. Should Balance/Received/Spent also update live as new mempool txs touch the address? If yes, this is a much bigger change (websocket payload + per-coin BigInt math on the JS side per constraint C1).
+10. **Empty-state coin labels.** Today the empty branches at `address.tmpl:50, 66, 79` hard-code `DCR`. Even if the address has zero activity, do we still want one row per known coin type, or just a single "No activity" line? Affects whether SSR has to know about coin types up front.
+
+## Evidence index
+
+- Template: `cmd/dcrdata/views/address.tmpl:1-112`.
+- Page handler: `cmd/dcrdata/internal/explorer/explorerroutes.go:1534-1651`; payload struct at 1538-1545; FiatBalance at 1617; dummy branch at 1592-1602.
+- Shared params: `cmd/dcrdata/internal/explorer/explorerroutes.go:1774-1789`.
+- DB AddressData / AddressHistory / balance flatten: `db/dcrpg/pgblockchain.go:2484-2592`, `2382-2480`; SQL: `db/dcrpg/internal/addrstmts.go:220-232`; balance aggregation drop: `db/dcrpg/queries.go:1453-1529`.
+- Types: `db/dbtypes/types.go:2304-2370`; `ReduceAddressHistory` at 2380.
+- Helpers: `cmd/dcrdata/internal/explorer/templates.go:31-38` (`coinSymbol`), 297-378 (`amountAsDecimalParts*`, `threeSigFigs`), 380-488 (SKA helpers), 561-708 (FuncMap registrations), 899-901.
+- FiatBalance source: `exchanges/bot.go:1025-1058`.
+- Frontend: `cmd/dcrdata/public/js/controllers/address_controller.js:153-192` (targets), 194-254 (connect / data-attr reads at 225-230), 285 (BLOCK_RECEIVED bind), 293-317 (QR), 774-806 (`_confirmMempoolTxs`).
+- newblock controller (no summary-card touch): `cmd/dcrdata/public/js/controllers/newblock_controller.js`.
+- Mocks: `cmd/dcrdata/internal/explorer/explorer_test.go:50-58`, `cmd/dcrdata/internal/api/noop_ds_test.go:29-31`.
+
+See also:
+
+- `wiki/code-analysis/address/flow.compact.md`, `wiki/code-analysis/address/flow.full.md` — the broader page flow this card is one piece of.
+- `wiki/core/constraints.md` C1 (precision), C3 (template + websocket parity — relevant if live summary updates are added), C7 (centralized coin-type label rendering — `coinSymbol` / `renderCoinType`).
+- `views/tx.tmpl:60, 101, 500, 573` — established multi-coin display pattern (`{{if eq .CoinType 0}}…{{else}}…{{end}}` + `coinSymbol`) to mirror in the summary card.

--- a/wiki/code-analysis/address/transactions.impact.md
+++ b/wiki/code-analysis/address/transactions.impact.md
@@ -1,0 +1,336 @@
+# Address page — transactions table — mutation impact
+
+Scope of this note: the bottom section of `/address/{address}` (header range / pagination, the `addressTable` rendering, merged-view footnote, numbered pagination, CSV download link, type & page-size selects) plus the `/addresstable/{address}` XHR refresh path. Summary card and charts card are explicitly out of scope.
+
+## 1. Scope
+
+### Server-rendered ranges
+
+- **`cmd/dcrdata/views/address.tmpl`** — the entire transactions block.
+  - `cmd/dcrdata/views/address.tmpl:185` — `{{if not .IsDummyAddress}}` — surface gate. Dummy addresses skip this section entirely.
+  - `cmd/dcrdata/views/address.tmpl:186` — `data-address-target="listbox"` wrapper.
+  - `cmd/dcrdata/views/address.tmpl:188` — `<h4>Transactions</h4>`.
+  - `cmd/dcrdata/views/address.tmpl:189-219` — `paginationheader`: range string + Previous/Next nav.
+    - `:190-193` — `range` text, including `txnCount` span (`data-txn-count="{{$TxnCount}}"`).
+    - `:194-218` — `pagebuttons` nav with `pageminus`/`pageplus` `<li>` items.
+  - `cmd/dcrdata/views/address.tmpl:221-226` — `listLoader` + `table` target wrapping `{{template "addressTable" .}}` (server-side initial render).
+  - `cmd/dcrdata/views/address.tmpl:227-229` — `mergedMsg` footnote ("*No unconfirmed transactions shown in merged views.").
+  - `cmd/dcrdata/views/address.tmpl:230-250` — `tablePagination` (numbered pagination + arrow links).
+  - `cmd/dcrdata/views/address.tmpl:251-296` — bottom row: CSV download button (252-254), `txntype` select (258-273), `pagesize` select (274-294).
+  - `cmd/dcrdata/views/address.tmpl:298` — closes `{{- end}}{{/* if not .IsDummyAddress */}}`.
+
+### Table template + XHR shell
+
+- **`cmd/dcrdata/views/extras.tmpl:210-315`** — `{{define "addressTable"}}` … `{{end}}` — the column layouts per `txntype`. Headers at 213-243, rows at 244-303, empty-state table at 306-313.
+- **`cmd/dcrdata/views/addresstable.tmpl:1-3`** — thin `{{define "addresstable"}}` wrapper that calls `{{template "addressTable" .Data}}`. Used by the XHR handler so the server returns just the inner `<table>`.
+
+## 2. Backend touch points
+
+### Routes (chi)
+
+- `cmd/dcrdata/main.go:768` — `GET /address/{address}` → `explore.AddressPage` (initial HTML).
+- `cmd/dcrdata/main.go:769` — `GET /addresstable/{address}` → `explore.AddressTable` (XHR JSON-wrapping HTML fragment).
+- `cmd/dcrdata/internal/api/apirouter.go:319-320` — `GET /download/address/io/{address}[/win]` → `app.addressIoCsvNoCR` / `app.addressIoCsvCR` (CSV).
+
+Both `/address` and `/addresstable` go through `explorer.AddressPathCtx` (middleware shared with the page itself).
+
+### Handlers
+
+- **`cmd/dcrdata/internal/explorer/explorerroutes.go:1534-1651`** — `AddressPage`. Inline `AddressPageData{*CommonPageData, Data: *dbtypes.AddressInfo, Type, CRLFDownload, FiatBalance, Pages}` at 1538-1545. Calls `parseAddressParams` (1548) → `AddressListData` (1604) → `xcBot.Conversion` (1617) → `calcPages` (1635) → `templates.exec("address", pageData)` (1637).
+- **`cmd/dcrdata/internal/explorer/explorerroutes.go:1654-1706`** — `AddressTable` (XHR refresh). Calls `parseAddressParams` (1658) → `AddressListData` (1665) → `calcPages` (1681) → `templates.exec("addresstable", { Data: addrData })` (1684). Returns JSON `{ tx_count: int64, html: string, pages: []pageNumber }` (1675-1682).
+- **`cmd/dcrdata/internal/explorer/explorerroutes.go:1772-1873`** — `parseAddressParams` (1774), `parsePaginationParams` (1832). Recognised query keys: `n`, `start`, `txntype`. Defaults: `n = defaultAddressRows = 20`, `start = 0`, `txntype = "all"`. Hard cap at `MaxAddressRows = 160` (`explorer.go:65`). Unknown `txntype` → `dbtypes.AddrTxnUnknown` → 400 from `AddressTable`, error page from `AddressPage`.
+- **`cmd/dcrdata/internal/explorer/explorerroutes.go:1875-1891`** — `AddressListData`. Pure pass-through to `dataSource.AddressData`.
+- **`cmd/dcrdata/internal/explorer/explorerroutes.go:2574-2587, 2646+`** — `pageNumber{Active, Link, Str}` and `calcPages(rows, pageSize, offset, link)`. `link` is a `fmt.Sprintf` template like `/address/{addr}?start=%d&n=20&txntype=all`.
+- **`cmd/dcrdata/internal/api/apiroutes.go:1682-1687, 1689-1775`** — `addressIoCsvNoCR` / `addressIoCsvCR` → `addressIoCsv(crlf, …)`. Streams CSV from `c.DataSource.AddressRowsCompact(ctx, address)`.
+
+### DB layer
+
+- **`db/dcrpg/pgblockchain.go:2484-2716`** — `(*ChainDB).AddressData`. Pulls confirmed history (`AddressHistory` 2496), generates skeleton via `dbtypes.ReduceAddressHistory` (2522), counts rows for the chosen view (merged → `mergedTxnCount` 2549; non-merged → from `balance.NumSpent`/`NumUnspent` 2556-2567), back-fills metadata via `FillAddressTransactions` (2577), then overlays unconfirmed txs from `pgb.mp.UnconfirmedTxnsForAddress` (2587). Mempool overlay is skipped for merged views (2602, 2646).
+- **`db/dcrpg/pgblockchain.go:2382-2481`** — `AddressHistory`. Cache-first; falls back to `updateAddressRows` + `dbtypes.SliceAddressRows`.
+- **`db/dcrpg/pgblockchain.go:2300-2331`** — `retrieveMergedTxnCount` and `mergedTxnCount` (cache-aware count for `merged` / `merged_credit` / `merged_debit`).
+- **`db/dcrpg/pgblockchain.go:2746-2804`** — `FillAddressTransactions`. Fills `Size`, `FormattedSize`, `Total`, `Time`, `Confirmations`, and (for matched txns) `MatchedTxIndex`.
+- **`db/dcrpg/pgblockchain.go:2259-2298`** — `AddressRowsCompact`. CSV download source; returns `[]*dbtypes.AddressRowCompact`.
+
+### Mocks
+
+- `cmd/dcrdata/internal/api/noop_ds_test.go:29` — `(noopDS).AddressHistory` (only `AddressHistory`, not `AddressData`).
+- `cmd/dcrdata/internal/explorer/explorer_test.go:53` — `(*mockDataSource).AddressData(ctx, address, N, offset, txnType) (*dbtypes.AddressInfo, error)` — must match the interface in `explorer.go:85`.
+
+### Types referenced by the table
+
+- **`db/dbtypes/types.go:2235-2254`** — `AddressTx`. Fields actually rendered in `addressTable`:
+  - `TxID` (`ChainHash`) — column 2 hash.
+  - `TxType` (`string`) — column 1.
+  - `InOutID` (`uint32`) — used by `Link()` for merged views (`/tx/{hash}/in|out/{idx}`).
+  - `FormattedSize` (`string`) — last column.
+  - `ReceivedTotal` (**`float64`** — VAR coins via `dcrutil.Amount.ToCoin()`).
+  - `SentTotal` (**`float64`** — same path).
+  - `IsFunding` (`bool`) — controls credit/debit cell layout in `merged` and `all`.
+  - `MatchedTx` (`*ChainHash`), `MatchedTxIndex` (`uint32`) — drive "spent" vs "unspent" / "source" vs "N/A" links.
+  - `MergedTxnCount` (`uint64`) — count cell in merged views.
+  - `BlockHeight` (`uint32`), `Confirmations` (`uint64`), `Time` (`TimeDef`) — last three columns.
+  - `CoinType` (`uint8`), `SKAValue` (`string`) — **populated by `dbtypes.ReduceAddressHistory:2412-2414, 2425-2427` but never read by any template today**.
+- **`db/dbtypes/types.go:2303-2346`** — `AddressInfo`. Container for the table; the template reads `.Transactions`, `.TxnType`, `.IsMerged`, `.NumTransactions`, `.TxnCount`, `.NumUnconfirmed`, `.Offset`, `.Limit`, `.Path`, `.Address`, `.IsDummyAddress`.
+- **`db/dbtypes/types.go:2380-2455`** — `ReduceAddressHistory`. The single funnel where atom values become `float64`. **Critical: the SKA branches (`addrOut.CoinType != 0`) leave `tx.ReceivedTotal` / `tx.SentTotal` at their zero value (`0.0`)** — they only stash the atoms-as-string in `tx.SKAValue`. The current template renders the float, which is `0`.
+
+### What `ReceivedTotal` / `SentTotal` actually are
+
+Today: **`float64` representing VAR coins**, computed via `dcrutil.Amount(addrOut.Value).ToCoin()` at `db/dbtypes/types.go:2392, 2408, 2421` and the mempool overlay at `db/dcrpg/pgblockchain.go:2633, 2695`. They are not coin-type-aware — for any `addrOut.CoinType != 0` row they are silently zero, and the template prints `0` in the Credit/Debit column.
+
+## 3. Per-`txntype` column layout
+
+Reference: `cmd/dcrdata/views/extras.tmpl:215-302`. Columns common to all views (in order): **Tx Type** (`{{.TxType}}`), **Input/Output ID** (`hashElide` of `{{.TxID}}`/`Link()`), then 1-3 amount/count columns (varies), then **Time (UTC)** (`{{.Time.DatetimeWithoutTZ}}` or "Unconfirmed"), **Age** (Stimulus `time` controller), **Confirms** (live-updated by `newblock`), **Size** (`{{.FormattedSize}}`).
+
+| `txntype`         | Variable columns (in order)                                                                                 | Driven by                                                             | Notes                                                                                                                         |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `all`             | Credit VAR / Debit VAR                                                                                      | `IsFunding` chooses which cell shows: `ReceivedTotal` or `SentTotal`. | Funding row → credit cell + (matched) "spent"/"unspent" link in debit cell (`extras.tmpl:266-275`). Non-funding → mirror image (`:276-285`). |
+| `unspent`         | Credit VAR (single column)                                                                                  | `ReceivedTotal`                                                       | Header literal `Credit VAR` (`:233`). Cell `:264-265`.                                                                        |
+| `credit`          | Credit VAR / (spent-link)                                                                                   | `ReceivedTotal` + `MatchedTx`                                         | Same as `all` funding branch (`:266-275`).                                                                                    |
+| `debit`           | (source-link / "N/A" / "sstxcommitment") / Debit VAR                                                        | `SentTotal == 0` → "sstxcommitment" cell (`:277-278`); `MatchedTx` → "source" link; otherwise "N/A". | `:276-285`.                                                                                                                   |
+| `merged`          | I/O Count / Credit VAR / Debit VAR                                                                          | `MergedTxnCount`; then `IsFunding` decides which side shows the amount, the other is `&mdash;` | `:228-231`, `:255-263`.                                                                                                       |
+| `merged_credit`   | Outputs (count) / Credit VAR                                                                                | `MergedTxnCount`, `ReceivedTotal`                                     | `:223-227`, `:252-254`.                                                                                                       |
+| `merged_debit`    | Inputs (count) / Debit VAR                                                                                  | `MergedTxnCount`, `SentTotal`                                         | `:218-222`, `:249-251`.                                                                                                       |
+
+Empty state (no transactions for this filter): `extras.tmpl:306-313` renders a single-cell table with `No "{{$txType}}" transactions found for this address.`
+
+`IsFunding` semantics — set in `dbtypes.ReduceAddressHistory:2400` from `addrOut.IsFunding`. For unconfirmed entries, the mempool overlay sets `IsFunding: true` for outpoints (`pgblockchain.go:2634`) and leaves it `false` for spending entries (`:2688-2698`).
+
+`MatchedTx` is `nil` for credit rows whose UTXO is still unspent. Rendering relies on `{{- if .MatchedTx}}` — `*ChainHash` so a nil pointer renders `<no value>` if used directly, but the template only uses `.MatchedTx` inside an `if`. The link path is `/tx/{hash}/in|out/{matchedTxIndex}` (`:269` for credit-side; `:280` for debit-side).
+
+## 4. Template touch points
+
+### Fields referenced under `addressTable` (`extras.tmpl:210-315`)
+
+`.TxnType`, `.Transactions`, and per-row: `.Confirmations`, `.TxID`, `.Link` (method, line 2258), `.TxType`, `.MergedTxnCount`, `.SentTotal`, `.ReceivedTotal`, `.IsFunding`, `.MatchedTx`, `.MatchedTxIndex`, `.Time.DatetimeWithoutTZ`, `.Time.T.Unix`, `.Time.UNIX`, `.BlockHeight`, `.FormattedSize`. None of these read `.CoinType` or `.SKAValue`.
+
+### Fields referenced under the `address.tmpl` table block (`:185-298`)
+
+`.IsDummyAddress`, `.Offset`, `.NumTransactions`, `.TxnCount` (calculated as `add .TxnCount .NumUnconfirmed` at line 8), `.NumUnconfirmed`, `.Limit`, `.Path`, `.Address`, `.IsMerged`, `.TxnType`, `.Transactions` (only `len`, for selecting the `pagesize` `<option>` at line 284), `$.Pages`, `$.CRLFDownload`.
+
+### Helper functions used in this surface
+
+- `add`, `subtract` (`templates.go` arithmetic helpers) — pagination math.
+- `intComma` (`templates.go:637-642`) — `range`, `txnCount`.
+- `hashlink` (`templates.go:826`), `hashElide` template (`extras.tmpl:198`), `hashStart` / `hashEnd` (`templates.go:836, 851`) — TxID rendering.
+- **`float64AsDecimalParts` (`templates.go:650`)** — used at `extras.tmpl:251, 254, 258, 262, 265, 267, 284`. Wraps `float64Formatting`. Always called with `8` decimal places (the VAR scale).
+- `decimalParts` template (`extras.tmpl:176-188`) — renders the `[]string` produced by `float64AsDecimalParts` / `amountAsDecimalParts`.
+
+### Hard-coded coin labels
+
+- **`Credit VAR`** literals: `extras.tmpl:222, 227, 230, 233, 235`.
+- **`Debit VAR`** literals: `extras.tmpl:222 (also "Debit VAR"), 231, 236` — actually four occurrences total: lines `222, 231, 236` plus the merged-debit header on `222` is "Debit VAR".
+
+These are uppercase already (the surrounding `address.tmpl` summary card still says `DCR` — see `address.tmpl:48, 50, 64, 66, 77, 79`). The table headers were renamed to `VAR` ahead of the multi-coin work; they remain inline string literals, in violation of constraint **C7** (centralised coin-type label rendering).
+
+## 5. Frontend touch points (URL contract + XHR refresh)
+
+### Stimulus controller
+
+`cmd/dcrdata/public/js/controllers/address_controller.js`. The transactions surface is co-mounted with `newblock` (`address.tmpl:11` — `data-controller="address newblock"`).
+
+### Targets used by this surface (declared at `:153-192`)
+
+- Input wiring: `txntype` (272), `pagesize` (279), `paginator` (204, 213), `pageminus` (200), `pageplus` (209).
+- Display wiring: `range` (190), `txnCount` (192), `paginationheader` (189), `pagebuttons` (197), `tablePagination` (230), `mergedMsg` (227), `listLoader` (222), `table` (223), `pending` (per-row, `extras.tmpl:246`), `numUnconfirmed` (`address.tmpl:89` — also referenced from the summary card).
+
+### Actions (Stimulus)
+
+- `change->address#changeTxType` (`address.tmpl:262`) → `:329` `fetchTable(this.txnType, this.pageSize, 0)`.
+- `change->address#changePageSize` (`:280`) → `:325` `fetchTable(this.txnType, this.pageSize, this.paginationParams.offset)`.
+- `address#prevPage` / `address#nextPage` (`:205, :214`) → `:333, :337` → `toPage(±1)` → `fetchTable`.
+- `click->address#pageNumberLink` (`:233, :241, :247`) → `:341` parses the anchor's `href` for `start`, `n`, `txntype` and calls `fetchTable`.
+- `mouseover->address#hashOver mouseout->address#hashOut` (`extras.tmpl:271, 280`) → `:808, :820` highlight the matching link in the same row.
+
+### URL query keys
+
+`address_controller.js:211-219` declares the persisted set: `chart`, `zoom`, `bin`, `flow`, **`n`**, **`start`**, **`txntype`**. (Chart keys are out of scope here.) `pagesize` is **not** a persisted key — page size flows in via the table fetch as `n=`. The select's `name="pagesize"` is never written to the URL; only the resulting `n=` is.
+
+### `fetchTable` URL construction
+
+`address_controller.js:319-323` `makeTableUrl(txType, count, offset)`:
+
+```
+/addresstable/{address}?txntype=${txType}&n=${count}&start=${offset}
+```
+
+(or `/treasurytable?...` for the treasury page, same controller.) `:363` `requestCount = count > 20 ? count : 20` — page sizes < 20 are silently bumped.
+
+### Server response shape
+
+`AddressTable` returns JSON: `{ tx_count: int64, html: string, pages: []pageNumber }` (`explorerroutes.go:1675-1682`). `pageNumber` JSON tags: `active`, `link`, `str` (`:2574-2578`). The `html` is the rendered `addresstable` template — the inner `<table>` plus its empty-state — never anything else. The XHR path therefore re-renders the **entire table inner HTML** on every fetch (full HTML fragment, not a JSON row schema). `fetchTable` (`:361`) uses `dompurify.sanitize(tableResponse.html)` and assigns to `tableTarget.innerHTML`, then rebuilds the numbered pagination via `setTablePaginationLinks` (`:437`) using `tableResponse.pages` plus arrow links built from `paginationParams.offset`/`pagesize`.
+
+### State write-through
+
+`fetchTable:366-372` writes `n`, `start`, `txntype` back to `this.settings` and calls `this.query.replace(this.settings)` — the address bar updates via TurboQuery (history-replace) without a full nav.
+
+### Other DOM that responds to events
+
+- `data-newblock-target="confirmations"` cells (`extras.tmpl:295-300`) are updated by `newblock_controller.js:36-43` on every `BLOCK_RECEIVED` event. The `data-confirmation-block-height` attribute is the integer block height the row was confirmed at; `-1` means unconfirmed.
+- `data-address-target="pending"` rows (`extras.tmpl:246`) are converted to confirmed by `address_controller.js:_confirmMempoolTxs` (`:774-806`) when the new block contains the row's `data-txid`. That handler also touches `tx.addr-tx-confirms`, `tx.addr-tx-time`, `tx.addr-tx-age > span`, and the global `txnCount` and `numUnconfirmed` count cells in the summary card.
+
+## 6. Multi-coin gaps (most critical section)
+
+### Float64 / VAR-only sites that lose SKA precision
+
+All sites below assume amounts fit `float64` (8 decimals, VAR). For SKA atoms (18 decimals), `float64` loses ~3 decimal digits and may render `0`.
+
+#### Backend
+
+- `db/dbtypes/types.go:2392` — `coin := dcrutil.Amount(addrOut.Value).ToCoin()`. The single funnel in `ReduceAddressHistory`.
+- `db/dbtypes/types.go:2408` — `tx.ReceivedTotal = coin` (only when `addrOut.CoinType == 0`).
+- `db/dbtypes/types.go:2421` — `tx.SentTotal = coin` (only when `addrOut.CoinType == 0`).
+- `db/dbtypes/types.go:2412-2414` and `:2425-2427` — for SKA rows (`CoinType != 0`), only `tx.SKAValue` and `tx.CoinType` are set. **`ReceivedTotal` / `SentTotal` remain at the zero default** — and the template prints those.
+- `db/dcrpg/pgblockchain.go:2632-2634` — mempool overlay for funding txs: `Total: txhelpers.TotalOutFromMsgTx(...).ToCoin()`, `ReceivedTotal: dcrutil.Amount(... .Value).ToCoin()`. No coin-type branch — every unconfirmed tx is treated as VAR.
+- `db/dcrpg/pgblockchain.go:2693-2695` — mempool overlay for spending txs: `Total`, `SentTotal` ditto. Same gap.
+- `db/dcrpg/pgblockchain.go:2763` — `txn.Total = dcrutil.Amount(dbTx.Sent).ToCoin()` in `FillAddressTransactions` (currently unused by `addressTable`, but feeds related surfaces).
+
+#### CSV download
+
+- `cmd/dcrdata/internal/api/apiroutes.go:1764` — `strconv.FormatFloat(dcrutil.Amount(r.Value).ToCoin(), 'f', -1, 64)` — VAR-only float formatting. `AddressRowCompact` (`db/dbtypes/types.go:1299-1309`) does **not** carry `CoinType` or `SKAValue`, so the CSV path can't distinguish coins even structurally.
+
+#### Templates
+
+- `cmd/dcrdata/views/extras.tmpl:251` — `(float64AsDecimalParts .SentTotal 8 false)` — merged_debit Debit cell.
+- `cmd/dcrdata/views/extras.tmpl:254` — `.ReceivedTotal` — merged_credit Credit cell.
+- `cmd/dcrdata/views/extras.tmpl:258` — `.ReceivedTotal` — merged Credit cell (when `IsFunding`).
+- `cmd/dcrdata/views/extras.tmpl:262` — `.SentTotal` — merged Debit cell (when not funding).
+- `cmd/dcrdata/views/extras.tmpl:265` — `.ReceivedTotal` — unspent Credit.
+- `cmd/dcrdata/views/extras.tmpl:267` — `.ReceivedTotal` — credit / all-funding Credit.
+- `cmd/dcrdata/views/extras.tmpl:277` — `if eq .SentTotal 0.0` — float compare to detect sstxcommitment. Will treat any SKA debit as `0.0` and force the "sstxcommitment" branch (incorrect for SKA debits).
+- `cmd/dcrdata/views/extras.tmpl:284` — `.SentTotal` — debit / all-spending Debit.
+
+All eight sites pass `8` decimal places, hard-coding the VAR scale. None reads `.CoinType` or `.SKAValue`.
+
+### Hard-coded `VAR` literals
+
+- `cmd/dcrdata/views/extras.tmpl:222` — `Debit VAR` (merged_debit header).
+- `cmd/dcrdata/views/extras.tmpl:227` — `Credit VAR` (merged_credit header).
+- `cmd/dcrdata/views/extras.tmpl:230` — `Credit VAR` (merged header).
+- `cmd/dcrdata/views/extras.tmpl:231` — `Debit VAR` (merged header).
+- `cmd/dcrdata/views/extras.tmpl:233` — `Credit VAR` (unspent header).
+- `cmd/dcrdata/views/extras.tmpl:235` — `Credit VAR` (default/credit/debit/all header).
+- `cmd/dcrdata/views/extras.tmpl:236` — `Debit VAR` (default/credit/debit/all header).
+
+(The summary card still uses `DCR` literals; they are out of scope here but mentioned for cross-check by spec authors.)
+
+### Frontend (controller)
+
+- `address_controller.js:84` — `${series.y} DCR` in the chart legend formatter (charts surface, but reachable via the same controller).
+- `address_controller.js:130, 140` — `ylabel: 'Total (DCR)'` / `'Balance (DCR)'`.
+
+These labels do not directly affect the table, but anyone touching coin labels on this controller should update them in the same change.
+
+## 7. Pagination + filter contract (server vs XHR parity)
+
+Both the initial render and the XHR refresh share `parseAddressParams` (`explorerroutes.go:1548, 1658` → `:1774`) and `AddressListData` (`:1604, 1665` → `:1881`). Both call `calcPages(int(addrData.TxnCount), int(limitN), int(offsetAddrOuts), linkTemplate)` — `addrData.TxnCount` is the **confirmed-only** count from `pgblockchain.go:2549` / `:2553-2567` (mempool count is added separately as `NumUnconfirmed` to `NumTransactions`, but the page index is computed off `TxnCount`).
+
+### Subtle parity points
+
+1. **`linkTemplate` differs between handlers**:
+   - `AddressPage:1627` — `fmt.Sprintf("/address/%s?start=%%d&n=%d&txntype=%v", …)` (note the literal `/address/`).
+   - `AddressTable:1673` — same path prefix `"/address/" + addrData.Address + "?start=%d&n=" + …`. Both produce identical link patterns. Anchors coming back through XHR therefore navigate to `/address/{addr}?...` — never `/addresstable/...`.
+2. **`limitN == 0` defaulting** is only applied in `AddressPage:1623-1625`, **not** in `AddressTable`. In practice the controller always sends `n` ≥ 20 (`:363`), but a hand-crafted XHR with `n=0` would compute a divide-by-zero / no-pagination response. `calcPages:2647-2649` guards against it.
+3. **XHR `tx_count` includes mempool, server-rendered range does too**: `AddressTable:1680` returns `addrData.TxnCount + addrData.NumUnconfirmed`; `address.tmpl:8` computes `$TxnCount := add .TxnCount .NumUnconfirmed`. Aligned.
+4. **`Pages` values share the same `link` template**, so the numbered pagination produced by SSR (`address.tmpl:236-244`) and by `setTablePaginationLinks` (`address_controller.js:437-471`) point at the same URLs.
+5. **`pagesize` selector is server-rendered only**: there is no `<select>` rebuild on XHR refresh. The controller's `setPageability` (`:388`) toggles `option.disabled` based on `paginationParams.count`, but the option set was decided at SSR time (`address.tmpl:284-292`) using `Txlen := len .Transactions` — a non-merged page might land on a `pagesize` that no longer maps to a server option after the user changes `txntype` to `merged`.
+6. **`numUnconfirmed` block (`address.tmpl:88-92`)** lives in the summary card but is mutated by the table-pending logic (`address_controller.js:_confirmMempoolTxs:791-802`). Cross-surface coupling.
+
+## 8. CSV download
+
+### Route
+
+`GET /download/address/io/{address}` (no CRLF) and `GET /download/address/io/{address}/win` (CRLF). `cmd/dcrdata/internal/api/apirouter.go:319-320`. Cached for 180 seconds via `m.CacheControl` middleware.
+
+### Trigger
+
+`address.tmpl:253` —
+
+```
+<a class="…" href="/download/address/io/{{.Address}}{{if $.CRLFDownload}}/win{{end}}" type="text/csv" download>
+```
+
+`CRLFDownload` is set from `strings.Contains(r.UserAgent(), "Windows")` (`explorerroutes.go:1621`). The `/win` suffix changes **only** the line endings (`writer.UseCRLF = crlf` at `apiroutes.go:1731`); columns and amount formatting are identical.
+
+### Schema
+
+Header row written at `apiroutes.go:1733-1734`:
+
+```
+tx_hash, direction, io_index, valid_mainchain, value, time_stamp, tx_type, matching_tx_hash
+```
+
+Per-row population (`apiroutes.go:1759-1768`):
+
+- `tx_hash` — `r.TxHash.String()`.
+- `direction` — `"1"` if `r.IsFunding`, else `"-1"`.
+- `io_index` — `r.TxVinVoutIndex` (uint32 → string).
+- `valid_mainchain` — `"1"` / `"0"`.
+- `value` — `strconv.FormatFloat(dcrutil.Amount(r.Value).ToCoin(), 'f', -1, 64)` — **VAR coin string** with up to 8 decimals (e.g. `1.23456789`). Float, not integer atoms.
+- `time_stamp` — Unix integer (`r.TxBlockTime`).
+- `tx_type` — `txhelpers.TxTypeToString(int(r.TxType))`.
+- `matching_tx_hash` — empty when nil.
+
+### Multi-coin status
+
+`AddressRowCompact` (`db/dbtypes/types.go:1299-1309`) lacks `CoinType` and `SKAValue`. The CSV path is therefore **structurally VAR-only** — there is no plumbing to emit the coin or SKA atoms even if the schema were extended. Adding multi-coin support requires changes to either `AddressRowCompact` (and its cache representation) or routing the CSV through `AddressRow` instead.
+
+Filename format (`apiroutes.go:1725-1726`): `address-io-{address}-{height}-{unixNow}.csv`.
+
+## 9. Cross-surface dependencies
+
+- **`txnCount` span** (`address.tmpl:192`, `data-address-target="txnCount"`, `data-txn-count`): displayed in the table header but mutated by `_confirmMempoolTxs` (`:789-790`) when a pending tx confirms. The summary card's "Received" outputs count (`address.tmpl:70`) is **not** the same — it's recomputed from `Balance.NumSpent + Balance.NumUnspent`.
+- **`numUnconfirmed`** (summary card, `address.tmpl:89-91`): also touched by `_confirmMempoolTxs` (`:791-802`), even though it lives outside this surface. Decreasing `numUnconfirmed` while increasing `txnCount` keeps the page consistent across pending-confirmation events.
+- **`data-newblock-target="confirmations"`** cells (`extras.tmpl:294-300`): updated en masse by the `newblock` controller on `BLOCK_RECEIVED` (`newblock_controller.js:36-43`). Re-rendered table rows (after XHR) need to re-attach via Stimulus' MutationObserver — happens automatically because the new HTML still carries the `data-newblock-target` attribute.
+- **`mergedMsg`** (`address.tmpl:227-229`, `data-address-target="mergedMsg"`): driven by `IsMerged` server-side and toggled client-side from `fetchTable` (`address_controller.js:377-382`) based on whether `txType.indexOf('merged') === -1`. Two sources of truth — keep them in sync.
+- **`pending` rows** (`extras.tmpl:246`, `data-address-target="pending"`): only present for `Confirmations == 0`; consumed by `_confirmMempoolTxs` (`:774-806`).
+- **`hashOver` / `hashOut`** highlights (`extras.tmpl:271, 280` → `:808, :820`): the controller iterates `this.hashTargets`, but no element in `extras.tmpl` carries `data-address-target="hash"`. The targets are declared (`:179, :180`) but unused on this page today — likely vestigial. The hover handlers do still work for the visual `blue-row` toggle on the link itself.
+- **Charts card vs table**: chart endpoints are coin-agnostic (`pgblockchain.go:3114` `TxHistoryData` — see `flow.full.md` §5). If the table grows a coin filter, chart aggregation will silently drift unless updated.
+- **`tx.tmpl` SKA gap** (`/wiki/code-analysis/transaction/flow.full.md` §5): the per-tx page that this table links to also currently mishandles SKA outputs — fixing the table without fixing `tx.tmpl` leaves users one click away from the same precision loss.
+
+## 10. Open product/UX questions
+
+These questions cannot be answered from code alone and must be decided before a feature spec lands.
+
+1. **Coin column or coin filter (or both)?**
+   - Add a `Coin` column to every view? It would be coin-symbol from `coinSymbol(.CoinType)` (constraint **C7**), so each row is self-describing.
+   - Or add a coin-type filter `<select>` next to `txntype` and keep one amount column per page?
+   - Or split into per-coin tables stacked vertically?
+2. **`Credit VAR` / `Debit VAR` header — per-row or per-column?**
+   - Drop `VAR` from the header and render the symbol per row (next to the amount)?
+   - Keep one header per coin and render per-coin columns (`Credit VAR`, `Credit SKA1`, …)? With 256 possible coin types this scales badly.
+   - Or rename to a generic `Credit` / `Debit` and rely on the `Coin` column?
+3. **Merged view across coins** — what does "merged" mean when an address has txs in multiple coins?
+   - Merge across coins (single rolled-up amount per merged-bucket — invalid because amounts in different coins can't sum)?
+   - Merge per coin (each merged row has a single `CoinType`)?
+   - Disallow merged views when the address has multi-coin history?
+4. **CSV column schema.**
+   - Add `coin_type` and `ska_value` columns? `value` then encodes VAR atoms (or coin string) and `ska_value` encodes SKA atoms.
+   - Or replace `value` with a single `amount_atoms` string column plus `coin_type` column, and let consumers parse the decimals from the coin's known scale?
+   - Either choice requires extending `AddressRowCompact` (and its cache representation) or rerouting CSV through `AddressRow`.
+5. **`SentTotal == 0.0` sstxcommitment heuristic** (`extras.tmpl:277`) — float-compare to a magic value. For SKA, the value is always `0.0` because the ReduceAddressHistory branch leaves it zero. Either replace the heuristic with an explicit flag on `AddressTx`, or special-case by `CoinType`.
+6. **Per-coin balance summary** — out of scope for this note, but a coin filter without per-coin balance numbers in the summary card will feel inconsistent.
+7. **Fiat conversion** (`xcBot.Conversion` at `explorerroutes.go:1617`): currently converts `Balance.TotalUnspent` as a VAR amount to fiat. If the address's balance becomes per-coin, what does the fiat number show? VAR-only? Sum of per-coin fiats? Hidden when there are non-VAR coins?
+8. **Pagination semantics across coins** — should `?txntype=` keep its current values (which are about credit/debit/merged, not about coin), with an orthogonal `?coin=` key? If yes, declare the key in `address_controller.js:211-219` and add a parser in `parsePaginationParams`.
+9. **Page-size `<option>` rebuild on filter change** — already a latent issue (§7 #5); the multi-coin work makes it worse if a coin filter further reduces row counts. Decide whether to rebuild `<select>` options on every XHR.
+10. **CSV cache key / cache invalidation** — the route is cached for 180s by middleware. If a `?coin=` filter is added, the cache key needs to include it, or each call must invalidate.
+11. **Real-time `pending` rows for SKA mempool txs** — `_confirmMempoolTxs` (`address_controller.js:774-806`) doesn't carry coin context today. Decide whether the per-row template needs `data-coin-type` and how the controller propagates it.
+12. **Footnote text** — "*No unconfirmed transactions shown in merged views." — does this still hold when merged is per-coin?
+
+---
+
+References used in this note:
+- `cmd/dcrdata/views/address.tmpl:1-304`
+- `cmd/dcrdata/views/extras.tmpl:176-315`
+- `cmd/dcrdata/views/addresstable.tmpl:1-3`
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:1534-1706, 1772-1891, 2574-2700`
+- `cmd/dcrdata/internal/explorer/explorer.go:59-65, 85`
+- `cmd/dcrdata/internal/explorer/templates.go:31, 220-295, 297-336, 637-672, 826-865, 899-901`
+- `cmd/dcrdata/internal/api/apirouter.go:310-324`
+- `cmd/dcrdata/internal/api/apiroutes.go:1682-1775`
+- `cmd/dcrdata/main.go:768-769`
+- `cmd/dcrdata/public/js/controllers/address_controller.js:152-471, 774-828, 895-902`
+- `cmd/dcrdata/public/js/controllers/newblock_controller.js:1-44`
+- `db/dbtypes/types.go:677-741, 1230-1328, 2235-2358, 2380-2455`
+- `db/dcrpg/pgblockchain.go:2259-2716, 2746-2804`
+- `cmd/dcrdata/internal/explorer/explorer_test.go:53`
+- `cmd/dcrdata/internal/api/noop_ds_test.go:29`

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -21,6 +21,10 @@ _Requirements and guidelines for specific features and pages._
 - blocks-list: specs/blocks-list/spec.md — rules for rendering list of blocks (block table on block list page)
 - chart-ska-coin-supply: specs/chart-ska-coin-supply/spec.md — rendering and logic rules for SKA coin supply charts
 - mempool-page: specs/mempool/spec.md — full multi-coin mempool page layout and logic
+- address-overview: specs/address-overview/spec.md — cross-feature contract for `/address/{address}` (multi-coin model, `ActiveCoins`, `?coin=` URL contract, real-time scope)
+- address-summary: specs/address-summary/spec.md — left-top card: per-coin Balance / Received / Spent, Unconfirmed, Stake %, fiat removal, empty state
+- address-charts: specs/address-charts/spec.md — right-top card: chart coin selector, per-coin endpoints (`?coin=N`), Tx Type 5/2-series rule, BigInt balance accumulation
+- address-transactions: specs/address-transactions/spec.md — bottom section: Coin column, coin filter, sstxcommitment gate, multi-coin CSV schema, server↔XHR parity
 
 ## 🤖 Code Traces
 

--- a/wiki/specs/address-charts/spec.md
+++ b/wiki/specs/address-charts/spec.md
@@ -1,0 +1,373 @@
+# Address Charts Card — Multi-Coin Spec
+
+Правая верхняя карточка на странице `/address/{address}` (`cmd/dcrdata/views/address.tmpl:113-183`). Контент: селектор вида графика (Balance / Tx Type / Sent-Received), кнопки Zoom, Group By, Flow-чекбоксы, Dygraphs canvas + полноэкранный режим.
+
+Этот документ — продолжение [address-overview/spec.md](../address-overview/spec.md). Технический разбор изменяемых файлов: `wiki/code-analysis/address/charts.impact.md`. Pattern reference для пер-монетных эндпоинтов: [chart-ska-coin-supply](../chart-ska-coin-supply/spec.md) и `wiki/code-analysis/charts/`.
+
+---
+
+## 1. Цель и охват
+
+### Входит
+
+- Введение **селектора монеты** в карточку графика (`?coin=` URL-ключ, общий с таблицей).
+- Перевод эндпоинта `amountflow` на пер-монетную выборку (включая SKA с строковыми атомами).
+- Поведение **Tx Type** chart: 5 серий для VAR, 2 серии (SentRtx / ReceivedRtx) для SKA.
+- Поведение **Balance** chart: накопление с правильной точностью (BigInt для SKA).
+- Замена жёстких `DCR`-меток в контроллере на `renderCoinType`.
+- Кеш `db/cache/addresscache.go` расширяется ключом `coin_type`.
+
+### Не входит
+
+- Live-обновление графиков (только refetch при смене параметров).
+- Изменение визуального дизайна Dygraph’а (цвета, легенда) — только метки и точность.
+- Per-coin lines на одном графике / one-chart-per-coin small multiples — выбран селекторный подход (см. §3).
+
+---
+
+## 2. Текущее поведение
+
+### 2.1 Backend
+
+- Маршруты: `/api/address/{address}/types/{chartgrouping}` и `/api/address/{address}/amountflow/{chartgrouping}` (`apirouter.go:185-186`). `balance` — псевдо-вид: фронт сам перепишет URL на `amountflow` (`address_controller.js:519`) и накопит сумму на JS-стороне.
+- Хендлеры: `getAddressTxTypesData`, `getAddressTxAmountFlowData` (`apiroutes.go:1777, 1813`).
+- Точка входа в БД: `(*ChainDB).TxHistoryData(ctx, address, addrChart, chartGroupings)` (`pgblockchain.go:3114-3115`). **Параметра `coinType` нет.**
+- SQL:
+  - `selectAddressTxTypesByAddress` (`addrstmts.go:312-321`) — без фильтра по `coin_type`; стейк-серии всегда VAR (по консенсусу).
+  - `selectAddressAmountFlowByAddress` (`addrstmts.go:323-329`) — `SUM(value)`, где `value` это `INT8` VAR-атомы; `ska_value TEXT` **игнорируется**.
+- Результат: для SKA-only адреса все серии `Sent`/`Received`/`Net` тождественно нулевые.
+- Кеш: `AddressCacheItem.history` — 2D-массив `[NumIntervals]*ChartsData` без разреза по монете (`addresscache.go:471-481, 1156-1163`).
+
+### 2.2 Frontend
+
+- TurboQuery-ключи карточки: `chart`, `zoom`, `bin`, `flow` (`address_controller.js:211-219`).
+- Селектор `<select>` с тремя опциями (`balance` / `types` / `amountflow`); `name`-атрибут используется `validChartType`.
+- Метки `DCR`:
+  - `address_controller.js:84` — `customizedFormatter` legend: `${series.y} DCR`.
+  - `address_controller.js:130` — `amountFlowGraphOptions.ylabel = 'Total (DCR)'`.
+  - `address_controller.js:140` — `balanceGraphOptions.ylabel = 'Balance (DCR)'`.
+  - `address_controller.js:120` — `typesGraphOptions.ylabel = 'Tx Count'` (без монеты — ОК).
+- `amountFlowProcessor` (`address_controller.js:30-53`) накапливает баланс на `Number` (`balance += v`) — для SKA это catastrophic.
+
+---
+
+## 3. Требуемое поведение
+
+### 3.1 Селектор монеты
+
+Над/в линию с селектором вида графика добавляется второй `<select>` — селектор монеты:
+
+```
+Chart  [Balance ▾]   Coin  [VAR ▾]
+Zoom   [All|Y|M|W|D]
+Group  [Y|M|W|D|Block]
+```
+
+**Правила отображения:**
+
+- Опции селектора монеты строятся по `AddressInfo.ActiveCoins` (см. address-overview §3).
+- Текстовые метки опций — через `coinSymbol` server-side; в `<option value>` — числовое `coin_type` (`0` для VAR, `1..255` для SKA{n}).
+- Опция "All" в этом селекторе **отсутствует**: график рисует один coin за раз (для разных порядков величины VAR и SKA общая ось не имеет смысла).
+- Если `?coin=` пуст или его значение не входит в `ActiveCoins` — используется первый элемент `ActiveCoins` (обычно VAR `0`).
+- Селектор скрыт, если в `ActiveCoins` ровно одна монета.
+
+**Selector binding:**
+
+- `data-address-target="coin"` (новый target).
+- `data-action="change->address#changeCoin"` (новое действие).
+
+`changeCoin` пишет `settings.coin = e.target.value` и вызывает общий помощник смены `?coin=` (см. address-overview §4), который **сбрасывает `?start=0`** перед `query.replace`.
+
+### 3.2 URL-ключ `coin`
+
+См. address-overview §4.
+
+В `address_controller.js:211-219` к `nullTemplate` добавляется ключ `'coin'`. На загрузке (`connect()`) значение нормализуется: если URL не содержит `?coin=`, либо `coin` ∉ `ActiveCoins`, фронт подставляет первую монету из `ActiveCoins`.
+
+### 3.3 Виды графиков под мульти-монету
+
+#### 3.3.1 Balance
+
+**Принципиальное изменение по сравнению с сегодняшним кодом:** кумулятивная сумма (running balance) **вычисляется на бэкенде**, а не на JS. Это:
+
+- снимает с фронта `BigInt`-арифметику для SKA (точность теперь — забота Go-слоя через `*big.Int.Add`, как уже сделано в `coin-supply/{N}` pipeline);
+- даёт серверному кешу хранить балансовый ряд в готовом виде;
+- мирится с принятым решением «1 fetch — 2 view» (см. ниже): балансовая серия едет дополнительным полем в том же `amountflow`-ответе.
+
+**Контракт:**
+
+- Fetch: тот же URL, что и `amountflow` (см. §3.3.3) — фронт по-прежнему рассматривает `balance` как «view» поверх ответа `amountflow`. URL-rewrite `chart === 'balance' → amountflow` (`address_controller.js:519`) сохраняется.
+- Backend в `amountflow`-ответе возвращает **дополнительный ряд** `balance` (для VAR — `[]float64`) или `balance_atoms` (для SKA — `[]string`), уже накопленный по `time`. Net-ряд уже есть; balance — это `cumsum(net)` посчитанный сервером.
+- Рендеринг: одна линия (Balance в выбранной монете) — фронт берёт серию **как есть** из ответа, никакой `balance += v` в JS.
+- ylabel: `Balance (${renderCoinType(coin)})`.
+- Легенда: для VAR — `formatAtomsAsCoinString(atoms, 0)` (8 знаков); для SKA — `splitSkaAtomsNoTrailing(atoms)`. **Никакой накопительной арифметики** на JS — `customizedFormatter` читает значение Y-ряда напрямую.
+
+**Backend:** в `parseRowsSentReceived` (`db/dcrpg/queries.go:4139-4163`) или в новом coin-aware варианте — после построения `received` / `sent` / `net` массивов добавить кумулятивный проход:
+
+- VAR: `balance[i] = balance[i-1] + net[i]` в `int64` атомах, затем `[]float64` через `toCoin` (как и `received`/`sent`/`net`).
+- SKA: `balance[i] = balance[i-1] + net[i]` через `*big.Int.Add` в атом-домене, transport как `[]string`.
+
+#### 3.3.2 Tx Type
+
+VAR-выбор:
+
+- Все 5 серий как сегодня: `SentRtx`, `ReceivedRtx`, `Tickets`, `Votes`, `RevokeTx`.
+- ylabel: `Tx Count`.
+
+SKA-выбор:
+
+- Только 2 серии: `SentRtx`, `ReceivedRtx`.
+- Stake-серии (`Tickets`, `Votes`, `RevokeTx`) **не отображаются** — они структурно VAR-only.
+- ylabel: `Tx Count`.
+- DB-запрос для SKA фильтруется по `coin_type = N` и не считает `tx_type IN (1,2,3)`.
+
+#### 3.3.3 Sent/Received (`amountflow`)
+
+- Fetch: per coin (`?coin=N`).
+- VAR: SQL агрегирует `SUM(value)` фильтруя `coin_type = 0`. Транспорт — `[]float64` через JSON (как сейчас).
+- SKA: SQL агрегирует `SUM(ska_value::numeric)` для `coin_type = N`, **transport как `[]string`**. JSON shape (включая балансовый ряд для view `balance`, см. §3.3.1):
+  ```json
+  {
+    "time": [...],
+    "received_atoms": ["1234...", "5678..."],
+    "sent_atoms": ["...", "..."],
+    "net_atoms": ["...", "..."],
+    "balance_atoms": ["...", "..."]
+  }
+  ```
+  Для VAR соответствующие поля — существующие `received` / `sent` / `net` `[]float64` плюс новое `balance` `[]float64`. SKA получает параллельные поля с суффиксом `_atoms` (или эквивалент — окончательная форма решается в импл-фазе при изменении `dbtypes.ChartsData`).
+- ylabel: `Total (${renderCoinType(coin)})`.
+- Flow-чекбоксы (Sent / Received / Net) работают как сегодня: переключают видимость серий.
+
+### 3.4 Endpoint contract
+
+**Решение:** `?coin=N` как **query parameter**, не path segment. Это отклонение от прецедента `coin-supply/{N}`; обоснование — отсутствие необходимости менять router и middleware (`m.AddressPathCtxN(1)`, `m.ChartGroupingCtx`).
+
+```
+GET /api/address/{addr}/types/{chartgrouping}?coin=N
+GET /api/address/{addr}/amountflow/{chartgrouping}?coin=N
+```
+
+Где `N ∈ {0, 1..255}`. `coin=0` (или отсутствует) — VAR (текущее поведение).
+
+**Backend:**
+
+- `TxHistoryData(ctx, address, addrChart, chartGroupings)` → `TxHistoryData(ctx, address, addrChart, chartGroupings, coinType uint8)`.
+- Хендлеры (`apiroutes.go:1777, 1813`) парсят `coin` query parameter (default `0`), валидируют против `0..255`.
+- SQL: новые версии `selectAddressTxTypesByAddress` / `selectAddressAmountFlowByAddress` принимают `coin_type` как параметр и фильтруют. Стейк-секции (`tx_type IN (1,2,3)`) добавляются только для VAR.
+- Cache: ключ `AddressCacheItem.history` расширяется на `coin_type` — становится 3D `[CoinType][NumIntervals]*ChartsData` (или эквивалентная map‘а). Singleflight-лок (`CacheLocks.bal.TryLock(address)`) остаётся per-address (можно расширить до `(address, coin)` в будущем для параллелизации, но это вне скоупа).
+- Mock: `cmd/dcrdata/internal/api/noop_ds_test.go:40-42` обновляется под новую сигнатуру.
+
+### 3.5 Frontend URL build
+
+`address_controller.js:fetchGraphData` (~496-527):
+
+- `chart === 'balance'` всё ещё переписывается в URL-сегмент `amountflow` (балансовая серия — производная от `amountflow`).
+- К URL добавляется `?coin=${this.settings.coin || 0}`.
+- Кеш `retrievedData` ключуется по `${chart}-${bin}-${coin}` (а не только `${chart}-${bin}`) — добавление монеты в ключ предотвращает кросс-монетную сериал-перекрёстку.
+
+### 3.6 SKA precision в JS
+
+**Принцип:** никакой `BigInt`-арифметики на JS. Любая накопительная сумма (running balance, totals и т.п.) считается на бэкенде; фронт получает уже готовые ряды атомных строк и **только форматирует их к показу**.
+
+- Атомные строки приходят с бэкенда уже накопленными (`balance_atoms`, см. §3.3.1) или поэлементно (`received_atoms` / `sent_atoms` / `net_atoms`, §3.3.3).
+- Для отображения легенды и осей Y — преобразование атомов в человекочитаемую форму через `splitSkaAtomsNoTrailing` / `formatAtomsAsCoinString` из `ska_helper.js`. Это **не математика**, а string→string форматирование.
+- Dygraph принимает `Number` для координат; для очень больших SKA-атомов это даёт визуально приемлемое масштабирование (потерянная точность нестрашна для пиксельной отрисовки), **но числа в легенде должны браться из исходных атомных строк**, не из значения, прошедшего через `Number`. `customizedFormatter` (`address_controller.js:55-87`) переписывается, чтобы для SKA-кейса брать данные из параллельного atoms-ряда (по индексу точки).
+- `amountFlowProcessor` (`address_controller.js:30-53`) — текущая логика `balance += v` **удаляется**: для view `balance` фронт читает готовый ряд `balance` / `balance_atoms` из ответа.
+
+### 3.7 Замена `DCR`-меток
+
+- `address_controller.js:84` — `customizedFormatter` использует `renderCoinType(this.settings.coin)` вместо литерала `DCR`.
+- `:130` — `amountFlowGraphOptions.ylabel = ...` строится динамически: `Total (${renderCoinType(coin)})`.
+- `:140` — `balanceGraphOptions.ylabel = ...` динамически: `Balance (${renderCoinType(coin)})`.
+- `:120` — `typesGraphOptions.ylabel = 'Tx Count'` — **не меняется** (метрика coin-agnostic).
+
+Когда `coin` меняется (`changeCoin`), эти строки label / ylabel пересоздаются и Dygraph перерисовывается.
+
+### 3.8 Поведение на dummy address
+
+Карточка графиков для dummy address короткое замыкание handler’а отсекает на уровне всего блока. Никакой специальной логики на frontend стороне не нужно.
+
+---
+
+## 4. UI mockup карточки
+
+```
+┌──────────────────────────────────────────────────┐
+│ Chart  [Balance ▾]   Coin  [SKA1 ▾]               │
+│ Zoom   [All|Year|Month|Week|Day]                  │
+│ Group  [Year|Month|Week|Day|Block]                │
+│                                                   │
+│  ┌──────────────────────────────────────────┐    │
+│  │ Balance (SKA1)                            │    │
+│  │  ▲                                        │    │
+│  │  │     ╭───╮                              │    │
+│  │  │ ╭───╯   ╰─╮                            │    │
+│  │  │╱           ╰─────────                   │    │
+│  │  └─────────────────────►                  │    │
+│  └──────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────┘
+```
+
+При выборе VAR — видны Sent/Received чекбоксы (для `amountflow`); ylabel `Balance (VAR)` или `Total (VAR)`. При выборе SKA — Tx Type chart показывает только 2 серии; остальные виды работают как для VAR с пер-монетной точностью.
+
+---
+
+## 5. Backend-изменения (детали)
+
+### 5.1 Сигнатуры
+
+```go
+// db/dcrpg/pgblockchain.go
+func (pgb *ChainDB) TxHistoryData(
+    ctx context.Context,
+    address string,
+    addrChart dbtypes.HistoryChart,
+    chartGroupings dbtypes.TimeBasedGrouping,
+    coinType uint8,
+) (cd *dbtypes.ChartsData, err error)
+
+// cmd/dcrdata/internal/api/apiroutes.go (DataSource interface)
+TxHistoryData(ctx context.Context, address string,
+    addrChart dbtypes.HistoryChart,
+    chartGroupings dbtypes.TimeBasedGrouping,
+    coinType uint8,
+) (*dbtypes.ChartsData, error)
+```
+
+### 5.2 SQL
+
+`db/dcrpg/internal/addrstmts.go`:
+
+- `MakeSelectAddressTxTypesByAddress` / `selectAddressTxTypesByAddress`:
+  - Добавить параметр `coin_type`.
+  - Для `coin_type = 0` (VAR): запрос как сейчас (`SentRtx` + `ReceivedRtx` + `Tickets` + `Votes` + `RevokeTx`).
+  - Для `coin_type != 0` (SKA): только `SentRtx` + `ReceivedRtx`, фильтр `WHERE coin_type = $N`.
+- `MakeSelectAddressAmountFlowByAddress` / `selectAddressAmountFlowByAddress`:
+  - Добавить параметр `coin_type`.
+  - Для VAR: `SUM(value) WHERE coin_type = 0`.
+  - Для SKA: `SUM(ska_value::numeric) WHERE coin_type = $N`, возвращать результат как строку.
+
+### 5.3 `dbtypes.ChartsData`
+
+`db/dbtypes/types.go:2030-2040`. Расширить так, чтобы JSON параллельно нёс VAR-`float64` и SKA-`string` поля, а также **накопленный balance-ряд** (см. §3.3.1):
+
+- VAR: добавить `Balance []float64` рядом с существующими `Received`/`Sent`/`Net`.
+- SKA: добавить `BalanceAtoms []string` рядом с `ReceivedAtoms`/`SentAtoms`/`NetAtoms`.
+
+Точная форма (один тип с обеими ветками vs два типа vs дискриминатор) выбирается при имплементации; ключевое требование — **никаких float-полей для SKA** и **никакой накопительной арифметики на JS** — `balance`-ряд всегда приходит уже посчитанным.
+
+`parseRowsSentReceived` (`db/dcrpg/queries.go:4139-4163`) или его coin-aware вариант: после построения per-bin Net-массива пройти кумулятивным проходом и заполнить Balance:
+
+- VAR: `int64`-аккумулятор по атомам, `[]float64` через `toCoin`.
+- SKA: `*big.Int` аккумулятор, `[]string` через `Text(10)`.
+
+### 5.4 Кеш
+
+`db/cache/addresscache.go`:
+
+- `AddressCacheItem.history` — добавить разрез по `coin_type`. Конкретная форма (`map[uint8]*HistoryByInterval` или `[256]*HistoryByInterval`) — на усмотрение импл-фазы.
+- `HistoryChart(address, kind, interval)` → `HistoryChart(address, kind, interval, coinType)`.
+- `StoreHistoryChart(...)` — сигнатура с `coinType`.
+
+### 5.5 Mock
+
+`cmd/dcrdata/internal/api/noop_ds_test.go:40-42`:
+
+```go
+func (n *noopDS) TxHistoryData(ctx context.Context, address string,
+    addrChart dbtypes.HistoryChart,
+    chartGroupings dbtypes.TimeBasedGrouping,
+    coinType uint8,
+) (*dbtypes.ChartsData, error) {
+    return nil, nil
+}
+```
+
+---
+
+## 6. Frontend-изменения (детали)
+
+### 6.1 `cmd/dcrdata/views/address.tmpl`
+
+В блоке chart-карточки (`address.tmpl:113-183`):
+
+- Добавить второй `<select>` с `data-address-target="coin"` и `data-action="change->address#changeCoin"`. Опции — пер-цикл по `.Data.ActiveCoins` через `coinSymbol`.
+- Удалить hardcoded coin labels: их в шаблоне нет, но проверить что и в новом select атрибут value содержит числовое `coin_type`, а текст — `{{coinSymbol .}}`.
+
+### 6.2 `cmd/dcrdata/public/js/controllers/address_controller.js`
+
+- `:153-191` — добавить target `coin`.
+- `:211-219` — добавить ключ `'coin'` в `nullTemplate`.
+- `:220-254` — в `connect()` нормализовать `settings.coin` против `ActiveCoins` (получаемого через новый `data-address-active-coins` атрибут, JSON-сериализованный массив `uint8`, или через initial fetch).
+- `:30-53` — `amountFlowProcessor` **упрощается**: вместо `balance += v` накопления — просто маппинг ответа в Dygraph-rows. Для view `balance` фронт читает поле `balance` (VAR) / `balance_atoms` (SKA) **как есть** из ответа. Никакого `BigInt` или `Number`-аккумулятора в JS не остаётся.
+- `:55-87` — `customizedFormatter`: динамическая метка (`renderCoinType(coin)`) и SKA-aware форматирование (`splitSkaAtomsNoTrailing` поверх атомной строки точки).
+- `:120, :130, :140` — динамические ylabels.
+- `:496-527` — `fetchGraphData`: добавить `?coin=` query, кешировать по `${chart}-${bin}-${coin}`.
+- Новый метод `changeCoin` (рядом с `changeGraph`/`changeBin`): пишет `settings.coin`, вызывает помощник смены `?coin=` (см. address-overview §4) и `setGraphQuery`.
+
+### 6.3 `address_controller.js:setGraphQuery` (`:635-637`)
+
+Сегодня `setGraphQuery()` пишет настройки в URL без вмешательства. Новое требование: смена `?coin=` обязана сбрасывать `?start=0` (но `?start=` принадлежит таблице, а chart-card им не управляет). Поэтому общий помощник делается в виде функции, доступной обоим контроллерам логики (`changeCoin`, `changeTxType` в таблице):
+
+```js
+// псевдокод
+applyCoinChange(newCoin) {
+  this.settings.coin = newCoin
+  delete this.settings.start    // pagination reset on coin change
+  this.query.replace(this.settings)
+  // Trigger refetches
+  this.drawGraph()
+  this.fetchTable()
+}
+```
+
+Точная форма (метод на контроллере vs утилита) — на усмотрение импл-фазы.
+
+---
+
+## 7. Точность и форматирование
+
+| Серия              | VAR (`coin=0`)                                          | SKA (`coin=N`)                                                                                |
+| ------------------ | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `Balance` (Y axis) | `[]float64 balance` готовый с бэкенда; 8 знаков         | `[]string balance_atoms` готовый с бэкенда; 18 знаков; legend через `splitSkaAtomsNoTrailing` |
+| `amountflow` поля  | `[]float64` (`received`/`sent`/`net`)                   | `[]string` атомов (`received_atoms` etc.)                                                     |
+| `Tx Type` счётчики | `[]uint64`/`uint32`                                     | `[]uint64`/`uint32` (только `SentRtx`/`ReceivedRtx`)                                          |
+| Метка монеты       | `renderCoinType(0)` → `"VAR"`                           | `renderCoinType(N)` → `"SKA{N}"`                                                              |
+
+**Запрещено:**
+
+- Передача SKA-атомов через `[]float64` или `Number`.
+- Inline-литералы `DCR` / `VAR` / `` `SKA${n}` `` в контроллере или в JSON.
+- Использование `1e-8` или `1e-18` в чистом виде в шаблоне или в JSON-pipeline (только в форматтерах для отображения).
+
+---
+
+## 8. Эффект на смежные инварианты
+
+- **TurboQuery нулевой шаблон:** новый ключ `coin` объявлен в `nullTemplate` — иначе он не персистится.
+- **Кеш бакетирования:** ключ кеша расширен на `coin_type`. Между разными монетами кеш изолирован (никакого cross-talk).
+- **Singleflight lock:** `CacheLocks.bal.TryLock(address)` остаётся per-address. При одновременном запросе одного адреса для разных монет последовательно выполнятся два запроса. Параллелизация per-(address, coin) — в скоуп не входит.
+- **`ChartsData` JSON-shape:** меняется. Любые внешние потребители этого endpoint’а обязаны быть переведены на новый формат. Внутри проекта: `address_controller.js`, `charts_controller.js` (если затронут — по референсу `coin-supply/{N}`).
+
+---
+
+## 9. Cross-reference
+
+- Балансы и активные монеты приходят с того же handler’а `AddressData` (см. address-overview §3, §7), что и summary-карточка. Никакого отдельного API `ActiveCoins` нет.
+- `?coin=` URL-ключ shared с таблицей (см. address-transactions §URL и §фильтр).
+- Замена `data-address-balance` (`address.tmpl:15`) — см. address-overview §8.3 (атрибут удалён).
+
+---
+
+## 10. ⚠️ Ключевые инварианты
+
+- График всегда отображает **ровно одну монету** (нет per-coin lines / small multiples).
+- Селектор монеты строится по `ActiveCoins`; если у адреса одна монета — селектор скрыт.
+- `?coin=` shared с таблицей; смена сбрасывает `?start=0`.
+- Tx Type для SKA — только 2 серии; стейк-серии не показываются.
+- SKA-атомы **никогда не проходят через `Number`** в JSON или в backend-pipeline.
+- **Никакой накопительной арифметики на JS** — `balance`-ряд приходит уже посчитанным с бэкенда (как и `coin-supply/{N}` precedent). На JS остаётся только string→string форматирование для отображения.
+- Метки монет — только через `renderCoinType` (JS) и `coinSymbol` (Go template).
+
+---

--- a/wiki/specs/address-overview/spec.md
+++ b/wiki/specs/address-overview/spec.md
@@ -1,0 +1,327 @@
+# Address Page — Multi-Coin Overview (cross-feature contract)
+
+Документ описывает кросс-страничные правила перевода `/address/{address}` на мульти-монетную модель **VAR + SKA{n}**. Он определяет общую модель адреса, URL-контракт, общие приёмы отображения и backend-изменения, которые затрагивают сразу несколько разделов страницы.
+
+Конкретные UI-правила вынесены в три отдельных спецификации:
+
+- [address-summary](../address-summary/spec.md) — левая верхняя карточка (Balance / Received / Spent / Unconfirmed / Stake %)
+- [address-charts](../address-charts/spec.md) — правая верхняя карточка (графики Balance / Tx Type / Sent-Received)
+- [address-transactions](../address-transactions/spec.md) — нижняя секция (таблица транзакций, фильтры, CSV-скачивание)
+
+Сопровождающий технический разбор находится в `wiki/code-analysis/address/`:
+
+- `flow.compact.md`, `flow.full.md` — общий поток данных
+- `summary.impact.md`, `charts.impact.md`, `transactions.impact.md` — пофичевые change-surface заметки
+
+---
+
+## 1. Контекст и цель
+
+Страница `/address/{address}` сегодня собрана под одно-монетную модель `dcrdata`:
+
+- `dbtypes.AddressInfo.Balance` — единственный `AddressBalance` без разреза по монете
+- Все суммы проходят через `dcrutil.Amount.ToCoin() float64` и в шаблоне снабжаются жёстко зашитой меткой `DCR`
+- Backend-эндпоинты графиков и SQL для `amountflow` агрегируют только по столбцу `addresses.value` (VAR-атомы), полностью игнорируя `addresses.ska_value`
+- Колонки таблицы транзакций называются `Credit VAR` / `Debit VAR`, суммы — `float64`
+
+Это нарушает инварианты [`wiki/core/constraints.md` C1, C7](../../core/constraints.md): SKA-значения не помещаются в `float64` (18 десятичных знаков), а метки монет должны рендериться через канонические хелперы.
+
+Цель редизайна — сделать страницу адекватной мульти-монетной природе сети при сохранении существующего UX-каркаса (TurboQuery URL state, пагинация, мерж-вью, CSV-выгрузка).
+
+---
+
+## 2. Модель адреса (multi-coin)
+
+**Адрес может содержать любые монеты одновременно.**
+
+Формально: один адрес-скрипт может являться получателем выходов любого `coin_type` (VAR `0`, SKA `1..255`). Хотя отдельная транзакция всегда одномонетная (см. `CLAUDE.md`), отдельный адрес — нет: на нём могут лежать VAR + произвольный набор `SKA{n}`.
+
+### Правила отображения монет (общие)
+
+Эти правила едины для всех трёх разделов страницы и совпадают с уже принятыми соглашениями в [block-details](../block-details/spec.md) и [mempool](../mempool/spec.md).
+
+- **Условное отображение:** VAR показывается всегда; SKA — только если присутствует на адресе (см. §3 `ActiveCoins`).
+- **Порядок:** `VAR → SKA1 → SKA2 → … → SKA{N}` по возрастанию `coin_type`.
+- **Точность:**
+  - VAR — до 8 знаков после запятой (формат через `dcrutil.Amount` / `float64AsDecimalParts`).
+  - SKA — до 18 знаков после запятой; **значения проходят через все слои строкой** (DB `TEXT`, REST/JSON, WebSocket, шаблоны). Никакой `ToCoin()` для SKA, никакого `Number(s)` без `BigInt` в JS.
+- **Метки монет:**
+  - Server-side: только через `coinSymbol(ct uint8) string` (`cmd/dcrdata/internal/explorer/templates.go`, FuncMap `coinSymbol`).
+  - Client-side: только через `renderCoinType(coinType)` (`cmd/dcrdata/public/js/helpers/ska_helper.js`).
+  - Никаких inline-литералов `DCR`, `VAR`, `` `SKA${n}` `` в шаблонах или контроллерах.
+
+---
+
+## 3. Активные монеты адреса (`ActiveCoins`)
+
+Чтобы карточки и фильтры показывали только релевантные адресу монеты, на `AddressInfo` добавляется поле:
+
+```go
+ActiveCoins []uint8 // отсортированный по возрастанию набор coin_type, под которые у адреса есть строки в `addresses`
+```
+
+Источник данных — новый запрос в `db/dcrpg/queries.go` рядом с `retrieveAddressBalance`:
+
+```sql
+SELECT DISTINCT coin_type
+FROM addresses
+WHERE address = $1
+ORDER BY coin_type
+```
+
+Заполнение происходит в `pgblockchain.go:AddressData` (или внутри `AddressHistory`) и кешируется так же, как остальные части `AddressBalance` (через `AddressCache`).
+
+### Правила использования `ActiveCoins`
+
+- Если `ActiveCoins` пуст и адрес не dummy — рендерить empty-state (см. §6).
+- Сортировка строк/опций монет должна следовать порядку `ActiveCoins` (он уже отсортирован).
+- VAR (`0`) всегда присутствует в `ActiveCoins`, если у адреса вообще были VAR-операции; для SKA-only адресов VAR в списке отсутствует — это нормально.
+
+---
+
+## 4. URL-контракт (`?coin=`)
+
+В TurboQuery-ключи (`address_controller.js:211-219`) добавляется один новый ключ — общий между картой графиков и таблицей:
+
+| Ключ      | Значения                                                                                   | Владелец на странице          |
+| --------- | ------------------------------------------------------------------------------------------ | ----------------------------- |
+| `coin`    | пусто \| `0` \| `1..255`                                                                   | charts + transactions (общий) |
+| `chart`   | `balance` \| `types` \| `amountflow`                                                       | charts                        |
+| `zoom`    | `<startMs>-<endMs>` (base-36)                                                              | charts                        |
+| `bin`     | `year` \| `month` \| `week` \| `day` \| `all`                                              | charts                        |
+| `flow`    | bitmap (Sent=2, Received=1, Net=4)                                                         | charts                        |
+| `n`       | размер страницы                                                                            | transactions                  |
+| `start`   | смещение                                                                                   | transactions                  |
+| `txntype` | `all` \| `unspent` \| `credit` \| `debit` \| `merged` \| `merged_credit` \| `merged_debit` | transactions                  |
+
+### Семантика `?coin=`
+
+- **`coin` отсутствует или пустой:**
+  - chart-карточка → активная монета по умолчанию **VAR** (если её нет в `ActiveCoins`, то первая из `ActiveCoins`).
+  - таблица → "All coins" (без фильтра, выводятся все строки).
+- **`coin=N`** (где `N ∈ ActiveCoins`):
+  - chart-карточка → серии графика для монеты `N`.
+  - таблица → отображаются только транзакции с `coin_type = N`.
+- **`coin=N`, где `N ∉ ActiveCoins`:** трактуется как отсутствующий — серверная логика тихо сбрасывает на default; на клиенте `address_controller.js` нормализует значение в `connect()`.
+
+### Изменение `?coin=`
+
+Любое изменение `?coin=` **сбрасывает `?start=0`** (пагинация теряет смысл при смене скоупа фильтра). Обе точки записи — селектор графика и фильтр таблицы — обязаны вызывать `setGraphQuery` / `setTableQuery` через единый помощник, делающий `delete this.settings.start` (или эквивалент) перед `query.replace`.
+
+Карточка summary `?coin=` **игнорирует** — она всегда показывает полный пер-монетный разрез.
+
+---
+
+## 5. Real-time updates
+
+Объём в этой переработке остаётся минимальным:
+
+- `numUnconfirmed` — обновляется живьём (см. address-summary §Unconfirmed) с пер-монетным разрезом.
+- `txnCount` — обновляется живьём (как сейчас, агрегатно).
+- **Balance / Received / Spent / Stake % — только SSR.** Никакого pubsub-канала под балансы адреса в этой переработке не вводится.
+
+Если в будущем понадобится живое обновление пер-монетных балансов, это будет отдельный спек: потребуется websocket-payload и BigInt-арифметика на JS-стороне (см. C1).
+
+---
+
+## 6. Dummy/zero address
+
+Сокращение в `cmd/dcrdata/internal/explorer/explorerroutes.go:1592-1602` (короткое замыкание для адреса нулевых выходов нерасходуемых тикетов) **остаётся без изменений**. Удаление приведёт к таймаутам БД на адресах с большим количеством выходов.
+
+Структурное условие: пустой `AddressInfo`, возвращаемый коротким замыканием, должен по форме совпадать с новым мульти-монетным шаблоном — то есть:
+
+- `Balance` (см. §7) допускает пустую пер-монетную карту/набор без специальных случаев в шаблоне
+- `ActiveCoins` пуст
+- `NumUnconfirmed` равен нулю или отсутствует
+
+---
+
+## 7. Backend-изменения (cross-cutting)
+
+### 7.1 `dbtypes.AddressBalance`
+
+Перейти от плоской структуры к пер-монетной. Концептуально:
+
+```go
+type AddressBalance struct {
+    Address string
+    Coins   map[uint8]*CoinBalance // ключ — coin_type
+    // Stake-метрики (FromStake, ToStake) — только для VAR; см. address-summary §Stake %
+    FromStake float64
+    ToStake   float64
+}
+
+type CoinBalance struct {
+    CoinType    uint8
+    NumSpent    int64
+    NumUnspent  int64
+    TotalSpent  int64  // VAR: атомы; для SKA — не используется
+    TotalUnspent int64 // VAR: атомы; для SKA — не используется
+    TotalSpentSKA   string // SKA-атомы как строка; для VAR — не используется
+    TotalUnspentSKA string // SKA-атомы как строка; для VAR — не используется
+    // Предсчитанное Received = TotalSpent + TotalUnspent в атомах своей монеты
+    // (см. address-summary §3.3) — чтобы шаблон не выполнял сложение SKA-строк.
+    TotalReceived    int64  // VAR-ветка
+    TotalReceivedSKA string // SKA-ветка
+}
+```
+
+Плюс на уровне самого `AddressBalance` (не per-coin) — **предсчитанные** скалярные счётчики, чтобы шаблон не пробегал по `Coins` map‘у с `add`:
+
+- `TotalOutputs int64` = `Σ (NumSpent + NumUnspent)` по всем монетам.
+- `TotalInputs  int64` = `Σ NumSpent` по всем монетам.
+
+Точную форму (две числовые пары VAR/SKA в одной структуре vs. два разных типа) определяет address-summary §10. Главное правило: **никаких `int64`-атомов для SKA** и **никакой арифметики над атомами в шаблоне**.
+
+### 7.2 `retrieveAddressBalance`, `ReduceAddressHistory`
+
+В `db/dcrpg/queries.go:retrieveAddressBalance` (~1453-1529) и `db/dbtypes/types.go:ReduceAddressHistory` (~2380+) сейчас сворачивают по `coin_type`, складывая разные scale’ы в один `int64`. Они должны сохранять разрез: SQL `SelectAddressSpentUnspentCountAndValue` (`db/dcrpg/internal/addrstmts.go:220-232`) уже группирует по `coin_type`; нужно перестать схлопывать.
+
+`FromStake` / `ToStake` считаются строго по VAR-секции (см. address-summary §Stake %).
+
+### 7.3 `dbtypes.AddressTx` / `AddressRow`
+
+`AddressRow.CoinType` и `AddressRow.SKAValue` уже несут пер-монетную информацию из БД. Нужно довести её до шаблона:
+
+- На `AddressTx` (тип в `dbtypes`) добавить (или активировать существующее) поле `CoinType uint8` и строковое поле атомов SKA (`SKAValue string`).
+- В `ReduceAddressHistory` (~`types.go:2380+`) при `addrOut.CoinType != 0` не клатать `addrOut.Value` через `ToCoin()`; передавать атомы в строковом виде.
+- Поле `SentTotal float64` / `ReceivedTotal float64` остаётся для VAR; для SKA добавить параллельные `SentTotalSKA string` / `ReceivedTotalSKA string` (или эквивалент). Точную форму — см. address-transactions §Backend-изменения.
+
+### 7.4 Мок-имплементации
+
+Любое изменение интерфейсов задевает три места:
+
+- `cmd/dcrdata/internal/explorer/explorer_test.go` (`mockDataSource.AddressHistory`, `AddressData`, `DevBalance`)
+- `cmd/dcrdata/internal/api/noop_ds_test.go` (`noopDS.AddressHistory`, `TxHistoryData`)
+- любые другие реализации в обычных тестах
+
+При изменении сигнатур моки обновляются в одном PR с продакшеновым кодом.
+
+---
+
+## 8. Шаблонные хелперы и шаблоны-партизаны
+
+### 8.1 Запрещённые конструкции на этой странице
+
+В рамках редизайна **нельзя**:
+
+- Вызывать `toFloat64Amount` для значений, которые могут быть SKA.
+- Вызывать `amountAsDecimalParts` для значений, которые могут быть SKA.
+- Вписывать в шаблон литералы `DCR`, `VAR`, `` `SKA${n}` ``.
+- В JS приводить SKA-атомы к `Number`/`parseFloat` или сравнивать SKA-значения через `===`/`==`.
+
+#### Почему `===` / `==` для SKA-атомов небезопасны
+
+Две причины (обе — следствия [C1](../../core/constraints.md): атомы SKA живут только как строки):
+
+**1. `==` запускает type coercion → precision loss.** Если одна сторона — `Number` (значение по умолчанию, `dataset.x`, поле другого источника), `==` приведёт строку к `Number`. У `Number` ~15 значащих цифр, у атомов SKA — 18+. Округление случается тихо, сравнение возвращает «равно» для разных значений:
+
+```js
+const atoms = "1000000000000000001";
+atoms == 1000000000000000001; // true  (правый операнд уже округлился до 1e18)
+BigInt(atoms) === 1000000000000000001n; // false (правильно)
+```
+
+**2. `===` на строках сравнивает лексически, а у одного значения может быть несколько канонических форм.** Атомы приходят из разных источников с разной нормализацией (`splitSkaAtomsNoTrailing` обрезает нули, шаблонные форматтеры — нет; JSON, dataset, форма поля — все могут отличаться):
+
+```js
+"100" === "0100"; // false (но численно равны)
+"1.00" === "1"; // false
+"1e18" === "1000000000000000000"; // false
+"+1" === "1"; // false
+```
+
+**Правильный паттерн — через `BigInt`:**
+
+```js
+BigInt(a) === BigInt(b); // равенство (численное, не лексическое)
+BigInt(a) > BigInt(b); // сравнение
+BigInt(atoms) === 0n; // вместо `atoms === 0` или `atoms == 0`
+```
+
+То же относится к VAR-атомам, если они проходят через JSON в строковой форме (для chart-эндпоинтов VAR остаётся `float64`, см. address-charts §3.3.3 — но любая будущая миграция к атомам строкой обязана следовать тому же правилу).
+
+### 8.2 Разрешённые / рекомендуемые хелперы
+
+Server-side (Go templates, `cmd/dcrdata/internal/explorer/templates.go`):
+
+- `coinSymbol(ct uint8) string` — метка монеты.
+- `formatAtomsAsCoinString(atomStr, coinType)` или `skaDecimalParts` — форматирование SKA-атомов.
+- `float64AsDecimalParts` / `amountAsDecimalParts` — **только** для VAR-веток.
+- `intComma`, `x100`, `add`, `subtract` — для счётов и процентов (coin-agnostic).
+
+Client-side (`cmd/dcrdata/public/js/helpers/`):
+
+- `renderCoinType(coinType)` — метка монеты (`null`/`undefined`/out-of-range → `"-"`).
+- `formatCoinAtoms(atomStr, coinType)` — three-significant-figure роутинг.
+- `formatAtomsAsCoinString(atomStr, coinType)` — полная точность с обрезкой trailing zeros.
+- `splitSkaAtoms(atomStr)` — `BigInt`-safe разделение атомов на цело-десятичную часть.
+- `splitSkaAtomsNoTrailing(atomStr)` — то же без trailing zeros.
+
+### 8.3 `data-address-balance`
+
+Атрибут на корневом контейнере `address.tmpl:15` (`data-address-balance="{{toFloat64Amount .Balance.TotalUnspent}}"`) **удаляется**. Сегодня он считывается в `address_controller.js:230` (`ctrl.balance`), но больше нигде не используется. Вводить пер-монетный JSON-вариант не нужно.
+
+### 8.4 Принцип распределения вычислений: бэкенд vs фронт
+
+Общее правило для всей страницы (применяется ко всем трём дочерним спекам):
+
+| Где живёт                                                        | Что считается                                                                              |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **Бэкенд (Go)**                                                  | Всё, что связано с **арифметикой над атомами**: суммы, кумулятивные суммы (running balance), пер-монетные итоги. Использует `int64` для VAR, `*big.Int` для SKA. |
+| **Бэкенд (Go)**                                                  | Все coin-agnostic скалярные счётчики и предсчитанные поля (`TotalOutputs`, `TotalInputs`, `TotalReceived`, `Balance []float64` / `BalanceAtoms []string` для chart-серий). |
+| **Шаблон / контроллер (Go template / JS)**                       | Только string→string форматирование (`coinSymbol`, `splitSkaAtomsNoTrailing`, `formatAtomsAsCoinString`), UI-state (зум, селекторы, нормализация `?coin=`), DOM-операции на real-time события. |
+| **Запрещено**                                                    | `BigInt`-арифметика на JS, `add`/`subtract`/кумсуммы атомов в Go-шаблоне (вне форматтеров), любая `Number`-конверсия SKA-атомов до точки рендера. |
+
+**Почему это важно:**
+
+- Точность: SKA-арифметика на `*big.Int` в Go — единственный безопасный путь (`Number` в JS теряет точность за 15-й цифрой; см. §8.1).
+- Кеширование: предсчитанные поля попадают в `AddressCache` и не пересчитываются на каждом рендере.
+- Симметрия с прецедентами: SKA `coin-supply/{N}` уже считается на бэкенде через `*big.Int.Add` (см. `wiki/code-analysis/charts/`), и Address charts/summary следуют тому же паттерну.
+- Простота фронта: в `address_controller.js` остаётся только UI-state и форматирование — никаких накопителей и `BigInt`-обёрток.
+
+#### Что с этим делают websocket-обновления
+
+В рамках текущего скоупа адресная страница реагирует только на `BLOCK_RECEIVED` ([§5](#5-real-time-updates)). Правила распределения вычислений действуют и здесь:
+
+- **Что в payload есть сегодня:** список confirmed txids. Coin-type на per-tx уровне в событии **нет**, и расширять payload **не требуется** — необходимая для пер-монетных декрементов coin-info уже на клиенте через SSR-атрибут `data-coin-type` (см. address-summary §3.5).
+- **Что обновляется живьём:** скалярные счётчики (`numUnconfirmed[N]`, `txnCount`). Это инкременты/декременты `int64` — арифметика безопасна даже на JS, никакого `BigInt` не нужно.
+- **Если бы понадобилось живо обновлять SKA-балансы (out of scope):** payload **обязан** нести уже посчитанные атомные строки (новые балансы на адрес), а не дельты к старому значению. Применение дельты на клиенте требовало бы `BigInt`-арифметики и нарушало C1 ([точность через слои](../../core/constraints.md#c1-numeric-precision--bifurcation)) и [C3](../../core/constraints.md#c3-template--websocket-parity) (паритет SSR ↔ live). Это правило фиксируется здесь, чтобы будущий «live-balances» спек не возвращал нас к JS-арифметике.
+- **Если бы понадобились живо появляющиеся mempool-строки (out of scope):** новые DOM-узлы создаются только через `<template>`-cloning ([C6](../../core/constraints.md#c6-in-dom-template-cloning)), не через `innerHTML` конкатенацию.
+
+---
+
+## 9. Связанные изменения, остающиеся вне скоупа
+
+- **Fiat conversion** — монеты сети (ни VAR, ни SKA) сейчас нигде не торгуются, реальной цены нет. В рамках этой переработки fiat-строка убирается из карточки summary целиком (см. address-summary §3.7). Пакет `exchanges/bot.go` остаётся в репозитории — его используют другие страницы (home, mempool, tx); их перевод/чистка — вне скоупа этого спека. Когда (и если) у монет появится реальный рынок, отдельный будущий спек вернёт fiat сразу пер-монетным.
+- **Live updates балансов** — выходит за пределы текущего скоупа; см. §5.
+
+---
+
+## 10. Чек-лист изменений на странице
+
+| Раздел        | Файл                                                                                         | Изменения (резюме)                                                                                          |
+| ------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Backend types | `db/dbtypes/types.go`                                                                        | `AddressBalance` пер-монетная; `AddressInfo.ActiveCoins []uint8`; SKA-поля на `AddressTx`.                  |
+| Backend DB    | `db/dcrpg/queries.go`, `db/dcrpg/pgblockchain.go`, `db/dcrpg/internal/addrstmts.go`          | новый `SELECT DISTINCT coin_type`; пер-монетный разрез в `retrieveAddressBalance` / `ReduceAddressHistory`. |
+| API (charts)  | `cmd/dcrdata/internal/api/apiroutes.go`, `apirouter.go`                                      | `?coin=N` query param; пер-монетная диспатч-логика в `TxHistoryData`.                                       |
+| Cache         | `db/cache/addresscache.go`                                                                   | ключ кеша расширен на `coin_type`.                                                                          |
+| Handler       | `cmd/dcrdata/internal/explorer/explorerroutes.go`                                            | парсинг `?coin=`, заполнение `ActiveCoins`, fiat больше не считается через `xcBot.Conversion`.              |
+| Templates     | `cmd/dcrdata/views/address.tmpl`, `extras.tmpl`, `addresstable.tmpl`                         | пер-монетные ряды; удаление `DCR`-литералов; `{{coinSymbol}}`; SKA-форматирование.                          |
+| Frontend      | `cmd/dcrdata/public/js/controllers/address_controller.js`                                    | новый ключ `coin` в settings; общий помощник смены `?coin=` со сбросом `?start=0`.                          |
+| Mocks         | `cmd/dcrdata/internal/explorer/explorer_test.go`, `cmd/dcrdata/internal/api/noop_ds_test.go` | обновление сигнатур; пустой `ActiveCoins` по умолчанию.                                                     |
+
+Подробные пер-разделные списки — в трёх дочерних спецификациях.
+
+---
+
+## 11. ⚠️ Ключевые инварианты
+
+- Адрес — **мульти-монетный**: одна страница может одновременно отображать несколько монет одного адреса.
+- VAR показывается всегда; SKA — только если в `ActiveCoins`.
+- Точность не теряется: SKA-атомы передаются строкой через все слои.
+- `?coin=` — единственный URL-ключ, общий между chart-карточкой и таблицей; смена сбрасывает `?start=0`.
+- Пустая монета фильтра (`?coin=` отсутствует) означает: chart по умолчанию VAR; таблица показывает все монеты.
+- Метки монет рендерятся только через `coinSymbol` / `renderCoinType`.
+
+---

--- a/wiki/specs/address-summary/spec.md
+++ b/wiki/specs/address-summary/spec.md
@@ -1,0 +1,312 @@
+# Address Summary Card — Multi-Coin Spec
+
+Левая верхняя карточка на странице `/address/{address}` (`cmd/dcrdata/views/address.tmpl:21-112`). Контент: адрес + QR, тип адреса, три суммарные числа (Balance / Received / Spent), Unconfirmed, Stake spending / income, dummy-уведомление.
+
+Этот документ — продолжение [address-overview/spec.md](../address-overview/spec.md). Технический разбор изменяемых файлов: `wiki/code-analysis/address/summary.impact.md`.
+
+---
+
+## 1. Цель и охват
+
+### Входит
+
+- Перевод Balance / Received / Spent на пер-монетный разрез
+- Удаление fiat-строки в этом редизайне
+- Перевод Unconfirmed на пер-монетный разрез
+- Stake spending / Stake income — оставить только VAR-секцию, считать корректно
+- Замена жёстких `DCR`-меток на `coinSymbol`
+- Empty-state «No activity» для пустого адреса
+- Удаление атрибута `data-address-balance`
+
+### Не входит
+
+- Адресная строка, QR-код, тип адреса, dummy-уведомление — **без изменений** (coin-agnostic).
+- Live-обновление балансов (только SSR; см. address-overview §5).
+- Любая работа с fiat-курсами (ни для VAR, ни для SKA): монеты сети ещё нигде не торгуются, поэтому fiat-блок убирается целиком (см. §3.7).
+- `?coin=` URL-ключ — карточка summary его игнорирует.
+
+---
+
+## 2. Текущее поведение
+
+Карточка читает единственный `dbtypes.AddressBalance` (`db/dbtypes/types.go:2350`) и рендерит:
+
+- **Balance** — `Balance.TotalUnspent` через `amountAsDecimalParts` + жёстко зашитая метка `DCR` (`address.tmpl:48`).
+- **Fiat** — `xcBot.Conversion(dcrutil.Amount(addrData.Balance.TotalUnspent).ToCoin())` (`explorerroutes.go:1617`), показывается под Balance.
+- **Received** — `add Balance.TotalSpent Balance.TotalUnspent` + `DCR`; ниже — `intComma (add NumSpent NumUnspent)` outputs (`address.tmpl:62-71`).
+- **Spent** — `Balance.TotalSpent` + `DCR`; ниже — `intComma NumSpent` inputs.
+- **Unconfirmed** — единственное число `NumUnconfirmed`, без разреза по монете.
+- **Stake spending** — `printf "%.1f" (x100 .Balance.FromStake)`, гейтится `HasStakeOutputs()`.
+- **Stake income** — `printf "%.1f" (x100 .Balance.ToStake)`, гейтится `HasStakeInputs()`.
+- **Dummy address notice** — текст по `IsDummyAddress`.
+
+Все денежные значения проходят через `dcrutil.Amount.ToCoin() float64`. Для адресов с SKA это нарушает [C1](../../core/constraints.md): 18 десятичных знаков SKA не помещаются в `float64`.
+
+---
+
+## 3. Требуемое поведение
+
+### 3.1 Общая структура карточки
+
+Карточка остаётся в той же DOM-сетке (адрес-блок слева, три суммарных числа в ряду, ниже — Unconfirmed / Stake-метрики, dummy-уведомление). Меняется содержимое числовых ячеек: каждая получает **вертикальный пер-монетный список**.
+
+### 3.2 Balance
+
+**Правила отображения:**
+
+- VAR показывается всегда (даже при нулевом балансе, если у адреса есть VAR-история).
+- SKA-строки показываются только для монет из `ActiveCoins` (см. address-overview §3).
+- Порядок: VAR → SKA1 → SKA{n} (по `ActiveCoins`).
+- VAR — 8 знаков после запятой через существующие хелперы (`amountAsDecimalParts`).
+- SKA — 18 знаков после запятой, атомы как строка через `formatAtomsAsCoinString` / `skaDecimalParts`.
+- Метка монеты — только через `{{coinSymbol .CoinType}}`.
+
+**Пример:**
+
+```
+Balance
+VAR    4,973.98183244
+SKA1   123.000000000000000001
+SKA2   0.000000000000000123
+```
+
+### 3.3 Received
+
+**Источник данных:** для каждой монеты значение `Received` **предсчитывается на бэкенде** (поле `TotalReceived` на `CoinBalance` — атомы по типу монеты: VAR `int64`, SKA `string`). В шаблоне **никакого** `{{add .TotalSpent .TotalUnspent}}` — для VAR это сработало бы, для SKA пришлось бы вводить отдельный template-хелпер `addSkaAtoms`, что лишняя точка отказа.
+
+Семантически `TotalReceived = TotalSpent + TotalUnspent`, но сложение делает Go-слой при заполнении `CoinBalance`.
+
+**Правила отображения:** те же, что у Balance.
+
+Под пер-монетным списком — **одна общая строка-итог** с количеством outputs:
+
+```
+Received
+VAR    12,000.00000000
+SKA1   500.000000000000000000
+--------
+8,921 outputs
+```
+
+Значение `outputs` — **предсчитанное** скалярное поле `TotalOutputs int64` на `AddressBalance` (счёт coin-agnostic, сумма `NumSpent + NumUnspent` по всем монетам). Шаблон не выполняет `{{add ...}}` — просто рендерит `intComma .Balance.TotalOutputs`. Строка отображается всегда, когда есть хотя бы одна монета в `ActiveCoins`.
+
+### 3.4 Spent
+
+Аналогично Received: пер-монетные суммы + один общий итог inputs:
+
+```
+Spent
+VAR    7,026.01816756
+--------
+3,412 inputs
+```
+
+Значение `inputs` — **предсчитанное** скалярное поле `TotalInputs int64` на `AddressBalance` (`NumSpent` по всем монетам). Шаблон рендерит `intComma .Balance.TotalInputs`.
+
+### 3.5 Unconfirmed
+
+**Текущее поведение:** одно число под label `Unconfirmed`.
+
+**Требуемое поведение:** пер-монетный разрез.
+
+```
+Unconfirmed:
+VAR    1
+SKA1   2
+```
+
+**Правила отображения:**
+
+- Раздел показывается, если суммарное `NumUnconfirmed > 0`.
+- Каждая строка — монета из `ActiveCoins` с ненулевым unconfirmed-счётом для этой монеты.
+- Порядок монет — общий: VAR → SKA1 → ….
+- Формат — целое число (без дробной части), `intComma`-разделитель тысяч.
+
+**Backend:** `pgb.mp.UnconfirmedTxnsForAddress(address)` (`db/dcrpg/pgblockchain.go:2587-2592`) сегодня возвращает один `int64`. Расширить до `map[uint8]int64` (или эквивалент). На `AddressInfo.NumUnconfirmed` оставить агрегатное число (для существующих потребителей вроде `txn-count` атрибута), плюс ввести `NumUnconfirmedByCoin map[uint8]int64`.
+
+**Frontend live update:** `_confirmMempoolTxs` (`address_controller.js:774-806`) сейчас инкрементирует `txnCount` и декрементирует один `numUnconfirmed`-target. Расширяется на N targets — по одному на монету, каждый помечен `data-coin-type="N"`.
+
+**Источник `coinType` на confirm-событии:** payload `BLOCK_RECEIVED` сегодня **не несёт** per-tx coin-type, и расширять его не нужно. Поток такой:
+
+1. `BLOCK_RECEIVED` приходит со списком confirmed txids.
+2. Контроллер находит pending-строки в DOM по существующему `data-txid` matching’у (как и сейчас).
+3. На каждой найденной строке читает `data-coin-type` — атрибут, добавленный в SSR-разметку при рендеринге Coin-колонки (см. address-transactions §6.4).
+4. Декрементирует `numUnconfirmed`-target с тем же `data-coin-type`. Если счётчик дошёл до 0 — строка скрывается (как сегодня).
+
+Это соответствует [C3](../../core/constraints.md) (template ↔ websocket parity): живой апдейт меняет только числа, не вводит новых DOM-узлов; вся coin-info уже отрендерена SSR. Расширения websocket payload не требуется.
+
+**Out of scope:** live-инкремент `numUnconfirmed` при появлении **нового** mempool-tx (без блока). Сейчас адресная страница не подписана на такие события — новые unconfirmed строки появляются только при reload / XHR-refresh. Если в будущем понадобится — отдельный спек, который должен решить, как на frontend появляются новые DOM-строки (по C6 — через `<template>`-cloning, не через innerHTML конкатенацию).
+
+### 3.6 Stake spending / Stake income
+
+**Концептуально:** stake-механизм существует только для VAR (consensus inheritance из dcrd). Для SKA эти метрики не определены.
+
+**Правила отображения:**
+
+- Строки `Stake spending` / `Stake income` показываются **только если у адреса есть VAR-активность** (т.е. `0 ∈ ActiveCoins`).
+- Числители и знаменатели рассчитываются строго в VAR-разрезе:
+  - `FromStake = (VAR atoms сошедшие со stake-выходов) / (VAR atoms total spent)`.
+  - `ToStake = (VAR atoms пришедшие со stake-выходов) / (VAR atoms total received)`.
+- Если у адреса нет VAR-активности, обе строки скрыты.
+- Если VAR-активность есть, но `HasStakeOutputs()` / `HasStakeInputs()` ложны — строки скрыты (как сегодня).
+
+**Backend:** `FromStake` / `ToStake` (поля на `AddressBalance`) сейчас считаются в `db/dcrpg/queries.go:1518-1524` поверх coin-flattened сумм. Нужно ограничить агрегацию VAR-секцией. Хелперы `HasStakeOutputs()` / `HasStakeInputs()` остаются булевыми, но их семантика — «у VAR-баланса есть stake-выходы/входы».
+
+### 3.7 Fiat row
+
+**Удаляется полностью.**
+
+Удаляется блок `address.tmpl:54-56` (`if $.FiatBalance ...`) и заполнение `FiatBalance` в `explorerroutes.go:1617` (вызов `exp.xcBot.Conversion`). Поле `FiatBalance *exchanges.Conversion` со структуры `AddressPageData` удаляется.
+
+Причина: монеты сети (ни VAR, ни SKA) сейчас нигде не торгуются — реальной цены не существует. Поэтому fiat-блок не имеет смысла даже в VAR-частном случае. `exchanges/bot.go` сам по себе **не удаляется** — его всё ещё используют другие страницы (home, mempool, tx); из них fiat-строка убирается отдельными изменениями вне этого спека (если/когда понадобится).
+
+Когда (и если) у монет появится реальный рынок и price feed, отдельный спек вернёт fiat в карточку — но уже изначально пер-монетным.
+
+### 3.8 Empty state
+
+Когда `ActiveCoins` пуст (адрес не имеет ни одной транзакции), карточка показывает упрощённую версию:
+
+```
+Balance:    —
+Received:   —
+Spent:      —
+```
+
+**Правила отображения:**
+
+- Без пер-монетного списка.
+- Без счётчиков outputs / inputs.
+- Без unconfirmed-блока.
+- Без stake-метрик.
+- Без fiat (его и так нет).
+
+Адресная строка, тип, QR — **без изменений**.
+
+### 3.9 Dummy address notice
+
+`{{if .IsDummyAddress}}*This a is dummy address...{{end}}` (`address.tmpl:107-111`) — **без изменений**. Короткое замыкание в handler’е (см. address-overview §6) гарантирует, что эта ветка работает с пустым `AddressInfo`.
+
+### 3.10 Атрибут `data-address-balance`
+
+Удаляется (`address.tmpl:15`). Соответственно — удаляется `ctrl.balance = $(...).attr('data-address-balance')` в `address_controller.js:230`. Само поле было неиспользуемым.
+
+---
+
+## 4. UI-mockup карточки целиком
+
+```
+┌──────────────────────────────────────────────────┐
+│ Address                                           │
+│ DsXXXX...XXX  📋  📷                              │
+│ pubkeyhash                                        │
+│                                                   │
+│ Balance                Received           Spent   │
+│ VAR  4,973.98183244    VAR  12,000.00     VAR  7,026.01     │
+│ SKA1 123.000…001       SKA1 500.000…000   --------          │
+│ SKA2 0.000…000123      --------           3,412 inputs      │
+│                        8,921 outputs                        │
+│                                                   │
+│ Unconfirmed:                                      │
+│ VAR    1                                          │
+│ SKA1   2                                          │
+│                                                   │
+│ Stake spending: 12.4%                             │
+│ Stake income:    3.7%                             │
+└──────────────────────────────────────────────────┘
+```
+
+Шрифт чисел — моноширинный (как сейчас), для SKA — выравнивание по точке.
+
+---
+
+## 5. Точность и форматирование
+
+| Величина                     | Тип в БД                  | Формат вывода                                                          |
+| ---------------------------- | ------------------------- | ---------------------------------------------------------------------- |
+| VAR Balance / Received / Spent | `int64` (атомы)           | `amountAsDecimalParts (atoms) true` → 8 знаков, разделители тысяч.    |
+| SKA Balance / Received / Spent | `string` (атомы по C1)    | `formatAtomsAsCoinString` или `skaDecimalParts` → 18 знаков, строка. |
+| Unconfirmed (любая монета)   | `int64` (счёт)            | `intComma`.                                                            |
+| Outputs / inputs total       | `int64` (счёт)            | `intComma`.                                                            |
+| Stake spending / income      | `float64` (доля)          | `printf "%.1f" (x100 ...)` → одно знач. после точки.                  |
+
+**Запрещено:**
+
+- `toFloat64Amount` для SKA-значений (precision loss).
+- `dcrutil.Amount.ToCoin()` для SKA-значений.
+- Inline-литералы `DCR` / `VAR` / `` `SKA${n}` `` в шаблоне.
+
+---
+
+## 6. Backend-изменения
+
+### 6.1 `dbtypes.AddressBalance`
+
+См. address-overview §7.1. Из перспективы summary card нужны:
+
+- Per-coin `TotalUnspent`, `TotalSpent`, `NumUnspent`, `NumSpent` (типы по монете: VAR-атомы `int64`, SKA-атомы `string`).
+- Per-coin **предсчитанное** `TotalReceived` (= `TotalSpent + TotalUnspent` в атомах своей монеты) — чтобы шаблон не выполнял сложение SKA-строк.
+- На уровне всего `AddressBalance` (не per-coin) — **предсчитанные** скаляры:
+  - `TotalOutputs int64` — `Σ (NumSpent + NumUnspent)` по всем монетам.
+  - `TotalInputs int64` — `Σ NumSpent` по всем монетам.
+- `FromStake float64`, `ToStake float64` — общие поля, считаются из VAR-сегмента.
+- `HasStakeOutputs()` / `HasStakeInputs()` — методы остаются, но опираются на VAR-секцию.
+
+**Принцип**: вся арифметика над атомами/счётчиками — в Go-слое (`retrieveAddressBalance` / `ReduceAddressHistory`). Шаблон только рендерит готовые значения через форматтеры.
+
+### 6.2 `dbtypes.AddressInfo`
+
+- Добавить `ActiveCoins []uint8` (см. address-overview §3).
+- `NumUnconfirmed int64` — оставить агрегатным (для существующих потребителей).
+- Добавить `NumUnconfirmedByCoin map[uint8]int64` (или []`{CoinType, Count}` пара — окончательное решение по форме оставлено в импл-фазу, но JSON и шаблон должны видеть пер-монетную структуру).
+
+### 6.3 Удаление `FiatBalance`
+
+- Поле `FiatBalance *exchanges.Conversion` удаляется из inline-структуры `AddressPageData` (`explorerroutes.go:1538-1545`).
+- Вызов `exp.xcBot.Conversion(...)` (`explorerroutes.go:1617`) удаляется.
+- `exchanges/bot.go` остаётся без изменений — пакет используется на других страницах (home, mempool, tx). Их перевод вне fiat-эры — отдельный скоуп.
+
+### 6.4 Mempool API для unconfirmed
+
+`db/dcrpg/pgblockchain.go:2587-2592` — расширить `pgb.mp.UnconfirmedTxnsForAddress(address)` до возврата map‘а. Реализация в `mempool/` пакете: проход по существующему unconfirmed списку с разрезом по `coin_type` каждой транзакции.
+
+### 6.5 Моки
+
+- `cmd/dcrdata/internal/explorer/explorer_test.go:50-58` — `mockDataSource.AddressHistory`/`AddressData`/`DevBalance` обновить под новый `AddressBalance`.
+- `cmd/dcrdata/internal/api/noop_ds_test.go:29-31` — `noopDS.AddressHistory` обновить так же.
+
+---
+
+## 7. Шаблон / frontend изменения
+
+### 7.1 `cmd/dcrdata/views/address.tmpl`
+
+Изменяемые строки (см. summary.impact.md §3 для полной таблицы):
+
+- `:15` — удалить `data-address-balance`.
+- `:42-86` — переписать три ячейки (Balance / Received / Spent) под пер-монетные списки.
+- `:54-56` — удалить блок Fiat.
+- `:87-103` — переписать ряд Unconfirmed / Stake под новые правила (Unconfirmed = пер-монетный список; Stake — гейт на VAR).
+
+Все литералы `DCR` (`:48, :50, :64, :66, :77, :79`) удаляются.
+
+### 7.2 `cmd/dcrdata/public/js/controllers/address_controller.js`
+
+- `:230` — удалить чтение `data-address-balance` (атрибут удалён).
+- `:774-806` (`_confirmMempoolTxs`) — обновить для пер-монетных `numUnconfirmed`-targets:
+  - на `event.detail` (или эквивалент) ожидать `{txid, coinType}` вместо плоского `txid`.
+  - матчить `numUnconfirmedTarget[i]` по `data-coin-type`; декрементировать совпавший.
+  - скрывать строку при достижении 0 (как сейчас).
+  - агрегатный `txnCount` инкрементируется как и раньше.
+
+---
+
+## 8. ⚠️ Ключевые инварианты
+
+- Карточка summary **никогда не теряет точность** для SKA: атомы строкой во всех слоях.
+- Пер-монетные списки следуют общим правилам: VAR всегда, SKA по `ActiveCoins`, порядок VAR→SKA1→…, метки только через `coinSymbol`.
+- Stake-метрики имеют смысл только для VAR; для SKA-only адресов их нет.
+- `?coin=` URL-ключ карточкой **игнорируется**.
+- Live updates: только пер-монетные unconfirmed-счётчики и общий txnCount.
+- Empty state — единственная упрощённая ветка; dummy address — отдельная (через handler short-circuit).
+
+---

--- a/wiki/specs/address-transactions/spec.md
+++ b/wiki/specs/address-transactions/spec.md
@@ -1,0 +1,388 @@
+# Address Transactions Section — Multi-Coin Spec
+
+Нижняя секция страницы `/address/{address}` (`cmd/dcrdata/views/address.tmpl:185-298`): шапка с диапазоном/пагинацией, таблица транзакций (`addressTable` из `extras.tmpl:210-315`, обёртка `addresstable.tmpl`), мерж-вью, селекторы Type / Page-size, CSV-выгрузка, постраничная навигация.
+
+Этот документ — продолжение [address-overview/spec.md](../address-overview/spec.md). Технический разбор изменяемых файлов: `wiki/code-analysis/address/transactions.impact.md`.
+
+---
+
+## 1. Цель и охват
+
+### Входит
+
+- Добавить колонку **Coin** в таблицу транзакций (per-row coin label).
+- Переименовать колонки **Credit VAR** / **Debit VAR** → **Credit** / **Debit** (метка монеты переезжает в строку).
+- Перевести amount-форматирование на пер-монетный путь: VAR через существующие хелперы; SKA — через `skaDecimalParts` / `formatAtomsAsCoinString` (атомы как строка).
+- Заменить float-эвристику `{{if eq .SentTotal 0.0}} sstxcommitment` на coin-aware условие (`.CoinType == 0` гейт).
+- Добавить **фильтр по монете** рядом с `txntype` selector (`<select>`, default "All").
+- Завести URL-ключ `?coin=` (общий с charts, см. address-overview §4) — смена сбрасывает `?start=0`.
+- CSV download: схема меняется — единая колонка `amount` (string) + новая `coin_type` колонка.
+- Mempool-overlay (`UnconfirmedTxnsForAddress`) выдаёт пер-монетные строки с правильными атомами.
+
+### Не входит
+
+- Графический внешний вид строк (стили, размеры) — только содержимое.
+- Поведение `pageNumberLink` / `prevPage` / `nextPage` под существующие URL-ключи (`?start=`, `?n=`) — без изменений, кроме сброса `?start=0` при смене `?coin=`.
+- Изменение `txntype` фильтра — без изменений (только мерж-вью теперь работают пер-монетно по умолчанию).
+- Live-обновление amount-значений — выходит за рамки скоупа.
+
+---
+
+## 2. Текущее поведение
+
+### 2.1 Таблица
+
+`addressTable` (`extras.tmpl:210-315`) рендерит разные наборы колонок в зависимости от `$txType`:
+
+| `$txType`        | Колонки                                                                       |
+| ---------------- | ----------------------------------------------------------------------------- |
+| `merged_debit`   | Tx Type, I/O, Cnt(Inputs), **Debit VAR**, Time, Age, Confirms, Size           |
+| `merged_credit`  | Tx Type, I/O, Cnt(Outputs), **Credit VAR**, Time, Age, Confirms, Size         |
+| `merged`         | Tx Type, I/O, I/O Count, **Credit VAR**, **Debit VAR**, Time, Age, Confirms, Size |
+| `unspent`        | Tx Type, I/O, **Credit VAR**, Time, Age, Confirms, Size                       |
+| `credit` / `all` (funding) | Tx Type, I/O, **Credit VAR**, MatchedTx, Time, Age, Confirms, Size  |
+| `debit` / `all` (spending) | Tx Type, I/O, MatchedTx, **Debit VAR**, Time, Age, Confirms, Size   |
+
+Все денежные ячейки рендерятся через `float64AsDecimalParts .ReceivedTotal 8 false` или `.SentTotal`. Для SKA-строк (где `CoinType != 0`) backend сегодня заполняет `ReceivedTotal`/`SentTotal` нулём (`db/dbtypes/types.go:2412-2414, 2425-2427`), и шаблон рендерит `0.00000000`.
+
+`CoinType` и `SKAValue` уже есть на `dbtypes.AddressTx`, но **не читаются ни одним шаблоном**.
+
+### 2.2 sstxcommitment heuristic
+
+В шаблоне `extras.tmpl:277` есть особый случай рендеринга для одной разновидности выходов — **sstx commitment output**.
+
+**Что это вообще такое.**
+
+При покупке тикета (SSTx-транзакция, часть Decred-style стейк-механизма) часть выходов записывает адрес и сумму, которые получат награду, когда тикет проголосует. Эти выходы называются *commitment outputs*: они **не тратятся напрямую** — их «раскрывают» только в момент голосования (SSGen) или revocation (SSRtx). На странице адреса такая запись отображается как debit-строка с **нулевой потраченной суммой** (логически — пометка о будущей награде, а не реальный расход).
+
+**Что делает текущий код.**
+
+```
+{{- if eq .SentTotal 0.0}}
+<td class="text-end">sstxcommitment</td>
+```
+
+Шаблон ловит «debit-строка с `SentTotal == 0`» через float-сравнение и подставляет лейбл `sstxcommitment` вместо обычной ссылки `source` / `N/A`.
+
+**Почему это концептуально VAR-only.**
+
+SSTx, SSGen, SSRtx — стейк-механика, унаследованная от dcrd; в Monetarium-сети она существует только для VAR (см. `CLAUDE.md`). У SKA-транзакций commitment-выходов нет в принципе.
+
+**Почему это тихо ломается под мульти-монету.**
+
+Backend сегодня **не заполняет** `SentTotal float64` для SKA-строк — оно всегда `0`, независимо от настоящей потраченной суммы (которая лежит в `SKAValue` строкой по [C1](../../core/constraints.md)). Float-сравнение `eq .SentTotal 0.0` будет ложно-положительно срабатывать на **каждой** SKA-debit-строке, и пользователь увидит лейбл `sstxcommitment` там, где никакого commitment’а быть не может.
+
+Исправление — см. §3.3.
+
+### 2.3 Селекторы и фильтры
+
+`address.tmpl:256-294` — два `<select>` справа под таблицей:
+
+- **Type** (`txntype`) — `all` / `unspent` / `credit` / `debit` / `merged` / `merged_credit` / `merged_debit`.
+- **Page size** — `20` / `40` / `80` / `160` (или меньшие варианты для маленьких адресов).
+
+URL-ключи: `?txntype=`, `?n=`, `?start=`. **Нет** ключа `?pagesize=` — размер страницы берётся через `?n=`.
+
+### 2.4 CSV download
+
+Маршрут `/download/address/io/{addr}` (опц. суффикс `/win` для CRLF). Хендлер строит CSV из `AddressRowsCompact` через `AddressRowCompact` — структура **без `CoinType` / `SKAValue`**. Колонка `value` — `dcrutil.Amount(...).ToCoin() float64`, VAR-only.
+
+### 2.5 XHR refresh
+
+`/addresstable/{addr}` (`explorerroutes.go:1654-1690`) возвращает JSON `{tx_count, html, pages}`, где `html` — полный inner-фрагмент `addressTable`. Frontend (`address_controller.js:fetchTable`, ~361-386) делает `dompurify.sanitize(html)` и `innerHTML = ...`.
+
+---
+
+## 3. Требуемое поведение
+
+### 3.1 Колонка Coin и переименование Credit/Debit
+
+**Все варианты `$txType`** получают новую колонку **Coin** между Tx Type и Credit/Debit.
+
+Заголовки **Credit VAR** / **Debit VAR** меняются на **Credit** / **Debit**.
+
+Каждая строка содержит:
+
+- `Tx Type` — без изменений (Regular / Ticket / Vote / Revocation / Mixed на VAR; на SKA только Regular).
+- `Tx ID` — без изменений (обычный hashlink).
+- **`Coin`** — `{{coinSymbol .CoinType}}` (`VAR` для VAR-строки, `SKA{N}` для SKA).
+- `Credit` / `Debit` — сумма в атомах строки, отформатированная по типу монеты:
+  - VAR: `float64AsDecimalParts (toFloat64Amount .Value) 8 false` (как сейчас, но **через `Value`** в атомах, а не через `ReceivedTotal`/`SentTotal` float).
+  - SKA: `skaDecimalParts .SKAValue` или `formatAtomsAsCoinString .SKAValue 1` (атомы как строка, 18 знаков).
+- Остальные колонки (Time, Age, Confirms, Size) — без изменений.
+
+#### Таблица колонок по `$txType`
+
+```
+all / credit (funding)
+Tx Type | Tx ID | Coin | Credit | Spent? | Time | Age | Confirms | Size
+
+all / debit (spending)
+Tx Type | Tx ID | Coin | Source | Debit | Time | Age | Confirms | Size
+
+unspent
+Tx Type | Tx ID | Coin | Credit | Time | Age | Confirms | Size
+
+merged_credit
+Tx Type | Tx ID | Coin | Cnt(Outputs) | Credit | Time | Age | Confirms | Size
+
+merged_debit
+Tx Type | Tx ID | Coin | Cnt(Inputs)  | Debit  | Time | Age | Confirms | Size
+
+merged
+Tx Type | Tx ID | Coin | I/O Count | Credit | Debit | Time | Age | Confirms | Size
+```
+
+**Важно:** в мерж-вью каждая строка по-прежнему происходит из одной транзакции (которая односмонетная по chain invariant) — у строки есть один well-defined `coin_type`. Колонка Coin содержит метку этой монеты.
+
+### 3.2 Точность
+
+- VAR amount → 8 знаков после запятой, `float64AsDecimalParts`.
+- SKA amount → 18 знаков, **строка**, через `skaDecimalParts` или `formatAtomsAsCoinString`.
+- Метка монеты в колонке Coin → `{{coinSymbol .CoinType}}`.
+
+### 3.3 sstxcommitment heuristic
+
+`extras.tmpl:277` меняется на:
+
+```
+{{- if and (eq .CoinType 0) (eq .SentTotal 0.0)}}
+<td class="text-end">sstxcommitment</td>
+```
+
+Гейт `eq .CoinType 0` означает «эвристика применяется только к VAR-строкам». SKA-строки никогда не считаются sstxcommitment (они и не могут им быть — sstx это VAR-only стейк-объект). Float-сравнение `eq .SentTotal 0.0` остаётся, но теперь оно безопасно: для VAR-строк `.SentTotal` всё ещё `float64`, и нулевое значение здесь корректно.
+
+### 3.4 Coin filter (`<select>`)
+
+В строке селекторов (`address.tmpl:256-294`) появляется новый `<select>`:
+
+```
+[Type: All ▾]   [Coin: All ▾]   [Page size: 20 ▾]
+```
+
+**Опции селектора Coin:**
+
+- `value="" → "All"` (default; означает «без фильтра, все монеты»).
+- `value="0" → coinSymbol 0 ("VAR")` — только если `0 ∈ ActiveCoins`.
+- `value="N" → coinSymbol N ("SKA{N}")` — для каждого `N ∈ ActiveCoins`, `N != 0`.
+- Селектор скрыт, если `len(ActiveCoins) <= 1` (только один coin → нечего выбирать).
+
+**Поведение:**
+
+- `<select data-address-target="coinFilter" data-action="change->address#changeCoin">`.
+- Изменение пишет `settings.coin = e.target.value` (или `delete settings.coin` если выбран «All»), сбрасывает `?start=0` (см. address-overview §4), делает refetch таблицы (`fetchTable`).
+- Текущее значение читается из URL в `connect()` и нормализуется (если значение не из `ActiveCoins` или не пустое — нормализуется к "All").
+
+### 3.5 Server-side фильтр
+
+`parseAddressParams` (`explorerroutes.go:1774-1789`) расширяется:
+
+- Парсит `?coin=` query parameter.
+- Валидирует против `0..255`.
+- Если значение не принадлежит `ActiveCoins` (или само поле отсутствует/пусто) — фильтр отсутствует.
+
+`AddressListData` (`explorerroutes.go:1877`) пробрасывает `coinType *uint8` в `dataSource.AddressData`. SQL `AddressHistory` (или его coin-aware вариант) добавляет `WHERE coin_type = $K` при заданном фильтре.
+
+**Эта же логика применяется к XHR `AddressTable` handler’у** (`explorerroutes.go:1654-1690`) — fetched `tx_count` и `pages` пересчитываются под текущий фильтр.
+
+### 3.6 Pagination
+
+URL-ключи `?n=` и `?start=` остаются без изменений. **Изменение `?coin=` сбрасывает `?start=0`** (см. address-overview §4).
+
+Существующие потоки (Previous/Next, numbered pages, page-size change) — без изменений.
+
+### 3.7 CSV download
+
+Схема **меняется** для всех адресов (не только SKA):
+
+| Колонка        | Тип         | Значение                                                                         |
+| -------------- | ----------- | -------------------------------------------------------------------------------- |
+| `direction`    | string      | `funding` / `spending` (как сегодня)                                             |
+| `tx_hash`      | string      | tx hash                                                                          |
+| `vout_index`   | int         | как сегодня                                                                      |
+| `coin_type`    | string      | `VAR` / `SKA1` / `SKA2` …                                                        |
+| `amount`       | string      | сумма в монете строки: VAR — 8dp, SKA — 18dp; **всегда строка**, без float       |
+| `time`         | iso8601     | как сегодня                                                                      |
+| `block_height` | int         | как сегодня                                                                      |
+| `confirmations`| int         | как сегодня                                                                      |
+
+(Точные имена колонок — на усмотрение импл-фазы; ключевое — единая `amount` строка + `coin_type`.)
+
+**Filter respect:** если в URL присутствует `?coin=N`, CSV-файл содержит только строки этой монеты; это делается через тот же серверный фильтр (см. §3.5).
+
+`/win` суффикс по-прежнему меняет CRLF — это ортогонально мульти-монетной переработке.
+
+### 3.8 Mempool overlay (unconfirmed строки)
+
+`pgblockchain.go:2632-2634, 2693-2695` сегодня кастует все unconfirmed суммы через `dcrutil.Amount(value).ToCoin()` без разреза по монете.
+
+Изменения:
+
+- Mempool-структуры (`mempool` package) обязаны нести `coin_type` и атомы для каждой unconfirmed-tx (для transactions-таблицы).
+- При overlay’е в `AddressData` строки получают:
+  - VAR: атомы → `Value int64` → `ReceivedTotal/SentTotal float64` (как сейчас).
+  - SKA: атомы → `SKAValue string`, `CoinType = N`. `ReceivedTotal/SentTotal` остаются `float64`-нулём (для SKA-строки шаблон их не читает).
+
+### 3.9 XHR refresh shape
+
+JSON-ответ `/addresstable/{addr}` остаётся `{tx_count, html, pages}`. `html` теперь содержит новую колонку `Coin` и пер-монетное форматирование amount’ов. `tx_count` отражает фильтр `?coin=` (если задан).
+
+Frontend `fetchTable` (`address_controller.js:361-386`):
+
+- URL построения: добавить `?coin=` к параметрам (`txntype`, `start`, `n`).
+- В остальном без изменений: `dompurify.sanitize` → `innerHTML = ...`.
+
+---
+
+## 4. UI mockup таблицы (вариант `all`)
+
+```
+Tx Type | Tx ID    | Coin | Credit       | Spent?  | Time             | Age | Conf | Size
+--------+----------+------+--------------+---------+------------------+-----+------+-----
+Regular | abc...12 | VAR  | 50.00000000  | spent   | 2025-01-12 10:23 | 4d  | 1,200| 234B
+Regular | def...34 | SKA1 | 1.000…001    | unspent | 2025-01-11 09:14 | 5d  | 1,310| 198B
+Regular | ghi...56 | VAR  | —            | source  | 2025-01-09 17:02 | 7d  | 1,500| 256B
+```
+
+Под таблицей (нижний ряд элементов):
+
+```
+[CSV Download]                         [Type: All ▾]  [Coin: All ▾]  [Page size: 20 ▾]
+```
+
+---
+
+## 5. Backend-изменения (детали)
+
+### 5.1 `dbtypes.AddressTx`
+
+Поля уже частично есть; нужно довести до шаблона:
+
+- `CoinType uint8` — coin тип строки.
+- `SKAValue string` — атомы SKA как строка (для VAR — пусто; шаблон не читает).
+- `ReceivedTotal float64`, `SentTotal float64` — остаются для VAR (атомы → coins).
+- Дополнительно: `IsSstxCommitment bool` — **опционально**, если будет принято решение перейти от float-эвристики к явному флагу. В текущем спеке принят более лёгкий вариант (гейт `CoinType == 0`); явный флаг — out of scope, но шаблон-замена под него тривиальна.
+
+### 5.2 `dbtypes.ReduceAddressHistory` и `FillAddressTransactions`
+
+- `ReduceAddressHistory` (`db/dbtypes/types.go:2380+`):
+  - При `addrOut.CoinType == 0` (VAR) — путь как сейчас, через `dcrutil.Amount(addrOut.Value).ToCoin()`.
+  - При `addrOut.CoinType != 0` (SKA) — установить `tx.SKAValue = addrOut.SKAValue`; не вызывать `ToCoin()`; `ReceivedTotal/SentTotal` оставить нулём.
+  - В обоих случаях — установить `tx.CoinType = addrOut.CoinType`.
+- `FillAddressTransactions` (`pgblockchain.go:2746`) — проверить, не забывает ли заполнять `CoinType` / `SKAValue` для строк, добавляемых из БД (не из mempool).
+
+### 5.3 `parseAddressParams` и handler’ы
+
+- `parseAddressParams` (`explorerroutes.go:1774`) парсит и валидирует `?coin=`.
+- `AddressPage` и `AddressTable` пробрасывают `coinFilter *uint8` в `AddressListData`.
+- `AddressListData` (`explorerroutes.go:1877`) → `dataSource.AddressData(..., coinFilter)` → `pgblockchain.go:AddressData(..., coinFilter)`.
+
+### 5.4 SQL фильтр
+
+`db/dcrpg/queries.go:AddressHistory` (~`pgblockchain.go:2382`) расширяется на необязательный фильтр `WHERE coin_type = $K`. Подобный фильтр нужен и для `mergedTxnCount` (`:2322`) — иначе фильтр не возвратит правильный `tx_count` для пагинации.
+
+### 5.5 CSV handler
+
+Найти роут `/download/address/io/{addr}[/win]` (хендлер строит CSV из `AddressRowsCompact` → `AddressRowCompact`):
+
+- Расширить `AddressRowCompact` полями `CoinType uint8`, `Amount string` (или `AmountAtoms string`).
+- В CSV-сериализаторе:
+  - `coin_type` → `coinSymbol(row.CoinType)`.
+  - `amount` → `formatCoinAtoms(row.Amount, row.CoinType)` (или эквивалент).
+  - **Никогда** не выводить `dcrutil.Amount(...).ToCoin()` для SKA-строк.
+- Поддержать фильтр `?coin=` через `parseAddressParams` или эквивалентный CSV-handler-параметр.
+
+### 5.6 Mempool-overlay
+
+`db/dcrpg/pgblockchain.go:2632-2634, 2693-2695` (`UnconfirmedTxnsForAddress` overlay):
+
+- Mempool tracker (`mempool/` package) уже несёт `coin_type` для каждой tx; протащить до overlay-кода.
+- Создавать `AddressTx` строки с правильными `CoinType` и `SKAValue`.
+- VAR-строки — путь как сейчас через `Value` / `ToCoin()`.
+
+### 5.7 Mocks
+
+- `cmd/dcrdata/internal/explorer/explorer_test.go` — `mockDataSource.AddressHistory`/`AddressData` сигнатуры обновляются под `coinFilter`.
+- `cmd/dcrdata/internal/api/noop_ds_test.go` — то же.
+
+---
+
+## 6. Frontend-изменения (детали)
+
+### 6.1 `cmd/dcrdata/views/address.tmpl`
+
+- `:189-219` (header пагинации) — без изменений.
+- `:256-294` — добавить `<select data-address-target="coinFilter">` с опциями по `.Data.ActiveCoins` (см. §3.4).
+
+### 6.2 `cmd/dcrdata/views/extras.tmpl`
+
+`{{define "addressTable"}}` (~210-315):
+
+- В каждом из 7 веток `$txType` — добавить колонку `<th>Coin</th>` сразу после Tx Type (либо после Tx ID, по визуальному предпочтению). Текущий рендер выбирает колонки кейс-за-кейсом — добавить Coin во все варианты.
+- Заголовки `Credit VAR` / `Debit VAR` (`:222, :227, :230, :231, :233, :235, :236`) → `Credit` / `Debit`.
+- В `<tbody>` row’е добавить `<td>{{coinSymbol .CoinType}}</td>`.
+- Каждый `<td class="text-end fs15">...float64AsDecimalParts...</td>` (`:251, 254, 258, 262, 265, 267, 284`) переписать на:
+  ```
+  {{- if eq .CoinType 0}}
+    {{template "decimalParts" (float64AsDecimalParts .ReceivedTotal 8 false)}}
+  {{- else}}
+    {{template "decimalParts" (skaDecimalParts .SKAValue)}}
+  {{- end}}
+  ```
+  (или эквивалент через `formatAtomsAsCoinString`). Точные хелперы — см. address-overview §8.2.
+- `:277` — гейт `{{if and (eq .CoinType 0) (eq .SentTotal 0.0)}}` (см. §3.3).
+
+### 6.3 `cmd/dcrdata/views/addresstable.tmpl`
+
+Без изменений (двухстрочная обёртка над `addressTable`).
+
+### 6.4 `cmd/dcrdata/public/js/controllers/address_controller.js`
+
+- `:153-191` — добавить target `coinFilter` (отдельно от chart-карточкого target `coin`, либо unify в один target — на усмотрение импл-фазы; имя `coin` уже зарезервировано картой графика).
+- `:211-219` — в `nullTemplate` ключ `'coin'` уже добавлен (см. address-charts §3.2). Здесь не дублировать — это shared key.
+- `:220-254` (`connect()`) — добавить чтение selector’а из URL и нормализацию против `ActiveCoins`.
+- `:361-386` (`fetchTable`) — добавить `?coin=` к URL построения.
+- Новый метод (или общий с charts-card) `changeCoin` — пишет `settings.coin`, сбрасывает `?start=0`, обновляет селектор и таблицы (`fetchTable`) **и** график (`drawGraph`).
+
+### 6.5 Sanitize-список
+
+`fetchTable` использует `dompurify.sanitize` (`address_controller.js:382`). Если новые HTML-конструкции (например, ` <span class="coin-badge">SKA1</span>` если будет принято решение оборачивать coin метки) добавят неподдерживаемые теги, добавить их в allowlist. Сейчас `<td>{{coinSymbol .CoinType}}</td>` — обычный текст, никаких новых тегов не требуется.
+
+---
+
+## 7. Точность и форматирование
+
+| Колонка / поле  | VAR (`coin_type=0`)                             | SKA (`coin_type=N`)                                     |
+| --------------- | ----------------------------------------------- | ------------------------------------------------------- |
+| Coin            | `coinSymbol 0` → `"VAR"`                        | `coinSymbol N` → `"SKA{N}"`                             |
+| Credit / Debit  | `float64AsDecimalParts .ReceivedTotal 8 false`  | `skaDecimalParts .SKAValue` или эквивалент              |
+| Cnt / I/O Count | `intComma .MergedTxnCount`                      | `intComma .MergedTxnCount` (count, coin-agnostic)       |
+| Time / Age / Confirms / Size | без изменений                      | без изменений                                           |
+| sstxcommitment | возможен по float-условию (`SentTotal == 0.0`)  | **никогда** (гейт `CoinType == 0`)                      |
+
+**Запрещено:**
+
+- Inline `Credit VAR` / `Debit VAR` / `Total DCR` / `DCR` в шаблоне.
+- `dcrutil.Amount(...).ToCoin()` или `.ReceivedTotal`/`.SentTotal` чтение для SKA-строк.
+- `eq .SentTotal 0.0` без гейта на `CoinType == 0`.
+
+---
+
+## 8. Server vs XHR парность
+
+`AddressPage` (`explorerroutes.go:1534`) и `AddressTable` (`:1654`) разделяют `parseAddressParams` и `AddressListData`. Любое изменение фильтра `?coin=` обязано проявиться **в обоих** обработчиках, иначе XHR-refresh покажет другие строки, чем initial render.
+
+Регрессионный сценарий: открытие страницы с `?coin=2`, затем переключение `?coin=1` через UI — оба render’а должны отдавать только `coin_type=1`.
+
+---
+
+## 9. ⚠️ Ключевые инварианты
+
+- Каждая строка таблицы — single-coin (chain invariant); колонка **Coin** всегда определена для каждой строки.
+- VAR amount — 8dp через float64-pipeline; SKA amount — 18dp атомы строкой; никогда не путать.
+- Фильтр `?coin=` ортогонален `?txntype=`, `?n=`, `?start=`; смена `?coin=` сбрасывает `?start=0`.
+- sstxcommitment-эвристика — VAR-only по гейту `CoinType == 0`.
+- CSV-схема единая для всех монет: одна строковая `amount` + `coin_type`; нет per-coin отдельных файлов.
+- XHR refresh должен быть полностью эквивалентен SSR при тех же параметрах.
+
+---


### PR DESCRIPTION
Splits /address/{address} multi-coin redesign into four feature specs
    backed by per-feature mutation-impact notes:
    
    - address-overview: cross-feature contract (ActiveCoins, ?coin= URL key,
      real-time scope, backend-vs-frontend principle, websocket payload rules)
    - address-summary: per-coin Balance/Received/Spent breakdown, fiat row
      removal, VAR-only stake %, per-coin Unconfirmed live updates
    - address-charts: in-card coin selector, ?coin=N query param,
      backend-computed cumulative balance series (no JS BigInt math)
    - address-transactions: Coin column + coin filter, sstxcommitment heuristic
      gated by CoinType==0, multi-coin CSV schema (amount string + coin_type)
    
    Impact notes under wiki/code-analysis/address/ enumerate change surface
    per UI region (handlers, types, templates, controllers, multi-coin gaps).
    Index updated with the four new entries.