### PR TITLE
mempool: add per-coin per-type amount aggregates

### DIFF
--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -672,14 +672,21 @@ type CoinFillData struct {
 }
 
 // MempoolCoinStats holds per-coin mempool transaction count, size, and amount.
+// Per-type *Amount fields use atom-string semantics matching Amount: VAR is an
+// int64-derived decimal string, SKA is a big.Int decimal string. For SKA coins
+// only RegularAmount is ever non-zero (SKA cannot be ticket/vote/revoke).
 type MempoolCoinStats struct {
-	TxCount      int    `json:"tx_count"`
-	Size         int32  `json:"size"`
-	Amount       string `json:"amount"` // VAR: int64 atom string; SKA: big.Int atom string
-	RegularCount int    `json:"regular_count"`
-	TicketCount  int    `json:"ticket_count"`
-	VoteCount    int    `json:"vote_count"`
-	RevokeCount  int    `json:"revoke_count"`
+	TxCount       int    `json:"tx_count"`
+	Size          int32  `json:"size"`
+	Amount        string `json:"amount"` // VAR: int64 atom string; SKA: big.Int atom string
+	RegularCount  int    `json:"regular_count"`
+	RegularAmount string `json:"regular_amount"`
+	TicketCount   int    `json:"ticket_count"`
+	TicketAmount  string `json:"ticket_amount"`
+	VoteCount     int    `json:"vote_count"`
+	VoteAmount    string `json:"vote_amount"`
+	RevokeCount   int    `json:"revoke_count"`
+	RevokeAmount  string `json:"revoke_amount"`
 }
 
 // TrimmedBlockInfo models data needed to display block info on the new home page

--- a/mempool/collector.go
+++ b/mempool/collector.go
@@ -525,6 +525,12 @@ func ParseTxns(txs []exptypes.MempoolTx, params *chaincfg.Params, lastBlock *Blo
 		tixCount  int
 		voteCount int
 		revCount  int
+		// Per-type VAR atom amounts (only populated for outer ct=0).
+		varRegAmt, varTixAmt, varVoteAmt, varRevAmt int64
+		// Per-type SKA atom amounts. Keyed by outer ct to mirror skaAmt.
+		// By chain invariant SKA appears only in Regular txs, so the
+		// ticket/vote/revoke maps stay empty in practice.
+		skaRegAmt, skaTixAmt, skaVoteAmt, skaRevAmt map[uint8]*big.Int
 	}
 	accum := make(map[uint8]*coinAccum)
 	getAccum := func(ct uint8) *coinAccum {
@@ -533,21 +539,38 @@ func ParseTxns(txs []exptypes.MempoolTx, params *chaincfg.Params, lastBlock *Blo
 		}
 		return accum[ct]
 	}
+	addSkaPerType := func(m *map[uint8]*big.Int, ct uint8, v *big.Int) {
+		if v == nil {
+			return
+		}
+		if *m == nil {
+			*m = make(map[uint8]*big.Int)
+		}
+		if (*m)[ct] == nil {
+			(*m)[ct] = new(big.Int)
+		}
+		(*m)[ct].Add((*m)[ct], v)
+	}
 	for _, tx := range txs {
 		if len(tx.SKATotals) == 0 {
 			a := getAccum(0)
 			a.txCount++
 			a.size += tx.Size
-			a.varAmt += int64(tx.TotalOut * 1e8)
+			atoms := int64(tx.TotalOut * 1e8)
+			a.varAmt += atoms
 			switch tx.Type {
 			case "Regular":
 				a.regCount++
+				a.varRegAmt += atoms
 			case "Ticket":
 				a.tixCount++
+				a.varTixAmt += atoms
 			case "Vote":
 				a.voteCount++
+				a.varVoteAmt += atoms
 			case "Revocation":
 				a.revCount++
+				a.varRevAmt += atoms
 			}
 		} else {
 			for ct, amtStr := range tx.SKATotals {
@@ -567,15 +590,27 @@ func ParseTxns(txs []exptypes.MempoolTx, params *chaincfg.Params, lastBlock *Blo
 				switch tx.Type {
 				case "Regular":
 					a.regCount++
+					addSkaPerType(&a.skaRegAmt, ct, v)
 				case "Ticket":
 					a.tixCount++
+					addSkaPerType(&a.skaTixAmt, ct, v)
 				case "Vote":
 					a.voteCount++
+					addSkaPerType(&a.skaVoteAmt, ct, v)
 				case "Revocation":
 					a.revCount++
+					addSkaPerType(&a.skaRevAmt, ct, v)
 				}
 			}
 		}
+	}
+	skaPerTypeStr := func(m map[uint8]*big.Int, ct uint8) string {
+		if m != nil {
+			if v := m[ct]; v != nil {
+				return v.String()
+			}
+		}
+		return "0"
 	}
 	coinStats := make(map[uint8]exptypes.MempoolCoinStats, len(accum))
 	for ct, a := range accum {
@@ -589,10 +624,21 @@ func ParseTxns(txs []exptypes.MempoolTx, params *chaincfg.Params, lastBlock *Blo
 		}
 		if ct == 0 {
 			s.Amount = fmt.Sprintf("%d", a.varAmt)
-		} else if a.skaAmt != nil {
-			if v := a.skaAmt[ct]; v != nil {
-				s.Amount = v.String()
+			s.RegularAmount = fmt.Sprintf("%d", a.varRegAmt)
+			s.TicketAmount = fmt.Sprintf("%d", a.varTixAmt)
+			s.VoteAmount = fmt.Sprintf("%d", a.varVoteAmt)
+			s.RevokeAmount = fmt.Sprintf("%d", a.varRevAmt)
+		} else {
+			s.Amount = "0"
+			if a.skaAmt != nil {
+				if v := a.skaAmt[ct]; v != nil {
+					s.Amount = v.String()
+				}
 			}
+			s.RegularAmount = skaPerTypeStr(a.skaRegAmt, ct)
+			s.TicketAmount = skaPerTypeStr(a.skaTixAmt, ct)
+			s.VoteAmount = skaPerTypeStr(a.skaVoteAmt, ct)
+			s.RevokeAmount = skaPerTypeStr(a.skaRevAmt, ct)
 		}
 		coinStats[ct] = s
 	}

--- a/mempool/collector_test.go
+++ b/mempool/collector_test.go
@@ -47,3 +47,79 @@ func TestParseTxns_CoinStats(t *testing.T) {
 		t.Errorf("SKA1 Amount: want 1000000000000000000, got %s", inv.CoinStats[1].Amount)
 	}
 }
+
+// TestParseTxns_PerTypeAmounts_VAR asserts that per-type amount aggregates are
+// populated for each tx-type on the VAR coin entry, with "0" for types that
+// received no contribution, and that the total Amount equals the sum of the
+// per-type amounts (internal consistency).
+func TestParseTxns_PerTypeAmounts_VAR(t *testing.T) {
+	params := chaincfg.MainNetParams()
+	lastBlock := &BlockID{Hash: chainhash.Hash{}, Height: 1, Time: 0}
+
+	txs := []exptypes.MempoolTx{
+		{Hash: "r1", TxID: "r1", Size: 100, TotalOut: 1.0, Type: "Regular"},
+		{Hash: "t1", TxID: "t1", Size: 100, TotalOut: 2.0, Type: "Ticket"},
+		{Hash: "v1", TxID: "v1", Size: 100, TotalOut: 3.0, Type: "Vote"},
+		{Hash: "x1", TxID: "x1", Size: 100, TotalOut: 4.0, Type: "Revocation"},
+	}
+
+	inv := ParseTxns(txs, params, lastBlock)
+	s := inv.CoinStats[0]
+
+	if got, want := s.RegularAmount, "100000000"; got != want {
+		t.Errorf("RegularAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.TicketAmount, "200000000"; got != want {
+		t.Errorf("TicketAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.VoteAmount, "300000000"; got != want {
+		t.Errorf("VoteAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.RevokeAmount, "400000000"; got != want {
+		t.Errorf("RevokeAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.Amount, "1000000000"; got != want {
+		t.Errorf("Amount (total): want %s, got %s", want, got)
+	}
+}
+
+// TestParseTxns_PerTypeAmounts_SKA_Precision asserts that an SKA Regular tx
+// with an 18-decimal amount that exceeds float64's significand round-trips
+// exactly through aggregation, and that ticket/vote/revoke amounts stay "0"
+// (SKA cannot appear in stake transactions).
+func TestParseTxns_PerTypeAmounts_SKA_Precision(t *testing.T) {
+	params := chaincfg.MainNetParams()
+	lastBlock := &BlockID{Hash: chainhash.Hash{}, Height: 1, Time: 0}
+
+	// 21-digit atom value, well beyond float64's 2^53 (~16 digits).
+	const bigAtoms = "123456789012345678901"
+	txs := []exptypes.MempoolTx{
+		{
+			Hash:      "s1",
+			TxID:      "s1",
+			Size:      200,
+			TotalOut:  0,
+			Type:      "Regular",
+			SKATotals: map[uint8]string{2: bigAtoms},
+		},
+	}
+
+	inv := ParseTxns(txs, params, lastBlock)
+	s := inv.CoinStats[2]
+
+	if got, want := s.RegularAmount, bigAtoms; got != want {
+		t.Errorf("SKA RegularAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.Amount, bigAtoms; got != want {
+		t.Errorf("SKA Amount (total): want %s, got %s", want, got)
+	}
+	for label, got := range map[string]string{
+		"TicketAmount": s.TicketAmount,
+		"VoteAmount":   s.VoteAmount,
+		"RevokeAmount": s.RevokeAmount,
+	} {
+		if got != "0" {
+			t.Errorf("SKA %s: want \"0\", got %q", label, got)
+		}
+	}
+}

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -360,41 +360,7 @@ func (p *MempoolMonitor) TxHandler(rawTx *chainjson.TxRawResult) error {
 	if p.inventory.CoinStats == nil {
 		p.inventory.CoinStats = make(map[uint8]exptypes.MempoolCoinStats)
 	}
-	if len(tx.SKATotals) == 0 {
-		s := p.inventory.CoinStats[0]
-		s.TxCount++
-		s.Size += tx.Size
-		s.Amount = addAtomStrings(s.Amount, fmt.Sprintf("%d", int64(tx.TotalOut*1e8)), false)
-		switch tx.Type {
-		case "Regular":
-			s.RegularCount++
-		case "Ticket":
-			s.TicketCount++
-		case "Vote":
-			s.VoteCount++
-		case "Revocation":
-			s.RevokeCount++
-		}
-		p.inventory.CoinStats[0] = s
-	} else {
-		for ct, amtStr := range tx.SKATotals {
-			s := p.inventory.CoinStats[ct]
-			s.TxCount++
-			s.Size += tx.Size
-			s.Amount = addAtomStrings(s.Amount, amtStr, true)
-			switch tx.Type {
-			case "Regular":
-				s.RegularCount++
-			case "Ticket":
-				s.TicketCount++
-			case "Vote":
-				s.VoteCount++
-			case "Revocation":
-				s.RevokeCount++
-			}
-			p.inventory.CoinStats[ct] = s
-		}
-	}
+	addTxToCoinStats(p.inventory.CoinStats, tx)
 
 	p.inventory.Unlock()
 	p.mtx.RUnlock()
@@ -574,6 +540,80 @@ func (p *MempoolMonitor) UnconfirmedTxnsForAddress(address string) (*txhelpers.A
 	}
 
 	return outs, int64(len(outs.TxnsStore)), nil
+}
+
+// addTxToCoinStats applies a single mempool tx's contribution to the per-coin
+// stats map in place, mirroring the batch aggregation in ParseTxns. The caller
+// owns map allocation. Per-type amount fields that never received a
+// contribution are emitted as "0" rather than the empty string.
+func addTxToCoinStats(stats map[uint8]exptypes.MempoolCoinStats, tx exptypes.MempoolTx) {
+	if len(tx.SKATotals) == 0 {
+		s := stats[0]
+		s.TxCount++
+		s.Size += tx.Size
+		atoms := fmt.Sprintf("%d", int64(tx.TotalOut*1e8))
+		s.Amount = addAtomStrings(s.Amount, atoms, false)
+		switch tx.Type {
+		case "Regular":
+			s.RegularCount++
+			s.RegularAmount = addAtomStrings(s.RegularAmount, atoms, false)
+		case "Ticket":
+			s.TicketCount++
+			s.TicketAmount = addAtomStrings(s.TicketAmount, atoms, false)
+		case "Vote":
+			s.VoteCount++
+			s.VoteAmount = addAtomStrings(s.VoteAmount, atoms, false)
+		case "Revocation":
+			s.RevokeCount++
+			s.RevokeAmount = addAtomStrings(s.RevokeAmount, atoms, false)
+		}
+		normalizeCoinStatsAmounts(&s)
+		stats[0] = s
+		return
+	}
+	for ct, amtStr := range tx.SKATotals {
+		s := stats[ct]
+		s.TxCount++
+		s.Size += tx.Size
+		s.Amount = addAtomStrings(s.Amount, amtStr, true)
+		switch tx.Type {
+		case "Regular":
+			s.RegularCount++
+			s.RegularAmount = addAtomStrings(s.RegularAmount, amtStr, true)
+		case "Ticket":
+			s.TicketCount++
+			s.TicketAmount = addAtomStrings(s.TicketAmount, amtStr, true)
+		case "Vote":
+			s.VoteCount++
+			s.VoteAmount = addAtomStrings(s.VoteAmount, amtStr, true)
+		case "Revocation":
+			s.RevokeCount++
+			s.RevokeAmount = addAtomStrings(s.RevokeAmount, amtStr, true)
+		}
+		normalizeCoinStatsAmounts(&s)
+		stats[ct] = s
+	}
+}
+
+// normalizeCoinStatsAmounts fills empty per-type amount strings with "0" so
+// the JSON contract is consistent for all tx types regardless of which types
+// have appeared in the mempool.
+func normalizeCoinStatsAmounts(s *exptypes.MempoolCoinStats) {
+	if s.Amount == "" {
+		s.Amount = "0"
+	}
+	if s.RegularAmount == "" {
+		s.RegularAmount = "0"
+	}
+	if s.TicketAmount == "" {
+		s.TicketAmount = "0"
+	}
+	if s.VoteAmount == "" {
+		s.VoteAmount = "0"
+	}
+	if s.RevokeAmount == "" {
+		s.RevokeAmount = "0"
+	}
 }
 
 // addAtomStrings adds two decimal atom strings. For SKA (isBig=true) it uses

--- a/mempool/monitor_test.go
+++ b/mempool/monitor_test.go
@@ -1,0 +1,102 @@
+package mempool
+
+import (
+	"testing"
+
+	exptypes "github.com/monetarium/monetarium-explorer/explorer/types"
+)
+
+// TestAddTxToCoinStats_IncrementalVAR verifies that the incremental per-tx
+// update applies counts and per-type amounts equivalently to the batch path:
+// after adding VAR Regular + Ticket + Vote + Revocation txs, each *Amount
+// field on CoinStats[0] reflects its tx-type only, and Amount equals the sum.
+func TestAddTxToCoinStats_IncrementalVAR(t *testing.T) {
+	stats := map[uint8]exptypes.MempoolCoinStats{}
+	txs := []exptypes.MempoolTx{
+		{Hash: "r1", Size: 100, TotalOut: 1.0, Type: "Regular"},
+		{Hash: "t1", Size: 100, TotalOut: 2.0, Type: "Ticket"},
+		{Hash: "v1", Size: 100, TotalOut: 3.0, Type: "Vote"},
+		{Hash: "x1", Size: 100, TotalOut: 4.0, Type: "Revocation"},
+	}
+	for _, tx := range txs {
+		addTxToCoinStats(stats, tx)
+	}
+	s := stats[0]
+	if got, want := s.RegularAmount, "100000000"; got != want {
+		t.Errorf("RegularAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.TicketAmount, "200000000"; got != want {
+		t.Errorf("TicketAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.VoteAmount, "300000000"; got != want {
+		t.Errorf("VoteAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.RevokeAmount, "400000000"; got != want {
+		t.Errorf("RevokeAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.Amount, "1000000000"; got != want {
+		t.Errorf("Amount: want %s, got %s", want, got)
+	}
+	if s.RegularCount != 1 || s.TicketCount != 1 || s.VoteCount != 1 || s.RevokeCount != 1 {
+		t.Errorf("per-type counts: %+v", s)
+	}
+	if s.TxCount != 4 {
+		t.Errorf("TxCount: want 4, got %d", s.TxCount)
+	}
+}
+
+// TestAddTxToCoinStats_IncrementalSKA_Precision verifies that an SKA Regular
+// tx with an amount exceeding float64's significand is preserved exactly
+// through the incremental path, and that ticket/vote/revoke amounts for the
+// SKA entry stay "0" by chain invariant.
+func TestAddTxToCoinStats_IncrementalSKA_Precision(t *testing.T) {
+	const bigAtoms = "123456789012345678901"
+	stats := map[uint8]exptypes.MempoolCoinStats{}
+	tx := exptypes.MempoolTx{
+		Hash:      "s1",
+		Size:      200,
+		Type:      "Regular",
+		SKATotals: map[uint8]string{2: bigAtoms},
+	}
+	addTxToCoinStats(stats, tx)
+
+	s := stats[2]
+	if got, want := s.RegularAmount, bigAtoms; got != want {
+		t.Errorf("SKA RegularAmount: want %s, got %s", want, got)
+	}
+	if got, want := s.Amount, bigAtoms; got != want {
+		t.Errorf("SKA Amount: want %s, got %s", want, got)
+	}
+	for label, got := range map[string]string{
+		"TicketAmount": s.TicketAmount,
+		"VoteAmount":   s.VoteAmount,
+		"RevokeAmount": s.RevokeAmount,
+	} {
+		if got != "0" {
+			t.Errorf("SKA %s: want \"0\", got %q", label, got)
+		}
+	}
+}
+
+// TestAddTxToCoinStats_IncrementalAccumulates verifies repeated adds for the
+// same coin accumulate the matching per-type amount without resetting it,
+// and that types that never receive a contribution stay "0".
+func TestAddTxToCoinStats_IncrementalAccumulates(t *testing.T) {
+	stats := map[uint8]exptypes.MempoolCoinStats{}
+	// Three VAR Regular txs.
+	for range 3 {
+		addTxToCoinStats(stats, exptypes.MempoolTx{
+			Hash: "r", Size: 100, TotalOut: 1.5, Type: "Regular",
+		})
+	}
+	s := stats[0]
+	if got, want := s.RegularAmount, "450000000"; got != want {
+		t.Errorf("RegularAmount: want %s, got %s", want, got)
+	}
+	if s.TicketAmount != "0" || s.VoteAmount != "0" || s.RevokeAmount != "0" {
+		t.Errorf("untouched per-type fields should be \"0\": %+v", s)
+	}
+	if s.Amount != "450000000" {
+		t.Errorf("Amount: want 450000000, got %s", s.Amount)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `RegularAmount`, `TicketAmount`, `VoteAmount`, `RevokeAmount` (atom-string) fields to `MempoolCoinStats`.
- Populates them in both the batch `ParseTxns` path (`mempool/collector.go`) and the incremental tx-handler path (`mempool/monitor.go`).
- Extracts the inline incremental per-coin update out of `TxHandler` into a pure `addTxToCoinStats` helper so it can be unit-tested without an RPC client.
- All amounts stay as atom-derived strings end-to-end (VAR int64-derived, SKA `big.Int`-derived); no `float64` coercion for SKA.
- Untouched per-type fields normalize to `"0"` for a consistent JSON contract.
- New fields propagate automatically through `MempoolShort.CoinStats` to the `sigMempoolUpdate` websocket event and the `getmempooltxs` handler — no payload plumbing changes.

Backend wave 2 of the mempool page rework (#183). Frontend sub-issues (#185 – #189) consume this contract and remain out of scope.

Closes #221.

## Test plan
- [x] `go test ./mempool/... ./explorer/...` — three new tests cover VAR all-types batch, SKA 18-decimal precision (21-digit atoms), incremental accumulation
- [x] `go build ./...` in repo root and `cmd/dcrdata`
- [x] `golangci-lint run -c .golangci.yml ./mempool/... ./explorer/...` — 0 issues
- [x] `gofmt -l` on touched packages — clean
- [x] Audit of all `MempoolCoinStats` struct literals — every call site uses named-field init, so the additive struct change is non-breaking
- [ ] End-to-end on local testnet: rebuild explorer, hit `/mempool`, then submit one tx per VAR type (Regular/Ticket/Vote/Revocation) and one SKA Regular tx; confirm the matching `*_amount` increments live via the `mempool` websocket event and that SKA non-Regular per-type amounts stay `"0"`