### PR TITLE
cmd/dcrdata: unify SKA-amount cell rendering across blocks tables

### DIFF
--- a/cmd/dcrdata/internal/explorer/home_viewmodel.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel.go
@@ -26,8 +26,10 @@ type HomeBlockRow struct {
 	VARAmount  string
 	VARSize    string
 
-	// SKAAmount is the pre-formatted aggregate SKA amount across all SKA types.
-	// Empty when the block has no SKA transactions.
+	// SKAAmount is the raw atom string of the first SKA row in CoinRows.
+	// The template renders the aggregate cell via formatSKAAmountCell, which
+	// uses SKAAmount only when len(SKASubRows) == 1. Empty when CoinRows has
+	// no SKA entries.
 	SKAAmount string
 
 	// SKASubRows holds per-SKA-type accordion breakdown rows.
@@ -81,7 +83,9 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 						varSize = "—"
 					}
 				} else {
-					// SKA row — add to sub-rows
+					// SKA row — add to sub-rows. Record the first SKA row's raw
+					// atom amount as the aggregate's source; the template
+					// resolves the displayed cell via formatSKAAmountCell.
 					txCount := fmt.Sprintf("%d", cr.TxCount)
 					size := humanize.Bytes(uint64(cr.Size))
 					subRows = append(subRows, SKASubRow{
@@ -90,14 +94,10 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 						Amount:    formatCoinAtoms(cr.Amount, cr.CoinType),
 						Size:      size,
 					})
+					if skaAmount == "" {
+						skaAmount = cr.Amount
+					}
 				}
-			}
-			// Aggregate SKA amount label: use first SKA row's amount if only one,
-			// or a count summary if multiple.
-			if len(subRows) == 1 {
-				skaAmount = subRows[0].Amount
-			} else if len(subRows) > 1 {
-				skaAmount = fmt.Sprintf("%d SKA types", len(subRows))
 			}
 		} else {
 			// No CoinRows — VAR-only block, fall back to Total.

--- a/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
@@ -149,9 +149,10 @@ func TestBuildHomeBlockRows_WithCoinRows(t *testing.T) {
 	if r.SKASubRows[0].Amount != wantSKA {
 		t.Errorf("SKASubRow Amount: got %q, want %q", r.SKASubRows[0].Amount, wantSKA)
 	}
-	// Single SKA type: SKAAmount should equal the sub-row amount.
-	if r.SKAAmount != wantSKA {
-		t.Errorf("SKAAmount: got %q, want %q", r.SKAAmount, wantSKA)
+	// SKAAmount carries the raw atom string; formatSKAAmountCell renders it
+	// in the template.
+	if r.SKAAmount != "1230000000000000000" {
+		t.Errorf("SKAAmount: got %q, want raw atom %q", r.SKAAmount, "1230000000000000000")
 	}
 }
 
@@ -179,7 +180,9 @@ func TestBuildHomeBlockRows_TransactionsSumsCoinRows(t *testing.T) {
 }
 
 // TestBuildHomeBlockRows_MultipleSKATypes verifies that multiple SKA types
-// produce multiple sub-rows and a count summary in SKAAmount.
+// produce multiple sub-rows and that SKAAmount carries the first SKA row's
+// raw atom amount. The template renders the count summary via
+// formatSKAAmountCell, so the view model itself records only raw atoms.
 func TestBuildHomeBlockRows_MultipleSKATypes(t *testing.T) {
 	b := &types.BlockBasic{
 		Height: 30,
@@ -198,9 +201,9 @@ func TestBuildHomeBlockRows_MultipleSKATypes(t *testing.T) {
 	if len(r.SKASubRows) != 2 {
 		t.Fatalf("expected 2 SKASubRows, got %d", len(r.SKASubRows))
 	}
-	// Multiple SKA types: SKAAmount should be a count summary.
-	if r.SKAAmount != "2 SKA types" {
-		t.Errorf("SKAAmount: got %q, want %q", r.SKAAmount, "2 SKA types")
+	if r.SKAAmount != "50000000000000000000" {
+		t.Errorf("SKAAmount: got %q, want first SKA row's raw atoms %q",
+			r.SKAAmount, "50000000000000000000")
 	}
 }
 

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -511,6 +511,27 @@ func formatCoinAtoms(atomStr string, coinType uint8) string {
 	return threeSigFigs(skaCoinValue(atomStr))
 }
 
+// formatSKAAmountCell renders the aggregate SKA-amount table cell shared by
+// the Latest Blocks (home) and Blocks listing tables. The rule is:
+//
+//	subRowCount == 0   → "—"      (no SKA issued at all)
+//	subRowCount == 1   → formatted SKA1 amount (zero-value rows render "0")
+//	subRowCount >= 2   → "Σ N"    (count summary)
+//
+// skaAmount is the raw SKA atom string of the first SKA row and is only used
+// when subRowCount == 1. The Go (server-render) and JS (WebSocket live-update)
+// helpers must stay aligned — see public/js/helpers/coin_rows_helper.js.
+func formatSKAAmountCell(skaAmount string, subRowCount int) string {
+	switch {
+	case subRowCount >= 2:
+		return fmt.Sprintf("Σ %d", subRowCount)
+	case subRowCount == 1:
+		return formatCoinAtoms(skaAmount, 1)
+	default:
+		return "—"
+	}
+}
+
 type periodMap struct {
 	y          string
 	mo         string
@@ -683,6 +704,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 			return float64(parseInt64(atomStr)) / 1e8
 		},
 		"formatCoinAtoms":         formatCoinAtoms,
+		"formatSKAAmountCell":     formatSKAAmountCell,
 		"formatAtomsAsCoinString": formatAtomsAsCoinString,
 		"coinDecimalParts": func(atomStr string, coinType uint8, useCommas bool, boldNumPlaces ...int) []string {
 			return coinDecimalParts(atomStr, coinType, useCommas, boldNumPlaces...)

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -953,3 +953,85 @@ func TestFormatCoinAtoms_LargeSKA(t *testing.T) {
 		t.Errorf("formatCoinAtoms(%q, SKA) = %q, want %q", atomStr, got, "900T")
 	}
 }
+
+// TestFormatSKAAmountCell exercises the shared rule that drives the SKA
+// aggregate cell in both the Latest Blocks and Blocks tables, covering all
+// six scenarios from the spec. The rule is:
+//
+//	subRowCount == 0   → "—"
+//	subRowCount == 1   → formatCoinAtoms(skaAmount, 1)  (zero-value renders "0")
+//	subRowCount >= 2   → "Σ N"
+func TestFormatSKAAmountCell(t *testing.T) {
+	// One SKA = 1e18 atoms.
+	oneSKA := "1000000000000000000"
+	tests := []struct {
+		name        string
+		skaAmount   string
+		subRowCount int
+		want        string
+	}{
+		{
+			name:        "scenario 1: no SKA issued",
+			skaAmount:   "",
+			subRowCount: 0,
+			want:        "—",
+		},
+		{
+			name:        "scenario 2: SKA1 issued, not in this block (zero-value row)",
+			skaAmount:   "0",
+			subRowCount: 1,
+			want:        "0",
+		},
+		{
+			name:        "scenario 3a: SKA1 present, 1 atom (~1e-18)",
+			skaAmount:   "1",
+			subRowCount: 1,
+			want:        formatCoinAtoms("1", 1),
+		},
+		{
+			name:        "scenario 3b: SKA1 present, 1.23 SKA",
+			skaAmount:   "1230000000000000000",
+			subRowCount: 1,
+			want:        "1.23",
+		},
+		{
+			name:        "scenario 3c: SKA1 present, 12,500 SKA",
+			skaAmount:   "12500000000000000000000",
+			subRowCount: 1,
+			want:        "12.5k",
+		},
+		{
+			name:        "scenario 4: SKA1 & SKA2 issued, neither in block",
+			skaAmount:   "0",
+			subRowCount: 2,
+			want:        "Σ 2",
+		},
+		{
+			name:        "scenario 5: SKA1 & SKA2 issued, one present",
+			skaAmount:   oneSKA,
+			subRowCount: 2,
+			want:        "Σ 2",
+		},
+		{
+			name:        "scenario 6: SKA1 & SKA2 issued, both present",
+			skaAmount:   oneSKA,
+			subRowCount: 2,
+			want:        "Σ 2",
+		},
+		{
+			name:        "many SKA types",
+			skaAmount:   "0",
+			subRowCount: 5,
+			want:        "Σ 5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatSKAAmountCell(tt.skaAmount, tt.subRowCount)
+			if got != tt.want {
+				t.Errorf("formatSKAAmountCell(%q, %d) = %q, want %q",
+					tt.skaAmount, tt.subRowCount, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/dcrdata/public/js/controllers/blocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/blocks_controller.js
@@ -62,7 +62,7 @@ export default class extends Controller {
 
     clone.querySelector('[data-type="tx"]').textContent = String(totalTxCount)
     clone.querySelector('[data-type="var-amount"]').textContent = varAmount
-    clone.querySelector('[data-type="ska-amount"]').textContent = skaAmount || '—'
+    clone.querySelector('[data-type="ska-amount"]').textContent = skaAmount
     clone.querySelector('[data-type="size"]').textContent = humanize.bytes(block.size)
     clone.querySelector('[data-type="votes"]').textContent = block.votes
     clone.querySelector('[data-type="tickets"]').textContent = block.tickets

--- a/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.js
@@ -63,7 +63,7 @@ export default class extends Controller {
 
     clone.querySelector('[data-type="tx"]').textContent = String(totalTxCount)
     clone.querySelector('[data-type="var-amount"]').textContent = varAmount
-    clone.querySelector('[data-type="ska-amount"]').textContent = skaAmount || '—'
+    clone.querySelector('[data-type="ska-amount"]').textContent = skaAmount
     clone.querySelector('[data-type="size"]').textContent = humanize.bytes(block.size)
     clone.querySelector('[data-type="votes"]').textContent = block.votes
     clone.querySelector('[data-type="tickets"]').textContent = block.tickets

--- a/cmd/dcrdata/public/js/helpers/coin_rows_helper.js
+++ b/cmd/dcrdata/public/js/helpers/coin_rows_helper.js
@@ -1,10 +1,33 @@
 import humanize from './humanize_helper'
 
 /**
+ * formatSKAAmountCell renders the aggregate SKA-amount table cell shared by
+ * the Latest Blocks (home) and Blocks listing tables. The rule is:
+ *
+ *   subRows.length === 0  → '—'      (no SKA issued at all)
+ *   subRows.length === 1  → formatted amount (zero-value rows render '0')
+ *   subRows.length >= 2   → 'Σ N'    (count summary)
+ *
+ * Mirrors the Go-side helper of the same name (cmd/dcrdata/internal/explorer
+ * /templates.go). Both helpers must produce identical strings — they back the
+ * server-rendered initial page and the WebSocket live update of the same row.
+ *
+ * @param {Array<{amount: string}>} subRows - SKA sub-rows from coinRowsToSKAData
+ * @returns {string} the cell text content
+ */
+export function formatSKAAmountCell(subRows) {
+  if (subRows.length >= 2) return `Σ ${subRows.length}`
+  if (subRows.length === 1) return subRows[0].amount
+  return '—'
+}
+
+/**
  * coinRowsToSKAData extracts VAR and SKA display data from a block's
  * coin_rows array.
  *
  * Returns { totalTxCount, varTxCount, varAmount, varSize, skaAmount, subRows }
+ * where skaAmount is the rendered aggregate-cell string (see
+ * formatSKAAmountCell).
  *
  * @param {object} block - block data from the BLOCK_RECEIVED event
  * @returns {{ totalTxCount: number, varTxCount: number, varAmount: string,
@@ -19,7 +42,7 @@ export function coinRowsToSKAData(block) {
       varTxCount: block.tx,
       varAmount: humanize.threeSigFigs(block.total),
       varSize: humanize.bytes(block.size),
-      skaAmount: '',
+      skaAmount: formatSKAAmountCell([]),
       subRows: []
     }
   }
@@ -51,13 +74,7 @@ export function coinRowsToSKAData(block) {
   totalTxCount -= (block.votes || 0) + (block.tickets || 0) + (block.revocations || 0)
   if (totalTxCount < 0) totalTxCount = 0
 
-  let skaAmount = ''
-  if (subRows.length === 1) {
-    skaAmount = subRows[0].amount
-  } else if (subRows.length > 1) {
-    skaAmount = `${subRows.length} SKA types`
-  }
-
+  const skaAmount = formatSKAAmountCell(subRows)
   return { totalTxCount, varTxCount, varAmount, varSize, skaAmount, subRows }
 }
 

--- a/cmd/dcrdata/public/js/helpers/coin_rows_helper.test.js
+++ b/cmd/dcrdata/public/js/helpers/coin_rows_helper.test.js
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { coinRowsToSKAData, formatSKAAmountCell } from './coin_rows_helper'
+import humanize from './humanize_helper'
+
+describe('formatSKAAmountCell', () => {
+  // Six scenarios from the spec, mirrored in Go's TestFormatSKAAmountCell.
+
+  it('scenario 1 (no SKA issued): subRows.length === 0 → "—"', () =>
+    expect(formatSKAAmountCell([])).toBe('—'))
+
+  it('scenario 2 (SKA1 issued, not in block — zero-value row): renders "0"', () =>
+    expect(formatSKAAmountCell([{ amount: '0' }])).toBe('0'))
+
+  it('scenario 3 (SKA1 present): renders the formatted amount', () => {
+    const amount = humanize.formatCoinAtoms('1230000000000000000', 1) // "1.23"
+    expect(formatSKAAmountCell([{ amount }])).toBe(amount)
+  })
+
+  it('scenario 3 (SKA1 present, 12,500 SKA): renders "12.5k"', () => {
+    const amount = humanize.formatCoinAtoms('12500000000000000000000', 1)
+    expect(formatSKAAmountCell([{ amount }])).toBe('12.5k')
+  })
+
+  it('scenario 4 (SKA1 & SKA2 issued, neither in block): "Σ 2"', () =>
+    expect(formatSKAAmountCell([{ amount: '0' }, { amount: '0' }])).toBe('Σ 2'))
+
+  it('scenario 5 (SKA1 & SKA2 issued, one present): "Σ 2"', () =>
+    expect(
+      formatSKAAmountCell([
+        { amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
+        { amount: '0' }
+      ])
+    ).toBe('Σ 2'))
+
+  it('scenario 6 (SKA1 & SKA2 issued, both present): "Σ 2"', () =>
+    expect(
+      formatSKAAmountCell([
+        { amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
+        { amount: humanize.formatCoinAtoms('2000000000000000000', 2) }
+      ])
+    ).toBe('Σ 2'))
+
+  it('many SKA types: "Σ 5"', () =>
+    expect(formatSKAAmountCell(Array(5).fill({ amount: '0' }))).toBe('Σ 5'))
+})
+
+describe('coinRowsToSKAData → skaAmount', () => {
+  // End-to-end: the cell text the WebSocket controllers paint into the row.
+
+  it('block with no coin_rows → "—"', () => {
+    const block = { tx: 1, total: 0.5, size: 200, votes: 0, tickets: 0, revocations: 0 }
+    expect(coinRowsToSKAData(block).skaAmount).toBe('—')
+  })
+
+  it('block with coin_rows but VAR only → "—"', () => {
+    const block = {
+      tx: 1,
+      total: 0.5,
+      size: 200,
+      votes: 0,
+      tickets: 0,
+      revocations: 0,
+      coin_rows: [{ coin_type: 0, symbol: 'VAR', tx_count: 1, amount: '100000000', size: 200 }]
+    }
+    expect(coinRowsToSKAData(block).skaAmount).toBe('—')
+  })
+
+  it('single SKA row with zero amount → "0"', () => {
+    const block = {
+      tx: 0,
+      total: 0,
+      size: 0,
+      votes: 0,
+      tickets: 0,
+      revocations: 0,
+      coin_rows: [{ coin_type: 1, symbol: 'SKA1', tx_count: 0, amount: '0', size: 0 }]
+    }
+    expect(coinRowsToSKAData(block).skaAmount).toBe('0')
+  })
+
+  it('single SKA row with 1.23 SKA → "1.23"', () => {
+    const block = {
+      tx: 0,
+      total: 0,
+      size: 0,
+      votes: 0,
+      tickets: 0,
+      revocations: 0,
+      coin_rows: [
+        { coin_type: 1, symbol: 'SKA1', tx_count: 1, amount: '1230000000000000000', size: 100 }
+      ]
+    }
+    expect(coinRowsToSKAData(block).skaAmount).toBe('1.23')
+  })
+
+  it('two SKA rows (both zero-value) → "Σ 2"', () => {
+    const block = {
+      tx: 0,
+      total: 0,
+      size: 0,
+      votes: 0,
+      tickets: 0,
+      revocations: 0,
+      coin_rows: [
+        { coin_type: 1, symbol: 'SKA1', tx_count: 0, amount: '0', size: 0 },
+        { coin_type: 2, symbol: 'SKA2', tx_count: 0, amount: '0', size: 0 }
+      ]
+    }
+    expect(coinRowsToSKAData(block).skaAmount).toBe('Σ 2')
+  })
+
+  it('two SKA rows, one with real activity → "Σ 2"', () => {
+    const block = {
+      tx: 0,
+      total: 0,
+      size: 0,
+      votes: 0,
+      tickets: 0,
+      revocations: 0,
+      coin_rows: [
+        { coin_type: 1, symbol: 'SKA1', tx_count: 2, amount: '1000000000000000000', size: 100 },
+        { coin_type: 2, symbol: 'SKA2', tx_count: 0, amount: '0', size: 0 }
+      ]
+    }
+    expect(coinRowsToSKAData(block).skaAmount).toBe('Σ 2')
+  })
+
+  it('three SKA rows → "Σ 3"', () => {
+    const block = {
+      tx: 0,
+      total: 0,
+      size: 0,
+      votes: 0,
+      tickets: 0,
+      revocations: 0,
+      coin_rows: [
+        { coin_type: 1, symbol: 'SKA1', tx_count: 1, amount: '1', size: 1 },
+        { coin_type: 2, symbol: 'SKA2', tx_count: 1, amount: '2', size: 1 },
+        { coin_type: 3, symbol: 'SKA3', tx_count: 1, amount: '3', size: 1 }
+      ]
+    }
+    expect(coinRowsToSKAData(block).skaAmount).toBe('Σ 3')
+  })
+})

--- a/cmd/dcrdata/views/blocks.tmpl
+++ b/cmd/dcrdata/views/blocks.tmpl
@@ -113,8 +113,7 @@
             .Valid}}title="Regular transactions invalidated by stakeholders." {{end}}>{{.Transactions}}</td>
           <td class="text-center" data-type="var-amount">{{if .VARAmount}}{{formatCoinAtoms .VARAmount
             0}}{{else}}{{threeSigFigs .Total}}{{end}}</td>
-          <td class="text-center" data-type="ska-amount">{{if .SKAAmount}}{{formatCoinAtoms .SKAAmount
-            1}}{{else}}—{{end}}</td>
+          <td class="text-center" data-type="ska-amount">{{formatSKAAmountCell .SKAAmount (len .SKASubRows)}}</td>
           <td class="text-center d-none d-sm-table-cell" data-type="size">{{.FormattedBytes}}</td>
           <td class="text-center d-none d-sm-table-cell" data-type="votes">{{.Voters}}</td>
           <td class="text-center d-none d-sm-table-cell" data-type="tickets">{{.FreshStake}}</td>

--- a/cmd/dcrdata/views/home_latest_blocks.tmpl
+++ b/cmd/dcrdata/views/home_latest_blocks.tmpl
@@ -42,7 +42,7 @@
         </td>
         <td class="text-end num" data-type="tx">{{.Transactions}}</td>
         <td class="text-end num" data-type="var-amount">{{.VARAmount}}</td>
-        <td class="text-end num" data-type="ska-amount">{{if .SKAAmount}}{{.SKAAmount}}{{else}}—{{end}}</td>
+        <td class="text-end num" data-type="ska-amount">{{formatSKAAmountCell .SKAAmount (len .SKASubRows)}}</td>
         <td class="text-end num d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="size">{{.FormattedBytes}}</td>
         <td class="text-end num" data-type="votes">{{.Voters}}</td>
         <td class="text-end num" data-type="tickets">{{.FreshStake}}</td>

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -139,6 +139,9 @@ type BlockBasic struct {
 	VARAmount  string
 	VARTxCount int
 	VARSize    string
+	// SKAAmount holds the raw atom amount of the first SKA row in CoinRows.
+	// Templates render the aggregate SKA cell via formatSKAAmountCell, which
+	// uses SKAAmount only when len(SKASubRows) == 1.
 	SKAAmount  string
 	SKASubRows []SKASubRow
 }
@@ -163,8 +166,6 @@ func (b *BlockBasic) FlattenCoinRows() {
 				Amount:    row.Amount,
 				Size:      humanize.Bytes(uint64(row.Size)),
 			})
-			// Use the first SKA row's amount as the summary; callers may
-			// override SKAAmount with an aggregate if needed.
 			if b.SKAAmount == "" {
 				b.SKAAmount = row.Amount
 			}

--- a/explorer/types/explorertypes_test.go
+++ b/explorer/types/explorertypes_test.go
@@ -326,6 +326,87 @@ func TestDeepCopys(t *testing.T) {
 	}
 }
 
+func TestFlattenCoinRows(t *testing.T) {
+	tests := []struct {
+		name              string
+		coinRows          []CoinRowData
+		voters            uint16
+		freshStake        uint8
+		revocations       uint32
+		wantVARAmount     string
+		wantVARTxCount    int
+		wantSKAAmount     string
+		wantSKASubRowsLen int
+	}{
+		{
+			name:              "VAR only",
+			coinRows:          []CoinRowData{{CoinType: 0, Symbol: "VAR", TxCount: 5, Amount: "100000000", Size: 200}},
+			wantVARAmount:     "100000000",
+			wantVARTxCount:    5,
+			wantSKAAmount:     "",
+			wantSKASubRowsLen: 0,
+		},
+		{
+			name: "VAR + single SKA",
+			coinRows: []CoinRowData{
+				{CoinType: 0, Symbol: "VAR", TxCount: 3, Amount: "100000000", Size: 200},
+				{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "1000000000000000000", Size: 100},
+			},
+			wantVARAmount:     "100000000",
+			wantVARTxCount:    3,
+			wantSKAAmount:     "1000000000000000000",
+			wantSKASubRowsLen: 1,
+		},
+		{
+			name: "VAR + two SKA — SKAAmount holds first row's atoms",
+			coinRows: []CoinRowData{
+				{CoinType: 0, Symbol: "VAR", TxCount: 2, Amount: "200000000", Size: 200},
+				{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "500000000000000000", Size: 100},
+				{CoinType: 2, Symbol: "SKA2", TxCount: 2, Amount: "750000000000000000", Size: 150},
+			},
+			wantVARAmount:     "200000000",
+			wantVARTxCount:    2,
+			wantSKAAmount:     "500000000000000000",
+			wantSKASubRowsLen: 2,
+		},
+		{
+			name: "three SKA, no VAR",
+			coinRows: []CoinRowData{
+				{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "1", Size: 1},
+				{CoinType: 2, Symbol: "SKA2", TxCount: 1, Amount: "2", Size: 1},
+				{CoinType: 3, Symbol: "SKA3", TxCount: 1, Amount: "3", Size: 1},
+			},
+			wantVARAmount:     "",
+			wantVARTxCount:    0,
+			wantSKAAmount:     "1",
+			wantSKASubRowsLen: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &BlockBasic{
+				CoinRows:    tt.coinRows,
+				Voters:      tt.voters,
+				FreshStake:  tt.freshStake,
+				Revocations: tt.revocations,
+			}
+			b.FlattenCoinRows()
+			if b.VARAmount != tt.wantVARAmount {
+				t.Errorf("VARAmount: got %q, want %q", b.VARAmount, tt.wantVARAmount)
+			}
+			if b.VARTxCount != tt.wantVARTxCount {
+				t.Errorf("VARTxCount: got %d, want %d", b.VARTxCount, tt.wantVARTxCount)
+			}
+			if b.SKAAmount != tt.wantSKAAmount {
+				t.Errorf("SKAAmount: got %q, want %q", b.SKAAmount, tt.wantSKAAmount)
+			}
+			if len(b.SKASubRows) != tt.wantSKASubRowsLen {
+				t.Errorf("SKASubRows length: got %d, want %d", len(b.SKASubRows), tt.wantSKASubRowsLen)
+			}
+		})
+	}
+}
+
 func TestBytesString(t *testing.T) {
 	tests := []struct {
 		s    uint64


### PR DESCRIPTION
Closes #256.

## Summary

- Replaces the `N SKA types` label with `Σ N` in the aggregate SKA cell of the home **Latest Blocks** table.
- Extends the same rendering to the `/blocks` listing (which previously rendered a single SKA row's atoms via `formatCoinAtoms` regardless of how many SKA types the block touched — the secondary bug called out in the issue).
- Consolidates server-render and WebSocket live-update onto a single rule, implemented as a shared helper on each side.

## The rule

| `subRows.length` | Cell renders |
|---|---|
| 0 | `—` |
| 1 | formatted SKA1 amount (zero-value row → `0`) |
| ≥ 2 | `Σ N` |

## Shared helpers

- **Go** — `formatSKAAmountCell(skaAmount string, subRowCount int) string` in `cmd/dcrdata/internal/explorer/templates.go`, also registered as a template func. Used by `home_viewmodel.go` (server-render of Latest Blocks) and called directly from both `home_latest_blocks.tmpl` and `blocks.tmpl`.
- **JS** — `formatSKAAmountCell(subRows)` exported from `cmd/dcrdata/public/js/helpers/coin_rows_helper.js`. Used inside `coinRowsToSKAData`, consumed by both `home_latest_blocks_controller` and `blocks_controller`. The `|| '—'` fallbacks at the controllers are dropped — the helper owns it.

## Other changes

- `HomeBlockRow.SKAAmount` now carries the first SKA row's raw atoms (matching `BlockBasic.SKAAmount`); the template owns the formatting. The earlier `BlockBasic.SKAAmountLabel` sibling field I had added in an intermediate iteration is gone — no longer needed once both templates call the shared helper.

## Tests

- `TestFormatSKAAmountCell` (Go) — all six spec scenarios plus a many-SKA case.
- `coin_rows_helper.test.js` (JS, new file) — mirrors the Go cases against `formatSKAAmountCell` directly, plus end-to-end through `coinRowsToSKAData`.
- `TestFlattenCoinRows` and `home_viewmodel_test.go` expectations updated for the simplified `SKAAmount` semantics.

## Test plan

- [ ] Pre-commit hook ran the full pipeline: gofmt, `go test ./...` on root + `cmd/dcrdata` modules, prettier, eslint, stylelint, vitest — all green (235/235 JS tests, was 220).
- [ ] Manual check: home page Latest Blocks with a multi-SKA block renders `Σ N`.
- [ ] Manual check: `/blocks` listing with a multi-SKA block renders `Σ N` (previously rendered the first SKA row's atoms formatted as SKA1).
- [ ] Manual check: WebSocket live update for a new multi-SKA block on both pages renders `Σ N`.
- [ ] Manual check: single-SKA blocks still show the formatted amount; no-SKA blocks still show `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)