### PR TITLE
wiki: add visualblocks trace and consolidate dual-transport pattern

### DIFF
--- a/wiki/code-analysis/block/flow.full.md
+++ b/wiki/code-analysis/block/flow.full.md
@@ -82,4 +82,4 @@ When modifying **`BlockData` (or Multi-Coin Extraction logic)**, you MUST check 
 - **Presentation State Duplication:** `cmd/dcrdata/internal/explorer/explorer.go` (~line 750) and `pubsub/pubsubhub.go` (~line 650) both run identical loops transforming `map[uint8]string` into sorted `[]PoWSKAReward`.
 
 See also:
-- /wiki/core/constraints.md (depends-on: C1 numeric precision & bifurcation; C2 dual pipeline mutation; C3 template + WebSocket parity; C4 perimeter flattening & array stability)
+- /wiki/core/constraints.md (depends-on: C1 numeric precision & bifurcation; C2 dual pipeline mutation; C3 template + WebSocket parity; C4 perimeter flattening & array stability; shares-pattern-with: C8 dual-transport shape asymmetry — REST `map[uint8]string` vs WebSocket sorted-array form for multi-coin amounts)

--- a/wiki/code-analysis/block/patterns.md
+++ b/wiki/code-analysis/block/patterns.md
@@ -67,8 +67,10 @@ Two independent rendering paths:
 
 Both must produce identical structures.
 
+In this domain the parity is **not** complete: REST exposes `map[uint8]string` while WebSocket emits sorted arrays — a concrete instance of dual-transport shape asymmetry.
+
 Implication:
-See [core/constraints.md#C3](../../core/constraints.md#C3)
+See [core/constraints.md#C3](../../core/constraints.md#C3) and [core/constraints.md#C8](../../core/constraints.md#C8)
 
 ---
 

--- a/wiki/code-analysis/transaction/flow.full.md
+++ b/wiki/code-analysis/transaction/flow.full.md
@@ -85,4 +85,4 @@ The overriding flow concept is **aggregation vs. index-preservation**. Mempool f
 
 See also:
 - /wiki/code-analysis/address/flow.full.md — the address page lists per-tx rows via `FillAddressTransactions` and inherits the same SKA template-rendering gap (address links upstream with `depends-on`).
-- /wiki/core/constraints.md (depends-on: C1 numeric precision & bifurcation; C2 dual pipeline mutation; C3 template + WebSocket parity; C4 perimeter flattening & array stability)
+- /wiki/core/constraints.md (depends-on: C1 numeric precision & bifurcation; C2 dual pipeline mutation; C3 template + WebSocket parity; C4 perimeter flattening & array stability; shares-pattern-with: C8 dual-transport shape asymmetry — mempool `SKATotals` aggregation vs confirmed verbatim `Vout` array)

--- a/wiki/code-analysis/transaction/patterns.md
+++ b/wiki/code-analysis/transaction/patterns.md
@@ -36,4 +36,4 @@ The codebase distrusts standard numeric serialization across boundaries.
 To optimize for bandwidth and UI speed, the system aggressively strips context from live entities at ingestion.
 
 - **The Pattern:** In motion (Mempool, WebSocket broadcasts), complex structural arrays (such as `Vout` outputs) are summed into a single total for the transaction's CoinType right at the ingestion layer. At rest (DB, REST API), the full dimensional array structure is provided.
-- **Implication for Mutation:** See [core/constraints.md#C4](../../core/constraints.md#C4)
+- **Implication for Mutation:** See [core/constraints.md#C4](../../core/constraints.md#C4) and [core/constraints.md#C8](../../core/constraints.md#C8) — the resulting `SKATotals` map vs verbatim `Vout` array is one of the named dual-transport shape asymmetries; cross-cutting tx features must reconcile both.

--- a/wiki/code-analysis/visualblocks/flow.compact.md
+++ b/wiki/code-analysis/visualblocks/flow.compact.md
@@ -1,0 +1,41 @@
+HTTP: `RPC → ChainDB.GetExplorerFullBlocks(30) → GetExplorerBlock (memo) → handler trims to TrimmedBlockInfo → visualblocks.tmpl`
+WS new-block: `Store → wsHub ← sigNewBlock → WebsocketBlock{BlockInfo,HomeInfo} → index.js → BLOCK_RECEIVED → controller._handleVisualBlocksUpdate (filters Coinbase JS-side)`
+WS mempool: `StoreMPData → exp.invs ; client "getmempooltrimmed" → MempoolInfo.Trim() + Subsidy=HomeInfo.NBlockSubsidy → controller.handleMempoolUpdate`
+
+Key Patterns:
+
+- **Dual transport, two shapes** — HTTP sends `TrimmedBlockInfo` (server-filtered); WS sends full `BlockInfo` (`Tx` not `Transactions`, includes coinbase). JS re-implements `FilterRegularTx`.
+- **Subsidy struct asymmetry** — `BlockSubsidy.Dev` (JSON `dev`, mempool tile) vs `chainjson.GetBlockSubsidyResult.Developer` (block tile). Template uses both names; JS uses `developer || dev`.
+- **Memoized DB block pointer** — `pgb.lastExplorerBlock` shared by all consumers; never mutate.
+- **Outer 30-tile cap** — `homePageBlocksMaxCount = 30` (Go const) + JS `box.removeChild(box.lastChild)`. Template does *not* enforce the outer cap; the handler already passes only 30 blocks.
+- **Per-tile internals cap** — template `clipSlice 30` when `> 50` (tickets, txs) + JS `splice(30)` mirrors it. Distinct from the outer cap.
+- **Lock map** — three locks (`pageData`, `invsMtx`, `MempoolInfo.RWMutex`); only `Store` nests two of them (`pageData.Lock` then `invsMtx.Lock`). `StoreMPData` and readers acquire sequentially without nesting. New code must not hold `invsMtx` while waiting on `pageData.Lock`.
+
+Critical Constraints:
+
+- All amount bars are **float64 VAR** (`flex-grow: {{.Total}}`); SKA atoms lossy through `dcrutil.Amount.ToCoin()`.
+- `MiningFee`/`TotalSent` sum across all coins via `ToCoin()` — VAR-precision only.
+- SKA SSFee distribution lives in `FeesByCoin`/`SSFeeTotalsByCoin` on `BlockInfo` — not surfaced on this page.
+- Treasury and StakeFees slices are dropped by the handler.
+- Empty-slot counts (5 votes, 20 tickets+revs) and `DCR` label are hardcoded.
+
+Mutation Checklist:
+
+- update `explorerroutes.go:VisualBlocks` AND `views/visualblocks.tmpl` AND `visualBlocks_controller.js` together
+- if changing `BlockInfo` JSON: also touch `home_latest_blocks_controller.js`, `status_controller.js`, `blocks_controller.js`, `time_controller.js`, `address_controller.js`
+- if changing `HomeInfo.NBlockSubsidy`: mirror in `pubsub/pubsubhub.go`
+- if changing the outer 30-tile cap: update Go const (`homePageBlocksMaxCount`) AND JS `removeChild` trim (template doesn't enforce the outer cap)
+- if changing the per-tile `> 50` truncation threshold: update template `clipSlice 30` AND JS `splice(30)` together
+- never mutate the pointer returned by `GetExplorerBlock`
+
+Silent Risks:
+
+- SKA tx amount through float64 → wrong `flex-grow`, dominant tile
+- Subsidy field rename one-sided → "fund" bar collapses to 0
+- New trimmed field added to template only → newer WS-pushed tiles miss it
+- Non-JSON `title` attribute → tooltip silently disabled
+
+Loud Failures:
+
+- Remove `block.Tx` from `BlockInfo` → Go nil deref + JS runtime error
+- Remove `HomeInfo.NBlockSubsidy` or `MempoolInfo.Trim()` → compile failure

--- a/wiki/code-analysis/visualblocks/flow.full.md
+++ b/wiki/code-analysis/visualblocks/flow.full.md
@@ -1,0 +1,143 @@
+### Section 1 — Overview
+Tracing the data flow that drives `/visualblocks` — the latest-N-blocks-plus-mempool tile page rendered as horizontal bars (rewards / votes / tickets / regular txs). The page has **two independent pipelines** that feed the same DOM: an HTTP `GET` handler that server-renders 30 trimmed blocks, and a WebSocket push channel that re-renders individual tiles when new blocks arrive or the mempool changes.
+
+### Section 2 — End-to-End Data Flow
+HTTP path (initial render):
+`monetarium-node JSON-RPC → blockdata.Collector → ChainDB.GetExplorerFullBlocks → ChainDB.GetExplorerBlock (memoized) → explorerUI.VisualBlocks (trim to *types.TrimmedBlockInfo) + MempoolInventory().Trim() → templates.exec("visualblocks") → visualblocks.tmpl → visualBlocks_controller.js`
+
+WebSocket new-block path:
+`blockdata.Collector → explorerUI.Store(blockData,msgBlock) → wsHub.HubRelay←sigNewBlock → websockethandlers.go (encode types.WebsocketBlock{Block:*BlockInfo, Extra:*HomeInfo}) → public/index.js (newblock → publish "BLOCK_RECEIVED") → visualBlocks_controller._handleVisualBlocksUpdate (filters Coinbase client-side) → prepends new DOM tile, trims to 30`
+
+WebSocket mempool path:
+`mempool.MempoolMonitor → explorerUI.StoreMPData (recompute CoinFills) → exp.invs ; client sends "getmempooltrimmed" → MempoolInfo.Trim() + inject HomeInfo.NBlockSubsidy → JSON → visualBlocks_controller.handleMempoolUpdate → replaces mempool tile`
+
+### Section 3 — Per-Layer Breakdown
+- **Location:** `cmd/dcrdata/main.go:694`
+  - **Data Structures:** chi router under `SyncStatusPageIntercept` group.
+  - **Transformations:** Registers `r.Get("/visualblocks", explore.VisualBlocks)`. The intercept hides the page during initial DB sync.
+- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go:320-382` (`VisualBlocks` handler) and `:134` (`homePageBlocksMaxCount = 30`)
+  - **Data Structures:** `[]*types.TrimmedBlockInfo`, `*types.TrimmedMempoolInfo`, `*types.HomeInfo`, anonymous struct embedding `*CommonPageData`.
+  - **Transformations:** Calls `GetHeight`, then `GetExplorerFullBlocks(ctx, h, h-30)`; for each `*BlockInfo` builds a `TrimmedBlockInfo` keeping only `Time/Height/Total/Fees/Subsidy/Votes/Tickets/Revs/Transactions`. `Transactions` is `FilterRegularTx(block.Tx)` — coinbase removed, **SKA-typed regular txs kept**. Treasury and StakeFees are dropped. Injects `HomeInfo.NBlockSubsidy` onto `mempoolInfo.Subsidy`.
+- **Location:** `db/dcrpg/pgblockchain.go:7172-7188` (`GetExplorerFullBlocks`)
+  - **Data Structures:** `[]*exptypes.BlockInfo`.
+  - **Transformations:** Loops `i := start; i > end; i--`, calls `getBlockVerbose(ctx, i, true)` then `GetExplorerBlock(ctx, data.Hash)`. Sequential — 30 calls per page load.
+- **Location:** `db/dcrpg/pgblockchain.go:6366-6633` (`GetExplorerBlock`)
+  - **Data Structures:** `*exptypes.BlockInfo` (full), `pgb.lastExplorerBlock` (single-block memo).
+  - **Transformations:** Memoizes the last hash and returns the same pointer to concurrent callers (`lastExplorerBlock.Lock`). Builds `BlockBasic`, enriches with `BlockSubsidy`, `GetSummaryByHash` (→ `CoinAmounts`, `CoinRows`, `TotalSentByCoin`, `RegularCoinCounts`, `FeesByCoin`), then parses every `RawSTx`/`RawTx` via `trimmedTxInfoFromMsgTx`. For revocations, looks up `retrieveTicketStatusByHash`. For non-VAR regular txs (lines 6529-6553) recomputes `FeeRaw` from `Σ Vin[i].SKAAmountIn − TotalRaw` because `makeExplorerTxBasic` lacks SKA fee data. `MiningFee` and `TotalSent` are summed via `dcrutil.Amount.ToCoin()` (VAR-precision float64).
+- **Location:** `explorer/types/explorertypes.go` (Go types)
+  - `TrimmedBlockInfo` at `:695-708` — `Total float64`, `Fees float64`, `Subsidy *chainjson.GetBlockSubsidyResult`, slices of `*TrimmedTxInfo`, plus `CoinRows []CoinRowData` (populated upstream but not consumed by this template).
+  - `TrimmedTxInfo` at `:356-365` (note the comment: *"for use with /visualblocks"*).
+  - `BlockInfo` at `:710-755` — full, sent over WS.
+  - `TrimmedMempoolInfo` at `:840-856` — has `Subsidy BlockSubsidy` (not `chainjson.GetBlockSubsidyResult`).
+  - `BlockSubsidy` at `:832-838` — JSON tag `"dev"`.
+  - `WebsocketBlock` at `:1354-1358` — `{Block *BlockInfo, Extra *HomeInfo}`.
+  - `MempoolInfo.Trim()` at `:897-935` — copies Trim'd tx slices + computes `Fees` via `dcrutil.Amount` summation.
+  - `FilterRegularTx` at `:1014-1023` — only filters `Coinbase`.
+- **Location:** `cmd/dcrdata/internal/explorer/explorer.go`
+  - **Data Structures:** `pageData{BlockInfo, BlockchainInfo, HomeInfo}` at `:209-216`, `exp.invs *types.MempoolInfo` guarded by `invsMtx`.
+  - **Transformations:** `Store()` at `:514-934` is the `BlockDataSaver` hook — rewrites `pageData.BlockInfo = GetExplorerBlock(...)`, updates `HomeInfo` (hashrate, supply, subsidy, rewards), then fires `sigNewBlock` and `sigMempoolUpdate` on the hub. `StoreMPData()` at `:483-512` is the `MempoolDataSaver` hook — derives issued SKA list from `HomeInfo.SKACoinSupply`, recomputes `CoinFills` via `computeCoinFills`, swaps `exp.invs`. See §4 for the full lock map.
+- **Location:** `cmd/dcrdata/internal/explorer/websockethandlers.go`
+  - **Data Structures:** `types.WebsocketBlock`, `types.MempoolShort`, `types.TrimmedMempoolInfo`.
+  - **Transformations:** `sigNewBlock` case at `:271-282` encodes `WebsocketBlock` (full `BlockInfo` + `HomeInfo`). Client-initiated `getmempooltrimmed` at `:150-167` returns `inv.Trim()` with `Subsidy` patched from `pageData.HomeInfo.NBlockSubsidy`.
+- **Location:** `cmd/dcrdata/public/index.js:46-64`
+  - **Transformations:** Registers `ws.registerEvtHandler('newblock', ...)` → parses JSON, sets `newBlock.block.unixStamp`, publishes `BLOCK_RECEIVED` on `globalEventBus`. Also registers `'exchange'`.
+- **Location:** `cmd/dcrdata/public/js/controllers/visualBlocks_controller.js:1-371`
+  - **Data Structures:** DOM only; reads JSON shapes — `block.Tx`, `block.Votes`, `block.Revs`, `block.MiningFee`, `block.TotalSent`, `block.time`, `block.height`, `block.Subsidy` from the WS, and trimmed shape from `getmempooltrimmedResp`.
+  - **Transformations:** `_handleVisualBlocksUpdate` (`:235-260`) does the JS-side equivalent of `FilterRegularTx`: `block.Tx.filter(!Coinbase)`. Inserts a new `.block.visible` node, removes the last sibling to maintain 30 in DOM. `handleMempoolUpdate` (`:262-267`) replaces the first child. `_refreshBlocksDisplay` toggles `.visible` to fill the viewport.
+- **Location:** `cmd/dcrdata/views/visualblocks.tmpl`
+  - **Data Structures:** `.Info` (`*types.HomeInfo`), `.Mempool` (`*types.TrimmedMempoolInfo`), `.Blocks` (`[]*types.TrimmedBlockInfo`).
+  - **Transformations:** Renders mempool tile + 30 block tiles. Uses `toFloat64Amount .Subsidy.PoW`/`.PoS`/`.Dev` for mempool (custom `BlockSubsidy`), `.Subsidy.Developer` for blocks (`chainjson.GetBlockSubsidyResult`). Hard caps via `clipSlice 30` when `> 50` (lines 89, 117, 197, 225). `flex-grow` driven by `.Total` / `.Fees` floats. Hardcoded label `DCR`.
+- **Location:** `cmd/dcrdata/public/scss/visualblocks.scss` (imported by `application.scss:49`).
+
+### Section 4 — Cross-Layer Dependencies
+- **Two transport shapes for "one block."** HTTP renders `TrimmedBlockInfo` (already filtered, `Transactions` field name). WebSocket pushes the full `BlockInfo` (`Tx` field name, includes coinbase). JS does the trim equivalent client-side. Rename anything on `BlockInfo`'s JSON and you must touch *both* the template and `visualBlocks_controller.js`.
+- **`Subsidy` is two different Go types depending on path.** Mempool tile gets `BlockSubsidy{Dev int64, …}` (JSON: `dev`). Block tiles get `chainjson.GetBlockSubsidyResult{Developer …}` (JSON: `developer`). Template uses both names; JS uses `subsidy.developer || subsidy.dev`. Any normalization attempt must update all three.
+- **Shared mutable state:** `exp.pageData` and `exp.invs` are read by Home, Mempool, `/visualblocks`, and `/ws`. Three distinct locks: `pageData.RWMutex`, `invsMtx` (the pointer guard on `explorerUI`), and `MempoolInfo.RWMutex` (embedded in the struct). `Store` (block saver) is the only path that nests two locks: `pageData.Lock()` then `invsMtx.Lock()` (see [explorer.go:547,608-614](../../../cmd/dcrdata/internal/explorer/explorer.go#L547-L614)). `StoreMPData` takes `pageData.RLock` then releases it before taking `invsMtx.Lock` — not nested. Readers acquire `invsMtx.RLock` briefly via `MempoolInventory()`, then `MempoolInfo.RLock` via `Trim()`, then `pageData.RLock` — sequential, not nested. The deadlock-relevant rule is therefore narrow: new code that holds `invsMtx` and then waits on `pageData.Lock` deadlocks against `Store`. Current code paths cannot deadlock among themselves.
+- **Memoized DB block pointer:** `pgb.lastExplorerBlock.blockInfo` is shared by every consumer of the most-recent block. Mutating the returned `*BlockInfo` in any handler (visualblocks, block page, `/ws`) corrupts everyone else's view.
+- **`pubsub/pubsubhub.go` duplicates the home subsidy/reward math** (per CLAUDE.md). `HomeInfo.NBlockSubsidy` reaches the visualblocks mempool tile via the WS subsidy patch — keep both updaters in sync.
+- **`homePageBlocksMaxCount = 30` enforced in three places:** Go constant, template `clipSlice 30` (per-tile internals), JS `splice(30)` / removeChild loop. Mismatches lead to off-by-one visual glitches and stuck DOM nodes.
+
+### Section 5 — Critical Constraints
+- **Float64 VAR-only amount path.** `TrimmedBlockInfo.Total`/`.Fees` and `TrimmedTxInfo.Total` (via `dcrutil.Amount.ToCoin()`) are `float64`. Per `core/constraints.md` C1, SKA atoms (18 decimals) exceed float64's significand and must stay as `big.Int`-derived strings end-to-end. Today's `/visualblocks` aggregate bars are **lossy for SKA**: `block.TotalSent` sums SKA tx amounts via `ToCoin()` (`pgblockchain.go:6594-6605`); SKA tx tiles size their `flex-grow` from `tx.Total float64`. Surfacing SKA precisely requires widening `TrimmedBlockInfo`/`TrimmedTxInfo` with atom-string fields, not adding more float64 fields.
+- **Coin-type single-tx invariant.** Per CLAUDE.md, every tx is single-coin and pays fees in its own coin. `MiningFee` here is summed only over VAR-counted fees through `dcrutil.Amount`. SKA SSFee distributions live in `BlockInfo.FeesByCoin`/`SSFeeTotalsByCoin` — *not* surfaced on this page.
+- **Memo non-mutation invariant.** `pgb.lastExplorerBlock` returns a shared pointer; handlers must treat it read-only after build.
+- **Empty-slot constants.** Template + JS both pad to `5` votes and `20` tickets+revs per tile. These mirror staking parameters; they are hardcoded, not chain-param-derived.
+- **CSS unit label.** `DCR` is hardcoded in `visualblocks.tmpl` (lines 34, 142) and `visualBlocks_controller.js` (lines 24, 61). It is decoupled from the chain symbol.
+- **`Tx` (WS) vs `Transactions` (HTTP).** Same logical slice, two names. Renaming requires touching both surfaces.
+
+### Section 6 — Mutation Impact
+When modifying `/visualblocks` data:
+- **Direct dependencies:**
+  - `explorerroutes.go:VisualBlocks` (handler / trim) and `views/visualblocks.tmpl` (template).
+  - `db/dcrpg/pgblockchain.go:GetExplorerBlock` and `GetExplorerFullBlocks` (DB layer + memo).
+  - `explorer/types/explorertypes.go` (`TrimmedBlockInfo`, `TrimmedTxInfo`, `TrimmedMempoolInfo`, `BlockSubsidy`, `WebsocketBlock`).
+  - `explorer.go:Store`/`StoreMPData` (background updaters of `pageData`/`invs`).
+  - `websockethandlers.go` `sigNewBlock` + `getmempooltrimmed` cases.
+  - `public/index.js` (WS → event bus) and `public/js/controllers/visualBlocks_controller.js` (DOM render).
+- **Indirect dependencies:**
+  - `pubsub/pubsubhub.go` — duplicates home-page subsidy/reward calc; changes to `HomeInfo.NBlockSubsidy` must mirror.
+  - Home page (`home_latest_blocks_controller.js`), block page, mempool page — all consume the same `BlockInfo`/`MempoolInfo` shapes via the same WS frames.
+  - `status_controller.js`, `blocks_controller.js`, `time_controller.js`, `address_controller.js` — all subscribe to `BLOCK_RECEIVED`.
+- **Serialization boundaries:**
+  - HTTP: Go template rendering of `TrimmedBlockInfo`/`TrimmedMempoolInfo`.
+  - WS new-block: `json.Encode(WebsocketBlock{Block:*BlockInfo, Extra:*HomeInfo})`.
+  - WS mempool: `json.Encode(*TrimmedMempoolInfo)` with patched `Subsidy`.
+- **Rendering layers:** `visualblocks.tmpl` (initial 30 tiles + mempool) and `visualBlocks_controller.js` (incremental updates).
+
+**Silent failures:**
+- A SKA-only tx renders with float64 `Total` from `ToCoin()` of 18-dp atoms → garbage `flex-grow`, the tile becomes the dominant bar in its block.
+- WS path mutates a field on the memoized `BlockInfo` pointer → subsequent HTTP visitors see corrupted state.
+- New `TrimmedBlockInfo` field added to template only → newer WS-pushed tiles silently miss the field while older server-rendered tiles show it.
+- Renaming `Subsidy.Developer` ↔ `Dev` on either side without touching all three (Go struct, template, JS) → the "fund" bar silently collapses to 0 width.
+- Setting a non-JSON `title` attribute → `setupTooltips` JSON.parse fails silently and that tile loses its tooltip.
+
+**Hard failures:**
+- Removing `block.Tx` from `BlockInfo` JSON: Go handler still calls `FilterRegularTx(block.Tx)` (`*TrimmedTxInfo` slice) → nil deref. JS calls `block.Tx.filter(...)` → runtime error.
+- Removing `HomeInfo.NBlockSubsidy`: `mempoolInfo.Subsidy = exp.pageData.HomeInfo.NBlockSubsidy` (explorerroutes.go:358 and websockethandlers.go:157) fails to compile.
+- Removing `MempoolInfo.Trim()`: handler at `:355` and WS case at `:154` fail to compile.
+
+### Section 7 — Common Pitfalls
+1. Assuming the WebSocket frame goes through the same trim as the HTTP handler. It does not — the WS sends a full `BlockInfo` and the JS controller re-implements `FilterRegularTx` (`block.Tx.filter(!Coinbase)`). Backend-only changes look correct on first page load and break on the next block.
+2. Treating SKA amounts as safe through `float64`. `flex-grow: {{.Total}}` will produce nonsense for SKA-precision values; surfacing SKA needs new atom-string fields and parallel template + JS handling.
+3. Conflating `block.Tx` (WS, full BlockInfo) with `block.Transactions` (HTTP, TrimmedBlockInfo). Same data, different names; both are used in this page alone.
+4. Mixing up `Subsidy.Developer` (chainjson) and `Subsidy.Dev` (BlockSubsidy). Both appear in the same `visualblocks.tmpl`.
+5. Expecting `Treasury` or `StakeFees` slices to appear — the handler drops them when building `TrimmedBlockInfo`.
+6. Changing `homePageBlocksMaxCount` without updating the JS `removeChild` trim that assumes 30, or the template's `clipSlice 30` per-tile.
+7. Mutating the `*BlockInfo` returned by `GetExplorerBlock` — it's a shared memoized pointer.
+8. Forgetting that `pubsub/pubsubhub.go` duplicates the subsidy/reward calc on the home path; a one-sided fix drifts the visualblocks mempool tile out of sync.
+
+### Section 8 — Evidence
+- `cmd/dcrdata/main.go:694` — route registration `r.Get("/visualblocks", explore.VisualBlocks)`.
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:134` — `homePageBlocksMaxCount = 30`.
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:320-382` — `VisualBlocks` handler (height → 30 full blocks → trim → mempool trim → template).
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:336-351` — explicit field projection into `TrimmedBlockInfo` (Treasury/StakeFees dropped, `FilterRegularTx(block.Tx)` for `Transactions`).
+- `db/dcrpg/pgblockchain.go:7172-7188` — `GetExplorerFullBlocks` sequential loop.
+- `db/dcrpg/pgblockchain.go:6366-6633` — `GetExplorerBlock`; memo at `:6371-6376` and `:6626-6630`; per-coin SKA fee recompute at `:6529-6553`; VAR `ToCoin()` summation at `:6594-6605`.
+- `explorer/types/explorertypes.go:356-365` — `TrimmedTxInfo` comment `// TrimmedTxInfo for use with /visualblocks`.
+- `explorer/types/explorertypes.go:695-708` — `TrimmedBlockInfo` shape (float64 `Total`/`Fees`).
+- `explorer/types/explorertypes.go:710-755` — `BlockInfo` (what WS actually sends).
+- `explorer/types/explorertypes.go:840-856` — `TrimmedMempoolInfo`.
+- `explorer/types/explorertypes.go:897-935` — `MempoolInfo.Trim()` (Fees summed via `dcrutil.Amount.ToCoin()`).
+- `explorer/types/explorertypes.go:1014-1023` — `FilterRegularTx` (only coinbase filtered).
+- `explorer/types/explorertypes.go:1354-1358` — `WebsocketBlock{Block:*BlockInfo, Extra:*HomeInfo}`.
+- `cmd/dcrdata/internal/explorer/explorer.go:209-216, 361-374` — `pageData` definition and init.
+- `cmd/dcrdata/internal/explorer/explorer.go:460-465` — `MempoolInventory()`.
+- `cmd/dcrdata/internal/explorer/explorer.go:480-512` — `StoreMPData` (see §4 for lock map; `Store` is the only path that nests `pageData.Lock` + `invsMtx.Lock`).
+- `cmd/dcrdata/internal/explorer/explorer.go:514-934` — `Store` (BlockDataSaver); `sigNewBlock`/`sigMempoolUpdate` fired at `:880`/`:890`.
+- `cmd/dcrdata/internal/explorer/websockethandlers.go:150-167` — `getmempooltrimmed` (Trim + patch `Subsidy = HomeInfo.NBlockSubsidy`).
+- `cmd/dcrdata/internal/explorer/websockethandlers.go:271-282` — `sigNewBlock` encodes `WebsocketBlock` (full `BlockInfo`).
+- `cmd/dcrdata/public/index.js:46-64` — `ws.registerEvtHandler('newblock', ...)` → `globalEventBus.publish('BLOCK_RECEIVED', newBlock)`.
+- `cmd/dcrdata/public/js/controllers/visualBlocks_controller.js:14-36` — `makeMempoolBlock` (reads `subsidy.dev`/`developer`).
+- `cmd/dcrdata/public/js/controllers/visualBlocks_controller.js:235-260` — `_handleVisualBlocksUpdate` (filters Coinbase, prepends DOM, trims to 30).
+- `cmd/dcrdata/public/js/controllers/visualBlocks_controller.js:262-267` — `handleMempoolUpdate`.
+- `cmd/dcrdata/views/visualblocks.tmpl` — full template (mempool tile + 30 blocks; subsidy field-name asymmetry; `clipSlice 30` when `>50`).
+- `cmd/dcrdata/public/scss/visualblocks.scss` and `cmd/dcrdata/public/scss/application.scss:49`.
+
+See also:
+- /wiki/code-analysis/visualblocks/patterns.md — domain patterns (cross-pipeline tile rendering, JS-side server-filter mirror, Subsidy struct asymmetry, triple-enforced 30-cap, memoized BlockInfo, shared page state, WS subsidy patch).
+- /wiki/code-analysis/visualblocks/impact.md — mutation impact, loud/silent failure modes, safe-change checklist.
+- /wiki/code-analysis/block/flow.full.md (shares-pattern-with: fan-out BlockDataSaver, dual transport shape REST vs WebSocket, multi-coin big.Int→string precision)
+- /wiki/code-analysis/transaction/flow.full.md (shares-pattern-with: mempool aggregation vs confirmed Vout-array — the same C8 dual-transport class)
+- /wiki/code-analysis/mempool/flow.full.md (depends-on: `MempoolInfo` aggregation, `CoinFills` derivation in `StoreMPData`; shares the trim/transport asymmetry)
+- /wiki/core/constraints.md (depends-on: C1 numeric precision — float64 VAR vs big.Int SKA; C2 dual pipeline; shares-pattern-with: C8 dual-transport shape asymmetry — HTTP `TrimmedBlockInfo` vs WebSocket full `BlockInfo`, with JS-side coinbase filter)
+- /wiki/specs/homepage-metrics/spec.md (shares-pattern-with: home-page latest-blocks tiles consume the same `BlockInfo` over the same WS frames)

--- a/wiki/code-analysis/visualblocks/impact.md
+++ b/wiki/code-analysis/visualblocks/impact.md
@@ -1,0 +1,174 @@
+# VisualBlocks Domain — Mutation Impact
+
+## When modifying: the `/visualblocks` page or its backing data
+
+You MUST verify all of the following layers, because the page has **two transport paths** that carry different shapes of the same logical entity (see [patterns.md#1](patterns.md) and [core/constraints.md#C8](../../core/constraints.md#C8)).
+
+---
+
+## 1. Direct Consumers
+
+### HTTP handler
+
+- File: [cmd/dcrdata/internal/explorer/explorerroutes.go:320-382](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L320-L382) (`VisualBlocks`)
+- Reads: `dataSource.GetHeight`, `GetExplorerFullBlocks`, `MempoolInventory().Trim()`, `pageData.HomeInfo.NBlockSubsidy`.
+- Risk: compile-time break if any field projected into `TrimmedBlockInfo` is renamed.
+
+### Template
+
+- File: [cmd/dcrdata/views/visualblocks.tmpl](../../../cmd/dcrdata/views/visualblocks.tmpl)
+- Reads: `.Info` (HomeInfo), `.Mempool` (TrimmedMempoolInfo with patched `Subsidy`), `.Blocks` (`[]*TrimmedBlockInfo`).
+- Risk: template-execution error (visible at request time, not compile time) if a `.Field` reference loses its backing field.
+
+### JS Controller
+
+- File: [cmd/dcrdata/public/js/controllers/visualBlocks_controller.js](../../../cmd/dcrdata/public/js/controllers/visualBlocks_controller.js)
+- Reads (from WS `newblock`): `block.Tx`, `block.Votes`, `block.Revs`, `block.MiningFee`, `block.TotalSent`, `block.time`, `block.height`, `block.Subsidy.{pow,pos,developer,dev}`.
+- Reads (from WS `getmempooltrimmedResp`): `mempool.{Transactions, Votes, Tickets, Revocations, Subsidy.pow/pos/dev, Total, Time}`.
+
+---
+
+## 2. Indirect Consumers (Same WebSocket Frames)
+
+`sigNewBlock` emits the **full** `BlockInfo` over `/ws`. Many controllers subscribe to `BLOCK_RECEIVED`:
+
+- `home_latest_blocks_controller.js`
+- `status_controller.js`
+- `blocks_controller.js`
+- `time_controller.js`
+- `address_controller.js`
+
+If you rename a field on `BlockInfo` (Go struct tag), every one of these must be checked. A breaking change here is **silent on `/visualblocks` until the next block arrives**.
+
+---
+
+## 3. Serialization Boundaries
+
+### HTTP (server-rendered)
+
+- Format: HTML via Go templates, fed by `TrimmedBlockInfo` (Go struct, drops Treasury / StakeFees, applies `FilterRegularTx`).
+
+### WebSocket — new block
+
+- Format: `json.Encode(types.WebsocketBlock{Block:*BlockInfo, Extra:*HomeInfo})` at [websockethandlers.go:271-282](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L271-L282).
+- **Full** `BlockInfo`, not trimmed. Client re-implements `FilterRegularTx`.
+
+### WebSocket — mempool
+
+- Format: `json.Encode(*TrimmedMempoolInfo)` at [websockethandlers.go:150-167](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L150-L167), with `Subsidy` patched from `HomeInfo.NBlockSubsidy`.
+
+Risk: breaking one boundary without the other → page renders correctly until the next push, then silently drifts.
+
+---
+
+## 4. Background Updaters (Shared State)
+
+### `Store` (BlockDataSaver)
+
+- File: [cmd/dcrdata/internal/explorer/explorer.go:514-934](../../../cmd/dcrdata/internal/explorer/explorer.go#L514-L934)
+- Mutates `pageData.BlockInfo`, `pageData.HomeInfo`, `exp.invs.CoinFills`.
+- Fires `sigNewBlock` + `sigMempoolUpdate`.
+
+### `StoreMPData` (MempoolDataSaver)
+
+- File: [cmd/dcrdata/internal/explorer/explorer.go:480-512](../../../cmd/dcrdata/internal/explorer/explorer.go#L480-L512)
+- Mutates `exp.invs`; computes `CoinFills` against `HomeInfo.SKACoinSupply`.
+
+### Duplicate calc in PubSub
+
+- File: `pubsub/pubsubhub.go` (per CLAUDE.md, home subsidy/reward math is duplicated). Any change to `HomeInfo.NBlockSubsidy` must mirror.
+
+---
+
+## 5. Database Layer
+
+### `GetExplorerFullBlocks` + `GetExplorerBlock`
+
+- Files: [db/dcrpg/pgblockchain.go:7172-7188](../../../db/dcrpg/pgblockchain.go#L7172-L7188), [:6366-6633](../../../db/dcrpg/pgblockchain.go#L6366-L6633).
+- `lastExplorerBlock` memo at `:6371-6376` returns a **shared pointer** to multiple page consumers.
+
+Risk: mutating the returned `*BlockInfo` in any handler corrupts all downstream consumers (see [patterns.md#5](patterns.md)).
+
+---
+
+## 6. Loud Failures (Compile / Runtime Errors)
+
+| Change                                                          | Effect                                                                        |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Remove `block.Tx` from `BlockInfo`                              | Go: `FilterRegularTx(block.Tx)` nil-deref at `explorerroutes.go:347`. JS: `block.Tx.filter(...)` runtime error. |
+| Remove `HomeInfo.NBlockSubsidy`                                 | Compile failure at `explorerroutes.go:358` and `websockethandlers.go:157`.    |
+| Remove `MempoolInfo.Trim()`                                     | Compile failure at `explorerroutes.go:355` and `websockethandlers.go:154`.    |
+| Rename `TrimmedBlockInfo.Total` / `.Fees`                       | Template parse error at request time.                                          |
+| Change `WebsocketBlock` JSON tag for `block` or `extra`         | JS sees `undefined` → first `block.Tx.filter` crashes immediately on next push. |
+
+---
+
+## 7. Silent Failures (High Risk)
+
+### Precision corruption
+
+- A SKA-only regular tx flows through `dcrutil.Amount.ToCoin() float64` ([pgblockchain.go:6594-6605](../../../db/dcrpg/pgblockchain.go#L6594-L6605)).
+- Its `tx.Total` (float64) becomes the `flex-grow` of the tile — the SKA tile silently dominates its row.
+- See [core/constraints.md#C1](../../core/constraints.md#C1).
+
+### Subsidy field-name one-sided rename
+
+- Rename `BlockSubsidy.Dev → Developer` without touching the chainjson side OR the JS `||` fallback → the mempool tile's "fund" bar silently collapses to 0 width.
+
+### New `TrimmedBlockInfo` field added to template only
+
+- Initial 30 tiles show the field. Newly-pushed WS tiles miss it because the JS controller hasn't been updated. Page looks correct on reload, silently drifts.
+- This is the canonical [core/constraints.md#C8](../../core/constraints.md#C8) failure mode for this domain.
+
+### Mutated memoized `*BlockInfo`
+
+- Any handler that mutates `block.Tx`/`block.Votes` post-`GetExplorerBlock` will corrupt the block-page view and subsequent visualblocks page loads until the next block invalidates the memo.
+
+### `pubsub/pubsubhub.go` divergence
+
+- One-sided fix to home-page subsidy calc → visualblocks mempool tile's PoW/PoS/Dev bars silently disagree with what `/ps` clients see.
+
+### Tooltip `title` attribute drift
+
+- The JS `setupTooltips` does `JSON.parse(tooltipElement.title)`. A non-JSON `title` silently disables the tooltip on that element (the `catch {}` block at lines 343-345 swallows the error).
+
+### Lock-order inversion (narrow)
+
+- `Store` is the only path that holds two `explorerUI` locks concurrently: `pageData.Lock()` first, then `invsMtx.Lock()` nested. Any new code that holds `invsMtx` and then waits on `pageData.Lock` would deadlock against `Store`. Current readers and `StoreMPData` acquire sequentially without nesting and cannot deadlock. See [patterns.md#6](patterns.md) for the full lock map.
+
+---
+
+## 8. Out-of-Scope Drops (Known Silent Filtering)
+
+The handler **does not** project the following BlockInfo fields onto `TrimmedBlockInfo`:
+
+- `Treasury` (treasury txs)
+- `StakeFees` (SSFee distribution)
+- `CoinAmounts`, `TotalSentByCoin`, `RegularCoinCounts`, `FeesByCoin` (multi-coin per-block aggregates)
+- `SKAPoWRewards` (per-coin PoW reward)
+
+`/visualblocks` is intentionally VAR-centric. Surfacing any of these requires widening `TrimmedBlockInfo` with atom-string fields **and** matching JS work — not adding more float64.
+
+---
+
+## 9. Safe-Change Checklist
+
+Before committing changes that touch the visualblocks data path:
+
+- [ ] HTTP handler updated AND `visualblocks.tmpl` renders the change correctly.
+- [ ] JS controller (`visualBlocks_controller.js`) renders the change identically on the next WS push.
+- [ ] If touching `BlockInfo`: every other `BLOCK_RECEIVED` subscriber (home, blocks, status, time, address) verified.
+- [ ] If touching `HomeInfo.NBlockSubsidy`: mirrored in `pubsub/pubsubhub.go`.
+- [ ] If touching the 30-cap: Go const AND JS `removeChild`/`splice` updated.
+- [ ] No mutation of the `*BlockInfo` returned by `GetExplorerBlock`.
+- [ ] No new code path holds `invsMtx` while waiting on `pageData.Lock` (would deadlock against `Store`, the only path that nests these two locks).
+- [ ] No SKA atom-string routed through `float64` / `dcrutil.Amount.ToCoin()` before the template/JS boundary.
+- [ ] `Subsidy` field-name asymmetry (`Dev` vs `Developer`) accounted for on every touched surface.
+
+---
+
+See also:
+
+- [code-analysis/visualblocks/patterns.md](patterns.md) — the patterns these risks emerge from.
+- [code-analysis/block/impact.md](../block/impact.md) — the upstream `BlockData` mutation impact; `/visualblocks` inherits it via `GetExplorerBlock` + WS `sigNewBlock`.
+- [core/constraints.md#C8](../../core/constraints.md#C8) — dual-transport shape asymmetry, the umbrella for the silent-drift risks above.

--- a/wiki/code-analysis/visualblocks/patterns.md
+++ b/wiki/code-analysis/visualblocks/patterns.md
@@ -1,0 +1,100 @@
+# VisualBlocks Domain Patterns
+
+Recurring patterns and invariants for the `/visualblocks` page. Most are domain-specific; cross-cutting concerns link out to `core/constraints.md`.
+
+## 1. Cross-Pipeline Tile Rendering
+
+The same DOM is produced two ways and then mutated in place:
+
+- **Initial render (HTTP):** server-side template walks `[]*TrimmedBlockInfo` and emits 30 `<div class="block">` tiles plus one mempool tile.
+- **Live update (WebSocket):** `visualBlocks_controller` consumes `newblock` and `mempool` events, builds new `<div class="block">` nodes in JS (`makeNode` + `dompurify`), and surgically `insertBefore`/`replaceChild` to mutate the same DOM.
+
+Implications:
+
+- Two render code paths must produce structurally identical DOM (class names, attribute shapes, `data-*` hooks).
+- DOM trim is also dual: template clips per-tile internals at `clipSlice 30` when `> 50`; JS trims total tile count via `removeChild` to keep ≤ 30.
+- See [core/constraints.md#C3](../../core/constraints.md#C3) (template + WebSocket parity) and [core/constraints.md#C8](../../core/constraints.md#C8) (dual-transport shape asymmetry — the *underlying data* shapes differ even though the *DOM output* must not).
+
+---
+
+## 2. JS-Side Equivalent of a Server Filter
+
+`FilterRegularTx` (Go, drops coinbase only) is the server's projection from `BlockInfo.Tx` to `TrimmedBlockInfo.Transactions`. The same filter is re-implemented client-side as `block.Tx.filter((tx) => !tx.Coinbase)` in `visualBlocks_controller._handleVisualBlocksUpdate` because the WebSocket sends the *unfiltered* `BlockInfo`.
+
+Implications:
+
+- The filter is **load-bearing duplicate code**. If the server filter changes (e.g. drop treasurybase too), the JS must change in the same commit.
+- This is the visualblocks-specific manifestation of [core/constraints.md#C8](../../core/constraints.md#C8).
+
+---
+
+## 3. Asymmetric `Subsidy` Struct (Domain Gotcha)
+
+Two different Go types reach the page under the same `.Subsidy` template field:
+
+| Tile           | Go type                                  | Source              | JSON tag for the "fund" field | Template / JS path           |
+| -------------- | ---------------------------------------- | ------------------- | ----------------------------- | ---------------------------- |
+| Mempool tile   | `BlockSubsidy` (explorertypes.go)        | `HomeInfo.NBlockSubsidy` | `Dev` → `"dev"`             | `{{.Subsidy.Dev}}`           |
+| Block tiles    | `chainjson.GetBlockSubsidyResult`        | `BlockInfo.Subsidy` | `Developer` → `"developer"` | `{{.Subsidy.Developer}}`     |
+| Live JS tile   | (same as block tile, via WebSocket JSON) | `BlockInfo.Subsidy` | `Developer` → `"developer"` | `subsidy.developer || subsidy.dev` |
+
+Both names appear in `visualblocks.tmpl`. JS uses the `||` fallback. Don't unify by renaming one side only — every consumer (template, JS, both Go structs, the WS encoder, and `pubsub/pubsubhub.go` which duplicates the home subsidy calc) must move together.
+
+---
+
+## 4. Triple-Enforced Display Cap
+
+The 30-tile limit is enforced in three places that all reference the same logical N:
+
+1. **Go:** `homePageBlocksMaxCount = 30` ([cmd/dcrdata/internal/explorer/explorerroutes.go:134](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L134)) — passed to `GetExplorerFullBlocks(ctx, h, h-30)`.
+2. **Template:** `clipSlice 30` applied **per-tile-internals** (tickets, txs) when `> 50`. Distinct from the outer 30-tile cap.
+3. **JS:** `box.removeChild(box.lastChild)` after each insert (controller line ~258) plus `splice(30)` for per-tile internals.
+
+Implications:
+
+- Changing the outer N requires updating the Go const AND the JS trim. The template `clipSlice 30` governs per-tile detail truncation and is logically distinct (governed by `> 50` threshold).
+- Empty-slot constants (`5` votes per tile, `20` tickets+revs per tile) are also hardcoded in both template and JS and reflect stake parameters.
+
+---
+
+## 5. Memoized Single-Block Pointer Share
+
+`pgb.lastExplorerBlock` ([db/dcrpg/pgblockchain.go:6366-6633](../../../db/dcrpg/pgblockchain.go#L6366-L6633)) caches the most recently built `*BlockInfo` keyed by hash. Every caller that requests the same hash gets the *same pointer*. Visualblocks, block page, mempool page, and `/ws` `sigNewBlock` all consume this.
+
+Implications:
+
+- Treat the returned `*BlockInfo` as **read-only** after `GetExplorerBlock` returns. Any handler-side mutation corrupts subsequent callers' views.
+- The memo only covers a single hash; calling `GetExplorerFullBlocks(h, h-30)` is still 30 sequential DB+RPC builds — the memo only helps when the most-recent block is fetched repeatedly across pages.
+
+---
+
+## 6. Background-Updated Shared Page State
+
+`exp.pageData` (RWMutex-guarded, BlockInfo + BlockchainInfo + HomeInfo) and `exp.invs` (`invsMtx`-guarded pointer to a `MempoolInfo`, which has its own embedded RWMutex) are mutated only by the background savers (`Store`, `StoreMPData`) and read by every page handler. **Three distinct locks** are in play:
+
+- `pageData.RWMutex` — guards `BlockInfo`/`HomeInfo`/`BlockchainInfo`.
+- `invsMtx` (on `explorerUI`) — guards the `*MempoolInfo` pointer itself.
+- `MempoolInfo.RWMutex` (embedded in the struct) — guards the mempool data.
+
+Observed acquisition patterns:
+
+- **`Store` (block saver, [explorer.go:547,608](../../../cmd/dcrdata/internal/explorer/explorer.go#L547-L614)):** holds `pageData.Lock()` (write) and **nests** `invsMtx.Lock()` inside it (lines 608-614). Both held simultaneously.
+- **`StoreMPData` ([explorer.go:484-507](../../../cmd/dcrdata/internal/explorer/explorer.go#L484-L507)):** takes `pageData.RLock()` (line 484), releases at line 492, *then* takes `invsMtx.Lock()` (line 505). **Not nested.**
+- **Readers** (e.g. `VisualBlocks`): take `invsMtx.RLock()` briefly via `MempoolInventory()` (to read the pointer), then `MempoolInfo.RLock()` via `Trim()`, then `pageData.RLock()`. Sequential, not nested.
+
+Implication: the only place two `explorerUI` locks are held concurrently is `Store` (pageData.Lock + invsMtx.Lock, in that order). New code that holds `invsMtx` and then waits on `pageData.Lock` would deadlock against `Store`. Readers as currently written cannot deadlock with the writers.
+
+---
+
+## 7. WebSocket Subsidy Patch
+
+The mempool tile on `/visualblocks` doesn't have its own subsidy data — both the HTTP handler ([explorerroutes.go:358](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L358)) and the WS `getmempooltrimmed` case ([websockethandlers.go:157](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L157)) copy `exp.pageData.HomeInfo.NBlockSubsidy` onto `mempoolInfo.Subsidy` just before serializing.
+
+Implication: Any change to `HomeInfo.NBlockSubsidy` shape (including the duplicated calc in `pubsub/pubsubhub.go`) must keep this patch valid on both paths.
+
+---
+
+See also:
+
+- [core/constraints.md#C8](../../core/constraints.md#C8) — dual-transport shape asymmetry (the umbrella for patterns 1, 2, 3 here).
+- [code-analysis/block/patterns.md](../block/patterns.md) — the same fan-out / dual-pipeline pattern at the BlockData layer.

--- a/wiki/core/constraints.md
+++ b/wiki/core/constraints.md
@@ -45,3 +45,25 @@ Rules:
 - Never construct labels inline (`` `SKA${n}` ``, hardcoded `"VAR"`, etc.). Always call the canonical function for the environment.
 - If the label format ever changes, update both `coinSymbol` and `renderCoinType` in the same change.
 - New formatting helpers for coin amounts go in `ska_helper.js` / `humanize_helper.js`, not in a controller.
+
+## C8: Dual-Transport Shape Asymmetry (applies to: block, transaction, visualblocks, mempool, frontend)
+
+C3 (parity) covers the *ideal*: a logical entity should be reproducible identically by template and WebSocket. C8 covers the *reality*: across several pages, the same logical entity travels in **different on-the-wire shapes** depending on transport, and the frontend must reconcile them. Pattern-Clone (C3) and Perimeter Flattening (C4) describe the symptoms; C8 names the concrete asymmetries that already exist and *must not silently drift further*.
+
+**Concrete manifestations:**
+
+- **Block** (REST vs WebSocket multi-coin amounts):
+  REST `/api/block/...` exposes `map[uint8]string` (`{"0":"...","1":"..."}`) derived from `BlockData.ExtraInfo`. WebSocket `pubsubhub` flattens the same maps into sorted `[]PoWSKAReward`-style arrays. The JS controllers require arrays; REST consumers tolerate maps. The transformation is duplicated in `explorerUI.Store` and `pubsub/pubsubhub.go.Store`. *See:* [/wiki/code-analysis/block/flow.full.md](../code-analysis/block/flow.full.md) §4.
+- **Transaction** (mempool aggregation vs confirmed array):
+  Mempool path squashes outputs into a single per-coin total (`MempoolTx.SKATotals map[uint8]string`) at ingestion via `txhelpers.SKATotalsFromMsgTx`. Confirmed path keeps the full `Vout` array verbatim from `dcrd`'s `GetRawTransactionVerbose` and exposes `apitypes.Vout[i].CoinType` / `SKAValue`. The JS mempool controller and the Go `tx.tmpl` template each handle only their respective shape; cross-cutting features must reconcile both. *See:* [/wiki/code-analysis/transaction/flow.full.md](../code-analysis/transaction/flow.full.md) §2, §9.
+- **VisualBlocks** (HTTP trim vs WebSocket full BlockInfo):
+  HTTP handler trims `*BlockInfo → *TrimmedBlockInfo` (drops Treasury/StakeFees, applies `FilterRegularTx` to remove coinbase, renames `block.Tx` → `Transactions`). WebSocket `sigNewBlock` emits the full `BlockInfo` (field name `Tx`, includes coinbase). `visualBlocks_controller.js._handleVisualBlocksUpdate` re-implements `FilterRegularTx` client-side (`block.Tx.filter(!Coinbase)`). Additionally, `Subsidy` is `BlockSubsidy{Dev}` for the mempool tile and `chainjson.GetBlockSubsidyResult{Developer}` for block tiles — both names appear in one template. *See:* [/wiki/code-analysis/visualblocks/flow.full.md](../code-analysis/visualblocks/flow.full.md) §4.
+
+**Rules wherever this pattern appears:**
+
+- Treat HTTP and WebSocket shapes as **two independent contracts**, not one. A change to a Go struct used on one path does not automatically reach the other.
+- Any logical field added to a server-rendered template must also be added to the WebSocket payload AND to the JS controller that consumes it — otherwise newly arriving entities silently miss the field while initial-render entities show it.
+- Any client-side reconciliation logic (filter, aggregate, map→array) is **load-bearing duplicate code** mirroring a backend transform. Update both sides together.
+- When two paths use different Go types for the "same" concept (e.g. `BlockSubsidy.Dev` vs `chainjson.GetBlockSubsidyResult.Developer`), document the mapping at the JS/template boundary; do not paper over it with one-sided renames.
+
+**Common failure mode:** Backend struct gets a new field. The HTTP handler is updated and the template renders the field. The next new block arrives via WebSocket, the JS re-renders that tile, and the field is missing. The page looks correct on initial load and silently broken on update — a class of bug that does not show up in `go build` or `go test`, only in live behavior.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -83,3 +83,12 @@ _Historical data fetching, cache aggregation, and payload serialization for UI c
 
 - flow (compact): code-analysis/charts/flow.compact.md — high-level summary of both VAR and SKA chart pipelines
 - flow (full): code-analysis/charts/flow.full.md — detailed, step-by-step function trace covering RPC/SQL → cache → API → controller → Dygraphs for both pipelines
+
+### VisualBlocks
+
+_The `/visualblocks` page: latest-N blocks plus mempool rendered as flex-grow tiles. Dual pipeline (HTTP `TrimmedBlockInfo` vs WebSocket full `BlockInfo`) with two different `Subsidy` struct shapes and a JS-side coinbase filter._
+
+- flow (compact): code-analysis/visualblocks/flow.compact.md — high-level summary of the HTTP + WS pipelines and the trim asymmetry
+- flow (full): code-analysis/visualblocks/flow.full.md — detailed, step-by-step function trace covering handler, DB memo, WS encoder, JS controller, and template
+- patterns: code-analysis/visualblocks/patterns.md — cross-pipeline tile rendering, JS-side server-filter mirror, Subsidy struct asymmetry, triple-enforced 30-cap, memoized BlockInfo, lock order, WS subsidy patch
+- impact: code-analysis/visualblocks/impact.md — mutation impact across HTTP/WS/JS/DB layers, loud and silent failure modes, safe-change checklist


### PR DESCRIPTION
## Summary

- Adds a complete code-analysis entry for the `/visualblocks` page: [flow.full.md](wiki/code-analysis/visualblocks/flow.full.md), [flow.compact.md](wiki/code-analysis/visualblocks/flow.compact.md), [patterns.md](wiki/code-analysis/visualblocks/patterns.md), [impact.md](wiki/code-analysis/visualblocks/impact.md). Traces the HTTP and WebSocket pipelines that feed the page (handler, DB memo, WS encoder, JS controller, template).
- Introduces **`C8: Dual-Transport Shape Asymmetry`** in [core/constraints.md](wiki/core/constraints.md) as a cross-domain entry naming the concrete on-the-wire shape mismatches observed in three flows:
  - **block**: REST `map[uint8]string` vs WebSocket sorted-array form.
  - **transaction**: mempool `SKATotals` aggregation vs confirmed verbatim `Vout` array.
  - **visualblocks**: HTTP `TrimmedBlockInfo` (server-filtered) vs WebSocket full `BlockInfo` (JS-side `FilterRegularTx`).
- Wires `shares-pattern-with: C8` links from `block/flow.full.md`, `transaction/flow.full.md`, and `visualblocks/flow.full.md`, plus brief references in `block/patterns.md` pattern #4 and `transaction/patterns.md` pattern #4.
- Updates [wiki/index.md](wiki/index.md) with the new visualblocks subsection (flow.compact / flow.full / patterns / impact).

## Notes

- No code changes — wiki / docs only.
- All factual claims were spot-verified against current source (line numbers, JSON struct tags, lock-order discipline). One material inaccuracy found during verification (overstated lock-order/deadlock claim) was corrected before commit.
- Branched from `develop` per project convention; targets `develop`.

## Test plan

- [ ] Review the new visualblocks/ files against the actual code paths referenced.
- [ ] Confirm C8 wording matches how the team prefers to talk about REST/WS shape asymmetry.
- [ ] Sanity-check rendered markdown on GitHub (tables, anchor links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)