### PR TITLE
fix: correctly calculate PoW and PoS SKA fee rewards

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -599,6 +599,63 @@ func BlockSKAFees(msgBlock *wire.MsgBlock) map[uint8]string {
 	return out
 }
 
+// BlockSKAPoWRewardsFromSTx extracts PoW SKA rewards from stake transactions.
+// It finds stakegen outputs that spend from coinbase (vin txid = zero hash, vout = max)
+// and have skaamountin in vin, which indicates PoW reward (miner portion of fees).
+// Returns map of coin type to total PoW reward amount in atoms.
+func BlockSKAPoWRewardsFromSTx(msgBlock *wire.MsgBlock) map[uint8]string {
+	if msgBlock == nil || len(msgBlock.STransactions) == 0 {
+		return nil
+	}
+
+	var zeroHash chainhash.Hash
+	maxVout := ^uint32(0)
+
+	skaRewards := make(map[uint8]*big.Int)
+
+	for _, stx := range msgBlock.STransactions {
+		if len(stx.TxIn) == 0 {
+			continue
+		}
+
+		// Check if spending from coinbase (txid = zero hash, vout = max)
+		vin := stx.TxIn[0]
+		if vin.PreviousOutPoint.Hash != zeroHash || vin.PreviousOutPoint.Index != maxVout {
+			continue
+		}
+
+		// Check if vin has skaamountin - this indicates PoW reward
+		if vin.SKAValueIn == nil || vin.SKAValueIn.Sign() <= 0 {
+			continue
+		}
+
+		// Sum SKA outputs and track coin type
+		var coinType uint8
+		for _, txout := range stx.TxOut {
+			if txout.CoinType.IsSKA() && txout.SKAValue != nil && txout.SKAValue.Sign() > 0 {
+				if coinType == 0 {
+					coinType = uint8(txout.CoinType)
+				}
+				if skaRewards[coinType] == nil {
+					skaRewards[coinType] = new(big.Int).Set(txout.SKAValue)
+				} else {
+					skaRewards[coinType].Add(skaRewards[coinType], txout.SKAValue)
+				}
+			}
+		}
+	}
+
+	if len(skaRewards) == 0 {
+		return nil
+	}
+
+	out := make(map[uint8]string, len(skaRewards))
+	for k, v := range skaRewards {
+		out[k] = v.String()
+	}
+	return out
+}
+
 // computeMiningFee calculates total mining fees from a block.
 // Formula: Mining Fee = Coinbase Output - PoW Subsidy
 // This is equivalent to summing (Inputs - Outputs) for all non-coinbase transactions,

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -69,6 +69,27 @@ const (
 	testnetNetName = "Testnet"
 )
 
+// divideByTwoSKAFees divides each amount in the map by 2 (big.Int).
+// Used to get PoW portion from total fees (fees are split 50/50 between PoW and PoS).
+func divideByTwoSKAFees(fees map[uint8]string) map[uint8]string {
+	if len(fees) == 0 {
+		return nil
+	}
+	half := make(map[uint8]string, len(fees))
+	two := big.NewInt(2)
+	for ct, amountStr := range fees {
+		amount, ok := new(big.Int).SetString(amountStr, 10)
+		if !ok || amount.Sign() <= 0 {
+			continue
+		}
+		half[ct] = amount.Div(amount, two).String()
+	}
+	if len(half) == 0 {
+		return nil
+	}
+	return half
+}
+
 // explorerDataSource implements extra data retrieval functions that require a
 // faster solution than RPC, or additional functionality.
 type explorerDataSource interface {
@@ -730,11 +751,13 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 			// Find the latest block specifically for this coin type
 			if totalStr, ok := blockData.ExtraInfo.SSFeeTotalsByCoin[ct]; ok && totalStr != "" {
 				if total, parsed := new(big.Int).SetString(totalStr, 10); parsed && blockData.Header.Voters > 0 {
-					perVote := new(big.Int).Div(total, big.NewInt(int64(blockData.Header.Voters)))
+					// Divide by 2 first to get PoS portion (fees are split 50/50 between PoW and PoS)
+					halfTotal := new(big.Int).Div(total, big.NewInt(2))
+					perVote := new(big.Int).Div(halfTotal, big.NewInt(int64(blockData.Header.Voters)))
 					perBlock = txhelpers.FormatSKAAtoms(perVote)
 					blockHeight = int64(blockData.Header.Height)
 					blockHash = blockData.Header.Hash
-					totalReward = total
+					totalReward = halfTotal
 				}
 			}
 
@@ -745,11 +768,13 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 						if total, parsed := new(big.Int).SetString(totalStr, 10); parsed {
 							bInfo := exp.dataSource.GetExplorerBlock(ctx, sum30[i].Hash)
 							if bInfo != nil && bInfo.BlockBasic.Voters > 0 {
-								perVote := new(big.Int).Div(total, big.NewInt(int64(bInfo.BlockBasic.Voters)))
+								// Divide by 2 first to get PoS portion (fees are split 50/50 between PoW and PoS)
+								halfTotal := new(big.Int).Div(total, big.NewInt(2))
+								perVote := new(big.Int).Div(halfTotal, big.NewInt(int64(bInfo.BlockBasic.Voters)))
 								perBlock = txhelpers.FormatSKAAtoms(perVote)
 								blockHeight = int64(sum30[i].Height)
 								blockHash = sum30[i].Hash
-								totalReward = total
+								totalReward = halfTotal
 								break
 							}
 						}
@@ -810,54 +835,58 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 		p.HomeInfo.SKAVoteRewards = nil
 	}
 
-	// PoW SKA rewards: prioritize rewards from the current block (miner-centric),
-	// then fallback to previous blocks if current block is empty.
+	// PoW SKA rewards: Extract from current block's stake transactions by identifying
+	// coinbase spends with skaamountin in vin (PoW reward indicator). Fall back to
+	// searching previous blocks if current block has no PoW rewards.
 	var powRewardsBlockHeight int64
-	if len(newBlockData.SKAPoWRewards) > 0 {
-		powRewardsBlockHeight = newBlockData.Height
-		for i := range newBlockData.SKAPoWRewards {
-			newBlockData.SKAPoWRewards[i].BlockHeight = powRewardsBlockHeight
-		}
-		p.HomeInfo.PoWSKARewards = newBlockData.SKAPoWRewards
-	} else {
-		var powRewardsMap map[uint8]string
-		if len(blockData.ExtraInfo.SKAPoWRewards) > 0 {
-			powRewardsBlockHeight = newBlockData.Height
-			powRewardsMap = blockData.ExtraInfo.SKAPoWRewards
-		} else {
-			// Fallback: Search backwards from the current block height.
-			// Use RPC to compute SKA fees from block transaction data.
-			// NOTE: This loop makes up to 4320 RPC calls. Consider caching SKA fees
-			// in the DB to avoid repeated RPC overhead in production.
-			currentHeight := newBlockData.Height
-			for h := currentHeight - 1; h >= currentHeight-4320 && h >= 0; h-- {
-				skaFees, err := exp.dataSource.GetBlockSKAFees(ctx, h)
-				if err != nil {
-					continue
-				}
-				if len(skaFees) > 0 {
-					powRewardsBlockHeight = h
-					powRewardsMap = skaFees
-					break
-				}
-			}
-		}
+	var powRewardsMap map[uint8]string
 
+	// First, try to extract PoW rewards directly from current block's stake transactions
+	if msgBlock != nil {
+		powRewardsMap = blockdata.BlockSKAPoWRewardsFromSTx(msgBlock)
 		if len(powRewardsMap) > 0 {
-			powRewards := make([]types.PoWSKAReward, 0, len(powRewardsMap))
-			for ct, amountStr := range powRewardsMap {
-				powRewards = append(powRewards, types.PoWSKAReward{
-					CoinType:    ct,
-					Symbol:      fmt.Sprintf("SKA%d", ct),
-					Amount:      amountStr,
-					BlockHeight: powRewardsBlockHeight,
-				})
-			}
-			sort.Slice(powRewards, func(i, j int) bool { return powRewards[i].CoinType < powRewards[j].CoinType })
-			p.HomeInfo.PoWSKARewards = powRewards
-		} else {
-			p.HomeInfo.PoWSKARewards = nil
+			powRewardsBlockHeight = newBlockData.Height
 		}
+	}
+
+	// Fallback: use ExtraInfo SKAPoWRewards if current block has none.
+	// These are total fees from regular transactions - need to divide by 2 to get PoW portion.
+	if len(powRewardsMap) == 0 && len(blockData.ExtraInfo.SKAPoWRewards) > 0 {
+		powRewardsBlockHeight = newBlockData.Height
+		powRewardsMap = divideByTwoSKAFees(blockData.ExtraInfo.SKAPoWRewards)
+	}
+
+	// Fallback: search backwards from the current block height for blocks with SKA activity.
+	// These are total fees - need to divide by 2 to get PoW portion.
+	if len(powRewardsMap) == 0 {
+		currentHeight := newBlockData.Height
+		for h := currentHeight - 1; h >= currentHeight-4320 && h >= 0; h-- {
+			skaFees, err := exp.dataSource.GetBlockSKAFees(ctx, h)
+			if err != nil {
+				continue
+			}
+			if len(skaFees) > 0 {
+				powRewardsBlockHeight = h
+				powRewardsMap = divideByTwoSKAFees(skaFees)
+				break
+			}
+		}
+	}
+
+	if len(powRewardsMap) > 0 {
+		powRewards := make([]types.PoWSKAReward, 0, len(powRewardsMap))
+		for ct, amountStr := range powRewardsMap {
+			powRewards = append(powRewards, types.PoWSKAReward{
+				CoinType:    ct,
+				Symbol:      fmt.Sprintf("SKA%d", ct),
+				Amount:      amountStr,
+				BlockHeight: powRewardsBlockHeight,
+			})
+		}
+		sort.Slice(powRewards, func(i, j int) bool { return powRewards[i].CoinType < powRewards[j].CoinType })
+		p.HomeInfo.PoWSKARewards = powRewards
+	} else {
+		p.HomeInfo.PoWSKARewards = nil
 	}
 
 	// If exchange monitoring is enabled, set the exchange rate.

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -290,8 +290,9 @@ func TestStore_PoWSKARewardsFallback(t *testing.T) {
 		defer exp.pageData.RUnlock()
 		if len(exp.pageData.HomeInfo.PoWSKARewards) != 1 {
 			t.Errorf("Expected 1 reward from fallback, got %d", len(exp.pageData.HomeInfo.PoWSKARewards))
-		} else if exp.pageData.HomeInfo.PoWSKARewards[0].Amount != "50" {
-			t.Errorf("Expected reward amount 50, got %s", exp.pageData.HomeInfo.PoWSKARewards[0].Amount)
+		} else if exp.pageData.HomeInfo.PoWSKARewards[0].Amount != "25" {
+			// Fees are split 50/50 between PoW and PoS, so fallback returns half of total fees
+			t.Errorf("Expected reward amount 25 (50/2), got %s", exp.pageData.HomeInfo.PoWSKARewards[0].Amount)
 		}
 	})
 


### PR DESCRIPTION
- Add BlockSKAPoWRewardsFromSTx() to extract PoW rewards from stake transactions
- Update PoW SKA Fee Reward logic to prioritize stake transaction extraction, then fallback to total fees divided by 2 (PoW portion)
- Update Vote SKA Fee Reward (PoS) to divide total fees by 2 before dividing by voters, showing only the staker portion of fees
- Fees are split 50/50 between PoW and PoS, so both sections now show correct portion: total fees / 2 for each