### PR TITLE
mempool: multi-coin support with precision-safe SKA fee rates

### DIFF
--- a/cmd/dcrdata/internal/explorer/mempool_template_test.go
+++ b/cmd/dcrdata/internal/explorer/mempool_template_test.go
@@ -1,0 +1,185 @@
+package explorer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/monetarium/monetarium-explorer/explorer/types"
+	"github.com/monetarium/monetarium-node/chaincfg"
+)
+
+// loadMempoolTemplate parses mempool.tmpl plus extras.tmpl with the production
+// helper FuncMap. Fails the test on parse error.
+func loadMempoolTemplate(t *testing.T) templates {
+	t.Helper()
+	funcMap := makeTemplateFuncMap(chaincfg.SimNetParams())
+	funcMap["asset"] = func(name string) string { return "/dist/" + name }
+	tmpl := newTemplates(viewsFolder, false, []string{"extras"}, funcMap)
+	if err := tmpl.addTemplate("mempool"); err != nil {
+		t.Fatalf("addTemplate mempool: %v", err)
+	}
+	return tmpl
+}
+
+// renderMempool executes the mempool template against a *types.MempoolInfo and
+// returns the rendered HTML.
+func renderMempool(t *testing.T, tmpl templates, inv *types.MempoolInfo) string {
+	t.Helper()
+	data := struct {
+		*CommonPageData
+		Mempool *types.MempoolInfo
+	}{
+		CommonPageData: &CommonPageData{Links: &links{}, Tip: &types.WebBasicBlock{}},
+		Mempool:        inv,
+	}
+	pt, ok := tmpl.templates["mempool"]
+	if !ok {
+		t.Fatal("mempool template not loaded")
+	}
+	var sb strings.Builder
+	if err := pt.template.ExecuteTemplate(&sb, "mempool", data); err != nil {
+		t.Fatalf("execute mempool: %v", err)
+	}
+	return sb.String()
+}
+
+// TestMempoolTemplate exercises mempool.tmpl across the spec-relevant shapes
+// (VAR-only, VAR+SKA, empty). The goal is to catch template regressions
+// without spinning up a node; behaviour-specific assertions verify the spec
+// requirements from wiki/specs/mempool/spec.md.
+func TestMempoolTemplate(t *testing.T) {
+	tmpl := loadMempoolTemplate(t)
+
+	t.Run("VAR-only mempool with regular tx", func(t *testing.T) {
+		inv := &types.MempoolInfo{
+			MempoolShort: types.MempoolShort{
+				NumRegular: 1,
+				LikelyMineable: types.LikelyMineable{
+					Total: 1.5, Count: 1, Size: 250,
+					RegularTotal: 1.5, FormattedSize: "250 B",
+				},
+				CoinStats: map[uint8]types.MempoolCoinStats{
+					0: {
+						TxCount: 1, Size: 250,
+						Amount:       "150000000",
+						RegularCount: 1, RegularAmount: "150000000",
+						TicketCount: 0, TicketAmount: "0",
+						VoteCount: 0, VoteAmount: "0",
+						RevokeCount: 0, RevokeAmount: "0",
+					},
+				},
+			},
+			Transactions: []types.MempoolTx{
+				{Hash: "varhash1", Time: 1, Size: 250, TotalOut: 1.5, FeeRate: 0.0001, Type: "Regular"},
+			},
+		}
+		out := renderMempool(t, tmpl, inv)
+
+		// Total Sent card: VAR row present, SKA absent.
+		if !strings.Contains(out, `data-mempool-target="totalSent"`) {
+			t.Error("missing totalSent container")
+		}
+		// Regular table has the new Coin column + spec-mandated header.
+		if !strings.Contains(out, ">Coin<") {
+			t.Error("expected Coin column header in Regular table")
+		}
+		if strings.Contains(out, ">Total DCR<") {
+			t.Error("found stale 'Total DCR' header — should be 'Total VAR'")
+		}
+		if !strings.Contains(out, "VAR/kB") {
+			t.Error("expected VAR/kB unit label")
+		}
+		// Treasury Spends removed.
+		if strings.Contains(out, "Treasury Spends") {
+			t.Error("Treasury Spends section should be removed")
+		}
+		// Empty state strings — Revocations table is empty (no revs), spec text.
+		if !strings.Contains(out, "No revocations in mempool.") {
+			t.Error("expected exact spec empty state for Revocations")
+		}
+		// VAR row in Regular table renders the symbol literal "VAR" via the
+		// non-SKATotals branch.
+		if !strings.Contains(out, "varhash1") {
+			t.Error("expected VAR tx hash in rendered output")
+		}
+	})
+
+	t.Run("VAR+SKA mempool — both Total Sent rows render", func(t *testing.T) {
+		inv := &types.MempoolInfo{
+			MempoolShort: types.MempoolShort{
+				NumRegular: 2,
+				LikelyMineable: types.LikelyMineable{
+					Total: 1.5, Count: 2, Size: 500,
+					RegularTotal: 1.5, FormattedSize: "500 B",
+				},
+				CoinStats: map[uint8]types.MempoolCoinStats{
+					0: {
+						TxCount: 1, Size: 250, Amount: "150000000",
+						RegularCount: 1, RegularAmount: "150000000",
+						TicketCount: 0, TicketAmount: "0",
+						VoteCount: 0, VoteAmount: "0",
+						RevokeCount: 0, RevokeAmount: "0",
+					},
+					1: {
+						TxCount: 1, Size: 250, Amount: "1230000000000000000",
+						RegularCount: 1, RegularAmount: "1230000000000000000",
+						TicketAmount: "0", VoteAmount: "0", RevokeAmount: "0",
+					},
+				},
+			},
+			Transactions: []types.MempoolTx{
+				{Hash: "varhash", Time: 1, Size: 250, TotalOut: 1.5, FeeRate: 0.0001, Type: "Regular"},
+				{Hash: "skahash", Time: 2, Size: 250, Type: "Regular",
+					SKATotals: map[uint8]string{1: "1230000000000000000"}},
+			},
+		}
+		out := renderMempool(t, tmpl, inv)
+
+		// SKA section in Transactions card appears.
+		if !strings.Contains(out, `data-coin-type="1"`) {
+			t.Error("expected SKA1 section in Transactions card")
+		}
+		// SKA tx row uses the coinSymbol branch.
+		if !strings.Contains(out, "skahash") {
+			t.Error("missing SKA tx hash in output")
+		}
+		// SKA row should not render `VAR/kB` (fee rate em-dash). The literal
+		// `—` is fine; we just verify no `VAR/kB` for the SKA row by checking
+		// only one VAR/kB occurrence (the one VAR tx).
+		varKbCount := strings.Count(out, "VAR/kB")
+		if varKbCount == 0 {
+			t.Error("expected at least one VAR/kB for the VAR tx")
+		}
+		// SSR Total Sent includes the SKA1 symbol.
+		if !strings.Contains(out, "SKA1") {
+			t.Error("expected SKA1 symbol in rendered output")
+		}
+	})
+
+	t.Run("Empty mempool — VAR card still shows, empty states correct", func(t *testing.T) {
+		inv := &types.MempoolInfo{
+			MempoolShort: types.MempoolShort{
+				LikelyMineable: types.LikelyMineable{FormattedSize: "0 B"},
+				CoinStats:      map[uint8]types.MempoolCoinStats{},
+			},
+		}
+		out := renderMempool(t, tmpl, inv)
+
+		// VAR row in Total Sent renders even with empty CoinStats (helper
+		// supplies zero stats).
+		if !strings.Contains(out, "VAR") {
+			t.Error("expected VAR symbol on empty mempool (always shown)")
+		}
+		// Spec empty states for every VAR-only table.
+		for _, want := range []string{
+			"No transactions in mempool.",
+			"No tickets in mempool.",
+			"No votes in mempool.",
+			"No revocations in mempool.",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("missing empty state %q", want)
+			}
+		}
+	})
+}

--- a/cmd/dcrdata/internal/explorer/mempool_template_test.go
+++ b/cmd/dcrdata/internal/explorer/mempool_template_test.go
@@ -130,7 +130,8 @@ func TestMempoolTemplate(t *testing.T) {
 			Transactions: []types.MempoolTx{
 				{Hash: "varhash", Time: 1, Size: 250, TotalOut: 1.5, FeeRate: 0.0001, Type: "Regular"},
 				{Hash: "skahash", Time: 2, Size: 250, Type: "Regular",
-					SKATotals: map[uint8]string{1: "1230000000000000000"}},
+					SKATotals:   map[uint8]string{1: "1230000000000000000"},
+					SKAFeeRates: map[uint8]string{1: "4920000000000000"}},
 			},
 		}
 		out := renderMempool(t, tmpl, inv)
@@ -143,9 +144,10 @@ func TestMempoolTemplate(t *testing.T) {
 		if !strings.Contains(out, "skahash") {
 			t.Error("missing SKA tx hash in output")
 		}
-		// SKA row should not render `VAR/kB` (fee rate em-dash). The literal
-		// `—` is fine; we just verify no `VAR/kB` for the SKA row by checking
-		// only one VAR/kB occurrence (the one VAR tx).
+		// SKA row renders SKA1/kB for its fee rate, never VAR/kB.
+		if !strings.Contains(out, "SKA1/kB") {
+			t.Error("expected SKA1/kB unit on SKA fee rate cell")
+		}
 		varKbCount := strings.Count(out, "VAR/kB")
 		if varKbCount == 0 {
 			t.Error("expected at least one VAR/kB for the VAR tx")

--- a/cmd/dcrdata/internal/explorer/mempool_template_test.go
+++ b/cmd/dcrdata/internal/explorer/mempool_template_test.go
@@ -89,9 +89,12 @@ func TestMempoolTemplate(t *testing.T) {
 		if !strings.Contains(out, "VAR/kB") {
 			t.Error("expected VAR/kB unit label")
 		}
-		// Treasury Spends removed.
+		// Treasury Spends and Treasury Adds both removed — Monetarium has no treasury.
 		if strings.Contains(out, "Treasury Spends") {
 			t.Error("Treasury Spends section should be removed")
+		}
+		if strings.Contains(out, "Treasury Adds") {
+			t.Error("Treasury Adds section should be removed")
 		}
 		// Empty state strings — Revocations table is empty (no revs), spec text.
 		if !strings.Contains(out, "No revocations in mempool.") {

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"math/big"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -511,6 +512,56 @@ func formatCoinAtoms(atomStr string, coinType uint8) string {
 	return threeSigFigs(skaCoinValue(atomStr))
 }
 
+// MempoolCoinRow is an ordered per-coin row for mempool template rendering.
+// VAR (CoinType=0) is always present; SKA-n rows follow ascending and only
+// when the coin has at least one mempool tx.
+type MempoolCoinRow struct {
+	CoinType uint8
+	Symbol   string
+	Stats    types.MempoolCoinStats
+}
+
+// orderedMempoolCoinStats returns the per-coin rows for the mempool page in the
+// order required by wiki/specs/mempool/spec.md: VAR (always), then SKA-n
+// ascending with TxCount > 0. Per the mempool flow.compact.md "SKA → Regular
+// only" invariant, all per-type *Count fields on SKA rows are zero except
+// RegularCount, so callers can safely render only the Regular row in the SKA
+// section.
+func orderedMempoolCoinStats(stats map[uint8]types.MempoolCoinStats) []MempoolCoinRow {
+	varStats, ok := stats[0]
+	if !ok {
+		varStats = types.MempoolCoinStats{
+			Amount:        "0",
+			RegularAmount: "0",
+			TicketAmount:  "0",
+			VoteAmount:    "0",
+			RevokeAmount:  "0",
+		}
+	}
+	rows := []MempoolCoinRow{{
+		CoinType: 0,
+		Symbol:   coinSymbol(0),
+		Stats:    varStats,
+	}}
+	skaKeys := make([]int, 0, len(stats))
+	for k, v := range stats {
+		if k == 0 || v.TxCount == 0 {
+			continue
+		}
+		skaKeys = append(skaKeys, int(k))
+	}
+	sort.Ints(skaKeys)
+	for _, k := range skaKeys {
+		ct := uint8(k)
+		rows = append(rows, MempoolCoinRow{
+			CoinType: ct,
+			Symbol:   coinSymbol(ct),
+			Stats:    stats[ct],
+		})
+	}
+	return rows
+}
+
 // formatSKAAmountCell renders the aggregate SKA-amount table cell shared by
 // the Latest Blocks (home) and Blocks listing tables. The rule is:
 //
@@ -706,6 +757,7 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"formatCoinAtoms":         formatCoinAtoms,
 		"formatSKAAmountCell":     formatSKAAmountCell,
 		"formatAtomsAsCoinString": formatAtomsAsCoinString,
+		"orderedMempoolCoinStats": orderedMempoolCoinStats,
 		"coinDecimalParts": func(atomStr string, coinType uint8, useCommas bool, boldNumPlaces ...int) []string {
 			return coinDecimalParts(atomStr, coinType, useCommas, boldNumPlaces...)
 		},

--- a/cmd/dcrdata/internal/explorer/websockethandlers.go
+++ b/cmd/dcrdata/internal/explorer/websockethandlers.go
@@ -303,14 +303,16 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					inv := exp.MempoolInventory()
 					inv.RLock()
 					newTxsPayload := struct {
-						Txs            []*types.MempoolTx   `json:"txs"`
-						CoinFills      []types.CoinFillData `json:"coin_fills"`
-						TotalFillRatio float64              `json:"total_fill_ratio"`
-						ActiveSKACount int                  `json:"active_ska_count"`
+						Txs            []*types.MempoolTx               `json:"txs"`
+						CoinFills      []types.CoinFillData             `json:"coin_fills"`
+						TotalFillRatio float64                          `json:"total_fill_ratio"`
+						ActiveSKACount int                              `json:"active_ska_count"`
+						CoinStats      map[uint8]types.MempoolCoinStats `json:"coin_stats"`
 					}{
 						CoinFills:      inv.MempoolShort.CoinFills,
 						TotalFillRatio: inv.MempoolShort.TotalFillRatio,
 						ActiveSKACount: inv.MempoolShort.ActiveSKACount,
+						CoinStats:      inv.MempoolShort.CoinStats,
 					}
 					inv.RUnlock()
 					clientData.RLock()

--- a/cmd/dcrdata/public/js/controllers/clipboard_controller.js
+++ b/cmd/dcrdata/public/js/controllers/clipboard_controller.js
@@ -1,22 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
 
-export const copyIcon = () => {
-  const copyIcon = document.createElement('span')
-  copyIcon.classList.add('monicon-copy')
-  copyIcon.classList.add('clickable')
-  copyIcon.dataset.controller = 'clipboard'
-  copyIcon.dataset.action = 'click->clipboard#copyTextToClipboard this'
-  return copyIcon.outerHTML
-}
-
-export const alertArea = () => {
-  const alertArea = document.createElement('span')
-  alertArea.classList.add('alert')
-  alertArea.classList.add('alert-success')
-  alertArea.classList.add('alert-copy')
-  return alertArea.outerHTML
-}
-
 export default class extends Controller {
   copyTextToClipboard(clickEvent) {
     const parentNode = clickEvent.srcElement.parentNode

--- a/cmd/dcrdata/public/js/controllers/mempool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.js
@@ -3,9 +3,18 @@ import dompurify from 'dompurify'
 import { each, map } from 'lodash-es'
 import humanize from '../helpers/humanize_helper'
 import Mempool from '../helpers/mempool_helper'
+import { renderCoinType, splitSkaAtomsNoTrailing } from '../helpers/ska_helper'
 import { keyNav } from '../services/keyboard_navigation_service'
 import ws from '../services/messagesocket_service'
 import { alertArea, copyIcon } from './clipboard_controller'
+
+const EMPTY_STATES = {
+  regular: { text: 'No transactions in mempool.', colspan: 6 },
+  tickets: { text: 'No tickets in mempool.', colspan: 5 },
+  votes: { text: 'No votes in mempool.', colspan: 8 },
+  revocations: { text: 'No revocations in mempool.', colspan: 4 },
+  tadds: { text: 'No treasury adds in mempool.', colspan: 3 }
+}
 
 function incrementValue(el) {
   if (!el) return
@@ -19,7 +28,64 @@ function rowNode(rowText) {
   return tbody.firstElementChild
 }
 
+// skaAmountHTML renders a SKA atom string into the standard .decimal-parts
+// HTML structure, matching the server-side decimalParts template output for
+// skaDecimalParts. BigInt-based; no float coercion.
+function skaAmountHTML(atomStr) {
+  const { intPart, bold, rest, trailingZeros } = splitSkaAtomsNoTrailing(atomStr || '0', false)
+  const intText = bold ? `${intPart}.${bold}` : intPart
+  let html = `<div class="decimal-parts d-inline-block"><span class="int">${intText}</span>`
+  if (bold && rest) html += `<span class="decimal">${rest}</span>`
+  if (bold && trailingZeros) html += `<span class="decimal trailing-zeroes">${trailingZeros}</span>`
+  html += '</div>'
+  return html
+}
+
+// txAmountHTML returns the inner HTML for a tx's Amount cell. SKA txs render
+// 18dp BigInt parts; VAR txs render 8dp float parts via humanize.decimalParts.
+// Per the dual-precision invariant (CLAUDE.md), SKA never goes through
+// float64.
+function txAmountHTML(tx) {
+  if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
+    const [, atomStr] = Object.entries(tx.ska_totals)[0]
+    return skaAmountHTML(atomStr)
+  }
+  return humanize.decimalParts(tx.total || 0, false, 8)
+}
+
+function txCoinSymbol(tx) {
+  if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
+    const [id] = Object.entries(tx.ska_totals)[0]
+    return renderCoinType(id)
+  }
+  return renderCoinType(0)
+}
+
+function txFeeRateHTML(tx) {
+  if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
+    // SKA fee rate not yet exposed precisely (MempoolTx.FeeRate is VAR-only
+    // float64; would lose precision). Tracked as follow-up; render em-dash.
+    return '&mdash;'
+  }
+  return `${tx.fee_rate} VAR/kB`
+}
+
 function txTableRow(tx) {
+  return rowNode(`<tr class="flash">
+        <td class="break-word clipboard">
+          <a class="hash" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a>
+          ${copyIcon()}
+          ${alertArea()}
+        </td>
+        <td class="text-start text-nowrap">${txCoinSymbol(tx)}</td>
+        <td class="mono fs15 text-end">${txAmountHTML(tx)}</td>
+        <td class="mono fs15 text-end">${tx.size} B</td>
+        <td class="mono fs15 text-end">${txFeeRateHTML(tx)}</td>
+        <td class="mono fs15 text-end" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
+    </tr>`)
+}
+
+function ticketTableRow(tx) {
   return rowNode(`<tr class="flash">
         <td class="break-word clipboard">
           <a class="hash" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a>
@@ -28,12 +94,25 @@ function txTableRow(tx) {
         </td>
         <td class="mono fs15 text-end">${humanize.decimalParts(String(tx.total), false, 8)}</td>
         <td class="mono fs15 text-end">${tx.size} B</td>
-        <td class="mono fs15 text-end">${tx.fee_rate} DCR/kB</td>
+        <td class="mono fs15 text-end">${tx.fee_rate} VAR/kB</td>
         <td class="mono fs15 text-end" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
     </tr>`)
 }
 
-function treasuryTxTableRow(tx) {
+function revocationTableRow(tx) {
+  return rowNode(`<tr class="flash">
+        <td class="break-word clipboard">
+          <a class="hash" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a>
+          ${copyIcon()}
+          ${alertArea()}
+        </td>
+        <td class="mono fs15 text-end">${humanize.decimalParts(String(tx.total), false, 8)}</td>
+        <td class="mono fs15 text-end">${tx.size} B</td>
+        <td class="mono fs15 text-end" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
+    </tr>`)
+}
+
+function treasuryAddTableRow(tx) {
   return rowNode(`<tr class="flash">
         <td class="break-word clipboard">
           <a class="hash" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a>
@@ -69,7 +148,8 @@ function buildTable(target, txType, txns, rowFn) {
       target.appendChild(tr)
     })
   } else {
-    target.innerHTML = `<tr class="no-tx-tr"><td colspan="${txType === 'votes' ? 8 : 4}">No ${txType} in mempool.</td></tr>`
+    const { text, colspan } = EMPTY_STATES[txType]
+    target.innerHTML = `<tr class="no-tx-tr"><td colspan="${colspan}">${text}</td></tr>`
   }
 }
 
@@ -80,12 +160,97 @@ function addTxRow(tx, target, rowFn) {
   target.insertBefore(rowFn(tx), target.firstChild)
 }
 
+function emptyVarStats() {
+  return {
+    tx_count: 0,
+    size: 0,
+    amount: '0',
+    regular_count: 0,
+    regular_amount: '0',
+    ticket_count: 0,
+    ticket_amount: '0',
+    vote_count: 0,
+    vote_amount: '0',
+    revoke_count: 0,
+    revoke_amount: '0'
+  }
+}
+
+// activeSkaIds returns SKA coin-type ids from a coin_stats payload that have at
+// least one mempool tx, sorted ascending. Mirrors orderedMempoolCoinStats in
+// templates.go for the SKA portion.
+function activeSkaIds(coinStats) {
+  if (!coinStats) return []
+  const ids = []
+  Object.entries(coinStats).forEach(([k, v]) => {
+    const id = parseInt(k)
+    if (id === 0 || !v || !v.tx_count || v.tx_count <= 0) return
+    ids.push(id)
+  })
+  ids.sort((a, b) => a - b)
+  return ids
+}
+
+function totalSentSkaCol(id, stats) {
+  const col = document.createElement('div')
+  col.className = 'col-12 col-md-6 col-lg-12 col-xl-6 text-center pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0'
+  col.setAttribute('data-coin-type', String(id))
+  const inner = document.createElement('div')
+  inner.className = 'd-inline-block text-center text-md-start text-lg-center text-xl-start'
+  const label = document.createElement('span')
+  label.className = 'text-secondary fs13'
+  label.textContent = 'Total Sent'
+  const amount = document.createElement('span')
+  amount.className = 'h4'
+  amount.textContent = humanize.formatCoinAtoms(stats.amount || '0', id)
+  const sym = document.createElement('span')
+  sym.className = 'text-secondary'
+  sym.textContent = renderCoinType(id)
+  inner.append(label, document.createElement('br'), amount, document.createTextNode(' '), sym)
+  col.appendChild(inner)
+  return col
+}
+
+function regularSkaCol(id, stats) {
+  const col = document.createElement('div')
+  col.className = 'col-12 col-md-6 col-lg-12 col-xl-6 pb-3'
+  col.setAttribute('data-coin-type', String(id))
+  const head = document.createElement('div')
+  head.className = 'text-center text-secondary fs13'
+  head.textContent = 'Regular'
+  const count = document.createElement('div')
+  count.className = 'text-center h4 mb-0'
+  count.textContent = String(stats.regular_count || 0)
+  const totalLine = document.createElement('div')
+  totalLine.className = 'text-center fs13'
+  const amount = document.createElement('span')
+  amount.textContent = humanize.formatCoinAtoms(stats.regular_amount || '0', id)
+  totalLine.append(amount, document.createTextNode(` ${renderCoinType(id)}`))
+  col.append(head, count, totalLine)
+  return col
+}
+
+// syncSkaColsIn rebuilds the SKA (CoinType > 0) child cols of a row to match
+// coin_stats. VAR cols (data-coin-type="0") and any non-coin cols are left
+// untouched. SKA cols are appended after VAR in ascending CoinType order, which
+// matches the server-side render order for stable layout across reloads.
+function syncSkaColsIn(row, coinStats, colFn) {
+  Array.from(row.children).forEach((child) => {
+    const raw = child.getAttribute('data-coin-type')
+    if (raw === null) return
+    const id = parseInt(raw, 10)
+    if (id !== 0) child.remove()
+  })
+  activeSkaIds(coinStats).forEach((id) => {
+    row.appendChild(colFn(id, coinStats[id]))
+  })
+}
+
 export default class extends Controller {
   static get targets() {
     return [
       'bestBlock',
       'bestBlockTime',
-      'tspendTransactions',
       'taddTransactions',
       'voteTransactions',
       'ticketTransactions',
@@ -93,6 +258,9 @@ export default class extends Controller {
       'regularTransactions',
       'mempool',
       'voteTally',
+      'totalSent',
+      'totalSentRow',
+      'transactionsRow',
       'regTotal',
       'regCount',
       'ticketTotal',
@@ -101,18 +269,16 @@ export default class extends Controller {
       'voteCount',
       'revTotal',
       'revCount',
-      'likelyTotal',
       'mempoolSize'
     ]
   }
 
   connect() {
-    // from txhelpers.DetermineTxTypeString
     const mempoolData = this.mempoolTarget.dataset
     ws.send('getmempooltxs', mempoolData.id)
     this.mempool = new Mempool(mempoolData, this.voteTallyTargets)
+    this.lastCoinStats = null
     this.txTargetMap = {
-      'Treasury Spend': this.tspendTransactionsTarget,
       Vote: this.voteTransactionsTarget,
       Ticket: this.ticketTransactionsTarget,
       Revocation: this.revocationTransactionsTarget,
@@ -121,15 +287,10 @@ export default class extends Controller {
     if (this.hasTaddTransactionsTarget) {
       this.txTargetMap['Treasury Add'] = this.taddTransactionsTarget
     }
-    this.countTargetMap = {
-      Vote: this.numVoteTarget,
-      Ticket: this.numTicketTarget,
-      Revocation: this.numRevocationTarget,
-      Regular: this.numRegularTarget
-    }
     ws.registerEvtHandler('newtxs', (evt) => {
       const m = JSON.parse(evt)
       const txs = Array.isArray(m) ? m : m.txs || []
+      if (!Array.isArray(m) && m.coin_stats) this.lastCoinStats = m.coin_stats
       this.mempool.mergeTxs(txs)
       this.renderNewTxns(txs)
       this.setMempoolFigures()
@@ -139,6 +300,7 @@ export default class extends Controller {
     })
     ws.registerEvtHandler('mempool', (evt) => {
       const m = JSON.parse(evt)
+      if (m.coin_stats) this.lastCoinStats = m.coin_stats
       this.mempool.replace(m)
       this.setMempoolFigures()
       this.updateBlock(m)
@@ -146,6 +308,7 @@ export default class extends Controller {
     })
     ws.registerEvtHandler('getmempooltxsResp', (evt) => {
       const m = JSON.parse(evt)
+      if (m.coin_stats) this.lastCoinStats = m.coin_stats
       this.mempool.replace(m)
       this.handleTxsResp(m)
       this.setMempoolFigures()
@@ -169,40 +332,55 @@ export default class extends Controller {
   }
 
   setMempoolFigures() {
-    const totals = this.mempool.totals()
+    this.applyCoinStats(this.lastCoinStats)
+    // Vote tally HTML is driven by the local Mempool helper; vote totals are
+    // already covered by applyCoinStats (CoinStats[0].vote_amount).
     const counts = this.mempool.counts()
-    this.regTotalTarget.textContent = humanize.threeSigFigs(totals.regular)
-    this.regCountTarget.textContent = counts.regular
-
-    this.ticketTotalTarget.textContent = humanize.threeSigFigs(totals.ticket)
-    this.ticketCountTarget.textContent = counts.ticket
-
-    this.voteTotalTarget.textContent = humanize.threeSigFigs(totals.vote)
-
     const ct = this.voteCountTarget
     while (ct.firstChild) ct.removeChild(ct.firstChild)
     this.mempool.voteSpans(counts.vote).forEach((span) => {
       ct.appendChild(span)
     })
-
-    this.revTotalTarget.textContent = humanize.threeSigFigs(totals.rev)
-    this.revCountTarget.textContent = counts.rev
-
-    this.likelyTotalTarget.textContent = humanize.threeSigFigs(totals.total)
+    const totals = this.mempool.totals()
     this.mempoolSizeTarget.textContent = humanize.bytes(totals.size)
-
     this.labelVotes()
-    // this.setVotes()
+  }
+
+  applyCoinStats(coinStats) {
+    const v = (coinStats && coinStats[0]) || emptyVarStats()
+    if (this.hasTotalSentTarget) {
+      this.totalSentTarget.textContent = humanize.formatCoinAtoms(v.amount || '0', 0)
+    }
+    if (this.hasRegCountTarget) this.regCountTarget.textContent = v.regular_count || 0
+    if (this.hasRegTotalTarget) {
+      this.regTotalTarget.textContent = humanize.formatCoinAtoms(v.regular_amount || '0', 0)
+    }
+    if (this.hasTicketCountTarget) this.ticketCountTarget.textContent = v.ticket_count || 0
+    if (this.hasTicketTotalTarget) {
+      this.ticketTotalTarget.textContent = humanize.formatCoinAtoms(v.ticket_amount || '0', 0)
+    }
+    if (this.hasVoteTotalTarget) {
+      this.voteTotalTarget.textContent = humanize.formatCoinAtoms(v.vote_amount || '0', 0)
+    }
+    if (this.hasRevCountTarget) this.revCountTarget.textContent = v.revoke_count || 0
+    if (this.hasRevTotalTarget) {
+      this.revTotalTarget.textContent = humanize.formatCoinAtoms(v.revoke_amount || '0', 0)
+    }
+    if (this.hasTotalSentRowTarget) {
+      syncSkaColsIn(this.totalSentRowTarget, coinStats, totalSentSkaCol)
+    }
+    if (this.hasTransactionsRowTarget) {
+      syncSkaColsIn(this.transactionsRowTarget, coinStats, regularSkaCol)
+    }
   }
 
   handleTxsResp(m) {
-    buildTable(this.regularTransactionsTarget, 'regular transactions', m.tx, txTableRow)
-    buildTable(this.revocationTransactionsTarget, 'revocations', m.revs, txTableRow)
+    buildTable(this.regularTransactionsTarget, 'regular', m.tx, txTableRow)
+    buildTable(this.revocationTransactionsTarget, 'revocations', m.revs, revocationTableRow)
     buildTable(this.voteTransactionsTarget, 'votes', m.votes, voteTxTableRow)
-    buildTable(this.ticketTransactionsTarget, 'tickets', m.tickets, txTableRow)
-    buildTable(this.tspendTransactionsTarget, 'tspends', m.tspends, treasuryTxTableRow)
+    buildTable(this.ticketTransactionsTarget, 'tickets', m.tickets, ticketTableRow)
     if (this.hasTaddTransactionsTarget) {
-      buildTable(this.taddTransactionsTarget, 'tadds', m.tadds, treasuryTxTableRow)
+      buildTable(this.taddTransactionsTarget, 'tadds', m.tadds, treasuryAddTableRow)
     }
   }
 
@@ -211,23 +389,31 @@ export default class extends Controller {
     // top, the end result matches the original input order (newest at top).
     const txsToRender = [...txs].reverse()
     each(txsToRender, (tx) => {
-      incrementValue(this.countTargetMap[tx.Type])
+      incrementValue(this.countTargetMap ? this.countTargetMap[tx.Type] : null)
       let rowFn
       switch (tx.Type) {
         case 'Vote':
           rowFn = voteTxTableRow
           break
-        case 'Treasury Spend':
-          rowFn = treasuryTxTableRow
+        case 'Ticket':
+          rowFn = ticketTableRow
+          break
+        case 'Revocation':
+          rowFn = revocationTableRow
           break
         case 'Treasury Add':
           if (!this.hasTaddTransactionsTarget) return
-          rowFn = treasuryTxTableRow
+          rowFn = treasuryAddTableRow
           break
+        case 'Treasury Spend':
+          // Treasury Spends are not displayed on the mempool page.
+          return
         default:
           rowFn = txTableRow
       }
-      addTxRow(tx, this.txTargetMap[tx.Type], rowFn)
+      const target = this.txTargetMap[tx.Type]
+      if (!target) return
+      addTxRow(tx, target, rowFn)
     })
   }
 

--- a/cmd/dcrdata/public/js/controllers/mempool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.js
@@ -1,12 +1,10 @@
 import { Controller } from '@hotwired/stimulus'
-import dompurify from 'dompurify'
 import { each, map } from 'lodash-es'
 import humanize from '../helpers/humanize_helper'
 import Mempool from '../helpers/mempool_helper'
 import { renderCoinType, splitSkaAtoms } from '../helpers/ska_helper'
 import { keyNav } from '../services/keyboard_navigation_service'
 import ws from '../services/messagesocket_service'
-import { alertArea, copyIcon } from './clipboard_controller'
 
 const EMPTY_STATES = {
   regular: { text: 'No transactions in mempool.', colspan: 6 },
@@ -21,39 +19,74 @@ function incrementValue(el) {
   el.textContent = parseInt(el.textContent) + 1
 }
 
-function rowNode(rowText) {
-  const tbody = document.createElement('tbody')
-  tbody.innerHTML = rowText
-  dompurify.sanitize(tbody, { IN_PLACE: true, FORBID_TAGS: ['svg', 'math'] })
-  return tbody.firstElementChild
+function setHashLink(el, hash, withTitle = true) {
+  el.href = `/tx/${hash}`
+  if (withTitle) el.title = hash
+  el.textContent = hash
 }
 
-// skaAmountHTML renders a SKA atom string into the standard .decimal-parts
-// HTML structure, matching the server-side decimalParts template output for
-// skaDecimalParts. BigInt-based; no float coercion.
-function skaAmountHTML(atomStr) {
+function setAgeCell(cell, time) {
+  cell.dataset.age = time
+  cell.textContent = humanize.timeSince(time)
+}
+
+// humanize.decimalParts returns HTML built from a server-provided numeric
+// value — no user-controlled content reaches this path, so innerHTML is safe.
+function setVarAmountHTML(cell, total) {
+  cell.innerHTML = humanize.decimalParts(String(total || 0), false, 8)
+}
+
+// appendSkaDecimalParts builds the .decimal-parts DOM structure for a SKA atom
+// string and appends it to parent. BigInt-based; no float coercion. Mirrors
+// the server-side skaDecimalParts template.
+function appendSkaDecimalParts(parent, atomStr) {
   const { intPart, bold, rest, trailingZeros } = splitSkaAtoms(atomStr || '0', false)
-  const intText = bold ? `${intPart}.${bold}` : intPart
-  let html = `<div class="decimal-parts d-inline-block"><span class="int">${intText}</span>`
-  if (bold && rest) html += `<span class="decimal">${rest}</span>`
-  if (bold && trailingZeros) html += `<span class="decimal trailing-zeroes">${trailingZeros}</span>`
-  html += '</div>'
-  return html
+  const wrap = document.createElement('div')
+  wrap.className = 'decimal-parts d-inline-block'
+  const intSpan = document.createElement('span')
+  intSpan.className = 'int'
+  intSpan.textContent = bold ? `${intPart}.${bold}` : intPart
+  wrap.appendChild(intSpan)
+  if (bold && rest) {
+    const restSpan = document.createElement('span')
+    restSpan.className = 'decimal'
+    restSpan.textContent = rest
+    wrap.appendChild(restSpan)
+  }
+  if (bold && trailingZeros) {
+    const tz = document.createElement('span')
+    tz.className = 'decimal trailing-zeroes'
+    tz.textContent = trailingZeros
+    wrap.appendChild(tz)
+  }
+  parent.appendChild(wrap)
 }
 
-// txAmountHTML returns the inner HTML for a tx's Amount cell. SKA txs render
-// 18dp BigInt parts; VAR txs render 8dp float parts via humanize.decimalParts.
-// Per the dual-precision invariant (CLAUDE.md), SKA never goes through
-// float64.
-function txAmountHTML(tx) {
+function fillTxAmountCell(cell, tx) {
   if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
     const [, atomStr] = Object.entries(tx.ska_totals)[0]
-    return skaAmountHTML(atomStr)
+    appendSkaDecimalParts(cell, atomStr)
+    return
   }
-  return humanize.decimalParts(tx.total || 0, false, 8)
+  setVarAmountHTML(cell, tx.total)
 }
 
-function txCoinSymbol(tx) {
+function fillTxFeeRateCell(cell, tx) {
+  if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
+    const [id] = Object.entries(tx.ska_totals)[0]
+    const rateAtoms = tx.ska_fee_rates && tx.ska_fee_rates[id]
+    if (!rateAtoms) {
+      cell.textContent = '—'
+      return
+    }
+    appendSkaDecimalParts(cell, rateAtoms)
+    cell.appendChild(document.createTextNode(` ${renderCoinType(id)}/kB`))
+    return
+  }
+  cell.textContent = `${tx.fee_rate} VAR/kB`
+}
+
+function txCoinSymbolText(tx) {
   if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
     const [id] = Object.entries(tx.ska_totals)[0]
     return renderCoinType(id)
@@ -61,85 +94,62 @@ function txCoinSymbol(tx) {
   return renderCoinType(0)
 }
 
-function txFeeRateHTML(tx) {
-  if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
-    const [id] = Object.entries(tx.ska_totals)[0]
-    const rateAtoms = tx.ska_fee_rates && tx.ska_fee_rates[id]
-    if (!rateAtoms) return '&mdash;'
-    return `${skaAmountHTML(rateAtoms)} ${renderCoinType(id)}/kB`
-  }
-  return `${tx.fee_rate} VAR/kB`
+function cloneTxRow(template, tx) {
+  const tr = template.content.firstElementChild.cloneNode(true)
+  setHashLink(tr.querySelector('[data-slot="hashLink"]'), tx.hash)
+  tr.querySelector('[data-slot="coinSymbol"]').textContent = txCoinSymbolText(tx)
+  fillTxAmountCell(tr.querySelector('[data-slot="amount"]'), tx)
+  tr.querySelector('[data-slot="size"]').textContent = `${tx.size} B`
+  fillTxFeeRateCell(tr.querySelector('[data-slot="feeRate"]'), tx)
+  setAgeCell(tr.querySelector('[data-slot="age"]'), tx.time)
+  return tr
 }
 
-function txTableRow(tx) {
-  return rowNode(`<tr class="flash">
-        <td class="break-word clipboard">
-          <a class="hash" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a>
-          ${copyIcon()}
-          ${alertArea()}
-        </td>
-        <td class="text-start text-nowrap">${txCoinSymbol(tx)}</td>
-        <td class="mono fs15 text-end">${txAmountHTML(tx)}</td>
-        <td class="mono fs15 text-end">${tx.size} B</td>
-        <td class="mono fs15 text-end">${txFeeRateHTML(tx)}</td>
-        <td class="mono fs15 text-end" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
-    </tr>`)
+function cloneTicketRow(template, tx) {
+  const tr = template.content.firstElementChild.cloneNode(true)
+  setHashLink(tr.querySelector('[data-slot="hashLink"]'), tx.hash)
+  setVarAmountHTML(tr.querySelector('[data-slot="amount"]'), tx.total)
+  tr.querySelector('[data-slot="size"]').textContent = `${tx.size} B`
+  tr.querySelector('[data-slot="feeRate"]').textContent = `${tx.fee_rate} VAR/kB`
+  setAgeCell(tr.querySelector('[data-slot="age"]'), tx.time)
+  return tr
 }
 
-function ticketTableRow(tx) {
-  return rowNode(`<tr class="flash">
-        <td class="break-word clipboard">
-          <a class="hash" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a>
-          ${copyIcon()}
-          ${alertArea()}
-        </td>
-        <td class="mono fs15 text-end">${humanize.decimalParts(String(tx.total), false, 8)}</td>
-        <td class="mono fs15 text-end">${tx.size} B</td>
-        <td class="mono fs15 text-end">${tx.fee_rate} VAR/kB</td>
-        <td class="mono fs15 text-end" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
-    </tr>`)
+function cloneRevocationRow(template, tx) {
+  const tr = template.content.firstElementChild.cloneNode(true)
+  setHashLink(tr.querySelector('[data-slot="hashLink"]'), tx.hash)
+  setVarAmountHTML(tr.querySelector('[data-slot="amount"]'), tx.total)
+  tr.querySelector('[data-slot="size"]').textContent = `${tx.size} B`
+  setAgeCell(tr.querySelector('[data-slot="age"]'), tx.time)
+  return tr
 }
 
-function revocationTableRow(tx) {
-  return rowNode(`<tr class="flash">
-        <td class="break-word clipboard">
-          <a class="hash" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a>
-          ${copyIcon()}
-          ${alertArea()}
-        </td>
-        <td class="mono fs15 text-end">${humanize.decimalParts(String(tx.total), false, 8)}</td>
-        <td class="mono fs15 text-end">${tx.size} B</td>
-        <td class="mono fs15 text-end" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
-    </tr>`)
+function cloneTreasuryAddRow(template, tx) {
+  const tr = template.content.firstElementChild.cloneNode(true)
+  setHashLink(tr.querySelector('[data-slot="hashLink"]'), tx.hash)
+  setVarAmountHTML(tr.querySelector('[data-slot="amount"]'), tx.total)
+  setAgeCell(tr.querySelector('[data-slot="age"]'), tx.time)
+  return tr
 }
 
-function treasuryAddTableRow(tx) {
-  return rowNode(`<tr class="flash">
-        <td class="break-word clipboard">
-          <a class="hash" href="/tx/${tx.hash}" title="${tx.hash}">${tx.hash}</a>
-          ${copyIcon()}
-          ${alertArea()}
-        </td>
-        <td class="mono fs15 text-end">${humanize.decimalParts(String(tx.total), false, 8)}</td>
-        <td class="mono fs15 text-end" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
-    </tr>`)
-}
-
-function voteTxTableRow(tx) {
-  return rowNode(`<tr class="flash" data-height="${tx.vote_info.block_validation.height}" data-blockhash="${tx.vote_info.block_validation.hash}">
-        <td class="break-word clipboard">
-          <a class="hash" href="/tx/${tx.hash}">${tx.hash}</a>
-          ${copyIcon()}
-          ${alertArea()}
-        </td>
-        <td class="mono fs15"><a href="/block/${tx.vote_info.block_validation.hash}">${tx.vote_info.block_validation.height}<span
-          class="small">${tx.vote_info.last_block ? ' best' : ''}</span></a></td>
-        <td class="mono fs15 text-end"><a href="/tx/${tx.vote_info.ticket_spent}">${tx.vote_info.mempool_ticket_index}<a/></td>
-        <td class="mono fs15 text-end">${tx.vote_info.vote_version}</td>
-        <td class="mono fs15 text-end d-none d-sm-table-cell">${humanize.decimalParts(String(tx.total), false, 8)}</td>
-        <td class="mono fs15 text-end">${humanize.bytes(tx.size)}</td>
-        <td class="mono fs15 text-end d-none d-sm-table-cell jsonly" data-time-target="age" data-age="${tx.time}">${humanize.timeSince(tx.time)}</td>
-    </tr>`)
+function cloneVoteRow(template, tx) {
+  const tr = template.content.firstElementChild.cloneNode(true)
+  const v = tx.vote_info
+  tr.dataset.height = v.block_validation.height
+  tr.dataset.blockhash = v.block_validation.hash
+  setHashLink(tr.querySelector('[data-slot="hashLink"]'), tx.hash, false)
+  const blockLink = tr.querySelector('[data-slot="blockLink"]')
+  blockLink.href = `/block/${v.block_validation.hash}`
+  tr.querySelector('[data-slot="blockHeight"]').textContent = v.block_validation.height
+  tr.querySelector('[data-slot="bestMarker"]').textContent = v.last_block ? ' best' : ''
+  const ticketLink = tr.querySelector('[data-slot="ticketLink"]')
+  ticketLink.href = `/tx/${v.ticket_spent}`
+  ticketLink.textContent = v.mempool_ticket_index
+  tr.querySelector('[data-slot="voteVersion"]').textContent = v.vote_version
+  setVarAmountHTML(tr.querySelector('[data-slot="amount"]'), tx.total)
+  tr.querySelector('[data-slot="size"]').textContent = humanize.bytes(tx.size)
+  setAgeCell(tr.querySelector('[data-slot="age"]'), tx.time)
+  return tr
 }
 
 function buildTable(target, txType, txns, rowFn) {
@@ -270,7 +280,12 @@ export default class extends Controller {
       'voteCount',
       'revTotal',
       'revCount',
-      'mempoolSize'
+      'mempoolSize',
+      'txRowTemplate',
+      'ticketRowTemplate',
+      'revocationRowTemplate',
+      'treasuryAddRowTemplate',
+      'voteRowTemplate'
     ]
   }
 
@@ -279,6 +294,13 @@ export default class extends Controller {
     ws.send('getmempooltxs', mempoolData.id)
     this.mempool = new Mempool(mempoolData, this.voteTallyTargets)
     this.lastCoinStats = null
+    this.txTableRow = (tx) => cloneTxRow(this.txRowTemplateTarget, tx)
+    this.ticketTableRow = (tx) => cloneTicketRow(this.ticketRowTemplateTarget, tx)
+    this.revocationTableRow = (tx) => cloneRevocationRow(this.revocationRowTemplateTarget, tx)
+    this.voteTxTableRow = (tx) => cloneVoteRow(this.voteRowTemplateTarget, tx)
+    this.treasuryAddTableRow = this.hasTreasuryAddRowTemplateTarget
+      ? (tx) => cloneTreasuryAddRow(this.treasuryAddRowTemplateTarget, tx)
+      : null
     this.txTargetMap = {
       Vote: this.voteTransactionsTarget,
       Ticket: this.ticketTransactionsTarget,
@@ -376,12 +398,12 @@ export default class extends Controller {
   }
 
   handleTxsResp(m) {
-    buildTable(this.regularTransactionsTarget, 'regular', m.tx, txTableRow)
-    buildTable(this.revocationTransactionsTarget, 'revocations', m.revs, revocationTableRow)
-    buildTable(this.voteTransactionsTarget, 'votes', m.votes, voteTxTableRow)
-    buildTable(this.ticketTransactionsTarget, 'tickets', m.tickets, ticketTableRow)
-    if (this.hasTaddTransactionsTarget) {
-      buildTable(this.taddTransactionsTarget, 'tadds', m.tadds, treasuryAddTableRow)
+    buildTable(this.regularTransactionsTarget, 'regular', m.tx, this.txTableRow)
+    buildTable(this.revocationTransactionsTarget, 'revocations', m.revs, this.revocationTableRow)
+    buildTable(this.voteTransactionsTarget, 'votes', m.votes, this.voteTxTableRow)
+    buildTable(this.ticketTransactionsTarget, 'tickets', m.tickets, this.ticketTableRow)
+    if (this.hasTaddTransactionsTarget && this.treasuryAddTableRow) {
+      buildTable(this.taddTransactionsTarget, 'tadds', m.tadds, this.treasuryAddTableRow)
     }
   }
 
@@ -394,23 +416,23 @@ export default class extends Controller {
       let rowFn
       switch (tx.Type) {
         case 'Vote':
-          rowFn = voteTxTableRow
+          rowFn = this.voteTxTableRow
           break
         case 'Ticket':
-          rowFn = ticketTableRow
+          rowFn = this.ticketTableRow
           break
         case 'Revocation':
-          rowFn = revocationTableRow
+          rowFn = this.revocationTableRow
           break
         case 'Treasury Add':
-          if (!this.hasTaddTransactionsTarget) return
-          rowFn = treasuryAddTableRow
+          if (!this.treasuryAddTableRow) return
+          rowFn = this.treasuryAddTableRow
           break
         case 'Treasury Spend':
           // Treasury Spends are not displayed on the mempool page.
           return
         default:
-          rowFn = txTableRow
+          rowFn = this.txTableRow
       }
       const target = this.txTargetMap[tx.Type]
       if (!target) return

--- a/cmd/dcrdata/public/js/controllers/mempool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.js
@@ -10,8 +10,7 @@ const EMPTY_STATES = {
   regular: { text: 'No transactions in mempool.', colspan: 6 },
   tickets: { text: 'No tickets in mempool.', colspan: 5 },
   votes: { text: 'No votes in mempool.', colspan: 8 },
-  revocations: { text: 'No revocations in mempool.', colspan: 4 },
-  tadds: { text: 'No treasury adds in mempool.', colspan: 3 }
+  revocations: { text: 'No revocations in mempool.', colspan: 4 }
 }
 
 function incrementValue(el) {
@@ -120,14 +119,6 @@ function cloneRevocationRow(template, tx) {
   setHashLink(tr.querySelector('[data-slot="hashLink"]'), tx.hash)
   setVarAmountHTML(tr.querySelector('[data-slot="amount"]'), tx.total)
   tr.querySelector('[data-slot="size"]').textContent = `${tx.size} B`
-  setAgeCell(tr.querySelector('[data-slot="age"]'), tx.time)
-  return tr
-}
-
-function cloneTreasuryAddRow(template, tx) {
-  const tr = template.content.firstElementChild.cloneNode(true)
-  setHashLink(tr.querySelector('[data-slot="hashLink"]'), tx.hash)
-  setVarAmountHTML(tr.querySelector('[data-slot="amount"]'), tx.total)
   setAgeCell(tr.querySelector('[data-slot="age"]'), tx.time)
   return tr
 }
@@ -262,7 +253,6 @@ export default class extends Controller {
     return [
       'bestBlock',
       'bestBlockTime',
-      'taddTransactions',
       'voteTransactions',
       'ticketTransactions',
       'revocationTransactions',
@@ -284,7 +274,6 @@ export default class extends Controller {
       'txRowTemplate',
       'ticketRowTemplate',
       'revocationRowTemplate',
-      'treasuryAddRowTemplate',
       'voteRowTemplate'
     ]
   }
@@ -298,17 +287,11 @@ export default class extends Controller {
     this.ticketTableRow = (tx) => cloneTicketRow(this.ticketRowTemplateTarget, tx)
     this.revocationTableRow = (tx) => cloneRevocationRow(this.revocationRowTemplateTarget, tx)
     this.voteTxTableRow = (tx) => cloneVoteRow(this.voteRowTemplateTarget, tx)
-    this.treasuryAddTableRow = this.hasTreasuryAddRowTemplateTarget
-      ? (tx) => cloneTreasuryAddRow(this.treasuryAddRowTemplateTarget, tx)
-      : null
     this.txTargetMap = {
       Vote: this.voteTransactionsTarget,
       Ticket: this.ticketTransactionsTarget,
       Revocation: this.revocationTransactionsTarget,
       Regular: this.regularTransactionsTarget
-    }
-    if (this.hasTaddTransactionsTarget) {
-      this.txTargetMap['Treasury Add'] = this.taddTransactionsTarget
     }
     ws.registerEvtHandler('newtxs', (evt) => {
       const m = JSON.parse(evt)
@@ -402,9 +385,6 @@ export default class extends Controller {
     buildTable(this.revocationTransactionsTarget, 'revocations', m.revs, this.revocationTableRow)
     buildTable(this.voteTransactionsTarget, 'votes', m.votes, this.voteTxTableRow)
     buildTable(this.ticketTransactionsTarget, 'tickets', m.tickets, this.ticketTableRow)
-    if (this.hasTaddTransactionsTarget && this.treasuryAddTableRow) {
-      buildTable(this.taddTransactionsTarget, 'tadds', m.tadds, this.treasuryAddTableRow)
-    }
   }
 
   renderNewTxns(txs) {
@@ -425,11 +405,7 @@ export default class extends Controller {
           rowFn = this.revocationTableRow
           break
         case 'Treasury Add':
-          if (!this.treasuryAddTableRow) return
-          rowFn = this.treasuryAddTableRow
-          break
         case 'Treasury Spend':
-          // Treasury Spends are not displayed on the mempool page.
           return
         default:
           rowFn = this.txTableRow

--- a/cmd/dcrdata/public/js/controllers/mempool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.js
@@ -63,9 +63,10 @@ function txCoinSymbol(tx) {
 
 function txFeeRateHTML(tx) {
   if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
-    // SKA fee rate not yet exposed precisely (MempoolTx.FeeRate is VAR-only
-    // float64; would lose precision). Tracked as follow-up; render em-dash.
-    return '&mdash;'
+    const [id] = Object.entries(tx.ska_totals)[0]
+    const rateAtoms = tx.ska_fee_rates && tx.ska_fee_rates[id]
+    if (!rateAtoms) return '&mdash;'
+    return `${skaAmountHTML(rateAtoms)} ${renderCoinType(id)}/kB`
   }
   return `${tx.fee_rate} VAR/kB`
 }

--- a/cmd/dcrdata/public/js/controllers/mempool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.js
@@ -3,7 +3,7 @@ import dompurify from 'dompurify'
 import { each, map } from 'lodash-es'
 import humanize from '../helpers/humanize_helper'
 import Mempool from '../helpers/mempool_helper'
-import { renderCoinType, splitSkaAtomsNoTrailing } from '../helpers/ska_helper'
+import { renderCoinType, splitSkaAtoms } from '../helpers/ska_helper'
 import { keyNav } from '../services/keyboard_navigation_service'
 import ws from '../services/messagesocket_service'
 import { alertArea, copyIcon } from './clipboard_controller'
@@ -32,7 +32,7 @@ function rowNode(rowText) {
 // HTML structure, matching the server-side decimalParts template output for
 // skaDecimalParts. BigInt-based; no float coercion.
 function skaAmountHTML(atomStr) {
-  const { intPart, bold, rest, trailingZeros } = splitSkaAtomsNoTrailing(atomStr || '0', false)
+  const { intPart, bold, rest, trailingZeros } = splitSkaAtoms(atomStr || '0', false)
   const intText = bold ? `${intPart}.${bold}` : intPart
   let html = `<div class="decimal-parts d-inline-block"><span class="int">${intText}</span>`
   if (bold && rest) html += `<span class="decimal">${rest}</span>`

--- a/cmd/dcrdata/public/js/controllers/mempool_fee_rate.test.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_fee_rate.test.js
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest'
+import { renderCoinType, splitSkaAtomsNoTrailing } from '../helpers/ska_helper'
+
+// Mirror of skaAmountHTML and txFeeRateHTML from mempool_controller.js. Kept in
+// sync with the controller; the test guards the rendered Fee Rate cell shape
+// for both VAR and SKA mempool rows. If the controller diverges, update both.
+function skaAmountHTML(atomStr) {
+  const { intPart, bold, rest, trailingZeros } = splitSkaAtomsNoTrailing(atomStr || '0', false)
+  const intText = bold ? `${intPart}.${bold}` : intPart
+  let html = `<div class="decimal-parts d-inline-block"><span class="int">${intText}</span>`
+  if (bold && rest) html += `<span class="decimal">${rest}</span>`
+  if (bold && trailingZeros) html += `<span class="decimal trailing-zeroes">${trailingZeros}</span>`
+  html += '</div>'
+  return html
+}
+
+function txFeeRateHTML(tx) {
+  if (tx.ska_totals && Object.keys(tx.ska_totals).length > 0) {
+    const [id] = Object.entries(tx.ska_totals)[0]
+    const rateAtoms = tx.ska_fee_rates && tx.ska_fee_rates[id]
+    if (!rateAtoms) return '&mdash;'
+    return `${skaAmountHTML(rateAtoms)} ${renderCoinType(id)}/kB`
+  }
+  return `${tx.fee_rate} VAR/kB`
+}
+
+describe('mempool txFeeRateHTML', () => {
+  it('VAR tx → "<rate> VAR/kB"', () => {
+    const tx = { fee_rate: 0.0001 }
+    expect(txFeeRateHTML(tx)).toBe('0.0001 VAR/kB')
+  })
+
+  it('SKA tx with ska_fee_rates → decimal-parts HTML and "SKA<n>/kB" suffix', () => {
+    const tx = {
+      ska_totals: { 1: '1230000000000000000' },
+      ska_fee_rates: { 1: '4920000000000000' }
+    }
+    const html = txFeeRateHTML(tx)
+    expect(html).toContain('class="decimal-parts d-inline-block"')
+    expect(html.endsWith(' SKA1/kB')).toBe(true)
+    // Never accidentally renders the VAR unit on the SKA branch.
+    expect(html.includes('VAR/kB')).toBe(false)
+  })
+
+  it('SKA tx without ska_fee_rates falls back to em-dash', () => {
+    const tx = { ska_totals: { 1: '1230000000000000000' } }
+    expect(txFeeRateHTML(tx)).toBe('&mdash;')
+  })
+
+  it('SKA tx with empty ska_fee_rates entry falls back to em-dash', () => {
+    const tx = {
+      ska_totals: { 2: '1' },
+      ska_fee_rates: { 2: '' }
+    }
+    expect(txFeeRateHTML(tx)).toBe('&mdash;')
+  })
+})

--- a/cmd/dcrdata/public/js/controllers/mempool_ska_sync.test.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_ska_sync.test.js
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest'
+
+// Mirror of the syncSkaColsIn logic from mempool_controller.js.
+// Kept in sync with the controller; the test guards the row-mutation contract.
+function activeSkaIds(coinStats) {
+  if (!coinStats) return []
+  const ids = []
+  Object.entries(coinStats).forEach(([k, v]) => {
+    const id = parseInt(k, 10)
+    if (id === 0 || !v || !v.tx_count || v.tx_count <= 0) return
+    ids.push(id)
+  })
+  ids.sort((a, b) => a - b)
+  return ids
+}
+
+function syncSkaColsIn(row, coinStats, colFn) {
+  Array.from(row.children).forEach((child) => {
+    const raw = child.getAttribute('data-coin-type')
+    if (raw === null) return
+    const id = parseInt(raw, 10)
+    if (id !== 0) child.remove()
+  })
+  activeSkaIds(coinStats).forEach((id) => {
+    row.appendChild(colFn(id, coinStats[id]))
+  })
+}
+
+function fakeColFn(id) {
+  const el = document.createElement('div')
+  el.setAttribute('data-coin-type', String(id))
+  el.dataset.test = 'sync-built'
+  el.textContent = `coin ${id}`
+  return el
+}
+
+function buildRow(staticCols, coinCols) {
+  const row = document.createElement('div')
+  for (let i = 0; i < staticCols; i++) {
+    const el = document.createElement('div')
+    el.textContent = `static ${i}`
+    row.appendChild(el)
+  }
+  coinCols.forEach((id) => {
+    const el = document.createElement('div')
+    el.setAttribute('data-coin-type', String(id))
+    el.textContent = `initial coin ${id}`
+    row.appendChild(el)
+  })
+  return row
+}
+
+function coinTypes(row) {
+  return Array.from(row.children)
+    .map((c) => c.getAttribute('data-coin-type'))
+    .filter((v) => v !== null)
+}
+
+describe('mempool syncSkaColsIn', () => {
+  it('removes SKA col when coin_stats drops the SKA entry (block-mined refresh)', () => {
+    // Initial: VAR + SKA1 cols rendered (e.g., after newtxs added SKA1 tx).
+    const row = buildRow(3, [0, 1])
+    expect(coinTypes(row)).toEqual(['0', '1'])
+
+    // Fresh mempool after block: only VAR remains in coin_stats.
+    const coinStats = {
+      0: { tx_count: 5, regular_count: 1, amount: '100', regular_amount: '50' }
+    }
+    syncSkaColsIn(row, coinStats, fakeColFn)
+
+    expect(coinTypes(row)).toEqual(['0'])
+    // Static children preserved.
+    expect(row.children.length).toBe(4)
+  })
+
+  it('adds SKA col when newly active in coin_stats', () => {
+    const row = buildRow(3, [0])
+    const coinStats = {
+      0: { tx_count: 5, regular_count: 1 },
+      1: { tx_count: 1, regular_count: 1, amount: '999', regular_amount: '999' }
+    }
+    syncSkaColsIn(row, coinStats, fakeColFn)
+    expect(coinTypes(row)).toEqual(['0', '1'])
+    // The SKA1 col should be the JS-built one, not the server-rendered initial.
+    const ska1 = row.querySelector('[data-coin-type="1"]')
+    expect(ska1.dataset.test).toBe('sync-built')
+  })
+
+  it('removes SKA col when tx_count drops to 0', () => {
+    const row = buildRow(3, [0, 2])
+    const coinStats = {
+      0: { tx_count: 5 },
+      2: { tx_count: 0 } // dropped to 0 → should be removed
+    }
+    syncSkaColsIn(row, coinStats, fakeColFn)
+    expect(coinTypes(row)).toEqual(['0'])
+  })
+
+  it('replaces JS-built SKA col on subsequent sync (data-coin-type preserved via setAttribute)', () => {
+    // Simulates: initial server-rendered → first sync replaces → second sync
+    // must still find and remove the JS-built col.
+    const row = buildRow(3, [0])
+    // First sync inserts SKA1.
+    syncSkaColsIn(
+      row,
+      { 0: { tx_count: 1 }, 1: { tx_count: 1, amount: '1', regular_amount: '1' } },
+      fakeColFn
+    )
+    expect(coinTypes(row)).toEqual(['0', '1'])
+    // Second sync (block mined): SKA1 absent.
+    syncSkaColsIn(row, { 0: { tx_count: 1 } }, fakeColFn)
+    expect(coinTypes(row)).toEqual(['0'])
+  })
+
+  it('handles coin_stats with only VAR by removing all SKA cols', () => {
+    const row = buildRow(3, [0, 1, 2, 3])
+    syncSkaColsIn(row, { 0: { tx_count: 1 } }, fakeColFn)
+    expect(coinTypes(row)).toEqual(['0'])
+  })
+
+  it('sorts inserted SKA cols ascending by id regardless of object insertion order', () => {
+    const row = buildRow(3, [0])
+    const coinStats = {
+      0: { tx_count: 1 },
+      3: { tx_count: 1, amount: '3', regular_amount: '3' },
+      1: { tx_count: 1, amount: '1', regular_amount: '1' },
+      2: { tx_count: 1, amount: '2', regular_amount: '2' }
+    }
+    syncSkaColsIn(row, coinStats, fakeColFn)
+    expect(coinTypes(row)).toEqual(['0', '1', '2', '3'])
+  })
+})

--- a/cmd/dcrdata/public/scss/utils.scss
+++ b/cmd/dcrdata/public/scss/utils.scss
@@ -24,6 +24,20 @@
   word-break: break-all;
 }
 
+// Lets the fractional digits of a `decimalParts`-rendered number wrap across
+// lines inside a narrow column. Overrides `.d-inline-block` on the wrapper so
+// the inner spans participate in normal text flow, and allows the fractional
+// span to break between digits (needed for SKA's 18-digit precision).
+.wrap-decimal {
+  .decimal-parts {
+    display: inline !important;
+  }
+
+  .decimal {
+    word-break: break-all;
+  }
+}
+
 .color-inherit {
   color: inherit !important;
 }

--- a/cmd/dcrdata/views/mempool.tmpl
+++ b/cmd/dcrdata/views/mempool.tmpl
@@ -287,10 +287,10 @@
                                   {{- if .SKATotals -}}
                                   {{- range $id, $amt := .SKATotals}}
                                   <td class="text-start text-nowrap">{{coinSymbol $id}}</td>
-                                  <td class="mono fs15 text-end">{{template "decimalParts" (skaDecimalParts $amt false)}}</td>
+                                  <td class="mono fs15 text-end wrap-decimal">{{template "decimalParts" (skaDecimalParts $amt false)}}</td>
                                   {{- end}}
                                   <td class="mono fs15 text-end">{{.Size}} B</td>
-                                  <td class="mono fs15 text-end">
+                                  <td class="mono fs15 text-end wrap-decimal">
                                     {{- if .SKAFeeRates -}}
                                     {{- range $id2, $rate := .SKAFeeRates -}}
                                     {{template "decimalParts" (skaDecimalParts $rate false)}} {{coinSymbol $id2}}/kB

--- a/cmd/dcrdata/views/mempool.tmpl
+++ b/cmd/dcrdata/views/mempool.tmpl
@@ -11,6 +11,7 @@
         >
             <div class="pb-2 h4">Mempool</div>
 
+            {{$varStats := index .CoinStats 0}}
             <div class="row mx-0 my-2">
                 <div class="col-24 col-sm-12 col-md-24 col-lg-12 bg-white py-3 px-3 position-relative">
                     <div class="card-pointer pointer-right d-none d-sm-block d-md-none d-lg-block"></div>
@@ -19,39 +20,37 @@
                         <span class="monicon-stack h5"></span>
                         <span class="h6 d-inline-block ps-2">Current Mempool</span>
                     </div>
-                    <div class="row">
-                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-2 pb-sm-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
-                            <div class="col-12 text-center">
-                                <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
-                                    <span class="text-secondary fs13">Total Sent</span>
-                                    <br>
-                                    <span class="h4" data-mempool-target="likelyTotal">{{threeSigFigs .LikelyMineable.Total}}</span> <span class="text-secondary">DCR</span>
-                                </div>
-                            </div>
-                            <div class="col-12 text-center">
-                                <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
-                                    <span class="text-secondary fs13">Last Block</span>
-                                    <br>
-                                    <span class="h4"><a href="/block/{{.LastBlockHeight}}" data-mempool-target="bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a></span>
-                                </div>
+                    <div class="row" data-mempool-target="totalSentRow">
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 text-center pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
+                            <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
+                                <span class="text-secondary fs13">Last Block</span>
+                                <br>
+                                <span class="h4"><a href="/block/{{.LastBlockHeight}}" data-mempool-target="bestBlock" data-hash="{{.LastBlockHash}}" data-keynav-priority>{{.LastBlockHeight}}</a></span>
                             </div>
                         </div>
-                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
-                            <div class="col-12 text-center">
-                                <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
-                                    <span class="text-secondary fs13" data-time-target="header" data-jstitle="Since Last Block">Last Block</span>
-                                    <br>
-                                    <span class="h4" data-mempool-target="bestBlockTime" data-time-target="age" data-age="{{.LastBlockTime}}"><span class="fs13">{{.FormattedBlockTime}}</span></span>
-                                </div>
-                            </div>
-                            <div class="col-12 text-center">
-                                <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
-                                    <span class="text-secondary fs13">Size</span>
-                                    <br>
-                                    <span class="h4" data-mempool-target="mempoolSize">{{.LikelyMineable.FormattedSize}}</span>
-                                </div>
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 text-center pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
+                            <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
+                                <span class="text-secondary fs13" data-time-target="header" data-jstitle="Since Last Block">Last Block</span>
+                                <br>
+                                <span class="h4" data-mempool-target="bestBlockTime" data-time-target="age" data-age="{{.LastBlockTime}}"><span class="fs13">{{.FormattedBlockTime}}</span></span>
                             </div>
                         </div>
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 text-center pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
+                            <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
+                                <span class="text-secondary fs13">Size</span>
+                                <br>
+                                <span class="h4" data-mempool-target="mempoolSize">{{.LikelyMineable.FormattedSize}}</span>
+                            </div>
+                        </div>
+                        {{range orderedMempoolCoinStats .CoinStats}}
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 text-center pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0" data-coin-type="{{.CoinType}}">
+                            <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
+                                <span class="text-secondary fs13">Total Sent</span>
+                                <br>
+                                <span class="h4"{{if eq .CoinType 0}} data-mempool-target="totalSent"{{end}}>{{formatCoinAtoms .Stats.Amount .CoinType}}</span> <span class="text-secondary">{{.Symbol}}</span>
+                            </div>
+                        </div>
+                        {{end}}
                     </div>
                 </div>
                 <div class="col-24 col-sm-12 col-md-24 col-lg-12 secondary-card pt-3 pb-3 px-3">
@@ -60,91 +59,55 @@
                       <span class="h6 d-inline-block ps-2">Transactions</span>
                     </div>
 
-                    <div class="row mt-1">
-                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-3">
-                            <div class="col-12">
-                                <div class="text-center text-secondary fs13">Regular</div>
-                                <div class="text-center h4 mb-0" data-mempool-target="regCount">{{.NumRegular}}</div>
-                                <div class="text-center fs13">
-                                    <span data-mempool-target="regTotal">{{threeSigFigs .LikelyMineable.RegularTotal}}</span> DCR
-                                </div>
-                            </div><!-- add treasury count here -->
-                            <div class="col-12">
-                                <div class="text-center text-secondary fs13">Tickets</div>
-                                <div class="text-center h4 mb-0" data-mempool-target="ticketCount">{{.NumTickets}}</div>
-                                <div class="text-center fs13">
-                                    <span data-mempool-target="ticketTotal">{{threeSigFigs .LikelyMineable.TicketTotal}}</span> DCR
-                                </div>
+                    <div class="row mt-1" data-mempool-target="transactionsRow">
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 pb-3">
+                            <div class="text-center text-secondary fs13">Tickets</div>
+                            <div class="text-center h4 mb-0" data-mempool-target="ticketCount">{{$varStats.TicketCount}}</div>
+                            <div class="text-center fs13">
+                                <span data-mempool-target="ticketTotal">{{formatCoinAtoms $varStats.TicketAmount 0}}</span> VAR
                             </div>
                         </div>
-                        <div class="col-24 col-md-12 col-lg-24 col-xl-12 row pb-3">
-                            <div class="col-12">
-                                <div class="text-center text-secondary fs13">Votes</div>
-                                <div class="text-center h4 mb-0" data-mempool-target="voteCount">
-                                    {{$afterFirst := false -}}
-                                    {{- range $hash, $tally := .VotingInfo.VoteTallys -}}
-                                        {{if $afterFirst}} + {{end}}
-                                        <span class="text-center position-relative d-inline-block"
-                                        data-mempool-target="voteTally"
-                                        data-hash="{{$hash}}"
-                                        data-affirmed="{{$tally.Affirmations}}"
-                                        data-count="{{$tally.VoteCount}}"
-                                        data-tooltip="for block {{$hash}}"
-                                        >{{$tally.VoteCount}}</span>
-                                        {{$afterFirst = true}}
-                                    {{- end}}
-                                </div>
-                                <div class="text-center fs13">
-                                    <span data-mempool-target="voteTotal">{{threeSigFigs .LikelyMineable.VoteTotal}}</span> DCR
-                                </div>
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 pb-3">
+                            <div class="text-center text-secondary fs13">Votes</div>
+                            <div class="text-center h4 mb-0" data-mempool-target="voteCount">
+                                {{$afterFirst := false -}}
+                                {{- range $hash, $tally := .VotingInfo.VoteTallys -}}
+                                    {{if $afterFirst}} + {{end}}
+                                    <span class="text-center position-relative d-inline-block"
+                                    data-mempool-target="voteTally"
+                                    data-hash="{{$hash}}"
+                                    data-affirmed="{{$tally.Affirmations}}"
+                                    data-count="{{$tally.VoteCount}}"
+                                    data-tooltip="for block {{$hash}}"
+                                    >{{$tally.VoteCount}}</span>
+                                    {{$afterFirst = true}}
+                                {{- end}}
                             </div>
-                            <div class="col-12">
-                                <div class="text-center text-secondary fs13">Revocations</div>
-                                <div class="text-center h4 mb-0" data-mempool-target="revCount">{{.NumRevokes}}</div>
-                                <div class="text-center fs13">
-                                    <span data-mempool-target="revTotal">{{threeSigFigs .LikelyMineable.RevokeTotal}}</span> DCR
-                                </div>
+                            <div class="text-center fs13">
+                                <span data-mempool-target="voteTotal">{{formatCoinAtoms $varStats.VoteAmount 0}}</span> VAR
                             </div>
                         </div>
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 pb-3">
+                            <div class="text-center text-secondary fs13">Revocations</div>
+                            <div class="text-center h4 mb-0" data-mempool-target="revCount">{{$varStats.RevokeCount}}</div>
+                            <div class="text-center fs13">
+                                <span data-mempool-target="revTotal">{{formatCoinAtoms $varStats.RevokeAmount 0}}</span> VAR
+                            </div>
+                        </div>
+                        {{range orderedMempoolCoinStats .CoinStats}}
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 pb-3" data-coin-type="{{.CoinType}}">
+                            <div class="text-center text-secondary fs13">Regular</div>
+                            <div class="text-center h4 mb-0"{{if eq .CoinType 0}} data-mempool-target="regCount"{{end}}>{{.Stats.RegularCount}}</div>
+                            <div class="text-center fs13">
+                                <span{{if eq .CoinType 0}} data-mempool-target="regTotal"{{end}}>{{formatCoinAtoms .Stats.RegularAmount .CoinType}}</span> {{.Symbol}}
+                            </div>
+                        </div>
+                        {{end}}
                     </div>
 
                 </div>
             </div>
             <div>
-              <div class="row">
-                  <div class="col-sm-24">
-                  <h4 class="pt-5 pb-2"><span>Treasury Spends</span></h4>
-                      <table class="table">
-                          <thead>
-                            <tr>
-                              <th>Transaction ID</th>
-                              <th class="text-end">Total DCR</th>
-                              <th class="text-end">Time in Mempool</th>
-                            </tr>
-                          </thead>
-                          <tbody data-mempool-target="tspendTransactions">
-                              {{if gt .NumTSpends 0 -}}
-                              {{- range .TSpends -}}
-                              <tr>
-                                  <td class="break-word clipboard">
-                                    <a class="hash lh1rem" href="/tx/{{.Hash}}" title="{{.Hash}}">{{.Hash}}</a>
-                                    {{template "copyTextIcon"}}
-                                  </td>
-                                  <td class="mono fs15 text-end">
-                                    {{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}
-                                  </td>
-                                  <td class="mono fs15 text-end" data-time-target="age" data-age="{{.Time}}"></td>
-                              </tr>
-                              {{- end -}}
-                              {{- else -}}
-                                  <tr class="no-tx-tr">
-                                      <td colspan="4">No treasury spends in mempool.</td>
-                                  </tr>
-                              {{- end}}
-                          </tbody>
-                      </table>
-                  </div>
-              </div>
               {{if gt .NumTAdds 0 -}}{{- /* this will be rare, so only show the section header and table if needed */ -}}
               <div class="row">
                   <div class="col-sm-24">
@@ -153,7 +116,7 @@
                           <thead>
                             <tr>
                               <th>Transaction ID</th>
-                              <th class="text-end">Total DCR</th>
+                              <th class="text-end">Total VAR</th>
                               <th class="text-end">Time in Mempool</th>
                             </tr>
                           </thead>
@@ -186,7 +149,7 @@
                               <th>Voting On</th>
                               <th class="text-end"><div class="inline-block position-relative"><span class="d-none d-sm-inline">Validator ID</span><span class="d-inline d-sm-none" data-tooltip="Validator ID">VID</span></div></th>
                               <th class="text-end"><div class="inline-block position-relative"><span class="d-none d-sm-inline">Vote Version</span><span class="d-inline d-sm-none" data-tooltip="Vote Version">Ver</span></div></th>
-                              <th class="text-end d-none d-sm-table-cell">Total DCR</th>
+                              <th class="text-end d-none d-sm-table-cell">Total VAR</th>
                               <th class="text-end">Size</th>
                               <th class="text-end d-none d-sm-table-cell jsonly">Time in Mempool</th>
                             </tr>
@@ -230,7 +193,7 @@
                           <thead>
                             <tr>
                               <th>Transaction ID</th>
-                              <th class="text-end">Total DCR</th>
+                              <th class="text-end">Total VAR</th>
                               <th class="text-end">Size</th>
                               <th class="text-end">Fee Rate</th>
                               <th class="text-end">Time in Mempool</th>
@@ -248,7 +211,7 @@
                                     {{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}
                                   </td>
                                   <td class="mono fs15 text-end">{{.Size}} B</td>
-                                  <td class="mono fs15 text-end">{{printf "%.8f" (.FeeRate)}} DCR/kB</td>
+                                  <td class="mono fs15 text-end">{{printf "%.8f" (.FeeRate)}} VAR/kB</td>
                                   <td class="mono fs15 text-end" data-time-target="age" data-age="{{.Time}}"></td>
                               </tr>
                               {{- end -}}
@@ -264,12 +227,12 @@
 
               <div class="row">
                   <div class="col-sm-24">
-                  <h4 class="pt-5 pb-2"><span>Revokes</span></h4>
+                  <h4 class="pt-5 pb-2"><span>Revocations</span></h4>
                       <table class="table">
                           <thead>
                             <tr>
                               <th>Transaction ID</th>
-                              <th class="text-end">Total DCR</th>
+                              <th class="text-end">Total VAR</th>
                               <th class="text-end">Size</th>
                               <th class="text-end">Time in Mempool</th>
                             </tr>
@@ -291,7 +254,7 @@
                               {{- end -}}
                               {{- else -}}
                                   <tr class="no-tx-tr">
-                                      <td colspan="4">No revokes in mempool.</td>
+                                      <td colspan="4">No revocations in mempool.</td>
                                   </tr>
                               {{- end}}
                           </tbody>
@@ -306,7 +269,8 @@
                           <thead>
                             <tr>
                               <th>Transaction ID</th>
-                              <th class="text-end">Total DCR</th>
+                              <th class="text-start">Coin</th>
+                              <th class="text-end">Amount</th>
                               <th class="text-end">Size</th>
                               <th class="text-end">Fee Rate</th>
                               <th class="text-end">Time in Mempool</th>
@@ -320,17 +284,25 @@
                                       <a class="hash lh1rem" href="/tx/{{.Hash}}">{{.Hash}}</a>
                                       {{template "copyTextIcon"}}
                                   </td>
-                                  <td class="mono fs15 text-end">
-                                    {{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}
-                                  </td>
+                                  {{- if .SKATotals -}}
+                                  {{- range $id, $amt := .SKATotals}}
+                                  <td class="text-start text-nowrap">{{coinSymbol $id}}</td>
+                                  <td class="mono fs15 text-end">{{template "decimalParts" (skaDecimalParts $amt false)}}</td>
+                                  {{- end}}
                                   <td class="mono fs15 text-end">{{.Size}} B</td>
-                                  <td class="mono fs15 text-end">{{printf "%.8f" (.FeeRate)}} DCR/kB</td>
+                                  <td class="mono fs15 text-end">&mdash;</td>
+                                  {{- else}}
+                                  <td class="text-start text-nowrap">VAR</td>
+                                  <td class="mono fs15 text-end">{{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}</td>
+                                  <td class="mono fs15 text-end">{{.Size}} B</td>
+                                  <td class="mono fs15 text-end">{{printf "%.8f" (.FeeRate)}} VAR/kB</td>
+                                  {{- end}}
                                   <td class="mono fs15 text-end" data-time-target="age" data-age="{{.Time}}"></td>
                               </tr>
                               {{- end -}}
                               {{- else -}}
                               <tr class="no-tx-tr">
-                                  <td colspan="5">No regular transactions in mempool.</td>
+                                  <td colspan="6">No transactions in mempool.</td>
                               </tr>
                               {{- end}}
                           </tbody>

--- a/cmd/dcrdata/views/mempool.tmpl
+++ b/cmd/dcrdata/views/mempool.tmpl
@@ -115,9 +115,14 @@
                       <table class="table">
                           <thead>
                             <tr>
-                              <th>Transaction ID</th>
+                              <th class="position-relative" data-tooltip="Transaction ID">
+                                <span class="d-sm-none">TxID</span>
+                                <span class="d-none d-sm-inline">Transaction ID</span>
+                              </th>
                               <th class="text-end">Total VAR</th>
-                              <th class="text-end">Time in Mempool</th>
+                              <th class="text-end position-relative" data-tooltip="Time in Mempool">
+                                Age
+                              </th>
                             </tr>
                           </thead>
                           <tbody data-mempool-target="taddTransactions">
@@ -145,13 +150,18 @@
                       <table class="table">
                           <thead>
                             <tr>
-                              <th>Transaction ID</th>
+                              <th class="position-relative" data-tooltip="Transaction ID">
+                                <span class="d-sm-none">TxID</span>
+                                <span class="d-none d-sm-inline">Transaction ID</span>
+                              </th>
                               <th>Voting On</th>
                               <th class="text-end"><div class="inline-block position-relative"><span class="d-none d-sm-inline">Validator ID</span><span class="d-inline d-sm-none" data-tooltip="Validator ID">VID</span></div></th>
                               <th class="text-end"><div class="inline-block position-relative"><span class="d-none d-sm-inline">Vote Version</span><span class="d-inline d-sm-none" data-tooltip="Vote Version">Ver</span></div></th>
                               <th class="text-end d-none d-sm-table-cell">Total VAR</th>
                               <th class="text-end">Size</th>
-                              <th class="text-end d-none d-sm-table-cell jsonly">Time in Mempool</th>
+                              <th class="text-end d-none d-sm-table-cell jsonly position-relative" data-tooltip="Time in Mempool">
+                                Age
+                              </th>
                             </tr>
                           </thead>
                           <tbody data-mempool-target="voteTransactions">
@@ -192,11 +202,19 @@
                       <table class="table">
                           <thead>
                             <tr>
-                              <th>Transaction ID</th>
+                              <th class="position-relative" data-tooltip="Transaction ID">
+                                <span class="d-sm-none">TxID</span>
+                                <span class="d-none d-sm-inline">Transaction ID</span>
+                              </th>
                               <th class="text-end">Total VAR</th>
                               <th class="text-end">Size</th>
-                              <th class="text-end">Fee Rate</th>
-                              <th class="text-end">Time in Mempool</th>
+                              <th class="text-end position-relative" data-tooltip="Fee Rate">
+                                <span class="d-sm-none">Fee</span>
+                                <span class="d-none d-sm-inline">Fee Rate</span>
+                              </th>
+                              <th class="text-end position-relative" data-tooltip="Time in Mempool">
+                                Age
+                              </th>
                             </tr>
                           </thead>
                           <tbody data-mempool-target="ticketTransactions">
@@ -231,10 +249,15 @@
                       <table class="table">
                           <thead>
                             <tr>
-                              <th>Transaction ID</th>
+                              <th class="position-relative" data-tooltip="Transaction ID">
+                                <span class="d-sm-none">TxID</span>
+                                <span class="d-none d-sm-inline">Transaction ID</span>
+                              </th>
                               <th class="text-end">Total VAR</th>
                               <th class="text-end">Size</th>
-                              <th class="text-end">Time in Mempool</th>
+                              <th class="text-end position-relative" data-tooltip="Time in Mempool">
+                                Age
+                              </th>
                             </tr>
                           </thead>
                           <tbody data-mempool-target="revocationTransactions">
@@ -268,12 +291,20 @@
                       <table class="table">
                           <thead>
                             <tr>
-                              <th>Transaction ID</th>
+                              <th class="position-relative" data-tooltip="Transaction ID">
+                                <span class="d-sm-none">TxID</span>
+                                <span class="d-none d-sm-inline">Transaction ID</span>
+                              </th>
                               <th class="text-start">Coin</th>
-                              <th class="text-end">Amount</th>
+                              <th class="text-end">Total</th>
                               <th class="text-end">Size</th>
-                              <th class="text-end">Fee Rate</th>
-                              <th class="text-end">Time in Mempool</th>
+                              <th class="text-end position-relative" data-tooltip="Fee Rate">
+                                <span class="d-sm-none">Fee</span>
+                                <span class="d-none d-sm-inline">Fee Rate</span>
+                              </th>
+                              <th class="text-end position-relative" data-tooltip="Time in Mempool">
+                                Age
+                              </th>
                             </tr>
                           </thead>
                           <tbody data-mempool-target="regularTransactions">

--- a/cmd/dcrdata/views/mempool.tmpl
+++ b/cmd/dcrdata/views/mempool.tmpl
@@ -290,7 +290,13 @@
                                   <td class="mono fs15 text-end">{{template "decimalParts" (skaDecimalParts $amt false)}}</td>
                                   {{- end}}
                                   <td class="mono fs15 text-end">{{.Size}} B</td>
-                                  <td class="mono fs15 text-end">&mdash;</td>
+                                  <td class="mono fs15 text-end">
+                                    {{- if .SKAFeeRates -}}
+                                    {{- range $id2, $rate := .SKAFeeRates -}}
+                                    {{template "decimalParts" (skaDecimalParts $rate false)}} {{coinSymbol $id2}}/kB
+                                    {{- end -}}
+                                    {{- else -}}&mdash;{{- end -}}
+                                  </td>
                                   {{- else}}
                                   <td class="text-start text-nowrap">VAR</td>
                                   <td class="mono fs15 text-end">{{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}</td>

--- a/cmd/dcrdata/views/mempool.tmpl
+++ b/cmd/dcrdata/views/mempool.tmpl
@@ -108,51 +108,6 @@
                 </div>
             </div>
             <div>
-              {{if gt .NumTAdds 0 -}}{{- /* this will be rare, so only show the section header and table if needed */ -}}
-              <div class="row">
-                  <div class="col-sm-24">
-                  <h4 class="pt-5 pb-2"><span>Treasury Adds</span></h4>
-                      <template data-mempool-target="treasuryAddRowTemplate">
-                          <tr class="flash">
-                              <td class="break-word clipboard">
-                                  <a class="hash" data-slot="hashLink"></a>
-                                  {{template "copyTextIcon"}}
-                              </td>
-                              <td class="mono fs15 text-end" data-slot="amount"></td>
-                              <td class="mono fs15 text-end" data-time-target="age" data-slot="age"></td>
-                          </tr>
-                      </template>
-                      <table class="table">
-                          <thead>
-                            <tr>
-                              <th class="position-relative" data-tooltip="Transaction ID">
-                                <span class="d-sm-none">TxID</span>
-                                <span class="d-none d-sm-inline">Transaction ID</span>
-                              </th>
-                              <th class="text-end">Total VAR</th>
-                              <th class="text-end position-relative" data-tooltip="Time in Mempool">
-                                Age
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody data-mempool-target="taddTransactions">
-                              {{range .TAdds -}}
-                              <tr>
-                                  <td class="break-word clipboard">
-                                    <a class="hash lh1rem" href="/tx/{{.Hash}}">{{.Hash}}</a>
-                                    {{template "copyTextIcon"}}
-                                  </td>
-                                  <td class="mono fs15 text-end">
-                                    {{template "decimalParts" (float64AsDecimalParts .TotalOut 8 false)}}
-                                  </td>
-                                  <td class="mono fs15 text-end" data-time-target="age" data-age="{{.Time}}"></td>
-                              </tr>
-                              {{- end}}
-                          </tbody>
-                      </table>
-                  </div>
-              </div>
-              {{- end}}
               <div class="row">
                   <div class="col-sm-24">
                   <h4 class="pt-3 pb-2"><span>Votes</span></h4>

--- a/cmd/dcrdata/views/mempool.tmpl
+++ b/cmd/dcrdata/views/mempool.tmpl
@@ -112,6 +112,16 @@
               <div class="row">
                   <div class="col-sm-24">
                   <h4 class="pt-5 pb-2"><span>Treasury Adds</span></h4>
+                      <template data-mempool-target="treasuryAddRowTemplate">
+                          <tr class="flash">
+                              <td class="break-word clipboard">
+                                  <a class="hash" data-slot="hashLink"></a>
+                                  {{template "copyTextIcon"}}
+                              </td>
+                              <td class="mono fs15 text-end" data-slot="amount"></td>
+                              <td class="mono fs15 text-end" data-time-target="age" data-slot="age"></td>
+                          </tr>
+                      </template>
                       <table class="table">
                           <thead>
                             <tr>
@@ -147,6 +157,24 @@
                   <div class="col-sm-24">
                   <h4 class="pt-3 pb-2"><span>Votes</span></h4>
 
+                      <template data-mempool-target="voteRowTemplate">
+                          <tr class="flash">
+                              <td class="break-word clipboard">
+                                  <a class="hash" data-slot="hashLink"></a>
+                                  {{template "copyTextIcon"}}
+                              </td>
+                              <td class="mono fs15">
+                                  <a data-slot="blockLink"><span data-slot="blockHeight"></span><span class="small" data-slot="bestMarker"></span></a>
+                              </td>
+                              <td class="mono fs15 text-end">
+                                  <a data-slot="ticketLink"></a>
+                              </td>
+                              <td class="mono fs15 text-end" data-slot="voteVersion"></td>
+                              <td class="mono fs15 text-end d-none d-sm-table-cell" data-slot="amount"></td>
+                              <td class="mono fs15 text-end" data-slot="size"></td>
+                              <td class="mono fs15 text-end d-none d-sm-table-cell jsonly" data-time-target="age" data-slot="age"></td>
+                          </tr>
+                      </template>
                       <table class="table">
                           <thead>
                             <tr>
@@ -199,6 +227,18 @@
               <div class="row">
                   <div class="col-sm-24">
                   <h4 class="pt-4 pb-2"><span>Tickets</span></h4>
+                      <template data-mempool-target="ticketRowTemplate">
+                          <tr class="flash">
+                              <td class="break-word clipboard">
+                                  <a class="hash" data-slot="hashLink"></a>
+                                  {{template "copyTextIcon"}}
+                              </td>
+                              <td class="mono fs15 text-end" data-slot="amount"></td>
+                              <td class="mono fs15 text-end" data-slot="size"></td>
+                              <td class="mono fs15 text-end" data-slot="feeRate"></td>
+                              <td class="mono fs15 text-end" data-time-target="age" data-slot="age"></td>
+                          </tr>
+                      </template>
                       <table class="table">
                           <thead>
                             <tr>
@@ -246,6 +286,17 @@
               <div class="row">
                   <div class="col-sm-24">
                   <h4 class="pt-5 pb-2"><span>Revocations</span></h4>
+                      <template data-mempool-target="revocationRowTemplate">
+                          <tr class="flash">
+                              <td class="break-word clipboard">
+                                  <a class="hash" data-slot="hashLink"></a>
+                                  {{template "copyTextIcon"}}
+                              </td>
+                              <td class="mono fs15 text-end" data-slot="amount"></td>
+                              <td class="mono fs15 text-end" data-slot="size"></td>
+                              <td class="mono fs15 text-end" data-time-target="age" data-slot="age"></td>
+                          </tr>
+                      </template>
                       <table class="table">
                           <thead>
                             <tr>
@@ -288,6 +339,19 @@
               <div class="row">
                   <div class="col-sm-24">
                   <h4 class="pt-5 pb-2"><span>Transactions</span></h4>
+                      <template data-mempool-target="txRowTemplate">
+                          <tr class="flash">
+                              <td class="break-word clipboard">
+                                  <a class="hash" data-slot="hashLink"></a>
+                                  {{template "copyTextIcon"}}
+                              </td>
+                              <td class="text-start text-nowrap" data-slot="coinSymbol"></td>
+                              <td class="mono fs15 text-end wrap-decimal" data-slot="amount"></td>
+                              <td class="mono fs15 text-end" data-slot="size"></td>
+                              <td class="mono fs15 text-end wrap-decimal" data-slot="feeRate"></td>
+                              <td class="mono fs15 text-end" data-time-target="age" data-slot="age"></td>
+                          </tr>
+                      </template>
                       <table class="table">
                           <thead>
                             <tr>

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -1399,10 +1399,11 @@ type MempoolTx struct {
 	TotalOut  float64        `json:"total"`
 	// Consider atom representation:
 	//TotalOutAmt int64        `json:"total_amount"`
-	Type      string           `json:"Type"`
-	TypeID    int              `json:"typeID"` // stake package types
-	VoteInfo  *VoteInfo        `json:"vote_info,omitempty"`
-	SKATotals map[uint8]string `json:"ska_totals,omitempty"`
+	Type        string           `json:"Type"`
+	TypeID      int              `json:"typeID"` // stake package types
+	VoteInfo    *VoteInfo        `json:"vote_info,omitempty"`
+	SKATotals   map[uint8]string `json:"ska_totals,omitempty"`
+	SKAFeeRates map[uint8]string `json:"ska_fee_rates,omitempty"` // SKA fee rate in atoms/kB, keyed by coin type
 }
 
 func (mpt *MempoolTx) DeepCopy() *MempoolTx {
@@ -1417,6 +1418,12 @@ func (mpt *MempoolTx) DeepCopy() *MempoolTx {
 		out.SKATotals = make(map[uint8]string, len(mpt.SKATotals))
 		for k, v := range mpt.SKATotals {
 			out.SKATotals[k] = v
+		}
+	}
+	if mpt.SKAFeeRates != nil {
+		out.SKAFeeRates = make(map[uint8]string, len(mpt.SKAFeeRates))
+		for k, v := range mpt.SKAFeeRates {
+			out.SKAFeeRates[k] = v
 		}
 	}
 	return &out

--- a/mempool/collector.go
+++ b/mempool/collector.go
@@ -152,14 +152,15 @@ func (t *DataCollector) mempoolTxns() ([]exptypes.MempoolTx, txhelpers.MempoolAd
 			Vin:       t.populateMempoolInputs(context.TODO(), msgTx, txType, txnsStore),
 			// Coinbase:  txhelpers.IsCoinBaseTx(msgTx), // commented because coinbase is not in mempool
 
-			Hash:      hashStr, // dup of TxID!
-			Time:      tx.Time,
-			Size:      tx.Size,
-			TotalOut:  dcrutil.Amount(totalOut).ToCoin(),
-			Type:      txhelpers.TxTypeToString(int(txType)),
-			TypeID:    int(txType),
-			VoteInfo:  voteInfo,
-			SKATotals: txhelpers.SKATotalsFromMsgTx(msgTx),
+			Hash:        hashStr, // dup of TxID!
+			Time:        tx.Time,
+			Size:        tx.Size,
+			TotalOut:    dcrutil.Amount(totalOut).ToCoin(),
+			Type:        txhelpers.TxTypeToString(int(txType)),
+			TypeID:      int(txType),
+			VoteInfo:    voteInfo,
+			SKATotals:   txhelpers.SKATotalsFromMsgTx(msgTx),
+			SKAFeeRates: txhelpers.SKAFeeRateMapFromAtoms(tx.SKAFee, msgTx),
 		})
 	}
 

--- a/mempool/monitor.go
+++ b/mempool/monitor.go
@@ -251,14 +251,15 @@ func (p *MempoolMonitor) TxHandler(rawTx *chainjson.TxRawResult) error {
 		VoutCount: len(msgTx.TxOut),
 		Vin:       p.collector.populateMempoolInputs(p.ctx, msgTx, txType, p.txnsStore),
 		// Coinbase is not in mempool
-		Hash:      hash,
-		Time:      rawTx.Time,
-		Size:      int32(len(rawTx.Hex) / 2),
-		TotalOut:  txhelpers.TotalOutFromMsgTx(msgTx).ToCoin(),
-		Type:      txTypeStr,
-		TypeID:    int(txType),
-		VoteInfo:  voteInfo,
-		SKATotals: txhelpers.SKATotalsFromMsgTx(msgTx),
+		Hash:        hash,
+		Time:        rawTx.Time,
+		Size:        int32(len(rawTx.Hex) / 2),
+		TotalOut:    txhelpers.TotalOutFromMsgTx(msgTx).ToCoin(),
+		Type:        txTypeStr,
+		TypeID:      int(txType),
+		VoteInfo:    voteInfo,
+		SKATotals:   txhelpers.SKATotalsFromMsgTx(msgTx),
+		SKAFeeRates: txhelpers.SKAFeeRateMapFromVerboseVin(rawTx.Vin, msgTx),
 	}
 
 	// Maintain a separate total that excludes votes for sidechain

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -509,15 +509,17 @@ loop:
 			inv := psh.MempoolInventory()
 			inv.RLock()
 			newTxsPayload := struct {
-				Txs            pstypes.TxList          `json:"txs"`
-				CoinFills      []exptypes.CoinFillData `json:"coin_fills"`
-				TotalFillRatio float64                 `json:"total_fill_ratio"`
-				ActiveSKACount int                     `json:"active_ska_count"`
+				Txs            pstypes.TxList                      `json:"txs"`
+				CoinFills      []exptypes.CoinFillData             `json:"coin_fills"`
+				TotalFillRatio float64                             `json:"total_fill_ratio"`
+				ActiveSKACount int                                 `json:"active_ska_count"`
+				CoinStats      map[uint8]exptypes.MempoolCoinStats `json:"coin_stats"`
 			}{
 				Txs:            txSlice,
 				CoinFills:      inv.MempoolShort.CoinFills,
 				TotalFillRatio: inv.MempoolShort.TotalFillRatio,
 				ActiveSKACount: inv.MempoolShort.ActiveSKACount,
+				CoinStats:      inv.MempoolShort.CoinStats,
 			}
 			inv.RUnlock()
 

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -1328,6 +1328,78 @@ func SKATotalsFromMsgTx(msgTx *wire.MsgTx) map[uint8]string {
 	return out
 }
 
+// skaCoinTypeOf returns the SKA coin-type of the first SKA output in msgTx and
+// true, or (0, false) if the tx has no SKA outputs. By the single-coin-per-tx
+// invariant this uniquely identifies the tx's SKA coin type.
+func skaCoinTypeOf(msgTx *wire.MsgTx) (uint8, bool) {
+	for _, v := range msgTx.TxOut {
+		if v.CoinType.IsSKA() {
+			return uint8(v.CoinType), true
+		}
+	}
+	return 0, false
+}
+
+// SKAFeeRateMapFromAtoms computes the SKA fee rate in atoms/kB from a fee
+// amount given in atoms (decimal string). Returns a map keyed by the tx's
+// single SKA coin type, or nil if feeAtoms is empty, the tx has no SKA
+// outputs, or the serialized size is zero. Negative fee amounts are clamped
+// to zero (mirrors the confirmed-tx path in db/dcrpg/pgblockchain.go).
+func SKAFeeRateMapFromAtoms(feeAtoms string, msgTx *wire.MsgTx) map[uint8]string {
+	if feeAtoms == "" {
+		return nil
+	}
+	ct, ok := skaCoinTypeOf(msgTx)
+	if !ok {
+		return nil
+	}
+	txSize := int64(msgTx.SerializeSize())
+	if txSize <= 0 {
+		return nil
+	}
+	fee, ok := new(big.Int).SetString(feeAtoms, 10)
+	if !ok || fee == nil {
+		return nil
+	}
+	if fee.Sign() < 0 {
+		fee.SetInt64(0)
+	}
+	rate := new(big.Int).Mul(fee, big.NewInt(1000))
+	rate.Quo(rate, big.NewInt(txSize))
+	return map[uint8]string{ct: rate.String()}
+}
+
+// SKAFeeRateMapFromVerboseVin computes the SKA fee rate in atoms/kB by summing
+// per-input SKAAmountIn atoms from a verbose tx's vin slice and subtracting
+// the matching coin-type output total. Returns nil for VAR-only txs. Negative
+// results (input sum < output sum) are clamped to zero.
+func SKAFeeRateMapFromVerboseVin(vin []chainjson.Vin, msgTx *wire.MsgTx) map[uint8]string {
+	ct, ok := skaCoinTypeOf(msgTx)
+	if !ok {
+		return nil
+	}
+	totalIn := new(big.Int)
+	for i := range vin {
+		s := vin[i].SKAAmountIn
+		if s == "" {
+			continue
+		}
+		v, ok := new(big.Int).SetString(s, 10)
+		if !ok || v == nil {
+			continue
+		}
+		totalIn.Add(totalIn, v)
+	}
+	totalOut := new(big.Int)
+	for _, o := range msgTx.TxOut {
+		if uint8(o.CoinType) == ct && o.SKAValue != nil {
+			totalOut.Add(totalOut, o.SKAValue)
+		}
+	}
+	fee := new(big.Int).Sub(totalIn, totalOut)
+	return SKAFeeRateMapFromAtoms(fee.String(), msgTx)
+}
+
 // TotalVout computes the total value of a slice of chainjson.Vout
 func TotalVout(vouts []chainjson.Vout) dcrutil.Amount {
 	var total dcrutil.Amount

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
 	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/dcrutil"
+	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
 	"github.com/monetarium/monetarium-node/wire"
 )
 
@@ -337,5 +338,121 @@ func TestSKATotalsFromMsgTx_VAROnly(t *testing.T) {
 	tx.AddTxOut(wire.NewTxOut(100_000_000, nil))
 	if got := SKATotalsFromMsgTx(tx); got != nil {
 		t.Errorf("expected nil for VAR-only tx, got %v", got)
+	}
+}
+
+// newSKAMsgTx returns a msg tx with one SKA output of the given coin type and
+// atoms, suitable for fee-rate helper tests.
+func newSKAMsgTx(t *testing.T, ct uint8, atoms *big.Int) *wire.MsgTx {
+	t.Helper()
+	tx := wire.NewMsgTx()
+	tx.AddTxOut(wire.NewTxOutSKA(atoms, cointype.CoinType(ct), nil))
+	return tx
+}
+
+func TestSKAFeeRateMapFromAtoms_VAROnly(t *testing.T) {
+	tx := wire.NewMsgTx()
+	tx.AddTxOut(wire.NewTxOut(100_000_000, nil))
+	if got := SKAFeeRateMapFromAtoms("1000", tx); got != nil {
+		t.Errorf("expected nil for VAR-only tx, got %v", got)
+	}
+}
+
+func TestSKAFeeRateMapFromAtoms_EmptyFee(t *testing.T) {
+	tx := newSKAMsgTx(t, 1, big.NewInt(1e18))
+	if got := SKAFeeRateMapFromAtoms("", tx); got != nil {
+		t.Errorf("expected nil for empty feeAtoms, got %v", got)
+	}
+}
+
+func TestSKAFeeRateMapFromAtoms_PositiveFee(t *testing.T) {
+	tx := newSKAMsgTx(t, 1, big.NewInt(1e18))
+	feeAtoms := "12345" // arbitrary
+	got := SKAFeeRateMapFromAtoms(feeAtoms, tx)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	fee, _ := new(big.Int).SetString(feeAtoms, 10)
+	want := new(big.Int).Mul(fee, big.NewInt(1000))
+	want.Quo(want, big.NewInt(int64(tx.SerializeSize())))
+	if got[1] != want.String() {
+		t.Errorf("rate: want %s, got %s", want.String(), got[1])
+	}
+	if _, hasVAR := got[0]; hasVAR {
+		t.Error("result should not contain VAR key")
+	}
+}
+
+func TestSKAFeeRateMapFromAtoms_ZeroFee(t *testing.T) {
+	tx := newSKAMsgTx(t, 2, big.NewInt(5e18))
+	got := SKAFeeRateMapFromAtoms("0", tx)
+	if got == nil {
+		t.Fatal("expected non-nil result for zero fee")
+	}
+	if got[2] != "0" {
+		t.Errorf("rate: want 0, got %s", got[2])
+	}
+}
+
+func TestSKAFeeRateMapFromAtoms_NegativeClampsToZero(t *testing.T) {
+	tx := newSKAMsgTx(t, 1, big.NewInt(1e18))
+	got := SKAFeeRateMapFromAtoms("-99", tx)
+	if got == nil {
+		t.Fatal("expected non-nil result for negative fee")
+	}
+	if got[1] != "0" {
+		t.Errorf("rate: want 0 (clamped), got %s", got[1])
+	}
+}
+
+func TestSKAFeeRateMapFromVerboseVin_VAROnly(t *testing.T) {
+	tx := wire.NewMsgTx()
+	tx.AddTxOut(wire.NewTxOut(100_000_000, nil))
+	vin := []chainjson.Vin{{SKAAmountIn: "1000"}}
+	if got := SKAFeeRateMapFromVerboseVin(vin, tx); got != nil {
+		t.Errorf("expected nil for VAR-only tx, got %v", got)
+	}
+}
+
+func TestSKAFeeRateMapFromVerboseVin_PositiveFee(t *testing.T) {
+	out := big.NewInt(1e18)
+	tx := newSKAMsgTx(t, 1, out)
+	// totalIn = out + 12345 → fee = 12345
+	in := new(big.Int).Add(out, big.NewInt(12345)).String()
+	vin := []chainjson.Vin{{SKAAmountIn: in}}
+	got := SKAFeeRateMapFromVerboseVin(vin, tx)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	want := new(big.Int).Mul(big.NewInt(12345), big.NewInt(1000))
+	want.Quo(want, big.NewInt(int64(tx.SerializeSize())))
+	if got[1] != want.String() {
+		t.Errorf("rate: want %s, got %s", want.String(), got[1])
+	}
+}
+
+func TestSKAFeeRateMapFromVerboseVin_InsufficientInputsClampsToZero(t *testing.T) {
+	// totalIn (1) < totalOut (1e18) → fee negative → clamp 0.
+	tx := newSKAMsgTx(t, 1, big.NewInt(1e18))
+	vin := []chainjson.Vin{{SKAAmountIn: "1"}}
+	got := SKAFeeRateMapFromVerboseVin(vin, tx)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got[1] != "0" {
+		t.Errorf("rate: want 0 (clamped), got %s", got[1])
+	}
+}
+
+func TestSKAFeeRateMapFromVerboseVin_EmptyAmountsClampToZero(t *testing.T) {
+	// All inputs missing SKAAmountIn → totalIn=0 → fee negative → 0.
+	tx := newSKAMsgTx(t, 1, big.NewInt(1e18))
+	vin := []chainjson.Vin{{}, {}}
+	got := SKAFeeRateMapFromVerboseVin(vin, tx)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got[1] != "0" {
+		t.Errorf("rate: want 0 (clamped), got %s", got[1])
 	}
 }

--- a/wiki/code-analysis/mempool/flow.compact.md
+++ b/wiki/code-analysis/mempool/flow.compact.md
@@ -18,7 +18,6 @@
 - **SKA → Regular only:** SKA `TicketAmount/VoteAmount/RevokeAmount` are always `"0"` (not `""`); `normalizeCoinStatsAmounts` + `skaPerTypeStr` enforce.
 - **`PctOfTC` is unclamped** — overflow must surface as text; SCSS clips visually.
 - **Inventory locking order:** `MempoolMonitor.mtx` (pointer) outermost, `MempoolInfo.RWMutex` (contents) inner. Reverse = deadlock risk against `Refresh`.
-- **`mempool.tmpl` is still VAR-centric** — renders `TotalOut` as DCR even for SKA txs; gap from `home_mempool.tmpl`.
 
 ### Mutation Checklist
 

--- a/wiki/code-analysis/mempool/flow.compact.md
+++ b/wiki/code-analysis/mempool/flow.compact.md
@@ -1,13 +1,36 @@
-- **Flow:** `mempool/monitor.go` → `inventory.CoinStats` → `StoreMPData(derive CoinFills)` → `explorerroutes.go` → `mempool.tmpl`
-- **Architectural Patterns:**
-  - Multi-coin Aggregation: Per-coin stats mapped by `uint8` CoinType.
-  - String-based Math: `addAtomStrings` used to preserve 18-decimal SKA precision.
-- **Constraints:** 
-  - Never parse SKA string amounts into `float64`.
-  - `TrimmedTxInfo` currently drops `SKATotals`.
-- **Mutation Checklist:**
-  - Add `SKATotals` to `TrimmedTxInfo`.
-  - Update `mempool.tmpl` to use `types.FormatSKAAmount`.
+### One-line Flow
+
+`node RPC / OnTxAccepted → mempool/collector.ParseTxns (batch) | mempool/monitor.TxHandler.addTxToCoinStats (incremental) → []MempoolDataSaver fan-out → explorerUI computeCoinFills → exp.invs / psh.invs → WS (root + pubsub) + HTTP (home_mempool.tmpl / mempool.tmpl) → homepage_controller.js rAF indicator flush`.
+
+### Key Architectural Patterns
+
+- **Dual collection paths (batch vs. incremental).** `ParseTxns` at block boundaries fully rebuilds `MempoolInfo.CoinStats`; `addTxToCoinStats` updates it incrementally per new tx. Both must stay equivalent. Tests: [mempool/monitor_test.go](../../../mempool/monitor_test.go).
+- **Multi-saver fan-out.** `MempoolMonitor` dispatches to `[]MempoolDataSaver`: `explorerUI` (computes `CoinFills`), `PubSubHub` (pointer-assign), `DataCache` (early-returns on incremental path via `stakeData==nil` guard).
+- **Dual-transport WS.** Root explorer WS ([websockethandlers.go](../../../cmd/dcrdata/internal/explorer/websockethandlers.go)) and `PubSubHub` ([pubsubhub.go](../../../pubsub/pubsubhub.go)) both emit identical `sigMempoolUpdate(MempoolShort)` and `sigNewTxs(Txs+CoinFills+TotalFillRatio+ActiveSKACount)` payloads. See [/wiki/code-analysis/visualblocks/patterns.md](../visualblocks/patterns.md).
+- **`CoinFills` derived in two sites.** Computed via `computeCoinFills(CoinStats, maxBlockSize, issuedSKA)` inside both `(*explorerUI).StoreMPData` (mempool change) and `(*explorerUI).Store` (new block, after `SKACoinSupply` refresh).
+- **`issuedSKA` seeding.** Drawn from `HomeInfo.SKACoinSupply` so ever-issued coin types render zero-fill bars even with no current mempool activity.
+- **rAF-batched indicator updates.** Frontend collapses overlapping `coin_fills` payloads into a single animation frame; bars are zeroed, never removed (`homepage_controller.js:216-269`).
+
+### Critical Constraints
+
+- **SKA precision:** SKA `Amount`/`*Amount` fields are 18-decimal `big.Int` strings; **never** `float64`. VAR uses `int64` decimal strings. `addAtomStrings(..., isBig)` enforces the split.
+- **Single-coin tx invariant:** One mempool tx ⇒ one coin type. `primaryCoinType` ([explorertypes.go:1056-1065](../../../explorer/types/explorertypes.go)) encodes this.
+- **SKA → Regular only:** SKA `TicketAmount/VoteAmount/RevokeAmount` are always `"0"` (not `""`); `normalizeCoinStatsAmounts` + `skaPerTypeStr` enforce.
+- **`PctOfTC` is unclamped** — overflow must surface as text; SCSS clips visually.
+- **Inventory locking order:** `MempoolMonitor.mtx` (pointer) outermost, `MempoolInfo.RWMutex` (contents) inner. Reverse = deadlock risk against `Refresh`.
+- **`mempool.tmpl` is still VAR-centric** — renders `TotalOut` as DCR even for SKA txs; gap from `home_mempool.tmpl`.
+
+### Mutation Checklist
+
+- New `MempoolCoinStats` field → update `ParseTxns` (batch) **AND** `addTxToCoinStats` (incremental) **AND** `normalizeCoinStatsAmounts` (if string) **AND** `MempoolShort.DeepCopy` **AND** monitor_test.go.
+- New `MempoolShort` field → `DeepCopy` + `Trim` + both WS encoders (root + pubsub).
+- New `CoinFillData` field or status → Go `computeCoinFills` **AND** JS `indicator_fill.js` mirror **AND** `home_mempool.tmpl` + `<template id="fill-bar-template">` **AND** `dev_indicators.go` fixtures.
+- New saver → must handle `stakeData == nil` (cf. `DataCache.StoreMPData`).
+- Change `CoinFills` inputs → update both call sites (`StoreMPData` AND new-block `Store`).
 
 See also:
-- /wiki/code-analysis/address/flow.compact.md (shares-pattern-with: mempool overlay into `NumUnconfirmed`)
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md) — full trace.
+- [/wiki/code-analysis/mempool/patterns.md](patterns.md) — reusable patterns from this flow.
+- [/wiki/code-analysis/mempool/impact.md](impact.md) — mutation-impact entries.
+- [/wiki/code-analysis/address/flow.compact.md](../address/flow.compact.md) (shares-pattern-with: mempool overlay into `NumUnconfirmed`).
+- [/wiki/core/constraints.md](../../core/constraints.md) (depends-on: C1 numeric precision; C2 dual pipeline mempool aggregation vs. persisted recalc).

--- a/wiki/code-analysis/mempool/flow.full.md
+++ b/wiki/code-analysis/mempool/flow.full.md
@@ -1,47 +1,254 @@
 ### Section 1 — Overview
-Tracing the data flow of mempool transactions and SKA-specific mempool metrics from the network monitor to the `mempool.tmpl` UI template.
+
+End-to-end trace of how mempool transactions reach the UI in the multi-coin (VAR + SKA{n}) model. Covers the **dual collection paths** (batch full-scan vs. per-tx incremental), the **fan-out to multiple savers** (explorerUI, PubSubHub, DataCache), the derivation of **CoinFills** from **CoinStats**, and the **dual-transport** websocket delivery (root + pubsub) plus the homepage templates and Stimulus controller that consume the data.
+
+---
 
 ### Section 2 — End-to-End Data Flow
-`RPC (raw tx) → mempool/monitor.go (parsing & aggregation) → inventory *MempoolInfo → explorer.go:StoreMPData (derive CoinFills) → explorerroutes.go (Mempool handler) → mempool.tmpl`
+
+```
+monetarium-node RPC / OnTxAccepted
+        │
+        ▼
+mempool/collector.go ── Collect() ─ ParseTxns() ──► *exptypes.MempoolInfo (batch, block boundary)
+        │                                              │
+mempool/monitor.go ── TxHandler() ─ addTxToCoinStats ──┤ (incremental, per tx)
+        │                                              │
+        │  fan-out via []MempoolDataSaver              ▼
+        ├──► explorerUI.StoreMPData ─ computeCoinFills ─► exp.invs (CoinFills/TotalFillRatio/ActiveSKACount)
+        ├──► PubSubHub.StoreMPData ─► psh.invs
+        └──► DataCache.StoreMPData  (skipped when stakeData==nil)
+
+exp.invs / psh.invs
+        │
+        ├── HTTP: explorerroutes.go Home/Mempool/VisualBlocks ─► views/home_mempool.tmpl, mempool.tmpl
+        ├── WS (root):   websockethandlers.go ─► sigMempoolUpdate(MempoolShort), sigNewTxs(Txs+CoinFills+…)
+        └── WS (pubsub): pubsubhub.go         ─► sigMempoolUpdate(MempoolShort), sigNewTxs(Txs+CoinFills+…)
+
+views/home_mempool.tmpl  ──► homepage_controller.js (rAF-buffered indicator updates, indicator_fill.js helpers)
+```
+
+---
 
 ### Section 3 — Per-Layer Breakdown
-- **Location:** `mempool/monitor.go`
-  - **Data Structures:** `msgTx`, `tx.SKATotals`, `inventory.CoinStats`
-  - **Transformations:** Parses raw wire transactions into `tx.SKATotals`. Aggregates amounts per SKA coin type into `MempoolCoinStats` strings via `addAtomStrings(..., isBig=true)`.
-- **Location:** `cmd/dcrdata/internal/explorer/explorer.go`
-  - **Data Structures:** `CoinFills`, `inv *types.MempoolInfo`
-  - **Transformations:** `computeCoinFills` computes `GQFillRatio`, `ExtraFillRatio`, etc., using the aggregated `CoinStats` and the block size limit.
-- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go`
-  - **Data Structures:** `MempoolInfo`
-  - **Transformations:** Hands the `MempoolInfo` struct to `mempool.tmpl` via the `.Mempool` template data field.
-- **Location:** `cmd/dcrdata/views/mempool.tmpl`
-  - **Data Structures:** `.Mempool.CoinFills`, `.Mempool.CoinStats`, `.Mempool.Transactions`
-  - **Transformations:** Displays high-level mempool counts and loops through txs.
+
+#### 3.1 Collection — `mempool/collector.go`
+
+- **Data structures:** `DataCollector`, `StakeData`, `exptypes.MempoolTx`, `exptypes.MempoolInput`.
+- **`(*DataCollector).Collect()`** — drains `GetRawMempoolVerbose(GRMAll)`, `GRMTickets`, `GRMVotes`, fee info, stake difficulty, and the best-block header. Returns a `*StakeData`, the full `[]exptypes.MempoolTx`, the `MempoolAddressStore`, and the `TxnsStore`.
+- **`(*DataCollector).mempoolTxns()`** — for each mempool entry: fetches the raw tx, decodes, sums **VAR-only outputs** into `totalOut` (filters by `v.CoinType == cointype.CoinTypeVAR`), populates `SKATotals` via `txhelpers.SKATotalsFromMsgTx`, calls `populateMempoolInputs` to enrich vin coin types.
+  - `mempool/collector.go:107-113` — VAR-only `totalOut` (SKA values are not summed into `TotalOut`).
+  - `mempool/collector.go:162` — `SKATotals: txhelpers.SKATotalsFromMsgTx(msgTx)` (returns `nil` for VAR-only txs).
+- **`populateMempoolInputs`** — for `TxTypeRegular` only, resolves `input.CoinType` and `input.SKAValue` from the prev outpoint, either via the mempool's own `TxnsStore` or by an RPC fallback `GetRawTransaction`. Returns `nil` for `SKAValue` outside Regular txs (`mempool/collector.go:169-206`).
+- **`ParseTxns`** — the batch aggregator that builds `MempoolInfo.MempoolShort.CoinStats`. Internally uses a `coinAccum` struct with **native `int64` (VAR) and `*big.Int` (SKA) accumulators** plus per-type accumulators for Regular/Ticket/Vote/Revocation; only at the end does it format `Amount`, `RegularAmount`, `TicketAmount`, `VoteAmount`, `RevokeAmount` to decimal-atom strings (`mempool/collector.go:519-644`).
+  - SKA per-type maps `skaRegAmt/skaTixAmt/skaVoteAmt/skaRevAmt` exist but **stay empty in practice** by chain invariant (SKA cannot be ticket/vote/revoke). `skaPerTypeStr` returns `"0"` when missing so the JSON contract is stable (`mempool/collector.go:607-614`).
+
+#### 3.2 Monitor / dispatch — `mempool/monitor.go`
+
+- **Data structures:** `MempoolMonitor` (holds `*exptypes.MempoolInfo` inventory under `mtx sync.RWMutex`), `[]MempoolDataSaver`.
+- **`(*MempoolMonitor).TxHandler(rawTx)`** (per-tx, incremental):
+  1. Ignores txs older than `LastBlockTime` (`monitor.go:128-131`).
+  2. Decodes; computes `tx.SKATotals` via `txhelpers.SKATotalsFromMsgTx(msgTx)` (`monitor.go:261`).
+  3. Appends to the appropriate slice (`Transactions/Tickets/Votes/Revocations/TSpends/TAdds`) under `p.mtx.RLock()` + `p.inventory.Lock()`.
+  4. **Incrementally updates `p.inventory.CoinStats`** via `addTxToCoinStats(...)` (`monitor.go:359-363`).
+  5. **DeepCopies inventory and fans out to all savers** with `stakeData == nil`: `go s.StoreMPData(nil, nil, invCopy)` (`monitor.go:368-377`). This is what triggers `computeCoinFills` recomputation on new-tx arrival without waiting for the next block.
+  6. Broadcasts `pstypes.SigNewTx` on `signalOuts`.
+- **`(*MempoolMonitor).CollectAndStore()`** (block boundary): calls `Refresh()` → `ParseTxns()`, atomically replaces `p.inventory`, fans out to all savers with non-nil `stakeData` and a deep-copied tx slice per saver.
+- **`addTxToCoinStats`** — incremental analogue of the `coinAccum` loop in `ParseTxns`. Uses `addAtomStrings(s.Amount, atoms, isBig)` for each `Amount`/per-type field, then `normalizeCoinStatsAmounts(&s)` to coerce any never-touched per-type amount from `""` to `"0"` (`monitor.go:545-617`). The function is the canonical reference for the contract: a regular VAR tx writes only `Amount` and `RegularAmount`; an SKA tx writes only the SKA-key entry's `Amount` and `RegularAmount`; per-type fields untouched by any tx still serialise as `"0"`.
+- **`addAtomStrings(a, b, isBig)`** — adds two decimal-atom strings: `big.Int` path when `isBig==true` (SKA), `int64 fmt.Sscan` path otherwise (VAR). Empty `a` returns `b` as-is (`monitor.go:621-637`). Failure to parse returns `a` unchanged — silent skip, no error path.
+
+#### 3.3 Savers — three `MempoolDataSaver` implementations
+
+`MempoolDataSaver` is `StoreMPData(*StakeData, []exptypes.MempoolTx, *exptypes.MempoolInfo)`:
+
+- **`mempool/mempoolcache.go::(*DataCache).StoreMPData`** — early-returns when `stakeData == nil` (`mempoolcache.go:46-51`). This is the explicit guard that lets `TxHandler` skip the cache on the incremental path. When called from `CollectAndStore`, stores `txs`, ticket fee info, fee/feeRate slices, ticket details, stake difficulty.
+- **`cmd/dcrdata/internal/explorer/explorer.go::(*explorerUI).StoreMPData`** (`explorer.go:483-512`):
+  1. Reads `pageData.HomeInfo.SKACoinSupply` to compute `issuedSKA` (the full set of ever-issued SKA coin types).
+  2. Reads `pageData.BlockchainInfo.MaxBlockSize` (fallback `393216.0`).
+  3. Calls `computeCoinFills(inv.CoinStats, maxBlockSize, issuedSKA)` → writes the results to **both** `inv.CoinFills` (legacy) **and** `inv.MempoolShort.CoinFills` plus `TotalFillRatio` and `ActiveSKACount`.
+  4. Replaces `exp.invs` under `exp.invsMtx.Lock`.
+  5. Resets the page ETag/Last-Modified.
+- **`pubsub/pubsubhub.go::(*PubSubHub).StoreMPData`** (`pubsubhub.go:620-626`) — only assigns `psh.invs = inv`. Does **not** recompute CoinFills (it consumes the values the explorer just wrote).
+
+Additional CoinFills recomputation lives in **`(*explorerUI).Store`** (new-block saver path) at `explorer.go:599-615`: after `HomeInfo.SKACoinSupply` is refreshed from the DB, fills are recomputed using the **new** issued set, so a freshly issued SKA coin gets a zero-fill indicator broadcast before its first mempool tx arrives.
+
+#### 3.4 `computeCoinFills` — `cmd/dcrdata/internal/explorer/explorer.go:1108-1217`
+
+- `varQuota = maxBlockSize * 0.10`; `skaPool = maxBlockSize * 0.90`; per-SKA quota = `skaPool / numSKA`.
+- Seeds the SKA key set from **both** the live `stats` map **and** the `issuedSKA` parameter so coins with no current mempool activity still appear (with zero fill).
+- VAR always first in the returned slice; SKA keys are sorted ascending.
+- Status logic per coin: `"ok"` (size ≤ quota), `"borrowing"` (over quota but `totalUsed ≤ maxBlockSize`), `"full"` (over total capacity).
+- **`PctOfTC` is intentionally NOT clamped** — overflow must surface as text. `IsOverflow = raw > 1.0`; visual width is clipped via SCSS at 100% (`explorer.go:1169-1180`). The SCSS clip is required because `coin_fills` JSON carries the raw value.
+
+#### 3.5 Type definitions — `explorer/types/explorertypes.go`
+
+- **`MempoolCoinStats`** (`:684-700`) — `TxCount`, `Size`, `Amount`, plus per-type `RegularCount/Amount`, `TicketCount/Amount`, `VoteCount/Amount`, `RevokeCount/Amount`. All `*Amount` fields are **atom-string** (VAR: `int64` decimal string; SKA: `big.Int` decimal string). For SKA, only `RegularAmount` is ever non-zero by chain invariant.
+- **`CoinFillData`** (`:665-682`) — `Symbol`, `GQFillRatio`, `ExtraFillRatio`, `OverflowFillRatio`, `GQPositionRatio`, `Status`, `PctOfTC`, `IsOverflow`.
+- **`MempoolShort`** (`:1126-1157`) — embedded in `MempoolInfo`; carries `CoinStats`, `CoinFills`, `TotalFillRatio`, `ActiveSKACount`. **`DeepCopy(MempoolShort)`** (`:1174-1248`) manually copies `CoinStats` (shallow per-entry copy — value type) and `CoinFills` via `CopyCoinFillSlice`.
+- **`MempoolInfo`** (`:866-878`) — embeds `MempoolShort`, holds tx slices and `Ident`; has its own embedded `sync.RWMutex` (separate from `MempoolMonitor.mtx`). `DeepCopy` produces a fully-detached snapshot for fan-out.
+- **`MempoolTx.SKATotals map[uint8]string`** (`:1405`) — per-coin SKA totals in atom-string form.
+- **`primaryCoinType(tx)`** (`:1056-1065`) — encodes the chain invariant "a mempool tx is single-coin": returns the single key from `SKATotals` or `0` for VAR (empty `SKATotals`).
+- **`TrimMempoolTx`** (`:1067-1099`) — now propagates `CoinType = primaryCoinType(tx)` and `SKASent = tx.SKATotals` onto `TxBasic`, so trimmed mempool entries no longer drop SKA totals. (Note: `TxBasic.SKASent` is marked `// Deprecated: use TotalRaw + CoinType` at `:353`.)
+- **`TrimmedMempoolInfo`** (`:847-863`) — for the home page; carries `CoinFills`, `TotalFillRatio`, `ActiveSKACount`, `CoinStats`. Built by `(*MempoolInfo).Trim()` (`:905-942`).
+
+#### 3.6 HTTP handlers — `cmd/dcrdata/internal/explorer/explorerroutes.go`
+
+- **`Home`** (`:182-...`) — renders `home_mempool.tmpl` via the home viewmodel; reads `exp.MempoolInventory()` and includes the entire `*types.MempoolInfo`.
+- **`Mempool`** (`:783-...`) — renders `mempool.tmpl` with the full `MempoolInfo` (still VAR-centric in the template — see Section 7).
+- **`VisualBlocks`** (`:353-368`) — calls `inv.Trim()` to render with a `*TrimmedMempoolInfo` (carrying `CoinFills`/`TotalFillRatio`/`ActiveSKACount`/`CoinStats`).
+
+#### 3.7 Websocket transports — **dual** (root + pubsub)
+
+Both transports serve identical JSON shapes for mempool signals. This is part of the project-wide dual-transport pattern documented in [wiki/code-analysis/visualblocks/patterns.md](../visualblocks/patterns.md).
+
+- **`cmd/dcrdata/internal/explorer/websockethandlers.go::RootWebsocket`** (root explorer WS):
+  - Client request `"getmempooltxs"` → marshals full `*types.MempoolInfo` (`:124-148`); short-circuits via `MempoolInfo.Ident` if the client already has the same id.
+  - Client request `"getmempooltrimmed"` → marshals `inv.Trim()` plus injected `Subsidy` (`:150-167`).
+  - `sigMempoolUpdate` → encodes `inv.MempoolShort` (`:284-293`).
+  - `sigNewTxs` → encodes an anonymous struct `{Txs, CoinFills, TotalFillRatio, ActiveSKACount}` snapshotted from `inv.MempoolShort` (`:298-324`).
+- **`pubsub/pubsubhub.go::sendLoop`** (pubsub WS):
+  - `sigMempoolUpdate` → encodes `inv.MempoolShort` (`:474-489`).
+  - `sigNewTxs` → encodes `{Txs, CoinFills, TotalFillRatio, ActiveSKACount}` (`:495-529`).
+
+In both pipelines the **CoinFills attached to `sigNewTxs` come from `MempoolShort.CoinFills` (not recomputed)** — the values were last written by `(*explorerUI).StoreMPData` when the new tx triggered the fan-out.
+
+#### 3.8 Templates — `cmd/dcrdata/views/`
+
+- **`home_mempool.tmpl`** — multi-coin aware:
+  - Total fill bar driven by `.Mempool.TotalFillRatio` (uses `mulf` and `minf`; visual width clamped at 100%, percentage text shows raw value).
+  - `{{range .Mempool.CoinFills}}` renders one bar per coin with `GQFillRatio`, `ExtraFillRatio`, `OverflowFillRatio`, `GQPositionRatio`, `PctOfTC`, `Status`, `IsOverflow`.
+  - LatestTransactions table uses `{{if .SKATotals}}` to render `SKA{n}` / `formatCoinAtoms` for SKA txs, else `VAR` / `threeSigFigs .TotalOut`.
+  - `<template id="fill-bar-template">` provides the DOM scaffolding used by `injectFillBar` for dynamically-added SKA bars.
+- **`mempool.tmpl`** — full-page mempool listings. **Still VAR-centric**: uses `.LikelyMineable.RegularTotal/TicketTotal/VoteTotal/RevokeTotal` as `DCR` and `{{float64AsDecimalParts .TotalOut 8 false}}` per row. **Does not render `CoinStats` or `CoinFills`**; SKA-only transactions render with a wrong/zero DCR amount in the Total column. This is a known asymmetry with `home_mempool.tmpl`.
+
+#### 3.9 Frontend — `cmd/dcrdata/public/js/`
+
+- **`controllers/homepage_controller.js`** registers handlers for `newtxs`, `mempool`, `getmempooltxsResp`. Key behaviours:
+  - All indicator DOM writes funnel through `updateIndicators(payload)` which schedules a single `requestAnimationFrame` flush; multiple payloads inside the same frame collapse into the latest (`:216-226`).
+  - `_flushIndicators` reads `coin_fills`, `total_fill_ratio`, `active_ska_count`. For each entry it calls `applyFillBar` (existing `[data-coin=…]`) or `injectFillBar` (new). Bars for coins no longer in the payload are zeroed via `zeroFillEntry`, **never removed**.
+  - `mempoolTableRow(tx)` uses `tx.ska_totals` to choose between SKA atom rendering (`humanize.formatCoinAtoms`) and VAR (`threeSigFigs(tx.total)`).
+- **`helpers/indicator_fill.js`** — JS mirror of the Go `computeCoinFills` output shape. Comments at `:20` and `:41` explicitly reference the Go function as the source of truth.
+- **`helpers/mempool_helper.js`** — maintains the client-side tx list / totals separately from the indicators.
+
+---
 
 ### Section 4 — Cross-Layer Dependencies
-- `explorerroutes.go` directly depends on `exp.MempoolInventory()` avoiding data races using a read lock (`inv.RLock()`).
-- The UI (websockets and templates) relies on the `MempoolCoinStats.Amount` string being formatted directly instead of parsed as a `float64` to avoid precision loss.
+
+- **Mempool → Explorer (saver):** `MempoolMonitor` calls `s.StoreMPData(...)` in goroutines after every tx (`TxHandler`) and every block (`CollectAndStore`). Order of saver registration matters: only **`explorerUI` recomputes `CoinFills`**; `PubSubHub` then reads them off the same `inv` pointer it was just handed. If `PubSubHub` ran before `explorerUI`, it would see stale fills — currently safe because savers run as separate goroutines and `PubSubHub` only reads on the next WS tick, but this is **not enforced**. (See impact.md.)
+- **Explorer → DB (one-way):** `(*explorerUI).Store` (new block) reads `VARCoinSupply` / `SKACoinSupply` from `dataSource` to refresh `HomeInfo.SKACoinSupply` and the issued-SKA set used for fills.
+- **Explorer ↔ pubsub (decoupled):** Each owns its own `invs` field and its own `invsMtx` (explorer in `explorer.go`, pubsub in `pubsubhub.go`). Both subscribe via the saver interface.
+- **Backend → Template:** `home_mempool.tmpl` reads `MempoolShort.CoinFills`, `TotalFillRatio`, `ActiveSKACount` directly; `mempool.tmpl` reads only `LikelyMineable` fields.
+- **Backend → JS:** The `coin_fills` JSON shape (lowercase snake_case symbol/`gq_fill_ratio`/`pct_of_tc`/...) is defined by struct tags on `CoinFillData`. JS in `indicator_fill.js` is a **mirror** — divergence is silent.
+- **Multi-coin invariant boundary:** `primaryCoinType` is the single place that encodes "one mempool tx is single-coin"; both `TrimMempoolTx` (mempool-page rendering) and any per-tx coin display depend on it.
+
+---
 
 ### Section 5 — Critical Constraints
-- **Precision rules:** SKA amounts use 18 decimals and are manipulated via `big.Int`. VAR uses 8 decimals. `addAtomStrings` with `isBig=true` MUST be used for SKA arithmetic.
-- **Data Trimming:** `TrimMempoolTx` currently discards `tx.SKATotals`. For individual SKA transactions to be accurately displayed in the mempool list, `TrimmedTxInfo` must be extended to preserve SKA amounts.
+
+1. **Precision bifurcation:** VAR uses 8 decimals and fits in `int64`/`float64`; SKA uses 18 decimals and **must** stay as `*big.Int` or its decimal-atom string. Never call `.ToCoin()` or any `float64` conversion on SKA values. All SKA arithmetic in mempool aggregation goes through `addAtomStrings(..., isBig=true)` or `*big.Int` accumulators (`mempool/monitor.go:625-632`, `mempool/collector.go:580-606`). See [wiki/core/constraints.md](../../core/constraints.md) C1.
+2. **Single-coin tx invariant:** Every mempool tx has outputs of exactly one coin type. `primaryCoinType` (`explorertypes.go:1056-1065`) and `SKATotals` size (≤1 in practice) both encode this. Code that iterates `SKATotals` and assumes multiple entries is wrong.
+3. **SKA-only-on-Regular invariant:** SKA txs are always `Type=="Regular"`. `MempoolCoinStats` SKA entries' `TicketAmount`/`VoteAmount`/`RevokeAmount` are always `"0"` (never `""` thanks to `normalizeCoinStatsAmounts` / `skaPerTypeStr`). Both incremental and batch paths preserve this.
+4. **Empty-string vs `"0"` JSON contract:** Per-type `*Amount` fields must serialise as `"0"` (never `""`) when no tx of that type has contributed. Enforced in both pipelines (incremental: `normalizeCoinStatsAmounts`; batch: `skaPerTypeStr`/`fmt.Sprintf("%d", 0)`).
+5. **Batch/incremental equivalence:** `ParseTxns` (block boundary, batch) and `addTxToCoinStats` (per-tx, incremental) must produce identical `MempoolCoinStats` outputs for the same input set. Any new aggregated field must be added in **both** places, plus tested (`mempool/monitor_test.go` covers the incremental path).
+6. **CoinFills are computed in two places:**
+   - `(*explorerUI).StoreMPData` — driven by mempool changes (tx or block fan-out from `MempoolMonitor`).
+   - `(*explorerUI).Store` — driven by new-block updates that refresh `SKACoinSupply` (so newly-issued SKA coins get bars before their first tx).
+   Changing the inputs of one without the other causes drift.
+7. **Inventory locking:** Two locks protect mempool state: `MempoolMonitor.mtx` (guards the `*MempoolInfo` pointer) and `MempoolInfo.RWMutex` (guards the struct contents). `TxHandler` takes `p.mtx.RLock()` then `p.inventory.Lock()`. `Refresh` swaps the pointer under `p.mtx.Lock()`. `DeepCopy` reads under `mpi.RLock()`. Reversing lock order risks deadlock.
+8. **DataCache nil-stakeData guard:** `TxHandler` calls savers with `stakeData == nil`; `DataCache.StoreMPData` must early-return on `nil` (`mempoolcache.go:49-51`). Adding new logic before the guard breaks the incremental path.
+9. **`PctOfTC` is unclamped:** Indicators must surface true overflow as text; SCSS handles visual clipping. Don't clamp in Go or JS.
+10. **`issuedSKA` semantics:** Passed to `computeCoinFills` so that ever-issued coin types render zero-fill bars even with no current activity. Sourced from `HomeInfo.SKACoinSupply`. If you ever fan-out fills before `Store` has populated `SKACoinSupply`, expect first-time SKA coins to be missing from the bar set until the next mempool tx for that coin.
+
+---
 
 ### Section 6 — Mutation Impact
-When modifying SKA data in mempool, check:
-- **Direct dependencies:** `mempool/monitor.go` (amount aggregation), `explorer/explorer.go` (`StoreMPData` metrics extraction).
-- **Indirect dependencies:** `mempool.tmpl` (must render strings correctly), `TrimmedTxInfo` (needs to propagate `SKATotals`).
-- **Silent failures:** Coercing `MempoolCoinStats.Amount` or `SKATotals` to `float64` will cause silent precision loss.
-- **Hard failures:** Adding keys to `CoinStats` map concurrently without write locks.
+
+When modifying **`MempoolCoinStats`** (new field, new tx-type bucket, format change):
+- Update batch path: `ParseTxns` `coinAccum` struct + final assignment (`mempool/collector.go:519-644`).
+- Update incremental path: `addTxToCoinStats` + `normalizeCoinStatsAmounts` (`mempool/monitor.go:545-617`).
+- If non-value type or non-shallow-safe: update `MempoolShort.DeepCopy` (`explorertypes.go:1236-1241`).
+- Update `mempool/monitor_test.go` (incremental equivalence) and any explorer fixtures.
+
+When modifying **`MempoolShort` / `MempoolInfo`** (new field):
+- Update `MempoolShort.DeepCopy` (`explorertypes.go:1174-1248`).
+- Update `MempoolInfo.Trim()` if the field should reach `TrimmedMempoolInfo` (`explorertypes.go:905-942`).
+- Update both WS encoders (`sigMempoolUpdate`, `sigNewTxs`) in `cmd/dcrdata/internal/explorer/websockethandlers.go` AND `pubsub/pubsubhub.go`.
+
+When modifying **`computeCoinFills`** (new ratio, status, formula):
+- The Go function: `cmd/dcrdata/internal/explorer/explorer.go:1108-1217`.
+- The JS mirror: `cmd/dcrdata/public/js/helpers/indicator_fill.js` (apply/inject/zero helpers).
+- Templates: `views/home_mempool.tmpl` fill-bar markup and the `<template id="fill-bar-template">`.
+- The dev fixtures: `cmd/dcrdata/internal/explorer/dev_indicators.go` (visual regression scenarios).
+- The dual-recompute call sites: `(*explorerUI).StoreMPData` AND `(*explorerUI).Store` new-block branch.
+
+When changing **`CoinFillData` JSON tags** (e.g. rename `pct_of_tc`):
+- Update struct tags in `explorertypes.go`.
+- Update JS consumers (`homepage_controller.js`, `indicator_fill.js`).
+- Update template references (`home_mempool.tmpl`).
+
+When adding a **new saver**:
+- It MUST handle `stakeData == nil` (incremental path) without corrupting state. Cf. `DataCache.StoreMPData`.
+- It MUST treat the `*MempoolInfo` it receives as **shared** when called from `CollectAndStore` (slice is deep-copied per saver but the struct pointer is shared from `TxHandler`).
+
+**Silent failure modes:**
+- Converting an SKA `Amount` string to `float64` anywhere in the pipeline → precision loss past ~17 significant digits (an 18-decimal SKA amount > 10 will mis-render).
+- Forgetting `isBig=true` for SKA in `addAtomStrings` → silently truncates SKA atoms to `int64`.
+- Adding a new per-type `*Amount` without updating `normalizeCoinStatsAmounts` → JSON contract emits `""` instead of `"0"`, frontend `parseFloat("")` returns `NaN`.
+- Recomputing CoinFills with an empty `issuedSKA` set (e.g. before `Store` runs) → newly-issued SKA coins missing from fill bars until their first tx.
+- Clamping `PctOfTC` in Go or JS → overflow indicator silently disappears.
+
+**Hard failure modes:**
+- Writing to `inv.CoinStats` without `inv.Lock()` while another goroutine reads → map concurrent access panic.
+- Calling `DeepCopy` while holding `inv.Lock()` (it takes `RLock` internally) → deadlock.
+- Reversing the `p.mtx` / `p.inventory` lock order → potential deadlock with the `Refresh` path.
+
+---
 
 ### Section 7 — Common Pitfalls
-- Storing SKA totals as `int64` or `float64` instead of `big.Int` or `string` in mempool aggregates.
-- Forgetting to pass the `isBig=true` flag for SKA transactions in `addAtomStrings`.
-- Not exposing `SKATotals` in `TrimmedTxInfo`, meaning the `mempool.tmpl` `range .Transactions` loop cannot render SKA transaction amounts.
+
+1. **Treating `MempoolTx.TotalOut` as the canonical tx amount.** It is **VAR-only atoms** (the collector filters by `CoinType == cointype.CoinTypeVAR` at `collector.go:107-113`). For an SKA tx, `TotalOut == 0`. Use `SKATotals` for SKA amounts. The `mempool.tmpl` page violates this (renders `TotalOut` as DCR for every row, including SKA txs).
+2. **Assuming `SKATotals` may contain multiple coin types.** By chain invariant it has at most one entry; code that loops over it is fine, but assumptions like `len(SKATotals) > 1` are dead branches.
+3. **Forgetting the incremental path.** Adding a new aggregated field to `ParseTxns` without mirroring in `addTxToCoinStats` makes the field correct only after the next block boundary — appears as "data lags by one block" bug.
+4. **Conflating `MempoolInfo.CoinFills` and `MempoolInfo.MempoolShort.CoinFills`.** They are kept in sync by `StoreMPData` and `Store`. JSON marshalling serialises only the embedded one (`MempoolShort.CoinFills`). The outer `MempoolInfo.CoinFills` exists for in-memory readers; if you read one without updating the other you get inconsistent behaviour between HTTP-rendered pages and JSON snapshots.
+5. **Adding a saver that mutates `inv` after `CollectAndStore`.** `CollectAndStore` passes one freshly-allocated `inv` to all savers; `TxHandler` passes a `DeepCopy`. A saver that mutates `inv` in the `CollectAndStore` path can be observed by other savers' goroutines.
+6. **Updating the SCSS clamp instead of the JS/Go raw value.** Bars visually clipping at 100% with text showing 150% is intentional. Removing the SCSS clamp produces broken layouts; clamping the value at source breaks the overflow signal.
+7. **Re-deriving `MempoolTx.Fees` for SKA.** The fee field is in VAR even for SKA txs (per CLAUDE.md chain invariant: SKA tx fees are paid in SKA, but the explorer currently surfaces the raw `dcrutil.Amount` from `txhelpers.TxFeeRate` which is VAR-typed — verify in `monitor.go:243-249` and `collector.go:143-149`). This is a known modelling gap.
+
+---
 
 ### Section 8 — Evidence
-- `mempool/monitor.go:384` — `s.Amount = addAtomStrings(s.Amount, amtStr, true)`
-- `explorer/types/explorertypes.go:859` — `TrimMempoolTx` creates a `TrimmedTxInfo` without mapping `SKATotals`.
+
+- `mempool/collector.go:65-167` — `mempoolTxns()`; VAR-only `totalOut` aggregation; `SKATotalsFromMsgTx` integration.
+- `mempool/collector.go:169-206` — `populateMempoolInputs`; per-input coin-type enrichment via TxnsStore + RPC fallback.
+- `mempool/collector.go:368-692` — `ParseTxns`; `coinAccum` batch aggregator; `skaPerTypeStr` `"0"` default.
+- `mempool/monitor.go:125-383` — `TxHandler`; tx classification, slice append, incremental `addTxToCoinStats`, DeepCopy fan-out.
+- `mempool/monitor.go:445-466` — `CollectAndStore`; fan-out with deep-copied tx slices.
+- `mempool/monitor.go:545-637` — `addTxToCoinStats`, `normalizeCoinStatsAmounts`, `addAtomStrings`.
+- `mempool/mempoolcache.go:46-69` — `DataCache.StoreMPData` with `stakeData == nil` guard.
+- `mempool/monitor_test.go:13-103` — incremental equivalence tests including precision boundary (`"123456789012345678901"` atoms).
+- `cmd/dcrdata/internal/explorer/explorer.go:483-512` — `explorerUI.StoreMPData`; `computeCoinFills` call + dual write to `inv.CoinFills` and `inv.MempoolShort.CoinFills`.
+- `cmd/dcrdata/internal/explorer/explorer.go:596-615` — new-block CoinFills recomputation after `SKACoinSupply` refresh.
+- `cmd/dcrdata/internal/explorer/explorer.go:1108-1217` — `computeCoinFills`; quota / borrowing / overflow logic.
+- `cmd/dcrdata/internal/explorer/websockethandlers.go:122-167` — `getmempooltxs`, `getmempooltrimmed`.
+- `cmd/dcrdata/internal/explorer/websockethandlers.go:284-324` — `sigMempoolUpdate`, `sigNewTxs` (root WS).
+- `pubsub/pubsubhub.go:474-529` — `sigMempoolUpdate`, `sigNewTxs` (pubsub WS).
+- `pubsub/pubsubhub.go:620-626` — `PubSubHub.StoreMPData` (assignment only).
+- `explorer/types/explorertypes.go:684-700` — `MempoolCoinStats`.
+- `explorer/types/explorertypes.go:847-942` — `TrimmedMempoolInfo`, `MempoolInfo`, `DeepCopy`, `Trim`.
+- `explorer/types/explorertypes.go:1056-1099` — `primaryCoinType`, `TrimMempoolTx`.
+- `explorer/types/explorertypes.go:1126-1248` — `MempoolShort` + `DeepCopy`.
+- `explorer/types/explorertypes.go:1384-1445` — `MempoolTx`, `DeepCopy`, `CopyMempoolTxSlice`, `CopyCoinFillSlice`.
+- `cmd/dcrdata/views/home_mempool.tmpl:21-66` — TotalBar + CoinFills bars + `<template id="fill-bar-template">`.
+- `cmd/dcrdata/views/home_mempool.tmpl:117-135` — LatestTransactions table with `SKATotals` branching.
+- `cmd/dcrdata/views/mempool.tmpl:23-345` — VAR-centric full-page mempool listings.
+- `cmd/dcrdata/public/js/controllers/homepage_controller.js:25-269` — handler registration, `updateIndicators` rAF batching, `_flushIndicators` apply/inject/zero loop.
+- `cmd/dcrdata/public/js/helpers/indicator_fill.js:20-168` — JS mirror of `computeCoinFills`.
+- `txhelpers/txhelpers.go:1305-1329` — `SKATotalsFromMsgTx`; nil-return for VAR-only txs.
 
 See also:
-- /wiki/code-analysis/address/flow.full.md — consumes this mempool data via `pgb.mp.UnconfirmedTxnsForAddress` to populate `NumUnconfirmed` (address links upstream with `depends-on`).
-- /wiki/core/constraints.md (depends-on: C1 numeric precision & bifurcation — `addAtomStrings(..., isBig=true)`; C2 dual pipeline — mempool aggregation vs persisted recalc)
+- [/wiki/code-analysis/mempool/patterns.md](patterns.md) — patterns extracted from this flow.
+- [/wiki/code-analysis/mempool/impact.md](impact.md) — mutation impact entries.
+- [/wiki/code-analysis/visualblocks/patterns.md](../visualblocks/patterns.md) (shares-pattern-with: **dual-transport WS** for mempool signals).
+- [/wiki/code-analysis/address/flow.full.md](../address/flow.full.md) (depends-on: address page consumes `pgb.mp.UnconfirmedTxnsForAddress` for `NumUnconfirmed`).
+- [/wiki/core/constraints.md](../../core/constraints.md) (depends-on: C1 precision bifurcation; C2 dual pipeline batch vs incremental).
+- [/wiki/specs/mempool/spec.md](../../specs/mempool/spec.md) (product spec for the multi-coin mempool page).

--- a/wiki/code-analysis/mempool/flow.full.md
+++ b/wiki/code-analysis/mempool/flow.full.md
@@ -94,7 +94,7 @@ Additional CoinFills recomputation lives in **`(*explorerUI).Store`** (new-block
 #### 3.6 HTTP handlers — `cmd/dcrdata/internal/explorer/explorerroutes.go`
 
 - **`Home`** (`:182-...`) — renders `home_mempool.tmpl` via the home viewmodel; reads `exp.MempoolInventory()` and includes the entire `*types.MempoolInfo`.
-- **`Mempool`** (`:783-...`) — renders `mempool.tmpl` with the full `MempoolInfo` (still VAR-centric in the template — see Section 7).
+- **`Mempool`** (`:783-...`) — renders `mempool.tmpl` with the full `MempoolInfo`. Template is multi-coin aware (Total Sent / Transactions cards iterate `CoinStats` via `orderedMempoolCoinStats`; Regular table branches on `.SKATotals`).
 - **`VisualBlocks`** (`:353-368`) — calls `inv.Trim()` to render with a `*TrimmedMempoolInfo` (carrying `CoinFills`/`TotalFillRatio`/`ActiveSKACount`/`CoinStats`).
 
 #### 3.7 Websocket transports — **dual** (root + pubsub)
@@ -105,10 +105,10 @@ Both transports serve identical JSON shapes for mempool signals. This is part of
   - Client request `"getmempooltxs"` → marshals full `*types.MempoolInfo` (`:124-148`); short-circuits via `MempoolInfo.Ident` if the client already has the same id.
   - Client request `"getmempooltrimmed"` → marshals `inv.Trim()` plus injected `Subsidy` (`:150-167`).
   - `sigMempoolUpdate` → encodes `inv.MempoolShort` (`:284-293`).
-  - `sigNewTxs` → encodes an anonymous struct `{Txs, CoinFills, TotalFillRatio, ActiveSKACount}` snapshotted from `inv.MempoolShort` (`:298-324`).
+  - `sigNewTxs` → encodes an anonymous struct `{Txs, CoinFills, TotalFillRatio, ActiveSKACount, CoinStats}` snapshotted from `inv.MempoolShort` (`:298-324`). `CoinStats` was added so the full-mempool page's per-coin Total Sent / Transactions cards update live without a follow-up `getmempooltxs` round-trip.
 - **`pubsub/pubsubhub.go::sendLoop`** (pubsub WS):
   - `sigMempoolUpdate` → encodes `inv.MempoolShort` (`:474-489`).
-  - `sigNewTxs` → encodes `{Txs, CoinFills, TotalFillRatio, ActiveSKACount}` (`:495-529`).
+  - `sigNewTxs` → encodes `{Txs, CoinFills, TotalFillRatio, ActiveSKACount, CoinStats}` (`:495-529`). Schema mirrors the root WS payload — both transports must change together (see [patterns.md "Dual-transport WebSocket"](patterns.md)).
 
 In both pipelines the **CoinFills attached to `sigNewTxs` come from `MempoolShort.CoinFills` (not recomputed)** — the values were last written by `(*explorerUI).StoreMPData` when the new tx triggered the fan-out.
 
@@ -119,7 +119,13 @@ In both pipelines the **CoinFills attached to `sigNewTxs` come from `MempoolShor
   - `{{range .Mempool.CoinFills}}` renders one bar per coin with `GQFillRatio`, `ExtraFillRatio`, `OverflowFillRatio`, `GQPositionRatio`, `PctOfTC`, `Status`, `IsOverflow`.
   - LatestTransactions table uses `{{if .SKATotals}}` to render `SKA{n}` / `formatCoinAtoms` for SKA txs, else `VAR` / `threeSigFigs .TotalOut`.
   - `<template id="fill-bar-template">` provides the DOM scaffolding used by `injectFillBar` for dynamically-added SKA bars.
-- **`mempool.tmpl`** — full-page mempool listings. **Still VAR-centric**: uses `.LikelyMineable.RegularTotal/TicketTotal/VoteTotal/RevokeTotal` as `DCR` and `{{float64AsDecimalParts .TotalOut 8 false}}` per row. **Does not render `CoinStats` or `CoinFills`**; SKA-only transactions render with a wrong/zero DCR amount in the Total column. This is a known asymmetry with `home_mempool.tmpl`.
+- **`mempool.tmpl`** — full-page mempool listings, multi-coin aware:
+  - Current Mempool card: `Total Sent` iterates `orderedMempoolCoinStats .CoinStats` and renders one `{amount, symbol}` line per coin (VAR always; SKA-n only when `TxCount > 0`).
+  - Transactions card: VAR section is static (Regular / Tickets / Votes / Revocations from `CoinStats[0]`); SKA sections render Regular-only inside `data-mempool-target="skaSections"` for live JS rebuild.
+  - Regular transactions table: `{{if .SKATotals}}` branches per row — SKA txs show `coinSymbol` + `skaDecimalParts $amt false`, VAR txs show `VAR` + `float64AsDecimalParts .TotalOut 8 false`. SKA Fee Rate cell renders `—` (em-dash) because `MempoolTx.FeeRate` is VAR-only float64; a follow-up will add `FeeRateRaw string` for precise SKA display.
+  - Tickets / Votes / Revocations tables stay VAR-only per spec; column headers say `Total VAR` and fee-rate unit is `VAR/kB`.
+  - Treasury Spends section removed; Treasury Adds retained.
+  - `CoinFills` is not consumed here (it's a homepage indicator-bar concept).
 
 #### 3.9 Frontend — `cmd/dcrdata/public/js/`
 
@@ -206,7 +212,7 @@ When adding a **new saver**:
 
 ### Section 7 — Common Pitfalls
 
-1. **Treating `MempoolTx.TotalOut` as the canonical tx amount.** It is **VAR-only atoms** (the collector filters by `CoinType == cointype.CoinTypeVAR` at `collector.go:107-113`). For an SKA tx, `TotalOut == 0`. Use `SKATotals` for SKA amounts. The `mempool.tmpl` page violates this (renders `TotalOut` as DCR for every row, including SKA txs).
+1. **Treating `MempoolTx.TotalOut` as the canonical tx amount.** It is **VAR-only atoms** (the collector filters by `CoinType == cointype.CoinTypeVAR` at `collector.go:107-113`). For an SKA tx, `TotalOut == 0`. Use `SKATotals` for SKA amounts. Both `mempool.tmpl` (Regular table) and `home_mempool.tmpl` now branch on `.SKATotals` per row.
 2. **Assuming `SKATotals` may contain multiple coin types.** By chain invariant it has at most one entry; code that loops over it is fine, but assumptions like `len(SKATotals) > 1` are dead branches.
 3. **Forgetting the incremental path.** Adding a new aggregated field to `ParseTxns` without mirroring in `addTxToCoinStats` makes the field correct only after the next block boundary — appears as "data lags by one block" bug.
 4. **Conflating `MempoolInfo.CoinFills` and `MempoolInfo.MempoolShort.CoinFills`.** They are kept in sync by `StoreMPData` and `Store`. JSON marshalling serialises only the embedded one (`MempoolShort.CoinFills`). The outer `MempoolInfo.CoinFills` exists for in-memory readers; if you read one without updating the other you get inconsistent behaviour between HTTP-rendered pages and JSON snapshots.
@@ -240,7 +246,7 @@ When adding a **new saver**:
 - `explorer/types/explorertypes.go:1384-1445` — `MempoolTx`, `DeepCopy`, `CopyMempoolTxSlice`, `CopyCoinFillSlice`.
 - `cmd/dcrdata/views/home_mempool.tmpl:21-66` — TotalBar + CoinFills bars + `<template id="fill-bar-template">`.
 - `cmd/dcrdata/views/home_mempool.tmpl:117-135` — LatestTransactions table with `SKATotals` branching.
-- `cmd/dcrdata/views/mempool.tmpl:23-345` — VAR-centric full-page mempool listings.
+- `cmd/dcrdata/views/mempool.tmpl` — full-page mempool listings; multi-coin aware (per-coin Total Sent, per-coin Transactions sections, SKA-aware Regular table).
 - `cmd/dcrdata/public/js/controllers/homepage_controller.js:25-269` — handler registration, `updateIndicators` rAF batching, `_flushIndicators` apply/inject/zero loop.
 - `cmd/dcrdata/public/js/helpers/indicator_fill.js:20-168` — JS mirror of `computeCoinFills`.
 - `txhelpers/txhelpers.go:1305-1329` — `SKATotalsFromMsgTx`; nil-return for VAR-only txs.

--- a/wiki/code-analysis/mempool/flow.full.md
+++ b/wiki/code-analysis/mempool/flow.full.md
@@ -124,7 +124,7 @@ In both pipelines the **CoinFills attached to `sigNewTxs` come from `MempoolShor
   - Transactions card: VAR section is static (Regular / Tickets / Votes / Revocations from `CoinStats[0]`); SKA sections render Regular-only inside `data-mempool-target="skaSections"` for live JS rebuild.
   - Regular transactions table: `{{if .SKATotals}}` branches per row — SKA txs show `coinSymbol` + `skaDecimalParts $amt false`, VAR txs show `VAR` + `float64AsDecimalParts .TotalOut 8 false`. SKA Fee Rate cell renders `—` (em-dash) because `MempoolTx.FeeRate` is VAR-only float64; a follow-up will add `FeeRateRaw string` for precise SKA display.
   - Tickets / Votes / Revocations tables stay VAR-only per spec; column headers say `Total VAR` and fee-rate unit is `VAR/kB`.
-  - Treasury Spends section removed; Treasury Adds retained.
+  - Treasury Spends and Treasury Adds sections both removed — Monetarium has no treasury (cf. `/treasury` → 410 in [core/pages.md](../../core/pages.md)), so neither tx type can occur on-chain. Backend `TAdds` / `NumTAdds` plumbing in `explorertypes.go`, `monitor.go`, `collector.go` is retained as dead code; UI no longer surfaces it.
   - `CoinFills` is not consumed here (it's a homepage indicator-bar concept).
 
 #### 3.9 Frontend — `cmd/dcrdata/public/js/`

--- a/wiki/code-analysis/mempool/impact.md
+++ b/wiki/code-analysis/mempool/impact.md
@@ -1,0 +1,137 @@
+## Risk: SKA precision lost via `float64` coercion
+
+**Trigger:**
+Anywhere an SKA atom string (`MempoolCoinStats.Amount`, per-type `*Amount`, `MempoolTx.SKATotals` value, `CoinFillData.Symbol`-keyed value) is parsed into a `float64` or passed through `dcrutil.Amount.ToCoin()`.
+
+**Affected flows:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+- [/wiki/code-analysis/charts/flow.full.md](../charts/flow.full.md)
+- [/wiki/code-analysis/transaction/flow.full.md](../transaction/flow.full.md)
+
+**Failure mode:** silent.
+
+**Description:**
+SKA uses 18 decimal places; an 18-decimal value > 10 already exceeds `float64`'s 53-bit significand, so the last digits are truncated/rounded with no error signal. The cooperative arithmetic helper `addAtomStrings(..., isBig=true)` and the batch `coinAccum.skaAmt map[uint8]*big.Int` are the only safe paths. Failure surfaces only when a user spot-checks a large SKA balance — by then the wrong value has been stored, broadcast, and rendered.
+
+---
+
+## Risk: Batch and incremental `CoinStats` paths drift
+
+**Trigger:**
+Adding a new aggregated field on `MempoolCoinStats` (or a new tx-type bucket) in only one of `ParseTxns` ([mempool/collector.go:519-644](../../../mempool/collector.go)) or `addTxToCoinStats` ([mempool/monitor.go:545-617](../../../mempool/monitor.go)).
+
+**Affected flows:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Failure mode:** silent until the next block boundary, then loud.
+
+**Description:**
+Mempool state can come from either path. The incremental path (`TxHandler`) is what produces the snapshot between blocks; the batch path (`CollectAndStore`) overrides it at every new block. A field implemented only in the batch path will appear to "lag by one block": correct at block boundary, drifts back to default during the block window. A field implemented only in the incremental path resets on every new block. Both manifest as flaky data depending on when the user loads the page. Tests in [mempool/monitor_test.go](../../../mempool/monitor_test.go) only cover the incremental path; the batch path is currently uncovered.
+
+---
+
+## Risk: `CoinFills` not recomputed when new SKA coin issued
+
+**Trigger:**
+Adding a new SKA coin type via on-chain issuance and skipping/breaking the recompute branch in `(*explorerUI).Store` ([cmd/dcrdata/internal/explorer/explorer.go:596-615](../../../cmd/dcrdata/internal/explorer/explorer.go)).
+
+**Affected flows:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+- [/wiki/code-analysis/charts/flow.full.md](../charts/flow.full.md)
+
+**Failure mode:** silent.
+
+**Description:**
+A newly issued SKA coin enters `HomeInfo.SKACoinSupply` only after `Store` refreshes it. `computeCoinFills` uses this set as `issuedSKA` so coins with no current mempool activity still render a zero-fill bar. If the recompute branch in `Store` is removed or guarded incorrectly, a freshly issued SKA coin will have no bar at all until its first mempool transaction triggers `(*explorerUI).StoreMPData`, which by then has the updated supply already. The window is short (next block), but the UX gap shows up in screenshots and CI fixtures.
+
+---
+
+## Risk: Saver misbehaves when `stakeData == nil`
+
+**Trigger:**
+A new `MempoolDataSaver` implementation reads `stakeData.Anything` without nil-checking, OR existing logic before the nil-guard in `DataCache.StoreMPData` is moved out.
+
+**Affected flows:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Failure mode:** loud (nil-deref panic) on every new mempool tx.
+
+**Description:**
+`TxHandler` calls all registered savers with `stakeData=nil` and `txsCopy=nil`. Only `inv` is non-nil. `DataCache.StoreMPData` explicitly returns at `mempoolcache.go:49-51`; `explorerUI` and `PubSubHub` only read `inv`. A saver that assumes `stakeData != nil` will panic on the first mempool tx after startup.
+
+---
+
+## Risk: `MempoolShort` field added without updating `DeepCopy` / `Trim`
+
+**Trigger:**
+Adding a new field on `MempoolShort` (or `MempoolInfo`) and forgetting to update `MempoolShort.DeepCopy` ([explorer/types/explorertypes.go:1174-1248](../../../explorer/types/explorertypes.go)) and/or `MempoolInfo.Trim` ([:905-942](../../../explorer/types/explorertypes.go)).
+
+**Affected flows:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+- [/wiki/code-analysis/visualblocks/flow.full.md](../visualblocks/flow.full.md)
+
+**Failure mode:** silent.
+
+**Description:**
+`DeepCopy` is used by `TxHandler` to hand savers a detached snapshot. A missing field there means the snapshot reverts to its zero value, so the saver/WS encoder sees stale data on the incremental path while batch-path payloads (which use the live inventory directly) look correct. `Trim` is the source for `TrimmedMempoolInfo` consumed by VisualBlocks (`getmempooltrimmed`); a missing field there silently drops it from that page only.
+
+---
+
+## Risk: WebSocket payload schema drift between transports
+
+**Trigger:**
+Changing the `sigMempoolUpdate` or `sigNewTxs` payload shape in only one of [cmd/dcrdata/internal/explorer/websockethandlers.go](../../../cmd/dcrdata/internal/explorer/websockethandlers.go) or [pubsub/pubsubhub.go](../../../pubsub/pubsubhub.go).
+
+**Affected flows:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+- [/wiki/code-analysis/visualblocks/flow.full.md](../visualblocks/flow.full.md)
+
+**Failure mode:** silent for one transport, loud for the other if JS parsing is strict.
+
+**Description:**
+Both files build the same anonymous payload struct by hand (`{Txs, CoinFills, TotalFillRatio, ActiveSKACount}` for `sigNewTxs`; `inv.MempoolShort` for `sigMempoolUpdate`). There's no shared encoder. A client connected to the root explorer WS receives a different shape than one connected via PubSub, and the divergence may not surface until a specific page or subscription is exercised.
+
+---
+
+## Risk: `CoinFillData` Go ↔ JS drift
+
+**Trigger:**
+Modifying `computeCoinFills` output shape (new field, renamed JSON tag, status string change) in Go without updating [public/js/helpers/indicator_fill.js](../../../cmd/dcrdata/public/js/helpers/indicator_fill.js) and the `<template id="fill-bar-template">` in [home_mempool.tmpl](../../../cmd/dcrdata/views/home_mempool.tmpl).
+
+**Affected flows:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Failure mode:** silent (indicators stop updating or update with `undefined` widths).
+
+**Description:**
+JS reads `entry.symbol`, `entry.gq_fill_ratio`, `entry.pct_of_tc`, etc. directly from the JSON payload; there's no contract enforcement. Renamed tags or new fields don't error — bars simply stop animating, or render with empty widths. Dev fixtures in [dev_indicators.go](../../../cmd/dcrdata/internal/explorer/dev_indicators.go) exercise the Go path only and won't catch JS-side drift.
+
+---
+
+## Risk: `mempool.tmpl` renders SKA txs as zero DCR
+
+**Trigger:**
+Routing more SKA transactions through the full mempool page without converting the row template to multi-coin rendering.
+
+**Affected flows:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Failure mode:** silent.
+
+**Description:**
+[cmd/dcrdata/views/mempool.tmpl](../../../cmd/dcrdata/views/mempool.tmpl) still uses `.LikelyMineable.RegularTotal/TicketTotal/VoteTotal/RevokeTotal` and `{{float64AsDecimalParts .TotalOut 8 false}}` per row — both VAR-only. `MempoolTx.TotalOut` for an SKA tx is `0` (collector sums VAR outputs only). The home page (`home_mempool.tmpl`) handles SKA correctly via `.SKATotals` branching; the full mempool page does not. Any SKA-heavy mempool state will silently render as a screen of zero-amount rows.
+
+---
+
+## Risk: Lock-order inversion on inventory
+
+**Trigger:**
+Code that takes `MempoolInfo.RWMutex` before `MempoolMonitor.mtx`, OR holds `MempoolInfo.Lock()` and calls a function that internally takes `MempoolInfo.RLock()` (e.g. `DeepCopy`).
+
+**Affected flows:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Failure mode:** loud (deadlock), but only under contention.
+
+**Description:**
+The canonical order is `p.mtx` (pointer) → `p.inventory` (contents). `Refresh` swaps the pointer under `p.mtx.Lock()` while readers hold `p.mtx.RLock()`. `DeepCopy` re-locks `mpi.RLock()` internally; calling it while already holding `mpi.Lock()` deadlocks. May go unnoticed in unit tests (no concurrency) and only surface under load.

--- a/wiki/code-analysis/mempool/impact.md
+++ b/wiki/code-analysis/mempool/impact.md
@@ -108,21 +108,6 @@ JS reads `entry.symbol`, `entry.gq_fill_ratio`, `entry.pct_of_tc`, etc. directly
 
 ---
 
-## Risk: `mempool.tmpl` renders SKA txs as zero DCR
-
-**Trigger:**
-Routing more SKA transactions through the full mempool page without converting the row template to multi-coin rendering.
-
-**Affected flows:**
-- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
-
-**Failure mode:** silent.
-
-**Description:**
-[cmd/dcrdata/views/mempool.tmpl](../../../cmd/dcrdata/views/mempool.tmpl) still uses `.LikelyMineable.RegularTotal/TicketTotal/VoteTotal/RevokeTotal` and `{{float64AsDecimalParts .TotalOut 8 false}}` per row — both VAR-only. `MempoolTx.TotalOut` for an SKA tx is `0` (collector sums VAR outputs only). The home page (`home_mempool.tmpl`) handles SKA correctly via `.SKATotals` branching; the full mempool page does not. Any SKA-heavy mempool state will silently render as a screen of zero-amount rows.
-
----
-
 ## Risk: Lock-order inversion on inventory
 
 **Trigger:**

--- a/wiki/code-analysis/mempool/patterns.md
+++ b/wiki/code-analysis/mempool/patterns.md
@@ -50,8 +50,8 @@ The incremental path is the reason `TxHandler` exists: live `CoinFills` indicato
 **Description:**
 Mempool updates are emitted on **two parallel WebSocket pipelines** that serve identical JSON shapes:
 
-- **Root explorer WS:** [cmd/dcrdata/internal/explorer/websockethandlers.go](../../../cmd/dcrdata/internal/explorer/websockethandlers.go) — handles `getmempooltxs` (full `MempoolInfo`), `getmempooltrimmed` (`TrimmedMempoolInfo` for VisualBlocks), and push events `sigMempoolUpdate(MempoolShort)` / `sigNewTxs({Txs, CoinFills, TotalFillRatio, ActiveSKACount})`.
-- **PubSub WS:** [pubsub/pubsubhub.go](../../../pubsub/pubsubhub.go) — emits the same `sigMempoolUpdate(MempoolShort)` / `sigNewTxs({…})` payloads. Subscription-aware via `client.isSubscribed`.
+- **Root explorer WS:** [cmd/dcrdata/internal/explorer/websockethandlers.go](../../../cmd/dcrdata/internal/explorer/websockethandlers.go) — handles `getmempooltxs` (full `MempoolInfo`), `getmempooltrimmed` (`TrimmedMempoolInfo` for VisualBlocks), and push events `sigMempoolUpdate(MempoolShort)` / `sigNewTxs({Txs, CoinFills, TotalFillRatio, ActiveSKACount, CoinStats})`.
+- **PubSub WS:** [pubsub/pubsubhub.go](../../../pubsub/pubsubhub.go) — emits the same `sigMempoolUpdate(MempoolShort)` / `sigNewTxs({…, CoinStats})` payloads. Subscription-aware via `client.isSubscribed`.
 
 Each transport owns its own `invs` pointer + mutex; both implement `MempoolDataSaver` and read the `CoinFills` previously written by `explorerUI`.
 

--- a/wiki/code-analysis/mempool/patterns.md
+++ b/wiki/code-analysis/mempool/patterns.md
@@ -1,0 +1,138 @@
+## Dual collection path: batch (block boundary) + incremental (per tx)
+
+**Appears in:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Description:**
+`MempoolMonitor` maintains the canonical `*exptypes.MempoolInfo` via two parallel update paths that must produce equivalent state:
+
+- **Batch:** `CollectAndStore` → `Refresh` → `ParseTxns` runs at every new block and on startup; iterates `[]MempoolTx` and builds aggregates from scratch using internal `coinAccum` structs with native `int64` / `*big.Int` accumulators, formatting to atom strings only at the end.
+- **Incremental:** `TxHandler` runs on every new tx; appends to the appropriate slice and updates `MempoolInfo.CoinStats` in place via `addTxToCoinStats`, using `addAtomStrings(..., isBig)` to keep VAR/SKA precision separated.
+
+Both paths normalise per-type `*Amount` fields to `"0"` when no tx of that type has contributed, so the JSON contract is identical regardless of which path produced the snapshot.
+
+**Constraints:**
+- Any new aggregated field on `MempoolCoinStats` (or any other batch output) MUST be added in both `ParseTxns` and `addTxToCoinStats`.
+- The incremental path uses `addAtomStrings` with explicit `isBig` flag; the batch path uses native accumulators. Mixing the two within one path (e.g. adding a string-based accumulator inside `ParseTxns`) risks precision loss.
+- Unit tests covering the incremental path live in [mempool/monitor_test.go](../../../mempool/monitor_test.go); add new field assertions there when extending `MempoolCoinStats`.
+
+---
+
+## Multi-saver fan-out via `MempoolDataSaver`
+
+**Appears in:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Description:**
+`MempoolMonitor` holds `[]MempoolDataSaver` and dispatches mempool snapshots to each (in a goroutine per saver). The interface is `StoreMPData(*StakeData, []exptypes.MempoolTx, *exptypes.MempoolInfo)`. Three implementations coexist:
+
+| Saver | Block boundary (CollectAndStore) | Per-tx (TxHandler, `stakeData == nil`) |
+|---|---|---|
+| `mempool.DataCache` | Stores stake-related fields | **Early-returns** (nil guard at `mempoolcache.go:49-51`) |
+| `explorer.explorerUI` | Recomputes `CoinFills` + assigns `exp.invs` | Same (drives indicator update without waiting for next block) |
+| `pubsub.PubSubHub` | Assigns `psh.invs` | Same |
+
+The incremental path is the reason `TxHandler` exists: live `CoinFills` indicators must update on every tx, not just on block boundaries.
+
+**Constraints:**
+- Every new saver MUST tolerate `stakeData == nil` without corrupting state.
+- `TxHandler` passes a `DeepCopy` to savers; `CollectAndStore` shares one `*MempoolInfo` between savers (slice is deep-copied per saver, but the struct pointer is shared). Mutating the inventory inside a saver is unsafe in the block path.
+- Only `explorerUI` computes `CoinFills`. `PubSubHub` consumes them. There's no ordering enforcement between saver goroutines — currently safe because `PubSubHub` reads `CoinFills` only on the next WS tick.
+
+---
+
+## Dual-transport WebSocket mempool delivery
+
+**Appears in:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+- [/wiki/code-analysis/visualblocks/flow.full.md](../visualblocks/flow.full.md)
+
+**Description:**
+Mempool updates are emitted on **two parallel WebSocket pipelines** that serve identical JSON shapes:
+
+- **Root explorer WS:** [cmd/dcrdata/internal/explorer/websockethandlers.go](../../../cmd/dcrdata/internal/explorer/websockethandlers.go) — handles `getmempooltxs` (full `MempoolInfo`), `getmempooltrimmed` (`TrimmedMempoolInfo` for VisualBlocks), and push events `sigMempoolUpdate(MempoolShort)` / `sigNewTxs({Txs, CoinFills, TotalFillRatio, ActiveSKACount})`.
+- **PubSub WS:** [pubsub/pubsubhub.go](../../../pubsub/pubsubhub.go) — emits the same `sigMempoolUpdate(MempoolShort)` / `sigNewTxs({…})` payloads. Subscription-aware via `client.isSubscribed`.
+
+Each transport owns its own `invs` pointer + mutex; both implement `MempoolDataSaver` and read the `CoinFills` previously written by `explorerUI`.
+
+**Constraints:**
+- Any change to the mempool WS payload schema MUST be applied in **both** files. They have no shared encoder.
+- The `sigNewTxs` payload snapshots `MempoolShort.CoinFills` at the moment of encoding, so the client sees fills consistent with the tx that triggered the broadcast.
+- Shares the broader **dual-transport** pattern with VisualBlocks; see [/wiki/code-analysis/visualblocks/patterns.md](../visualblocks/patterns.md).
+
+---
+
+## Atom-string arithmetic for multi-precision aggregation
+
+**Appears in:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+- [/wiki/code-analysis/charts/flow.full.md](../charts/flow.full.md)
+
+**Description:**
+Per-coin aggregate amounts (`MempoolCoinStats.Amount`, `RegularAmount`, etc.) are stored as **decimal-atom strings**, not numeric types, so the same field can losslessly carry VAR (8-decimal `int64`) or SKA (18-decimal `*big.Int`) values. Arithmetic uses `addAtomStrings(a, b, isBig bool)`:
+
+- `isBig == true` → parse both with `big.Int.SetString` and add; on parse failure, return `a` unchanged (silent skip).
+- `isBig == false` → `fmt.Sscan` into `int64` and sum.
+- Empty `a` returns `b` as-is.
+
+Per-type fields default to `"0"` (not `""`) so the JSON contract is stable regardless of which tx types have appeared in the mempool.
+
+**Constraints:**
+- Pass `isBig=true` for any SKA coin-type key; passing `false` silently truncates to `int64`.
+- Don't introduce a path that converts an SKA atom string to `float64` for arithmetic — precision loss past ~17 sig figs.
+- Empty fields must be normalised to `"0"` before serialisation (incremental: `normalizeCoinStatsAmounts`; batch: `skaPerTypeStr` / `fmt.Sprintf("%d", 0)`).
+
+---
+
+## Derived view written into two places
+
+**Appears in:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Description:**
+`CoinFills` is a **derived** view computed from `CoinStats` and the `issuedSKA` set. It is written into the same `MempoolInfo` from **two different triggers**:
+
+1. `(*explorerUI).StoreMPData` — runs on every mempool change (per-tx or block-boundary fan-out from `MempoolMonitor`).
+2. `(*explorerUI).Store` — runs on every new block, after `HomeInfo.SKACoinSupply` is refreshed from the DB. This is the only path where newly issued SKA coins enter the `issuedSKA` set, so it's the only path that can attach a zero-fill bar for a brand-new coin type before its first mempool tx.
+
+Both call sites also write to **two struct fields**: `inv.CoinFills` (legacy, for in-memory readers) and `inv.MempoolShort.CoinFills` (JSON-serialised).
+
+**Constraints:**
+- Changes to `computeCoinFills` inputs or outputs need both call sites updated.
+- Changes to the field set need both `inv.CoinFills` and `inv.MempoolShort.CoinFills` written; otherwise HTTP-rendered pages drift from JSON snapshots.
+- The JS mirror in [public/js/helpers/indicator_fill.js](../../../cmd/dcrdata/public/js/helpers/indicator_fill.js) must track the Go output shape; divergence is silent.
+
+---
+
+## Inventory locking: pointer mutex + contents mutex
+
+**Appears in:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Description:**
+Mempool state uses two locks:
+
+- `MempoolMonitor.mtx sync.RWMutex` — guards the **pointer** `p.inventory *MempoolInfo`. `Refresh()` takes the write lock to swap in a new inventory.
+- `MempoolInfo.RWMutex` (embedded) — guards the **contents** of the inventory struct (slices, maps, counters).
+
+Standard access pattern in `TxHandler`: `p.mtx.RLock()` (pin the pointer) → `p.inventory.Lock()` (mutate contents) → release in reverse order. `DeepCopy` takes only the contents `RLock`. Replacing the pointer takes only `p.mtx.Lock()`.
+
+**Constraints:**
+- Always take `p.mtx` before `p.inventory`. Reversing risks deadlock with `Refresh`.
+- `DeepCopy` already locks; don't wrap calls to it in another `RLock`/`Lock` of the same instance.
+- After `Refresh` swaps the pointer, in-flight readers holding the old pointer still see consistent state (Go GC retains the old struct until they release).
+
+---
+
+## rAF-batched live indicator updates
+
+**Appears in:**
+- [/wiki/code-analysis/mempool/flow.full.md](flow.full.md)
+
+**Description:**
+`homepage_controller.js` funnels all indicator DOM writes through `updateIndicators(payload)` which schedules a single `requestAnimationFrame` flush. If multiple WS payloads arrive within the same frame, only the latest is rendered (older payloads are dropped, not queued). Bars for coins no longer present in the payload are zeroed via `zeroFillEntry`, **not removed** — so transient absence (e.g. mempool draining) doesn't cause DOM churn.
+
+**Constraints:**
+- New indicator update paths must go through `updateIndicators`, not write DOM directly.
+- The `[data-coin="SKA{n}"]` attribute is the identity key; rename and you break re-targeting.
+- The `<template id="fill-bar-template">` element in [home_mempool.tmpl](../../../cmd/dcrdata/views/home_mempool.tmpl) is the source of truth for new SKA bar markup. Editing the inline `<div class="fill-bar">` without also editing the template causes dynamically-injected bars to differ from server-rendered ones.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -72,10 +72,12 @@ _Aggregation and grouping of blocks over specific time intervals (days, weeks, m
 
 ### Mempool
 
-_Multi-coin aggregation, websocket data preparation, and template rendering for unconfirmed transactions._
+_Multi-coin aggregation (CoinStats + derived CoinFills), dual collection paths (batch ParseTxns at block boundary vs. incremental addTxToCoinStats per tx), multi-saver fan-out, dual-transport WS delivery, and live indicator rendering._
 
-- flow (compact): code-analysis/mempool/flow.compact.md — high-level summary of mempool state aggregation
-- flow (full): code-analysis/mempool/flow.full.md — detailed, step-by-step function trace for deep debugging of mempool data tracking
+- flow (compact): code-analysis/mempool/flow.compact.md — high-level summary of mempool state aggregation, fan-out, and WS delivery
+- flow (full): code-analysis/mempool/flow.full.md — detailed, step-by-step function trace covering monitor/collector, savers, CoinFills derivation, WS encoders, templates, and JS controller
+- patterns: code-analysis/mempool/patterns.md — batch+incremental aggregation, multi-saver fan-out, dual-transport WS, atom-string arithmetic, derived-view dual write, inventory locking, rAF indicator batching
+- impact: code-analysis/mempool/impact.md — precision, batch/incremental drift, CoinFills recompute gaps, saver nil-guard, DeepCopy/Trim omissions, WS schema drift, Go↔JS drift, mempool.tmpl SKA gap, lock-order inversion
 
 ### Charts
 

--- a/wiki/specs/mempool/spec.md
+++ b/wiki/specs/mempool/spec.md
@@ -124,8 +124,8 @@
 - Колонка:
   - `Total DCR` → `Total VAR`
 
-- Таблица **Treasury Spends**:
-  - должна быть удалена
+- Таблицы **Treasury Spends** и **Treasury Adds**:
+  - должны быть удалены (в Monetarium нет казначейства — см. [core/pages.md](../../core/pages.md), маршруты `/treasury` и `/treasurytable` возвращают 410)
 
 ---
 


### PR DESCRIPTION
## Summary

- Make the mempool view multi-coin aware: per-coin Total Sent / Transactions stats and per-coin fee rates rendered on the mempool page, replacing VAR-centric logic.
- Add precision-safe `SKAFeeRates` (atoms/kB, BigInt-derived strings) on `MempoolTx`, populated from both the batch (`SKAFee` on verbose entries) and incremental (`SKAAmountIn`) paths, and rendered via the existing `skaDecimalParts` / `skaAmountHTML` formatters. SKA's 18 decimals can't survive `float64`, so atoms stay as strings end-to-end.
- Push `CoinStats` on the `sigNewTxs` pubsub payload so the full mempool page can refresh without an extra request.
- Drop both the Treasury Spends **and** Treasury Adds sections from the mempool view — Monetarium has no treasury (`/treasury` and `/treasurytable` already return 410, see [wiki/core/pages.md](wiki/core/pages.md)), so neither tx type can occur on-chain. Backend `TAdds` / `NumTAdds` plumbing is left untouched (separate cleanup).
- Frontend: rework `mempool_controller.js` for multi-coin sync, add responsive table-header tooltips, and clean up `clipboard_controller.js`.
- Tests: new `mempool_template_test.go`, `mempool_fee_rate.test.js`, `mempool_ska_sync.test.js`, plus added cases in `txhelpers_test.go`.
- Wiki: new `mempool/impact.md` and `mempool/patterns.md`; flow docs updated to reflect multi-coin behavior.

## Test plan

- [ ] `cd cmd/dcrdata && npm test` — vitest passes (covers `mempool_fee_rate` and `mempool_ska_sync`).
- [ ] `cd cmd/dcrdata && go test ./internal/explorer/...` — covers new `mempool_template_test.go`.
- [ ] `go test ./txhelpers/...` from repo root — covers new txhelpers cases.
- [ ] `cd cmd/dcrdata && npm run build && go build -o monetarium-explorer .` — frontend bundle + binary build cleanly.
- [ ] Manual: run the explorer against a node with mixed VAR + SKA{n} mempool activity; verify per-coin Total Sent / Transactions stats, that SKA fee-rate column renders precise atoms (no em-dash), and that the full mempool page updates on `sigNewTxs` without an extra fetch.
- [ ] Manual: confirm neither Treasury Spends nor Treasury Adds sections render.
- [ ] Manual: hover transaction-table headers at narrow viewport widths to confirm responsive tooltips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)