### PR TITLE
db/dcrpg: fix SKA precision in address amountflow query

### DIFF
--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -345,9 +345,14 @@ const (
 		WHERE address=$1 AND coin_type=$2 AND valid_mainchain
 		GROUP BY timestamp
 		ORDER BY timestamp;`
+	// VAR amounts come from value INT8; SKA amounts come from ska_value TEXT
+	// (1e18-scale atoms that exceed int64). Both columns are emitted on every
+	// row; the WHERE coin_type=$2 filter ensures only one pair is non-zero.
 	selectAddressAmountFlowByAddress = `SELECT %s as timestamp,
-		SUM(CASE WHEN is_funding = TRUE THEN value ELSE 0 END) as received,
-		SUM(CASE WHEN is_funding = FALSE THEN value ELSE 0 END) as sent
+		SUM(CASE WHEN is_funding = TRUE  AND coin_type = 0 THEN value ELSE 0 END) as received,
+		SUM(CASE WHEN is_funding = FALSE AND coin_type = 0 THEN value ELSE 0 END) as sent,
+		COALESCE(SUM(CASE WHEN is_funding = TRUE  AND coin_type > 0 THEN NULLIF(ska_value, '')::numeric ELSE 0 END), 0)::text as received_ska,
+		COALESCE(SUM(CASE WHEN is_funding = FALSE AND coin_type > 0 THEN NULLIF(ska_value, '')::numeric ELSE 0 END), 0)::text as sent_ska
 		FROM addresses
 		WHERE address=$1 AND coin_type=$2 AND valid_mainchain
 		GROUP BY timestamp

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -4293,24 +4293,26 @@ func parseRowsSentReceived(rows *sql.Rows, coinType uint8) (*dbtypes.ChartsData,
 	var balanceSKA, receivedSKA, sentSKA big.Int
 	for rows.Next() {
 		var blockTime time.Time
-		var received, sent uint64
-		err := rows.Scan(&blockTime, &received, &sent)
+		var receivedVAR, sentVAR uint64
+		var receivedSKAStr, sentSKAStr string
+		err := rows.Scan(&blockTime, &receivedVAR, &sentVAR, &receivedSKAStr, &sentSKAStr)
 		if err != nil {
 			return nil, err
 		}
 
 		items.Time = append(items.Time, dbtypes.NewTimeDef(blockTime))
 		if coinType == 0 {
-			items.Received = append(items.Received, toCoin(received))
-			items.Sent = append(items.Sent, toCoin(sent))
-			net := int64(received) - int64(sent)
+			items.Received = append(items.Received, toCoin(receivedVAR))
+			items.Sent = append(items.Sent, toCoin(sentVAR))
+			net := int64(receivedVAR) - int64(sentVAR)
 			items.Net = append(items.Net, toCoin(net))
 			balanceVAR += net
 			items.Balance = append(items.Balance, toCoin(balanceVAR))
 		} else {
 			// SKA: DB values are raw atom counts (1e18 scale). Use big.Int throughout.
-			r := new(big.Int).SetUint64(received)
-			s := new(big.Int).SetUint64(sent)
+			// COALESCE(..., 0)::text in the SQL guarantees valid decimal strings.
+			r, _ := new(big.Int).SetString(receivedSKAStr, 10)
+			s, _ := new(big.Int).SetString(sentSKAStr, 10)
 			receivedSKA.Add(&receivedSKA, r)
 			sentSKA.Add(&sentSKA, s)
 			net := new(big.Int).Sub(r, s)


### PR DESCRIPTION
## Summary

- Fixes a silent precision bug in `selectAddressAmountFlowByAddress`: for `coin_type > 0` it summed the `INT8 value` column, truncating 1e18-scale SKA atoms into `uint64` (typically to 0). `/api/address/{addr}/amountflow/{bin}?coin=N` therefore shipped zeroed `Received` / `Sent` / `Net` / `Balance` series for every SKA coin.
- Mirrors the pattern already used by `SelectAddressSpentUnspentCountAndValue`: emit both `value` (VAR `INT8`) and `COALESCE(SUM(NULLIF(ska_value,'')::numeric), 0)::text` (SKA atoms as text). `parseRowsSentReceived` scans both pairs and, for `coin_type > 0`, builds the running `big.Int` from the text columns instead of from the truncated `uint64`.

## Why this had to land before the UI work

This is a prerequisite for the address-page multi-coin frontend (issues #248–#250). The bug was invisible up to now because **no frontend exercises the SKA chart path** — `address_controller.js` hard-codes the VAR scale (`toCoin / 1e8`, `digitsAfterDecimal: 8`, `DCR` legend), so the chart card silently rendered as VAR-only even on SKA-holding addresses.

Issue #249 introduces a coin selector that wires the chart card to `?coin=N`. The moment that ships, every SKA chart would visibly render as flat zeros and we'd ship a regression. Fixing the SQL first means PR #249 can consume correct `received`/`sent`/`net`/`balance_atoms` series from day one of the coin dropdown being available, and the SKA pipeline (`/api/address/{addr}/amountflow/{bin}?coin=N` → `parseRowsSentReceived` → JSON `received_atoms`/`sent_atoms`/`net_atoms`/`balance_atoms`) is end-to-end correct.

The fix is scoped to one SQL edit and one Go scan edit — small enough to be its own PR for changelog / cherry-pick clarity and revertable independently of the UI work.

## Scope notes

- `parseRowsSentReceived` is also called by `binnedTreasuryIO`, but the treasury subsystem was removed and `MakeSelectTreasuryIOStatement` returns an empty string — `db.QueryContext` errors before `Scan` is reached, so the wider scan signature is safe.
- The `WHERE coin_type=$2` filter remains; the `CASE WHEN coin_type = 0` / `coin_type > 0` guards inside the SUMs are belt-and-braces so the VAR/SKA pairs cleanly produce zeros when the filter resolves to the other coin family.

## Test plan

- [x] `cd db/dcrpg && go build ./...`
- [x] `cd db/dcrpg && go test ./...`
- [x] `cd cmd/dcrdata && go build ./...`
- [x] `cd cmd/dcrdata && go test ./...`
- [x] `./lint.sh` (only pre-existing govet hits in vendored `node_modules/flatted/`)
- [x] Manual: `/api/address/{ska-addr}/amountflow/day?coin=1` against a SKA1-holding testnet address — confirm `received`/`sent` totals match the per-coin summary card SQL (`SelectAddressSpentUnspentCountAndValue`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)