### PR TITLE
db/dcrpg: fix multicoin balance not showing on address page

### DIFF
--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -55,7 +55,7 @@ type DataSource interface {
 	GetBlockByHash(context.Context, string) (*wire.MsgBlock, error)
 	SpendingTransaction(ctx context.Context, fundingTx string, vout uint32) (string, uint32, error)
 	SpendingTransactions(ctx context.Context, fundingTxID string) ([]string, []uint32, []uint32, error)
-	AddressHistory(ctx context.Context, address string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)
+	AddressHistory(ctx context.Context, address string, N, offset int64, txnType dbtypes.AddrTxnViewType, coinType uint8) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)
 	FillAddressTransactions(ctx context.Context, addrInfo *dbtypes.AddressInfo) error
 	AddressTransactionDetails(ctx context.Context, addr string, count, skip int64,
 		txnType dbtypes.AddrTxnViewType) (*apitypes.Address, error)

--- a/cmd/dcrdata/internal/api/noop_ds_test.go
+++ b/cmd/dcrdata/internal/api/noop_ds_test.go
@@ -26,7 +26,7 @@ func (noopDS) SpendingTransaction(_ context.Context, _ string, _ uint32) (string
 func (noopDS) SpendingTransactions(_ context.Context, _ string) ([]string, []uint32, []uint32, error) {
 	return nil, nil, nil, nil
 }
-func (noopDS) AddressHistory(_ context.Context, _ string, _, _ int64, _ dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
+func (noopDS) AddressHistory(_ context.Context, _ string, _, _ int64, _ dbtypes.AddrTxnViewType, _ uint8) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
 	return nil, nil, nil
 }
 func (noopDS) FillAddressTransactions(_ context.Context, _ *dbtypes.AddressInfo) error { return nil }

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -102,7 +102,7 @@ type explorerDataSource interface {
 	PoolStatusForTicket(ctx context.Context, txid string) (dbtypes.TicketSpendType, dbtypes.TicketPoolStatus, error)
 	TreasuryBalance(context.Context) (*dbtypes.TreasuryBalance, error)
 	TreasuryTxns(ctx context.Context, n, offset int64, txType stake.TxType) ([]*dbtypes.TreasuryTx, error)
-	AddressHistory(ctx context.Context, address string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)
+	AddressHistory(ctx context.Context, address string, N, offset int64, txnType dbtypes.AddrTxnViewType, coinType uint8) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error)
 	AddressData(ctx context.Context, address string, N, offset int64, txnType dbtypes.AddrTxnViewType, coinType uint8) (*dbtypes.AddressInfo, error)
 	DevBalance(ctx context.Context) (*dbtypes.AddressBalance, error)
 	FillAddressTransactions(ctx context.Context, addrInfo *dbtypes.AddressInfo) error

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -47,7 +47,7 @@ func (m *mockDataSource) TreasuryBalance(context.Context) (*dbtypes.TreasuryBala
 func (m *mockDataSource) TreasuryTxns(ctx context.Context, n, offset int64, txType stake.TxType) ([]*dbtypes.TreasuryTx, error) {
 	return nil, nil
 }
-func (m *mockDataSource) AddressHistory(ctx context.Context, address string, N, offset int64, txnType dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
+func (m *mockDataSource) AddressHistory(ctx context.Context, address string, N, offset int64, txnType dbtypes.AddrTxnViewType, coinType uint8) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
 	return nil, nil, nil
 }
 func (m *mockDataSource) AddressData(ctx context.Context, address string, N, offset int64, txnType dbtypes.AddrTxnViewType, coinType uint8) (*dbtypes.AddressInfo, error) {

--- a/db/dbtypes/coinfilter_test.go
+++ b/db/dbtypes/coinfilter_test.go
@@ -1,0 +1,105 @@
+package dbtypes
+
+import "testing"
+
+// filterByCoin returns only the rows matching coinType, preserving order.
+func filterByCoin(rows []*AddressRow, coinType uint8) []*AddressRow {
+	out := make([]*AddressRow, 0, len(rows))
+	for _, r := range rows {
+		if r.CoinType == coinType {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// mixedCoinRows builds a deterministic row set that is mostly VAR (coin 0)
+// with the SKA1 (coin 1) rows at the tail — the shape that exposes the
+// "filter after pagination" bug.
+func mixedCoinRows() []*AddressRow {
+	rows := make([]*AddressRow, 0, 10)
+	for i := 0; i < 10; i++ {
+		var h ChainHash
+		h[0] = byte(i)
+		ct := uint8(0)
+		if i >= 8 { // last two rows are SKA1
+			ct = 1
+		}
+		rows = append(rows, &AddressRow{
+			Address:        "Dtest",
+			ValidMainChain: true,
+			IsFunding:      i%2 == 0,
+			TxHash:         h,
+			TxVinVoutIndex: uint32(i),
+			CoinType:       ct,
+		})
+	}
+	return rows
+}
+
+// TestCoinTypeAllSentinel guards the sentinel the original one-line balance
+// fix relies on: CoinTypeAll must be a reserved value that no real coin index
+// can take, otherwise "all coins" would silently collapse to a single coin.
+func TestCoinTypeAllSentinel(t *testing.T) {
+	if CoinTypeAll != 255 {
+		t.Fatalf("CoinTypeAll changed to %d; the all-coins sentinel must stay 255 "+
+			"and remain distinct from every real coin index", CoinTypeAll)
+	}
+	for ct := 0; ct < 255; ct++ {
+		if uint8(ct) == CoinTypeAll {
+			t.Fatalf("real coin index %d collides with CoinTypeAll", ct)
+		}
+	}
+}
+
+// TestCoinFilterBeforePagination is a regression test for the address-page
+// coin filter. Coin filtering MUST be applied before LIMIT/OFFSET pagination.
+// If it is applied after (filter a single already-paginated page), pages come
+// back under-filled and rows of the selected coin become unreachable even
+// though the per-coin count says they exist. This codifies why AddressHistory
+// restricts to the coin before SliceAddressRows.
+func TestCoinFilterBeforePagination(t *testing.T) {
+	const skaCoin uint8 = 1
+	const pageSize = 3
+
+	rows := mixedCoinRows()
+	wantSKA := filterByCoin(rows, skaCoin) // ground truth: 2 rows
+	if len(wantSKA) != 2 {
+		t.Fatalf("fixture sanity: expected 2 SKA1 rows, got %d", len(wantSKA))
+	}
+
+	// Correct order: filter to the coin, THEN paginate. The first page must
+	// contain all SKA1 rows since pageSize >= number of SKA1 rows.
+	correctPage0, err := SliceAddressRows(filterByCoin(rows, skaCoin), pageSize, 0, AddrTxnAll)
+	if err != nil {
+		t.Fatalf("SliceAddressRows (correct order) failed: %v", err)
+	}
+	if len(correctPage0) != len(wantSKA) {
+		t.Fatalf("filter-before-paginate: page 0 should hold all %d SKA1 rows, got %d",
+			len(wantSKA), len(correctPage0))
+	}
+	for _, r := range correctPage0 {
+		if r.CoinType != skaCoin {
+			t.Fatalf("filter-before-paginate returned a non-SKA1 row (coin %d)", r.CoinType)
+		}
+	}
+
+	// Buggy order: paginate the full mixed set first, THEN filter that page.
+	// Because the SKA1 rows fall outside the first page, page 0 yields none —
+	// the defect this test guards against.
+	page0Mixed, err := SliceAddressRows(rows, pageSize, 0, AddrTxnAll)
+	if err != nil {
+		t.Fatalf("SliceAddressRows (buggy order) failed: %v", err)
+	}
+	buggyPage0 := filterByCoin(page0Mixed, skaCoin)
+	if len(buggyPage0) >= len(wantSKA) {
+		t.Fatalf("test no longer demonstrates the bug: filter-after-paginate "+
+			"returned %d/%d SKA1 rows on page 0", len(buggyPage0), len(wantSKA))
+	}
+
+	// And confirm the rows really are unreachable on the first page with the
+	// buggy order, while the correct order surfaces them immediately.
+	if len(buggyPage0) != 0 {
+		t.Fatalf("expected 0 SKA1 rows on buggy page 0, got %d", len(buggyPage0))
+	}
+}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1752,7 +1752,7 @@ func (pgb *ChainDB) AddressTransactionsAll(ctx context.Context, address string) 
 	defer cancel()
 
 	const limit = 3000000
-	addressRows, err = retrieveAddressTxns(ctx, pgb.db, address, limit, 0, 0)
+	addressRows, err = retrieveAddressTxns(ctx, pgb.db, address, limit, 0, dbtypes.CoinTypeAll)
 	// addressRows, err = retrieveAllMainchainAddressTxns(ctx, pgb.db, address)
 	err = pgb.replaceCancelError(err)
 	return

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -2872,45 +2872,10 @@ SPENDING_TX_DUPLICATE_CHECK:
 		addrData.Balance.TotalInputs++
 	} // range addressUTXOs.PrevOuts
 
-	// Totals from funding and spending transactions.
-	if addrData.Balance.Coins == nil {
-		addrData.Balance.Coins = make(map[uint8]*dbtypes.CoinBalance)
-	}
-	if addrData.Balance.Coins[0] == nil {
-		addrData.Balance.Coins[0] = dbtypes.NewCoinBalance(0)
-	}
-	addrData.Balance.Coins[0].NumSpent += numSent
-	addrData.Balance.Coins[0].NumUnspent += (numReceived - numSent)
-	addrData.Balance.Coins[0].TotalSpent += sent
-	addrData.Balance.Coins[0].TotalUnspent += (received - sent)
-	addrData.Balance.TotalInputs += numSent
-	addrData.Balance.TotalOutputs += numReceived
-
-	// Write accumulated SKA values into CoinBalance.
-	for ct, acc := range skaReceivedByType {
-		if addrData.Balance.Coins[ct] == nil {
-			addrData.Balance.Coins[ct] = dbtypes.NewCoinBalance(ct)
-		}
-		cb := addrData.Balance.Coins[ct]
-		spent := skaSpentByType[ct]
-		var unspent big.Int
-		unspent.Set(acc)
-		if spent != nil {
-			cb.TotalSpentSKA = spent.String()
-			unspent.Sub(&unspent, spent)
-		}
-		cb.TotalUnspentSKA = unspent.String()
-		cb.TotalReceivedSKA = acc.String()
-	}
-	for ct, acc := range skaSpentByType {
-		if skaReceivedByType[ct] != nil {
-			continue // already handled above
-		}
-		if addrData.Balance.Coins[ct] == nil {
-			addrData.Balance.Coins[ct] = dbtypes.NewCoinBalance(ct)
-		}
-		addrData.Balance.Coins[ct].TotalSpentSKA = acc.String()
-	}
+	// NOTE: Unconfirmed transactions are NOT added to the balance display.
+	// This is intentional - only confirmed transactions affect the balance.
+	// Unconfirmed transactions are tracked separately via NumUnconfirmed and
+	// NumUnconfirmedByCoin, which are displayed as indicators to users.
 
 	// Sort by date and calculate block height.
 	addrData.PostProcess(uint32(pgb.Height()))

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1784,7 +1784,7 @@ func (pgb *ChainDB) AddressTransactionsAllMerged(ctx context.Context, address st
 // AddressHistoryAll retrieves N address rows of type AddrTxnAll, skipping over
 // offset rows first, in order of block time.
 func (pgb *ChainDB) AddressHistoryAll(ctx context.Context, address string, N, offset int64) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
-	return pgb.AddressHistory(ctx, address, N, offset, dbtypes.AddrTxnAll)
+	return pgb.AddressHistory(ctx, address, N, offset, dbtypes.AddrTxnAll, dbtypes.CoinTypeAll)
 }
 
 // TicketPoolBlockMaturity returns the block at which all tickets with height
@@ -2423,10 +2423,63 @@ func (pgb *ChainDB) CountTransactions(ctx context.Context, addr string, txnView 
 // containing values for a certain type of transaction (all, credits, or debits)
 // for the given address.
 func (pgb *ChainDB) AddressHistory(ctx context.Context, address string, N, offset int64,
-	txnView dbtypes.AddrTxnViewType) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
+	txnView dbtypes.AddrTxnViewType, coinType uint8) ([]*dbtypes.AddressRow, *dbtypes.AddressBalance, error) {
 	_, err := stdaddr.DecodeAddress(address, pgb.chainParams)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// Coin-filtered views must paginate over the per-coin row subset. The
+	// row cache (and the SQL LIMIT/OFFSET it mirrors) operate on the full
+	// all-coin set, so filtering after pagination yields under-filled pages
+	// with most coin rows unreachable. Restrict to the coin first, then
+	// slice for the requested page/view.
+	if coinType != dbtypes.CoinTypeAll {
+		var fullRows []*dbtypes.AddressRow
+		compact, blockID := pgb.AddressCache.Rows(address, coinType)
+		if blockID != nil {
+			fullRows = dbtypes.UncompactRows(compact)
+		} else {
+			// Cache miss: populate the address row cache, then filter.
+			allRows, uErr := pgb.updateAddressRows(ctx, address)
+			if uErr != nil && !errors.Is(uErr, dbtypes.ErrNoResult) && !errors.Is(uErr, sql.ErrNoRows) {
+				if IsRetryError(uErr) {
+					return pgb.AddressHistory(ctx, address, N, offset, txnView, coinType)
+				}
+				return nil, nil, fmt.Errorf("failed to updateAddressRows: %w", uErr)
+			}
+			for _, r := range allRows {
+				if r.CoinType == coinType {
+					fullRows = append(fullRows, r)
+				}
+			}
+		}
+
+		pagedRows, sErr := dbtypes.SliceAddressRows(fullRows, int(N), int(offset), txnView)
+		if sErr != nil {
+			return nil, nil, fmt.Errorf("failed to SliceAddressRows: %w", sErr)
+		}
+
+		// Always use the full per-coin DB balance so the Coins map stays
+		// complete for the coin selector; a row-derived shortcut would yield
+		// a single-coin balance for the coin-filtered slice.
+		balance, _, bErr := pgb.AddressBalance(ctx, address)
+		if bErr != nil && !errors.Is(bErr, dbtypes.ErrNoResult) && !errors.Is(bErr, sql.ErrNoRows) {
+			log.Errorf("AddressBalance failed for %s: %v, returning rows anyway", address, bErr)
+			balance = &dbtypes.AddressBalance{
+				Address: address,
+				Coins:   make(map[uint8]*dbtypes.CoinBalance),
+			}
+		}
+		if balance != nil && balance.Coins != nil {
+			if varBal, ok := balance.Coins[0]; ok {
+				balance.TotalSpent = varBal.TotalSpent
+				balance.TotalUnspent = varBal.TotalUnspent
+				balance.NumSpent = varBal.NumSpent
+				balance.NumUnspent = varBal.NumUnspent
+			}
+		}
+		return pagedRows, balance, nil
 	}
 
 	// Try the address rows cache.
@@ -2451,7 +2504,7 @@ func (pgb *ChainDB) AddressHistory(ctx context.Context, address string, N, offse
 			// be updated with this data, although it may not be. Try again.
 			if IsRetryError(err) {
 				// Try again, starting with cache.
-				return pgb.AddressHistory(ctx, address, N, offset, txnView)
+				return pgb.AddressHistory(ctx, address, N, offset, txnView, dbtypes.CoinTypeAll)
 			}
 			return nil, nil, fmt.Errorf("failed to updateAddressRows: %w", err)
 		}
@@ -2550,7 +2603,7 @@ func (pgb *ChainDB) AddressData(ctx context.Context, address string, limitN, off
 		return nil, err
 	}
 
-	addrHist, balance, err := pgb.AddressHistory(ctx, address, limitN, offsetAddrOuts, txnType)
+	addrHist, balance, err := pgb.AddressHistory(ctx, address, limitN, offsetAddrOuts, txnType, coinType)
 	if dbtypes.IsTimeoutErr(err) {
 		return nil, err
 	}
@@ -2597,39 +2650,10 @@ func (pgb *ChainDB) AddressData(ctx context.Context, address string, limitN, off
 			addrData = new(dbtypes.AddressInfo)
 		}
 
-		// Filter transactions by coin type if specified
-		if coinType != dbtypes.CoinTypeAll {
-			// Filter main transaction list
-			if len(addrData.Transactions) > 0 {
-				filtered := make([]*dbtypes.AddressTx, 0, len(addrData.Transactions))
-				for _, tx := range addrData.Transactions {
-					if tx.CoinType == coinType {
-						filtered = append(filtered, tx)
-					}
-				}
-				addrData.Transactions = filtered
-			}
-			// Filter funding transactions
-			if len(addrData.TxnsFunding) > 0 {
-				filtered := make([]*dbtypes.AddressTx, 0, len(addrData.TxnsFunding))
-				for _, tx := range addrData.TxnsFunding {
-					if tx.CoinType == coinType {
-						filtered = append(filtered, tx)
-					}
-				}
-				addrData.TxnsFunding = filtered
-			}
-			// Filter spending transactions
-			if len(addrData.TxnsSpending) > 0 {
-				filtered := make([]*dbtypes.AddressTx, 0, len(addrData.TxnsSpending))
-				for _, tx := range addrData.TxnsSpending {
-					if tx.CoinType == coinType {
-						filtered = append(filtered, tx)
-					}
-				}
-				addrData.TxnsSpending = filtered
-			}
-		}
+		// Coin filtering is applied at the query/cache layer by
+		// AddressHistory (per-coin rows are paginated correctly there), so
+		// addrData.Transactions / TxnsFunding / TxnsSpending are already
+		// restricted to the requested coin. No post-pagination filtering.
 
 		// Balances and txn counts
 		populateTemplate()
@@ -2747,11 +2771,9 @@ func (pgb *ChainDB) AddressData(ctx context.Context, address string, limitN, off
 		addrData.UnconfirmedTxns = new(dbtypes.AddressTransactions)
 	}
 
-	// Funding transactions (unconfirmed)
-	var received, sent, numReceived, numSent int64
-	// Per-coin SKA accumulators for the mempool overlay.
-	skaReceivedByType := make(map[uint8]*big.Int)
-	skaSpentByType := make(map[uint8]*big.Int)
+	// Funding transactions (unconfirmed). These are shown in the transaction
+	// list but, by design, do not contribute to the balance totals (see the
+	// note after the spending loop).
 FUNDING_TX_DUPLICATE_CHECK:
 	for _, f := range addressUTXOs.Outpoints {
 		// TODO: handle merged transactions
@@ -2811,21 +2833,6 @@ FUNDING_TX_DUPLICATE_CHECK:
 				addrData.Transactions = append(addrData.Transactions, addrTx)
 			}
 		}
-
-		if addrData.Balance.Coins[coinType] == nil {
-			addrData.Balance.Coins[coinType] = dbtypes.NewCoinBalance(coinType)
-		}
-		if coinType == 0 {
-			received += fundingTx.Tx.TxOut[f.Index].Value
-			numReceived++
-		} else {
-			addrData.Balance.Coins[coinType].NumUnspent++
-			if skaReceivedByType[coinType] == nil {
-				skaReceivedByType[coinType] = new(big.Int)
-			}
-			dbtypes.BigAddSKA(skaReceivedByType[coinType], receivedSKA)
-		}
-		addrData.Balance.TotalOutputs++
 	}
 
 	// Spending transactions (unconfirmed)
@@ -2901,28 +2908,13 @@ SPENDING_TX_DUPLICATE_CHECK:
 				addrData.Transactions = append(addrData.Transactions, addrTx)
 			}
 		}
-
-		coinType := f.CoinType
-		if addrData.Balance.Coins[coinType] == nil {
-			addrData.Balance.Coins[coinType] = dbtypes.NewCoinBalance(coinType)
-		}
-		if coinType == 0 {
-			sent += valuein
-			numSent++
-		} else {
-			if skaSpentByType[coinType] == nil {
-				skaSpentByType[coinType] = new(big.Int)
-			}
-			dbtypes.BigAddSKA(skaSpentByType[coinType], f.SKAValue)
-		}
-		addrData.Balance.Coins[coinType].NumSpent++
-		addrData.Balance.TotalInputs++
 	} // range addressUTXOs.PrevOuts
 
-	// NOTE: Unconfirmed transactions are NOT added to the balance display.
-	// This is intentional - only confirmed transactions affect the balance.
-	// Unconfirmed transactions are tracked separately via NumUnconfirmed and
-	// NumUnconfirmedByCoin, which are displayed as indicators to users.
+	// NOTE: Unconfirmed (mempool) transactions appear in the transaction list
+	// above but are intentionally NOT folded into the balance totals: only
+	// confirmed transactions affect the balance. Unconfirmed activity is
+	// surfaced separately via NumUnconfirmed and NumUnconfirmedByCoin, which
+	// the UI displays as pending indicators.
 
 	// Sort by date and calculate block height.
 	addrData.PostProcess(uint32(pgb.Height()))
@@ -3065,7 +3057,7 @@ func (pgb *ChainDB) addressInfo(ctx context.Context, addr string, count, skip in
 	}
 
 	// Get rows from the addresses table for the address
-	addrHist, balance, err := pgb.AddressHistory(ctx, addr, count, skip, txnType)
+	addrHist, balance, err := pgb.AddressHistory(ctx, addr, count, skip, txnType, dbtypes.CoinTypeAll)
 	if err != nil {
 		log.Errorf("Unable to get address %s history: %v", address, err)
 		return nil, nil, err

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1744,9 +1744,9 @@ func (pgb *ChainDB) AddressTransactions(ctx context.Context, address string, N, 
 */
 
 // AddressTransactionsAll retrieves all non-merged main chain addresses table
-// rows for the given address. There is presently a hard limit of 3 million rows
-// that may be returned, which is more than 4x the count for the treasury
-// address as of mainnet block 521900.
+// rows for the given address, across all coin types. There is presently a hard
+// safety limit of 3 million rows that may be returned (a cap on result size,
+// independent of coin type).
 func (pgb *ChainDB) AddressTransactionsAll(ctx context.Context, address string) (addressRows []*dbtypes.AddressRow, err error) {
 	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
 	defer cancel()
@@ -1759,20 +1759,14 @@ func (pgb *ChainDB) AddressTransactionsAll(ctx context.Context, address string) 
 }
 
 // AddressTransactionsAllMerged retrieves all merged (stakeholder-approved and
-// mainchain only) addresses table rows for the given address. There is
-// presently a hard limit of 3 million rows that may be returned, which is more
-// than 4x the count for the treasury address as of mainnet block 521900.
+// mainchain only) addresses table rows for the given address, aggregated across
+// all coin types. There is presently a hard safety limit of 3 million rows that
+// may be returned (a cap on result size, independent of coin type).
 func (pgb *ChainDB) AddressTransactionsAllMerged(ctx context.Context, address string) (addressRows []*dbtypes.AddressRow, err error) {
 	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
 	defer cancel()
 
 	const limit = 3000000
-	// Note: The merged query (SelectAddressMergedView) doesn't filter by coin_type
-	// in SQL - it aggregates all coin types together. However, there is a latent
-	// bug in retrieveAddressMergedTxns: the coinType=0 is passed to the generic
-	// retrieveAddressTxnsStmt which binds it to $2 (LIMIT), resulting in LIMIT 0.
-	// This works only because AddressRowsMerged uses the non-merged cache path.
-	// The merged Insight API path should be investigated separately.
 	addressRows, err = retrieveAddressMergedTxns(ctx, pgb.db, address, limit, 0)
 	// const onlyValidMainchain = true
 	// _, addressRows, err = retrieveAllAddressMergedTxns(ctx, pgb.db, address,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1768,7 +1768,11 @@ func (pgb *ChainDB) AddressTransactionsAllMerged(ctx context.Context, address st
 
 	const limit = 3000000
 	// Note: The merged query (SelectAddressMergedView) doesn't filter by coin_type
-	// in SQL - it aggregates all coin types together. The offset (0) here is correct.
+	// in SQL - it aggregates all coin types together. However, there is a latent
+	// bug in retrieveAddressMergedTxns: the coinType=0 is passed to the generic
+	// retrieveAddressTxnsStmt which binds it to $2 (LIMIT), resulting in LIMIT 0.
+	// This works only because AddressRowsMerged uses the non-merged cache path.
+	// The merged Insight API path should be investigated separately.
 	addressRows, err = retrieveAddressMergedTxns(ctx, pgb.db, address, limit, 0)
 	// const onlyValidMainchain = true
 	// _, addressRows, err = retrieveAllAddressMergedTxns(ctx, pgb.db, address,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -2719,6 +2719,9 @@ func (pgb *ChainDB) AddressData(ctx context.Context, address string, limitN, off
 		}
 	}
 
+	// Store coin type filter before it's shadowed by local variables
+	coinTypeFilter := coinType
+
 	// Check for unconfirmed transactions.
 	addressUTXOs, numByCoin, err := pgb.mp.UnconfirmedTxnsForAddress(address)
 	if err != nil || addressUTXOs == nil {
@@ -2799,7 +2802,10 @@ FUNDING_TX_DUPLICATE_CHECK:
 				CoinType:         coinType,
 				SKAValue:         receivedSKA,
 			}
-			addrData.Transactions = append(addrData.Transactions, addrTx)
+			// Filter by coin type if specified
+			if coinTypeFilter == dbtypes.CoinTypeAll || coinTypeFilter == coinType {
+				addrData.Transactions = append(addrData.Transactions, addrTx)
+			}
 		}
 
 		if addrData.Balance.Coins[coinType] == nil {
@@ -2886,7 +2892,10 @@ SPENDING_TX_DUPLICATE_CHECK:
 				CoinType:       coinType,
 				SKAValue:       f.SKAValue,
 			}
-			addrData.Transactions = append(addrData.Transactions, addrTx)
+			// Filter by coin type if specified
+			if coinTypeFilter == dbtypes.CoinTypeAll || coinTypeFilter == coinType {
+				addrData.Transactions = append(addrData.Transactions, addrTx)
+			}
 		}
 
 		coinType := f.CoinType

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1767,6 +1767,8 @@ func (pgb *ChainDB) AddressTransactionsAllMerged(ctx context.Context, address st
 	defer cancel()
 
 	const limit = 3000000
+	// Note: The merged query (SelectAddressMergedView) doesn't filter by coin_type
+	// in SQL - it aggregates all coin types together. The offset (0) here is correct.
 	addressRows, err = retrieveAddressMergedTxns(ctx, pgb.db, address, limit, 0)
 	// const onlyValidMainchain = true
 	// _, addressRows, err = retrieveAllAddressMergedTxns(ctx, pgb.db, address,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -2593,6 +2593,40 @@ func (pgb *ChainDB) AddressData(ctx context.Context, address string, limitN, off
 			addrData = new(dbtypes.AddressInfo)
 		}
 
+		// Filter transactions by coin type if specified
+		if coinType != dbtypes.CoinTypeAll {
+			// Filter main transaction list
+			if len(addrData.Transactions) > 0 {
+				filtered := make([]*dbtypes.AddressTx, 0, len(addrData.Transactions))
+				for _, tx := range addrData.Transactions {
+					if tx.CoinType == coinType {
+						filtered = append(filtered, tx)
+					}
+				}
+				addrData.Transactions = filtered
+			}
+			// Filter funding transactions
+			if len(addrData.TxnsFunding) > 0 {
+				filtered := make([]*dbtypes.AddressTx, 0, len(addrData.TxnsFunding))
+				for _, tx := range addrData.TxnsFunding {
+					if tx.CoinType == coinType {
+						filtered = append(filtered, tx)
+					}
+				}
+				addrData.TxnsFunding = filtered
+			}
+			// Filter spending transactions
+			if len(addrData.TxnsSpending) > 0 {
+				filtered := make([]*dbtypes.AddressTx, 0, len(addrData.TxnsSpending))
+				for _, tx := range addrData.TxnsSpending {
+					if tx.CoinType == coinType {
+						filtered = append(filtered, tx)
+					}
+				}
+				addrData.TxnsSpending = filtered
+			}
+		}
+
 		// Balances and txn counts
 		populateTemplate()
 

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -102,26 +102,22 @@ func TestMergeRows(t *testing.T) {
 	if err != nil {
 		t.Errorf("err should have been nil, was: %v", err)
 	}
-	if rows == nil {
+	if len(rows) == 0 {
 		t.Fatalf("should have rows, got none")
 	}
 
-	// Regression test: AddressTransactionsAll must return ALL coin types,
-	// not just VAR (coin type 0). This was a bug where the shortcut path
-	// in AddressHistory filtered by coin_type=0 instead of CoinTypeAll.
+	// AddressTransactionsAll must not silently coin-filter; over a multi-coin
+	// address it returns every coin type. The shared test DB is seeded from a
+	// VAR-only mainnet fixture, so this test cannot exercise the multi-coin
+	// case — that regression is guarded DB-free by TestCoinFilterBeforePagination
+	// in db/dbtypes/coinfilter_test.go. Here we only sanity-check the rows.
 	coinTypes := make(map[uint8]bool)
 	for _, r := range rows {
 		coinTypes[r.CoinType] = true
 	}
-	if len(coinTypes) == 0 {
-		t.Error("expected at least one coin type in rows")
-	}
 	if len(coinTypes) > 1 {
-		var types []uint8
-		for ct := range coinTypes {
-			types = append(types, ct)
-		}
-		t.Logf("AddressTransactionsAll returned %d rows with %d coin types: %v", len(rows), len(types), types)
+		t.Logf("AddressTransactionsAll returned %d rows spanning coin types %v",
+			len(rows), coinTypes)
 	}
 
 	tStart := time.Now()

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -106,6 +106,24 @@ func TestMergeRows(t *testing.T) {
 		t.Fatalf("should have rows, got none")
 	}
 
+	// Regression test: AddressTransactionsAll must return ALL coin types,
+	// not just VAR (coin type 0). This was a bug where the shortcut path
+	// in AddressHistory filtered by coin_type=0 instead of CoinTypeAll.
+	coinTypes := make(map[uint8]bool)
+	for _, r := range rows {
+		coinTypes[r.CoinType] = true
+	}
+	if len(coinTypes) == 0 {
+		t.Error("expected at least one coin type in rows")
+	}
+	if len(coinTypes) > 1 {
+		var types []uint8
+		for ct := range coinTypes {
+			types = append(types, ct)
+		}
+		t.Logf("AddressTransactionsAll returned %d rows with %d coin types: %v", len(rows), len(types), types)
+	}
+
 	tStart := time.Now()
 	// mergedRows, mrMap, err := dbtypes.MergeRows(rows)
 	mergedRows, err := dbtypes.MergeRows(rows)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1881,9 +1881,21 @@ func retrieveAddressTxns(ctx context.Context, db *sql.DB, address string, N, off
 
 // Merged address transactions queries.
 
+// retrieveAddressMergedTxns fetches the per-transaction aggregated ("merged")
+// main chain address rows. SelectAddressMergedView has no coin_type predicate
+// (it aggregates all coin types) and binds $1=address, $2=LIMIT, $3=OFFSET, so
+// it must be queried directly. Routing it through retrieveAddressTxnsStmt would
+// inject a coin type as $2, which the merged statement uses as LIMIT — passing
+// the historical coinType=0 there produced "LIMIT 0" and silently returned no
+// rows.
 func retrieveAddressMergedTxns(ctx context.Context, db *sql.DB, address string, N, offset int64) ([]*dbtypes.AddressRow, error) {
-	return retrieveAddressTxnsStmt(ctx, db, address, N, offset,
-		internal.SelectAddressMergedView, mergedQuery, 0)
+	rows, err := db.QueryContext(ctx, internal.SelectAddressMergedView, address, N, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer closeRows(rows)
+	const onlyValidMainchain = true
+	return scanAddressMergedRows(rows, address, mergedQuery, onlyValidMainchain)
 }
 
 // Address transaction query helpers.


### PR DESCRIPTION
The shortcut path in AddressHistory was fetching only coin type 0 (VAR) instead of all coin types when calling AddressTransactionsAll. This caused SKA coin balances to be missing from the cached balance.

Fix: Pass dbtypes.CoinTypeAll (255) instead of 0 to retrieveAddressTxns in AddressTransactionsAll so all coin types are fetched for the balance computation.