### PR TITLE
cmd/dcrdata,db: multi-coin address page fixes (CSV, merged rows, flow chart)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ db/dcrpg/chkdcrpg/chkdcrpg
 go.work
 go.work.sum
 .claude/settings.local.json
+.github/scripts/tasks.json

--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -1803,7 +1803,7 @@ func (c *appContext) addressIoCsv(crlf bool, w http.ResponseWriter, r *http.Requ
 		if r.CoinType == 0 {
 			amount = strconv.FormatFloat(dcrutil.Amount(r.Value).ToCoin(), 'f', 8, 64)
 		} else {
-			amount = dbtypes.FormatSKAPerVAR(r.SKAValue, r.CoinType)
+			amount = dbtypes.FormatSKACoins(r.SKAValue)
 		}
 
 		err = writer.Write([]string{

--- a/cmd/dcrdata/internal/api/apiroutes_test.go
+++ b/cmd/dcrdata/internal/api/apiroutes_test.go
@@ -466,7 +466,7 @@ func TestAddressCSV_CoinFiltering(t *testing.T) {
 			"SKA CSV",
 			"/address/io/" + testAddr + "?coin=1",
 			http.StatusOK,
-			"1 SKA1", // coin_type, amount (18dp human-readable)
+			"1,1,0,Regular,", // coin_type=1, amount=1 (bare decimal, no label)
 		},
 	}
 	// ...

--- a/cmd/dcrdata/public/js/controllers/address_controller.js
+++ b/cmd/dcrdata/public/js/controllers/address_controller.js
@@ -201,6 +201,21 @@ function createOptions() {
   }
 }
 
+// Map an amount-flow bitmap to a Dygraph visibility object.
+// Flow bits: 1 = Received, 2 = Sent, 4 = Net. The amountflow chart has four
+// series — Dygraph indices 0 received, 1 sent, 2 & 3 net — so the single Net
+// bit drives both net series. Values are real booleans: Dygraph's object-form
+// setVisibility assigns them verbatim, and other range-selector code paths
+// expect booleans, not raw bitmask numbers.
+export function flowVisibility(bitmap) {
+  return {
+    0: (bitmap & 1) !== 0,
+    1: (bitmap & 2) !== 0,
+    2: (bitmap & 4) !== 0,
+    3: (bitmap & 4) !== 0
+  }
+}
+
 let ctrl = null
 
 export default class extends Controller {
@@ -785,23 +800,21 @@ export default class extends Controller {
   }
 
   updateFlow() {
-    const bitmap = ctrl.flow
+    const bitmap = this.flow
     if (bitmap === 0) {
       // If all boxes are unchecked, just leave the last view
-      // in place to prevent chart errors with zero visible datasets
+      // in place to prevent chart errors with zero visible datasets.
       return
     }
-    ctrl.settings.flow = bitmap
-    ctrl.setGraphQuery()
-    // Set the graph dataset visibility based on the bitmap
-    // Dygraph dataset indices: 0 received, 1 sent, 2 & 3 net
-    const visibility = {}
-    visibility[0] = bitmap & 1
-    visibility[1] = bitmap & 2
-    visibility[2] = visibility[3] = bitmap & 4
-    Object.keys(visibility).forEach((idx) => {
-      ctrl.graph.setVisibility(idx, visibility[idx])
-    })
+    this.settings.flow = bitmap
+    this.setGraphQuery()
+    // Apply the whole visibility map in a single setVisibility call. Dygraph
+    // runs predraw_ on every setVisibility, so toggling indices one at a time
+    // can leave the chart transiently with zero visible series, which crashes
+    // the range selector (computeCombinedSeriesAndLimits_ dereferences an
+    // empty array). The object form applies all indices, then redraws once;
+    // bitmap is non-zero here, so at least one series is always visible.
+    this.graph.setVisibility(flowVisibility(bitmap))
   }
 
   setFlowChecks() {

--- a/cmd/dcrdata/public/js/controllers/address_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/address_controller.test.js
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub the @hotwired/stimulus import so the controller module loads in jsdom.
+vi.mock('@hotwired/stimulus', () => ({
+  Controller: class {
+    constructor(element) {
+      this.element = element
+    }
+  }
+}))
+
+const { default: AddressController, flowVisibility } = await import('./address_controller.js')
+
+// ---------------------------------------------------------------------------
+// Fake Dygraph that reproduces the real range-selector invariant.
+//
+// dygraphs' computeCombinedSeriesAndLimits_ does `for (t = 0; t < d[0].length;
+// t++)` where `d` only holds the *visible* series. When zero series are
+// visible, `d` is empty and `d[0]` is undefined, throwing
+// "Cannot read properties of undefined (reading 'length')". Every setVisibility
+// call triggers predraw_, so any transient all-invisible state crashes.
+//
+// This fake mirrors that: it applies visibility, then on each redraw throws if
+// no series are visible. The (idx, val) form redraws per call (the old buggy
+// path); the object-map form applies everything then redraws once (the fix).
+// ---------------------------------------------------------------------------
+function makeFakeGraph(initialVisibility) {
+  const vis = [...initialVisibility]
+  const graph = {}
+  graph.vis = vis
+  graph.redrawCount = 0
+  graph.setVisibilityCalls = []
+  graph._redraw = function () {
+    graph.redrawCount++
+    // Mirror computeCombinedSeriesAndLimits_: it builds `d` from visible
+    // series only and then dereferences `d[0].length`. With zero visible
+    // series that throws "Cannot read properties of undefined".
+    const d = vis.filter((v) => v).map(() => [[0, 0]])
+    if (d.length === 0) {
+      throw new TypeError("Cannot read properties of undefined (reading 'length')")
+    }
+  }
+  graph.setVisibility = function (t, e) {
+    graph.setVisibilityCalls.push([t, e])
+    if (t !== null && typeof t === 'object' && !Array.isArray(t)) {
+      for (const n in t) vis[n] = t[n]
+    } else {
+      vis[t] = e
+    }
+    graph._redraw()
+  }
+  return graph
+}
+
+function makeBoxes(state) {
+  // state: { received, sent, net } booleans
+  const boxes = [
+    { value: '2', checked: !!state.sent },
+    { value: '1', checked: !!state.received },
+    { value: '4', checked: !!state.net }
+  ]
+  boxes.forEach = Array.prototype.forEach.bind(boxes)
+  return boxes
+}
+
+function makeController(graph, boxes) {
+  const ctrl = new AddressController(document.createElement('div'))
+  ctrl.graph = graph
+  ctrl.flowBoxes = boxes
+  ctrl.settings = {}
+  ctrl.query = { replace: vi.fn() }
+  return ctrl
+}
+
+describe('flowVisibility', () => {
+  it('maps Received only (bit 1)', () => {
+    expect(flowVisibility(1)).toEqual({ 0: true, 1: false, 2: false, 3: false })
+  })
+
+  it('maps Sent only (bit 2)', () => {
+    expect(flowVisibility(2)).toEqual({ 0: false, 1: true, 2: false, 3: false })
+  })
+
+  it('maps Net only (bit 4) onto both net series', () => {
+    expect(flowVisibility(4)).toEqual({ 0: false, 1: false, 2: true, 3: true })
+  })
+
+  it('maps Received + Net', () => {
+    expect(flowVisibility(5)).toEqual({ 0: true, 1: false, 2: true, 3: true })
+  })
+
+  it('maps all three checked', () => {
+    expect(flowVisibility(7)).toEqual({ 0: true, 1: true, 2: true, 3: true })
+  })
+
+  it('returns booleans, never raw bitmask numbers', () => {
+    for (const v of Object.values(flowVisibility(4))) {
+      expect(typeof v).toBe('boolean')
+    }
+  })
+})
+
+describe('updateFlow range-selector regression', () => {
+  let graph
+
+  beforeEach(() => {
+    // Default chart state: only Received (series 0) visible.
+    graph = makeFakeGraph([true, false, false, false])
+  })
+
+  it('does not change the graph when all boxes are unchecked', () => {
+    const ctrl = makeController(graph, makeBoxes({ received: false, sent: false, net: false }))
+    expect(() => ctrl.updateFlow()).not.toThrow()
+    expect(graph.vis).toEqual([true, false, false, false])
+    expect(graph.setVisibilityCalls).toHaveLength(0)
+  })
+
+  it('uncheck Received then check Net does not crash the range selector', () => {
+    // Step 1: user unchecks Received (everything off) — early return, desync.
+    const ctrl = makeController(graph, makeBoxes({ received: false, sent: false, net: false }))
+    ctrl.updateFlow()
+    expect(graph.vis).toEqual([true, false, false, false]) // graph untouched
+
+    // Step 2: user checks Net. This is the reported crash sequence.
+    ctrl.flowBoxes = makeBoxes({ received: false, sent: false, net: true })
+    expect(() => ctrl.updateFlow()).not.toThrow()
+
+    expect(graph.vis).toEqual([false, false, true, true])
+    // Atomic: a single setVisibility call with an object map, one redraw —
+    // never a transient all-invisible predraw.
+    expect(graph.setVisibilityCalls).toHaveLength(1)
+    expect(typeof graph.setVisibilityCalls[0][0]).toBe('object')
+    expect(graph.redrawCount).toBe(1)
+  })
+
+  it('persists the bitmap to settings/query when flow changes', () => {
+    const ctrl = makeController(graph, makeBoxes({ received: true, sent: false, net: true }))
+    ctrl.updateFlow()
+    expect(ctrl.settings.flow).toBe(5)
+    expect(ctrl.query.replace).toHaveBeenCalledWith(ctrl.settings)
+    expect(graph.vis).toEqual([true, false, true, true])
+  })
+})

--- a/cmd/dcrdata/views/address.tmpl
+++ b/cmd/dcrdata/views/address.tmpl
@@ -334,7 +334,7 @@
                 name="txntype"
                 data-address-target="txntype"
                 data-action="change->address#changeTxType"
-                class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropwdown"
+                class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropdown"
                 {{- if not .ActiveCoins}} disabled{{end}}
               >
                   <option {{if eq $txType "all"}}selected{{end}} value="all">All</option>
@@ -353,7 +353,7 @@
                 name="coin"
                 data-address-target="coinFilter"
                 data-action="change->address#changeCoin"
-                class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropwdown"
+                class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropdown"
               >
                   <option value="">All</option>
                   {{- range .ActiveCoins}}
@@ -365,7 +365,7 @@
               <span title="This address only has {{coinSymbol $onlyCoin}} transactions">
                 <select
                   name="coin"
-                  class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropwdown"
+                  class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropdown"
                   disabled
                 >
                   <option value="{{$onlyCoin}}" selected>{{coinSymbol $onlyCoin}}</option>
@@ -375,7 +375,7 @@
               <span title="This address has no transactions">
                 <select
                   name="coin"
-                  class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropwdown"
+                  class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropdown"
                   disabled
                 >
                   <option value="" selected>All</option>

--- a/db/cache/addresscache.go
+++ b/db/cache/addresscache.go
@@ -900,6 +900,9 @@ func (ac *AddressCache) Rows(addr string, coinType uint8) ([]*dbtypes.AddressRow
 		return nil, nil
 	}
 	ac.cacheMetrics.rowHit()
+	if coinType == dbtypes.CoinTypeAll {
+		return rows, aci.blockID()
+	}
 	var filtered []*dbtypes.AddressRowCompact
 	for _, r := range rows {
 		if r.CoinType == coinType {

--- a/db/cache/addresscache_test.go
+++ b/db/cache/addresscache_test.go
@@ -144,3 +144,46 @@ func TestAddressCacheItem_Transactions(t *testing.T) {
 		}
 	}
 }
+
+// TestAddressCacheRows_CoinTypeAll verifies that Rows honors the
+// dbtypes.CoinTypeAll (255) "no filter" sentinel by returning every cached row
+// across coin types, while still filtering correctly for a specific coin. This
+// guards the address-io CSV download, which fetches with CoinTypeAll when no
+// ?coin=N query parameter is supplied.
+func TestAddressCacheRows_CoinTypeAll(t *testing.T) {
+	const addr = "Dsnieug5H7Zn3SjUWwbcZ17ox9d3F2TEvZV"
+
+	hash, _ := chainhash.NewHashFromStr("000000000000000013a7c09f195ee4b28cd68599173c918037d67ec5b65c8c7d")
+	txHash, _ := chainhash.NewHashFromStr("05e7195ce139c62a46cb77e0002018a14ebe7e6442cd6c2e39274902a44a2a66")
+
+	rows := []*dbtypes.AddressRowCompact{
+		{Address: addr, TxHash: dbtypes.ChainHash(*txHash), CoinType: 0, ValidMainChain: true},
+		{Address: addr, TxHash: dbtypes.ChainHash(*txHash), CoinType: 0, ValidMainChain: true},
+		{Address: addr, TxHash: dbtypes.ChainHash(*txHash), CoinType: 1, ValidMainChain: true},
+		{Address: addr, TxHash: dbtypes.ChainHash(*txHash), CoinType: 2, ValidMainChain: true},
+	}
+
+	ac := NewAddressCache(100, 10, 1<<20)
+	if !ac.StoreRowsCompact(addr, rows, NewBlockID(hash, 329985)) {
+		t.Fatal("StoreRowsCompact failed")
+	}
+
+	// CoinTypeAll must return every row, unfiltered.
+	all, blockID := ac.Rows(addr, dbtypes.CoinTypeAll)
+	if blockID == nil {
+		t.Fatal("CoinTypeAll: expected cache hit (non-nil blockID)")
+	}
+	if len(all) != len(rows) {
+		t.Fatalf("CoinTypeAll: got %d rows, want %d", len(all), len(rows))
+	}
+
+	// A specific coin type must still filter to that coin only.
+	varRows, blockID := ac.Rows(addr, 0)
+	if blockID == nil || len(varRows) != 2 {
+		t.Fatalf("coin 0: got %d rows, want 2", len(varRows))
+	}
+	ska1Rows, blockID := ac.Rows(addr, 1)
+	if blockID == nil || len(ska1Rows) != 1 {
+		t.Fatalf("coin 1: got %d rows, want 1", len(ska1Rows))
+	}
+}

--- a/db/dbtypes/coinfilter_test.go
+++ b/db/dbtypes/coinfilter_test.go
@@ -2,6 +2,129 @@ package dbtypes
 
 import "testing"
 
+// TestMergedRowsPreserveCoinAndSKA guards the address-page bug where selecting a
+// merged view (e.g. "Merged debits") with a SKA coin still rendered "VAR" in the
+// Coin column and a zero amount. Merging dropped CoinType and the SKA atom value
+// because AddressRowMerged carried neither, so every merged row defaulted to
+// CoinType 0 (VAR) with an empty SKA string. Merging by tx hash never mixes
+// coins (a transaction is single-coin), so a merged row must carry the coin type
+// of its constituents and the summed SKA atoms.
+func TestMergedRowsPreserveCoinAndSKA(t *testing.T) {
+	const skaCoin uint8 = 1
+
+	// Two SKA1 debit rows in the same transaction; merging must sum the SKA
+	// atoms and keep CoinType == skaCoin.
+	var txHash ChainHash
+	txHash[0] = 0xab
+	rows := []*AddressRow{
+		{
+			Address:        "Dtest",
+			ValidMainChain: true,
+			IsFunding:      false,
+			TxHash:         txHash,
+			TxVinVoutIndex: 0,
+			Value:          0, // SKA value is not carried in the VAR int64 column
+			CoinType:       skaCoin,
+			SKAValue:       "1000000000000000000", // 1 SKA1 (1e18 atoms)
+		},
+		{
+			Address:        "Dtest",
+			ValidMainChain: true,
+			IsFunding:      false,
+			TxHash:         txHash,
+			TxVinVoutIndex: 1,
+			Value:          0,
+			CoinType:       skaCoin,
+			SKAValue:       "2000000000000000000", // 2 SKA1
+		},
+	}
+
+	merged, err := SliceAddressRows(rows, 10, 0, AddrMergedTxnDebit)
+	if err != nil {
+		t.Fatalf("SliceAddressRows merged-debit failed: %v", err)
+	}
+	if len(merged) != 1 {
+		t.Fatalf("expected 1 merged row, got %d", len(merged))
+	}
+	got := merged[0]
+	if got.CoinType != skaCoin {
+		t.Fatalf("merged row CoinType = %d, want %d (Coin column would render VAR)",
+			got.CoinType, skaCoin)
+	}
+	if got.SKAValue != "3000000000000000000" {
+		t.Fatalf("merged row SKAValue = %q, want %q (summed SKA atoms)",
+			got.SKAValue, "3000000000000000000")
+	}
+	if got.IsFunding { // debit: net is a spend, so IsFunding must be false
+		t.Fatalf("merged SKA debit row IsFunding = true, want false")
+	}
+
+	// VAR merged rows must keep working: CoinType 0, value summed in Value.
+	var varHash ChainHash
+	varHash[0] = 0xcd
+	varRows := []*AddressRow{
+		{Address: "Dtest", ValidMainChain: true, IsFunding: false, TxHash: varHash, Value: 100, CoinType: 0},
+		{Address: "Dtest", ValidMainChain: true, IsFunding: false, TxHash: varHash, Value: 250, CoinType: 0},
+	}
+	mergedVAR, err := SliceAddressRows(varRows, 10, 0, AddrMergedTxnDebit)
+	if err != nil {
+		t.Fatalf("SliceAddressRows merged-debit (VAR) failed: %v", err)
+	}
+	if len(mergedVAR) != 1 {
+		t.Fatalf("expected 1 merged VAR row, got %d", len(mergedVAR))
+	}
+	if mergedVAR[0].CoinType != 0 {
+		t.Fatalf("merged VAR row CoinType = %d, want 0", mergedVAR[0].CoinType)
+	}
+	if mergedVAR[0].Value != 350 {
+		t.Fatalf("merged VAR row Value = %d, want 350", mergedVAR[0].Value)
+	}
+	if mergedVAR[0].SKAValue != "" {
+		t.Fatalf("merged VAR row SKAValue = %q, want empty", mergedVAR[0].SKAValue)
+	}
+}
+
+// TestMergedCompactMixedCoins covers the all-coins ("Coin: All") merged path
+// that flows through MergeRowsCompactRange (the row-cache entry point). VAR and
+// SKA transactions in one merged result must each retain their own coin type
+// and value rather than collapsing every row to VAR.
+func TestMergedCompactMixedCoins(t *testing.T) {
+	var varHash, skaHash ChainHash
+	varHash[0] = 0x01
+	skaHash[0] = 0x02
+	rows := []*AddressRowCompact{
+		{Address: "Dtest", ValidMainChain: true, IsFunding: true, TxHash: varHash, Value: 500, CoinType: 0},
+		{Address: "Dtest", ValidMainChain: true, IsFunding: true, TxHash: skaHash, CoinType: 2, SKAValue: "7000000000000000000"},
+	}
+
+	merged := MergeRowsCompactRange(rows, 10, 0, AddrMergedTxn)
+	if len(merged) != 2 {
+		t.Fatalf("expected 2 merged rows, got %d", len(merged))
+	}
+	byCoin := map[uint8]*AddressRowMerged{}
+	for _, m := range merged {
+		byCoin[m.CoinType] = m
+	}
+	v, ok := byCoin[0]
+	if !ok {
+		t.Fatalf("VAR merged row missing; coin types present: %v", byCoin)
+	}
+	if v.Value() != 500 || v.SKAValueStr() != "" {
+		t.Fatalf("VAR merged row: Value=%d SKAValueStr=%q, want 500 and empty",
+			v.Value(), v.SKAValueStr())
+	}
+	s, ok := byCoin[2]
+	if !ok {
+		t.Fatalf("SKA2 merged row missing; coin types present: %v", byCoin)
+	}
+	if s.SKAValueStr() != "7000000000000000000" {
+		t.Fatalf("SKA2 merged row SKAValueStr=%q, want 7000000000000000000", s.SKAValueStr())
+	}
+	if !s.IsFunding() {
+		t.Fatalf("SKA2 merged credit row IsFunding()=false, want true")
+	}
+}
+
 // filterByCoin returns only the rows matching coinType, preserving order.
 func filterByCoin(rows []*AddressRow, coinType uint8) []*AddressRow {
 	out := make([]*AddressRow, 0, len(rows))

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -2423,22 +2423,27 @@ func BigAddSKA(acc *big.Int, s string) {
 // bigAddSKA is the package-local alias.
 func bigAddSKA(acc *big.Int, s string) { BigAddSKA(acc, s) }
 
-// FormatSKAPerVAR formats a SKA atom string as a human-readable coin amount
-// (e.g. "1.23 SKA1"). coinType is the SKA type number (1-255).
-func FormatSKAPerVAR(atomsStr string, coinType uint8) string {
+// FormatSKACoins converts a SKA atom string to a bare decimal coin amount
+// (atoms ÷ 1e18), with no coin label and trailing zeros trimmed (e.g. "1.23",
+// "0.0000000000000005"). Invalid/empty input yields "0". This is the
+// machine-readable form used by the CSV export, where the coin is identified
+// by a separate column.
+//
+// Note: not to be confused with txhelpers.FormatSKAAtoms, which returns the
+// raw atom integer string unchanged (no ÷1e18).
+func FormatSKACoins(atomsStr string) string {
 	atoms, ok := new(big.Int).SetString(atomsStr, 10)
 	if !ok {
-		return "0 SKA" + strconv.FormatUint(uint64(coinType), 10)
+		return "0"
 	}
 	denom := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
 	coins := new(big.Float).Quo(new(big.Float).SetInt(atoms), new(big.Float).SetInt(denom))
-	label := "SKA" + strconv.FormatUint(uint64(coinType), 10)
 	s := coins.Text('f', 18)
 	if strings.Contains(s, ".") {
 		s = strings.TrimRight(s, "0")
 		s = strings.TrimRight(s, ".")
 	}
-	return s + " " + label
+	return s
 }
 
 // HasStakeOutputs checks whether any of the Address tx outputs were

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -1324,29 +1324,89 @@ type AddressRowCompact struct {
 // as needed. Also node that MergedCount is of type int32 since that is big
 // enough and it allows using the padding with TxType and ValidMainChain.
 type AddressRowMerged struct {
-	Address        string
-	TxBlockTime    int64
-	TxHash         ChainHash
-	AtomsCredit    uint64
-	AtomsDebit     uint64
+	Address     string
+	TxBlockTime int64
+	TxHash      ChainHash
+	AtomsCredit uint64
+	AtomsDebit  uint64
+	// SKAAtomsCredit/SKAAtomsDebit accumulate SKA atoms (CoinType != 0). They
+	// are nil for VAR rows. SKA atoms exceed uint64, so they cannot share the
+	// AtomsCredit/AtomsDebit fields and must accumulate as *big.Int.
+	SKAAtomsCredit *big.Int
+	SKAAtomsDebit  *big.Int
 	MergedCount    int32
 	TxType         int16
 	ValidMainChain bool
+	// CoinType is the coin type of the merged transaction. A transaction is
+	// always single-coin, so every row merged under one tx hash shares it.
+	CoinType uint8
 }
 
-// IsFunding indicates the the transaction is "net funding", meaning that
-// AtomsCredit > AtomsDebit.
+// add folds a single non-merged constituent row into the merged row, keeping
+// VAR (uint64) and SKA (*big.Int) accumulators separate by coin type.
+func (arm *AddressRowMerged) add(coinType uint8, isFunding bool, value uint64, skaValue string) {
+	arm.CoinType = coinType
+	if coinType == 0 {
+		if isFunding {
+			arm.AtomsCredit += value
+		} else {
+			arm.AtomsDebit += value
+		}
+		return
+	}
+	if isFunding {
+		if arm.SKAAtomsCredit == nil {
+			arm.SKAAtomsCredit = new(big.Int)
+		}
+		BigAddSKA(arm.SKAAtomsCredit, skaValue)
+	} else {
+		if arm.SKAAtomsDebit == nil {
+			arm.SKAAtomsDebit = new(big.Int)
+		}
+		BigAddSKA(arm.SKAAtomsDebit, skaValue)
+	}
+}
+
+// skaNet returns SKAAtomsCredit - SKAAtomsDebit (signed), treating nil as zero.
+func (arm *AddressRowMerged) skaNet() *big.Int {
+	credit := arm.SKAAtomsCredit
+	if credit == nil {
+		credit = new(big.Int)
+	}
+	debit := arm.SKAAtomsDebit
+	if debit == nil {
+		debit = new(big.Int)
+	}
+	return new(big.Int).Sub(credit, debit)
+}
+
+// IsFunding indicates the transaction is "net funding": for VAR, AtomsCredit >
+// AtomsDebit; for SKA, the net SKA atom balance is positive.
 func (arm *AddressRowMerged) IsFunding() bool {
+	if arm.CoinType != 0 {
+		return arm.skaNet().Sign() > 0
+	}
 	return arm.AtomsCredit > arm.AtomsDebit
 }
 
-// Value returns the absolute (non-negative) net value of the transaction as
-// abs(AtomsCredit - AtomsDebit).
+// Value returns the absolute (non-negative) net VAR value of the transaction as
+// abs(AtomsCredit - AtomsDebit). It is meaningful only for VAR (CoinType == 0);
+// SKA values are reported via SKAValueStr.
 func (arm *AddressRowMerged) Value() uint64 {
 	if arm.AtomsCredit > arm.AtomsDebit {
 		return arm.AtomsCredit - arm.AtomsDebit
 	}
 	return arm.AtomsDebit - arm.AtomsCredit
+}
+
+// SKAValueStr returns the absolute net SKA atom value as a decimal string for
+// SKA rows (CoinType != 0), or "" for VAR rows.
+func (arm *AddressRowMerged) SKAValueStr() string {
+	if arm.CoinType == 0 {
+		return ""
+	}
+	net := arm.skaNet()
+	return net.Abs(net).String()
 }
 
 // SliceAddressRows selects a subset of the elements of the AddressRow slice
@@ -1659,11 +1719,7 @@ func MergeRows(rows []*AddressRow) ([]*AddressRowMerged, error) {
 				ValidMainChain: r.ValidMainChain,
 			}
 
-			if r.IsFunding {
-				mr.AtomsCredit = r.Value
-			} else {
-				mr.AtomsDebit = r.Value
-			}
+			mr.add(r.CoinType, r.IsFunding, r.Value, r.SKAValue)
 
 			hashMap[r.TxHash] = &mr
 			mergedRows = append(mergedRows, &mr)
@@ -1672,11 +1728,7 @@ func MergeRows(rows []*AddressRow) ([]*AddressRowMerged, error) {
 
 		// Update existing transaction in the mergedRows slice.
 		row.MergedCount++
-		if r.IsFunding {
-			row.AtomsCredit += r.Value
-		} else {
-			row.AtomsDebit += r.Value
-		}
+		row.add(r.CoinType, r.IsFunding, r.Value, r.SKAValue)
 	}
 
 	//fmt.Printf("MergeRows: guess = %d, actual = %d\n", numUniqueHashesGuess, len(mergedRows))
@@ -1765,11 +1817,7 @@ func MergeRowsRange(rows []*AddressRow, N, offset int, txnView AddrTxnViewType) 
 				ValidMainChain: r.ValidMainChain,
 			}
 
-			if r.IsFunding {
-				mr.AtomsCredit = r.Value
-			} else {
-				mr.AtomsDebit = r.Value
-			}
+			mr.add(r.CoinType, r.IsFunding, r.Value, r.SKAValue)
 
 			hashMap[r.TxHash] = &mr
 			mergedRows = append(mergedRows, &mr)
@@ -1778,11 +1826,7 @@ func MergeRowsRange(rows []*AddressRow, N, offset int, txnView AddrTxnViewType) 
 
 		// Update existing transaction in the mergedRows slice.
 		row.MergedCount++
-		if r.IsFunding {
-			row.AtomsCredit += r.Value
-		} else {
-			row.AtomsDebit += r.Value
-		}
+		row.add(r.CoinType, r.IsFunding, r.Value, r.SKAValue)
 	}
 
 	return mergedRows, nil
@@ -1815,11 +1859,7 @@ func MergeRowsCompact(rows []*AddressRowCompact) []*AddressRowMerged {
 				ValidMainChain: r.ValidMainChain,
 			}
 
-			if r.IsFunding {
-				mr.AtomsCredit = r.Value
-			} else {
-				mr.AtomsDebit = r.Value
-			}
+			mr.add(r.CoinType, r.IsFunding, r.Value, r.SKAValue)
 
 			hashMap[r.TxHash] = &mr
 			mergedRows = append(mergedRows, &mr)
@@ -1828,11 +1868,7 @@ func MergeRowsCompact(rows []*AddressRowCompact) []*AddressRowMerged {
 
 		// Update existing transaction.
 		row.MergedCount++
-		if r.IsFunding {
-			row.AtomsCredit += r.Value
-		} else {
-			row.AtomsDebit += r.Value
-		}
+		row.add(r.CoinType, r.IsFunding, r.Value, r.SKAValue)
 	}
 
 	//fmt.Printf("MergeRowsCompact: guess = %d, actual = %d\n", numUniqueHashesGuess, len(mergedRows))
@@ -1916,11 +1952,7 @@ func MergeRowsCompactRange(rows []*AddressRowCompact, N, offset int, txnView Add
 				ValidMainChain: r.ValidMainChain,
 			}
 
-			if r.IsFunding {
-				mr.AtomsCredit = r.Value
-			} else {
-				mr.AtomsDebit = r.Value
-			}
+			mr.add(r.CoinType, r.IsFunding, r.Value, r.SKAValue)
 
 			hashMap[r.TxHash] = &mr
 			mergedRows = append(mergedRows, &mr)
@@ -1929,11 +1961,7 @@ func MergeRowsCompactRange(rows []*AddressRowCompact, N, offset int, txnView Add
 
 		// Update existing merged row.
 		row.MergedCount++
-		if r.IsFunding {
-			row.AtomsCredit += r.Value
-		} else {
-			row.AtomsDebit += r.Value
-		}
+		row.add(r.CoinType, r.IsFunding, r.Value, r.SKAValue)
 	}
 
 	return mergedRows
@@ -2008,6 +2036,8 @@ func UncompactMergedRows(merged []*AddressRowMerged) []*AddressRow {
 			// no VinVoutDbID for merged
 			MergedCount: uint64(r.MergedCount),
 			TxType:      r.TxType,
+			CoinType:    r.CoinType,
+			SKAValue:    r.SKAValueStr(),
 		})
 	}
 	return rows

--- a/db/dbtypes/types_test.go
+++ b/db/dbtypes/types_test.go
@@ -361,3 +361,27 @@ func TestReduceAddressHistory_MixedCoin(t *testing.T) {
 		t.Errorf("SKA TotalUnspentSKA: want 2500000000000000000, got %q", skaCoin.TotalUnspentSKA)
 	}
 }
+
+// TestFormatSKACoins covers the label-free SKA atoms→coins formatter used by
+// the CSV export (the amount column must be a bare parseable number, with the
+// coin disambiguated by the separate coin_type column).
+func TestFormatSKACoins(t *testing.T) {
+	cases := []struct {
+		atoms string
+		want  string
+	}{
+		{"", "0"},
+		{"not-a-number", "0"},
+		{"0", "0"},
+		{"500", "0.0000000000000005"},
+		{"70000000", "0.00000000007"},
+		{"1000000000000000000", "1"},
+		{"5000000000000000000000", "5000"},
+		{"1230000000000000000", "1.23"},
+	}
+	for _, c := range cases {
+		if got := FormatSKACoins(c.atoms); got != c.want {
+			t.Errorf("FormatSKACoins(%q) = %q, want %q", c.atoms, got, c.want)
+		}
+	}
+}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -2298,6 +2298,9 @@ func (pgb *ChainDB) AddressRowsCompact(ctx context.Context, address string, coin
 
 	// We have a result.
 	compact := dbtypes.CompactRows(rows)
+	if coinType == dbtypes.CoinTypeAll {
+		return compact, err
+	}
 	var filtered []*dbtypes.AddressRowCompact
 	for _, r := range compact {
 		if r.CoinType == coinType {

--- a/mempool/monitor_test.go
+++ b/mempool/monitor_test.go
@@ -3,7 +3,11 @@ package mempool
 import (
 	"testing"
 
+	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
+	"github.com/monetarium/monetarium-node/wire"
+
 	exptypes "github.com/monetarium/monetarium-explorer/explorer/types"
+	"github.com/monetarium/monetarium-explorer/txhelpers"
 )
 
 // TestAddTxToCoinStats_IncrementalVAR verifies that the incremental per-tx
@@ -98,5 +102,58 @@ func TestAddTxToCoinStats_IncrementalAccumulates(t *testing.T) {
 	}
 	if s.Amount != "450000000" {
 		t.Errorf("Amount: want 450000000, got %s", s.Amount)
+	}
+}
+
+// TestUnconfirmedTxnsForAddress_PerCoinCounts is the regression guard for
+// issue #247: an address with one unconfirmed VAR tx and two unconfirmed SKA1
+// txs must report numByCoin[0]==1, numByCoin[1]==2, and an aggregate of 3.
+// Counts are distinct per tx hash (not per outpoint), so two outpoints from
+// the same SKA1 tx still count once.
+func TestUnconfirmedTxnsForAddress_PerCoinCounts(t *testing.T) {
+	const addr = "TestAddr"
+
+	// Three distinct unconfirmed txs funding the address: one VAR (coin 0)
+	// and two SKA1 (coin 1). The VAR tx contributes two outpoints to prove
+	// the count is per-tx, not per-outpoint.
+	varHash := chainhash.Hash{0x01}
+	ska1aHash := chainhash.Hash{0x02}
+	ska1bHash := chainhash.Hash{0x03}
+
+	txnsStore := txhelpers.TxnsStore{
+		varHash:   {CoinInfo: txhelpers.CoinInfoMap{0: {CoinType: 0}, 1: {CoinType: 0}}},
+		ska1aHash: {CoinInfo: txhelpers.CoinInfoMap{0: {CoinType: 1}}},
+		ska1bHash: {CoinInfo: txhelpers.CoinInfoMap{0: {CoinType: 1}}},
+	}
+
+	outs := txhelpers.NewAddressOutpoints(addr)
+	outs.Outpoints = []*wire.OutPoint{
+		{Hash: varHash, Index: 0},
+		{Hash: varHash, Index: 1}, // same tx, second output — must not double-count
+		{Hash: ska1aHash, Index: 0},
+		{Hash: ska1bHash, Index: 0},
+	}
+
+	p := &MempoolMonitor{txnsStore: txnsStore}
+	p.addrMap.store = txhelpers.MempoolAddressStore{addr: outs}
+
+	_, numByCoin, err := p.UnconfirmedTxnsForAddress(addr)
+	if err != nil {
+		t.Fatalf("UnconfirmedTxnsForAddress: %v", err)
+	}
+
+	if got := numByCoin[0]; got != 1 {
+		t.Errorf("numByCoin[VAR]: want 1, got %d", got)
+	}
+	if got := numByCoin[1]; got != 2 {
+		t.Errorf("numByCoin[SKA1]: want 2, got %d", got)
+	}
+
+	var aggregate int64
+	for _, n := range numByCoin {
+		aggregate += n
+	}
+	if aggregate != 3 {
+		t.Errorf("aggregate NumUnconfirmed: want 3, got %d", aggregate)
 	}
 }

--- a/wiki/code-analysis/address/charts.impact.md
+++ b/wiki/code-analysis/address/charts.impact.md
@@ -178,7 +178,8 @@ Group-By buttons:
 Flow checkboxes (only relevant for `amountflow`):
 - `:160-174` `<div data-address-target="flow" data-action="change->address#updateFlow">` — initially `d-hide`-friendly (Bootstrap `d-hide` toggled by `popChartCache`).
 - Checkbox values are bitmask flags: `Sent=2`, `Received=1` (default checked), `Net=4`. Encoded as a base-10 bitmap in URL (`?flow=`).
-- `updateFlow` (line 639) maps the bitmap to Dygraph series visibility for indices 0/1/2/3.
+- `updateFlow` maps the bitmap to Dygraph series visibility for indices 0/1/2/3 via the pure `flowVisibility(bitmap)` export (Net bit 4 drives both net series 2 & 3).
+- **Invariant — apply visibility atomically.** Dygraph runs `predraw_` on *every* `setVisibility` call, and the range selector's `computeCombinedSeriesAndLimits_` dereferences `d[0].length` over the *visible* series only. Toggling indices one at a time can leave a transient all-invisible state that throws `Cannot read properties of undefined (reading 'length')`. `updateFlow` must pass the full map in a single `setVisibility(object)` call (one redraw), and its `bitmap === 0` early-return guarantees ≥1 visible series. Regression covered by `address_controller.test.js`.
 
 Chart canvas + loader:
 - `:176-180` chart wrapper div with the `address_chart` class.

--- a/wiki/code-analysis/address/flow.compact.md
+++ b/wiki/code-analysis/address/flow.compact.md
@@ -13,7 +13,7 @@ chi `/address/{addr}` → `AddressPathCtx` → `AddressPage` + `middleware.GetCo
 
 ### Critical Constraints
 - **Coin filter must precede LIMIT/OFFSET** (`TestCoinFilterBeforePagination`).
-- **`CoinTypeAll` must stay 255**, distinct from every real coin (`TestCoinTypeAllSentinel`).
+- **`CoinTypeAll` must stay 255**, distinct from every real coin (`TestCoinTypeAllSentinel`). Any in-memory `if r.CoinType == coinType` row filter must short-circuit on `CoinTypeAll` (return all rows) — `AddressCache.Rows` / `AddressRowsCompact` do; missing this empties the no-`?coin=` CSV (`TestAddressCacheRows_CoinTypeAll`).
 - **Mempool must not affect balance** — confirmed-DB only by design; don't reintroduce the deleted accumulator.
 - **Merged view has no `coin_type` predicate** — query `SelectAddressMergedView` directly with `(address,N,offset)`; the old stmt-helper route bound `coinType=0` as `LIMIT 0` → zero rows (fixed `be28442e`).
 - **SKA precision (C1):** atoms stay strings to the render boundary; never `ToCoin()`/float a displayed SKA value.

--- a/wiki/code-analysis/address/flow.compact.md
+++ b/wiki/code-analysis/address/flow.compact.md
@@ -1,38 +1,50 @@
 ### One-line Flow
-chi `/address/{addr}` → `AddressPathCtx` → `AddressPage` → `parseAddressParams` + `middleware.GetCoinCtx` → `AddressListData(... coinType)` → PG `AddressData` (`AddressHistory` + `mergedTxnCount` / `CountTransactions` + `FillAddressTransactions` + `mempool.UnconfirmedTxnsForAddress` returning per-coin counts) → `templates.exec("address", AddressPageData{Data:*AddressInfo, Pages, FiatBalance:nil})` → `address` Stimulus controller (TurboQuery URL state; charts via `/api/address/{addr}/{types|amountflow}/{bin}?coin=N`; table via `/addresstable/{addr}?...&coin=N`; CSV via `/download/address/io/{addr}?coin=N`).
+chi `/address/{addr}` → `AddressPathCtx` → `AddressPage` + `middleware.GetCoinCtx` → `AddressData(...coinType)` → `AddressHistory(...,coinType)` [`coinType≠255`: load full per-coin rows, **filter then `SliceAddressRows`**, + full `AddressBalance`] → mempool overlay appends coin-filtered unconfirmed rows but **not** balance → `AddressInfo{Balance.Coins, ActiveCoins, NumUnconfirmedByCoin}` → `address.tmpl` (`range .ActiveCoins`) + `extras.tmpl` (Coin column) → `address` controller (TurboQuery incl. `coin`; charts `/api/address/{addr}/{types|amountflow}/{bin}?coin=N`; table `/addresstable/{addr}?...&coin=N`).
+
+> Revised at `HEAD=1b670255` (PR #265/#266 + db coin-filter series). Prior revision (`a8f641f2`) is overturned — see delta table below.
 
 ### Key Architectural Patterns
-- **Inline page-payload struct:** `AddressPageData{*CommonPageData, Data, Type, CRLFDownload, Pages, FiatBalance interface{}}` — the project's standard wrapper around a `dbtypes.*Info` core. `FiatBalance` is currently always `nil` (commented `TODO: Remove once frontend is updated for multi-coin support`).
-- **Dual-field migration shim:** `AddressBalance` carries both the new `Coins map[uint8]*CoinBalance` (per-coin truth) and legacy flat `TotalSpent`/`TotalUnspent`/`NumSpent`/`NumUnspent` fields synced from `Coins[0]` (VAR-only). The template still reads the flat fields. Three sync points must stay in lockstep: `ReduceAddressHistory`, `AddressBalance` shortcut, and `AddressData` after the cache miss path.
-- **`?coin=` URL contract via `CoinCtx` middleware:** `?coin=N` (1-255) selects a single coin; absence or `255` means "no filter". A single sentinel `dbtypes.CoinTypeAll = 255` flows everywhere; chart pipeline collapses `CoinTypeAll → 0` (VAR) silently.
-- **Per-coin SKA accumulation:** every place that aggregates SKA atoms uses `*big.Int` + `dbtypes.BigAddSKA(acc, decimalString)` and writes back as `string` (e.g. `CoinBalance.TotalReceivedSKA`, `ChartsData.BalanceAtoms`). VAR continues to flow as `int64` atoms / `float64` coins.
-- **Shared params parser:** `parseAddressParams` is reused by HTML (`AddressPage`), XHR (`AddressTable`); coin filter comes from `middleware.GetCoinCtx(r)` — out-of-band from `parseAddressParams`. Both entry points must read both.
-- **TurboQuery URL ownership:** every UI write (chart, bin, zoom, pagination, type filter) goes through `this.query.replace(this.settings)` (history-replace, no full nav). All persisted keys must be declared with null values in `connect()`. `coin` is **not** in the null-template today.
-- **Zoom encoding:** base-36 ms timestamps `"<start>-<end>"`; `Zoom.validate` clamps silently to current data range — stale values never error.
+- **Filter-before-paginate (new invariant):** coin-filtered `AddressHistory` pulls the full per-coin row set (cache or `updateAddressRows`), filters by `r.CoinType`, *then* `SliceAddressRows`. Filtering after LIMIT/OFFSET = unreachable rows. Guarded by `db/dbtypes/coinfilter_test.go`.
+- **`?coin=` URL contract via `CoinCtx`:** `?coin=N` (1–254) selects one coin; absent/invalid/`255` ⇒ `CoinTypeAll=255` (no filter). Chart pipeline + JS `effectiveCoin()` both collapse `CoinTypeAll→0` (VAR). `coin` is now in the controller TurboQuery null-template and on `linkTemplate`.
+- **Confirmed-only balance:** the mempool accumulator block in `AddressData` was deleted; unconfirmed rows still listed (coin-filtered) but never folded into `Balance.Coins`. Unconfirmed surfaces via `NumUnconfirmed` / `NumUnconfirmedByCoin`.
+- **Per-coin SKA strings end-to-end:** `CoinBalance.Total*SKA` strings + `ChartsData.*Atoms` strings; server precomputes cumulative VAR `Balance` (int64→float64) and SKA `BalanceAtoms` (`big.Int`→string). JS uses `Number()` only for pixel positioning; legend reads original strings from `skaAtomsByTime`.
+- **`jsonMarshal` template func:** coerces `[]uint8`→`[]int` so `data-active-coins` is a JSON array, not base64; controller `JSON.parse`s it into `activeCoins`.
+- **Coin-keyed chart cache:** keys are `${chart}-${bin}-${coin}`; `drawGraph` short-circuit also compares `settings.coin`.
 
 ### Critical Constraints
-- **Backend is multi-coin; frontend renders VAR only (summary card + chart axes).** `AddressBalance.Coins` is populated end-to-end, but `address.tmpl` reads `Balance.TotalUnspent`/`Balance.TotalSpent`/`Balance.NumSpent`/`Balance.NumUnspent` (all flat-VAR fields) and labels everything `DCR`. Chart controller still emits `${series.y} DCR`, `Total (DCR)`, `Balance (DCR)`. SKA-aware payload (`ReceivedTotalSKA`, `SentTotalSKA`, `BalanceAtoms`, etc.) is delivered but unread.
-- **`?coin=` is in the URL contract for backend, not yet for the controller.** TurboQuery null-template (`address_controller.js:211-219`) does not declare `coin`. Adding a coin selector means: declare here, thread through `fetchTable`/`fetchGraphData` URL builders, and add to the `address.tmpl` container `data-` attrs.
-- **`FiatBalance` is currently always `nil`.** The `if $.FiatBalance` branch in the template never fires; the fiat row was removed pending a multi-coin price model.
-- **Dummy/zero address branch** (`AddressInfo.IsDummyAddress: true`) prevents DB timeouts on the unspendable ticket-change address. Required.
-- **Stale `?zoom=` across chart-type changes:** `changeGraph`/`changeBin` call `setGraphQuery` without resetting `settings.zoom`; URL keeps the prior chart's window, `validateZoom` silently clamps it.
-- **SKA precision in chart `amountflow` SQL — fixed in PR #263.** `selectAddressAmountFlowByAddress` now emits dual VAR/SKA `SUM` columns (`value INT8` for `coin_type = 0`; `NULLIF(ska_value,'')::numeric::text` for `coin_type > 0`), and `parseRowsSentReceived` scans both pairs — building the `*big.Int` accumulator from the text columns when `coinType > 0`. The previous bug (single `SUM(value)` truncating 1e18 SKA atoms to ~zero) is gone end-to-end on the backend. See `charts.impact.md §6.3` for the trace.
+- **Coin filter must precede LIMIT/OFFSET** (`TestCoinFilterBeforePagination`).
+- **`CoinTypeAll` must stay 255**, distinct from every real coin (`TestCoinTypeAllSentinel`).
+- **Mempool must not affect balance** — confirmed-DB only by design; don't reintroduce the deleted accumulator.
+- **Merged view has no `coin_type` predicate** — query `SelectAddressMergedView` directly with `(address,N,offset)`; the old stmt-helper route bound `coinType=0` as `LIMIT 0` → zero rows (fixed `be28442e`).
+- **SKA precision (C1):** atoms stay strings to the render boundary; never `ToCoin()`/float a displayed SKA value.
+- **Coin labels centralized (C7):** `coinSymbol` (template) / `renderCoinType` (JS); no `DCR`/`VAR` literals.
+- `AddressHistory(... txnView, coinType uint8)` — 6-site signature (DB, two Go interfaces, four mocks).
 
 ### Mutation Checklist
-When modifying the address page:
-- [ ] Touching `AddressInfo`/`AddressBalance` fields? Grep `address.tmpl`, `addressTable.tmpl` (defined in `extras.tmpl`), the three handlers in `explorerroutes.go` (`AddressPage` ~1535, `AddressTable` ~1652, `AddressListData` ~1875), DB layer (`pgblockchain.go` AddressData/AddressHistory/retrieveAddressBalance/ReduceAddressHistory), and four mocks: `cmd/dcrdata/internal/explorer/explorer_test.go`, `cmd/dcrdata/internal/api/noop_ds_test.go`, `cmd/dcrdata/internal/api/address_api_test.go`, `cmd/dcrdata/internal/api/apiroutes_test.go`.
-- [ ] Adding a per-coin field? It needs to populate from **three** code paths: `ReduceAddressHistory` (paginated row reduction), `retrieveAddressBalance` (SQL aggregate), and `AddressData`'s mempool overlay. Drop the legacy flat-field sync only when the template stops reading it.
-- [ ] New URL query key? Add a null entry in `address_controller.js:connect()` settings template (211-219) **and** decide whether it belongs in the URL builders (`makeTableUrl` ~319, `fetchGraphData` ~517). For coin-aware keys, also touch `apirouter.go` (`m.CoinCtx` middleware chain) and CSV route.
-- [ ] New chart kind or group-by bin? Match `<select>`/`<button>` `name`/`value` ↔ `apirouter.go` URL segment ↔ `fetchGraphData` URL construction.
-- [ ] Touching zoom-relevant code? Decide explicitly what `settings.zoom` means after the change (drop / project / keep) before `setGraphQuery` writes it to the URL.
-- [ ] Working on the chart `amountflow` SQL or `parseRowsSentReceived`? The dual-column SKA/VAR pattern was established by PR #263 — preserve it: VAR sums `value INT8`, SKA sums `NULLIF(ska_value,'')::numeric::text`, and the Go scan reads four columns (`receivedVAR, sentVAR uint64, receivedSKAStr, sentSKAStr string`).
-- [ ] Multi-coin frontend work? `AddressInfo.Balance.Coins` already carries the per-coin map; `ActiveCoins []uint8` carries the sorted list. Format SKA atoms as strings via `formatAtomsAsCoinString`/`skaDecimalParts`/`coinSymbol` at the template boundary, never via `ToCoin()`.
+- [ ] Change `AddressHistory` signature? Update `db/dcrpg/pgblockchain.go`, `explorer.go:105`, `apiroutes.go:58`, and mocks `noop_ds_test.go`, `explorer_test.go`, `pgblockchain_test.go`.
+- [ ] Per-coin field on `AddressInfo`/`CoinBalance`? Populate at `pgblockchain.go:2626` **and** `:2691` (both `ActiveCoins` branches) and `:2762` (`NumUnconfirmedByCoin`); confirm `retrieveAddressBalance` aggregate + the filter-before-paginate balance path.
+- [ ] New URL query key? Add to `address_controller.js` null-template (`:271-275`), `coinUrlSegment`/URL builders, `linkTemplate` (Go), and decide `CoinCtx` involvement.
+- [ ] `ChartsData` field rename? Update the matching JS string key in `amountFlowProcessor` — `omitempty` hides a mismatch (silent blank SKA chart).
+- [ ] Unconfirmed display work? Use `NumUnconfirmedByCoin`; do NOT re-fold mempool amounts into balance.
+- [ ] Merged-view query? Call `SelectAddressMergedView` directly `(address,N,offset)`; never via the coin-injecting stmt helper.
+- [ ] SKA values? `coinSymbol`/`skaDecimalParts` (template) or `renderCoinType`/`splitSkaAtomsNoTrailing` (JS); never float a displayed SKA amount.
+- [ ] `data-coin-type` attr or unconfirmed-decrement logic? Keep the SSR attr and JS string compare in lockstep.
+
+### Stale-Claim Delta (prior `a8f641f2` revision → current)
+| Prior wiki claim | Current reality |
+|---|---|
+| Frontend renders VAR only; hard-coded `DCR` | Multi-coin end-to-end; `coinSymbol`/`renderCoinType`; per-coin summary + Coin column |
+| `coin` not in TurboQuery null-template; controller not coin-aware | `coin` in null-template; `changeCoin`/`coinUrlSegment`/`effectiveCoin`; coin-keyed cache |
+| `FiatBalance` always nil, branch never fires | Field + template branch **deleted** |
+| Mempool overlay folds into balance totals | Removed; balance confirmed-only; mempool via `NumUnconfirmedByCoin` |
+| `AddressHistory(... txnView)` | `AddressHistory(... txnView, coinType uint8)` |
+| (not documented) | merged-view LIMIT-0 fix + filter-before-paginate invariant + regression tests |
+| Chart `amountflow` SKA SQL fix (PR #263) | Still valid; JS chart pipeline now coin-keyed + server-precomputed cumulative balance |
 
 See also:
-- /wiki/code-analysis/charts/flow.compact.md (shares-pattern-with: TurboQuery + Zoom validation; per-coin chart endpoints)
-- /wiki/code-analysis/transaction/flow.compact.md (depends-on: address tx list rendering)
-- /wiki/code-analysis/address/summary.impact.md (depends-on: summary card multi-coin migration — last unconverted surface)
-- /wiki/code-analysis/address/transactions.impact.md (depends-on: per-tx Coin column / coin filter UX)
-- /wiki/code-analysis/address/charts.impact.md (depends-on: chart `?coin=` URL wiring; SKA SQL precision fix in PR #263)
-- /wiki/core/constraints.md#C1 (depends-on: float64-vs-string precision — backend honored, template + controller still violate for SKA)
-- /wiki/core/constraints.md#C7 (depends-on: centralised coin-type label rendering — `DCR` literals still hard-coded in `address.tmpl` and `address_controller.js`)
+- /wiki/code-analysis/address/flow.full.md (Sections 1–8)
+- /wiki/code-analysis/charts/flow.compact.md (shares-pattern-with: TurboQuery URL ownership; per-coin chart endpoints; SKA atom strings)
+- /wiki/code-analysis/transaction/flow.compact.md (depends-on: address tx-list / Coin-column rendering)
+- /wiki/code-analysis/address/patterns.md (shares-pattern-with: CoinCtx contract, coin-aware aggregation — **reconcile via `Consolidate: address`**)
+- /wiki/code-analysis/address/{summary,transactions,charts}.impact.md (**describe now-completed/overturned migration — stale, reconcile next**)
+- /wiki/core/constraints.md#C1, #C7 (now honored in template + controller)

--- a/wiki/code-analysis/address/flow.compact.md
+++ b/wiki/code-analysis/address/flow.compact.md
@@ -16,6 +16,8 @@ chi `/address/{addr}` → `AddressPathCtx` → `AddressPage` + `middleware.GetCo
 - **`CoinTypeAll` must stay 255**, distinct from every real coin (`TestCoinTypeAllSentinel`). Any in-memory `if r.CoinType == coinType` row filter must short-circuit on `CoinTypeAll` (return all rows) — `AddressCache.Rows` / `AddressRowsCompact` do; missing this empties the no-`?coin=` CSV (`TestAddressCacheRows_CoinTypeAll`).
 - **Mempool must not affect balance** — confirmed-DB only by design; don't reintroduce the deleted accumulator.
 - **Merged view has no `coin_type` predicate** — query `SelectAddressMergedView` directly with `(address,N,offset)`; the old stmt-helper route bound `coinType=0` as `LIMIT 0` → zero rows (fixed `be28442e`).
+- **CSV download is a deliberate full export.** `/download/address/io/{addr}` link (`address.tmpl:327`) is static — no `?coin=`/`?txntype=`; `addressIoCsv` always pulls `AddressRowsCompact(..., CoinTypeAll)` (full, non-merged, all-coin). On-page Type/Coin filters scoping it was explicitly declined; don't "fix" it. Rows still carry correct per-row coin/amount.
+- **Merged rows carry coin + SKA.** `AddressRowMerged{CoinType, SKAAtomsCredit/Debit *big.Int}`; `Merge*` builders fold via `add()`, `UncompactMergedRows` emits `CoinType`+`SKAValueStr()`. Fixes "Merged debits + SKA1 → VAR" bug. Guarded by `TestMergedRowsPreserveCoinAndSKA`/`TestMergedCompactMixedCoins`. Supersedes the VAR-only-merged assumption.
 - **SKA precision (C1):** atoms stay strings to the render boundary; never `ToCoin()`/float a displayed SKA value.
 - **Coin labels centralized (C7):** `coinSymbol` (template) / `renderCoinType` (JS); no `DCR`/`VAR` literals.
 - `AddressHistory(... txnView, coinType uint8)` — 6-site signature (DB, two Go interfaces, four mocks).

--- a/wiki/code-analysis/address/flow.full.md
+++ b/wiki/code-analysis/address/flow.full.md
@@ -44,6 +44,13 @@ and the transaction table; charts are per-coin. Mempool/unconfirmed activity is
   ├─ XHR table:  /addresstable/{addr}?txntype=…&n=…&start=…&coin=N
   │     → AddressTable → same AddressData path; linkTemplate also &coin=N
   │
+  ├─ CSV download: /download/address/io/{addr}[/win]   (STATIC href — carries NO ?coin=, NO ?txntype=)
+  │     → addressIoCsv → GetCoinCtx(r) ⇒ always CoinTypeAll (link never sets ?coin=)
+  │       → AddressRowsCompact(ctx, addr, CoinTypeAll) ⇒ FULL non-merged, all-coin row set
+  │     → streamed CSV. By design the on-page Type/Coin filters do NOT scope the
+  │       download — it is a complete raw export. Rows still render the correct
+  │       per-row coin/amount (compact rows carry CoinType + SKAValue).
+  │
   └─ Charts:     /api/address/{addr}/{amountflow|types}/{bin}?coin=N
         → re.With(m.ChartGroupingCtx, m.CoinCtx) → getAddressTx*Data → GetCoinCtx(r)
         → TxHistoryData(...coinType) → retrieveTxHistoryByAmountFlow(...coinType)
@@ -244,6 +251,21 @@ balanceSKA` → `items.BalanceAtoms`.
    helper (LIMIT-0 trap).
 6. **Centralized coin labels (core constraint C7).** Use `coinSymbol`
    (template) / `renderCoinType` (JS); no hard-coded `DCR`/`VAR` literals.
+7. **CSV download is a deliberate full, non-merged, all-coin export.** The
+   `address.tmpl:327` link is static — it carries no `?coin=` / `?txntype=`,
+   and the controller never rewrites it. `addressIoCsv` reads `GetCoinCtx(r)`
+   (so a future link *could* scope by coin) but never reads `txntype` and
+   always calls `AddressRowsCompact`. The on-page Type/Coin filters scoping the
+   download was considered and explicitly declined; it is a raw data dump, not
+   a "what you see" export. Don't "fix" the unfiltered behavior as a bug.
+8. **Merged rows carry their coin type + SKA atoms.** `AddressRowMerged` has
+   `CoinType` and `SKAAtomsCredit/Debit (*big.Int)`; the four `Merge*` builders
+   fold each constituent via `add()` and `UncompactMergedRows` emits
+   `CoinType` + `SKAValueStr()`. A tx is single-coin, so a tx-hash-keyed merged
+   row is unambiguous. Guarded by `TestMergedRowsPreserveCoinAndSKA` /
+   `TestMergedCompactMixedCoins`. (This supersedes the older assumption that
+   merged rows were VAR-only — that produced the "Merged debits + SKA1 shows
+   VAR" bug.)
 
 ---
 
@@ -265,7 +287,9 @@ When modifying *the address coin-filter / multi-coin path*, check:
 
 **Serialization boundaries**
 - `ChartsData` json tags; `data-active-coins` via `jsonMarshal`;
-  `&coin=N` on `linkTemplate` (HTML + table) and all JS URL builders + CSV.
+  `&coin=N` on `linkTemplate` (HTML + table) and all JS URL builders. The CSV
+  download link is **static** and intentionally carries neither `&coin=N` nor
+  `&txntype=` (see Constraint 7) — do not list it as a coin-URL builder.
 
 **Rendering layers**
 - Summary card, Coin column, chart legend/ylabel, coin selectors, unconfirmed
@@ -297,6 +321,8 @@ When modifying *the address coin-filter / multi-coin path*, check:
 - Trusting the prior wiki's "frontend VAR-only / `coin` not in null-template"
   — both now false.
 - Populating only one of the two `ActiveCoins` assignment branches.
+- "Fixing" the CSV download so it respects the page Type/Coin filters — the
+  unfiltered full export is intentional (Constraint 7), not an oversight.
 
 ---
 

--- a/wiki/code-analysis/address/flow.full.md
+++ b/wiki/code-analysis/address/flow.full.md
@@ -1,171 +1,334 @@
-### 1. Overview
-Tracing the data flow that renders the address page (`/address/{address}`), powers its chart endpoints, persists chart/pagination state in the URL via TurboQuery, and threads the new `?coin=N` filter through every read path (HTML, XHR, chart API, CSV). Captures (a) the multi-coin backend shape that landed in commits `4ebe5cf0…7a08c3d3` (PR #258), (b) the dual-field migration shim the frontend still depends on, (c) the stale-zoom-param failure mode in the chart controller, and (d) the SKA-precision fix in the chart `amountflow` SQL (PR #263, commit `49953185`).
+# Address Page — Full Flow
 
-### 2. End-to-End Data Flow
-chi router (`main.go`) → `AddressPathCtx` middleware → `explorerUI.AddressPage` → `parseAddressParams` + `middleware.GetCoinCtx` → `AddressListData(ctx, addr, txnType, N, offset, coinType)` → `dataSource.AddressData` (PG: `AddressHistory` for paginated rows + `*AddressBalance` with `Coins map[uint8]*CoinBalance` + `retrieveAddressCoinTypes` for `ActiveCoins` + `mergedTxnCount`/`CountTransactions` + `FillAddressTransactions` + `mempool.UnconfirmedTxnsForAddress` → per-coin overlay onto `Balance.Coins`) → `templates.exec("address", AddressPageData)` → `views/address.tmpl` → browser → `address` Stimulus controller (`TurboQuery` for URL state, fetches `/api/address/{addr}/{types|amountflow}/{bin}` for charts and `/addresstable/{addr}?...` for table refresh).
+> **Code-grounded as of `HEAD` = `1b670255`** (PR #265 + PR #266 + the `db/dcrpg`
+> coin-filter series, merged 2026-05-14/15). This supersedes the prior revision
+> written at `a8f641f2` (2026-05-13), whose central thesis — "backend multi-coin,
+> frontend renders VAR only, `?coin=` not wired in the controller" — is now false.
+> See §9 (`flow.compact.md`) for the stale-claim delta table.
 
-### 3. Per-Layer Breakdown
-- **Location:** [cmd/dcrdata/main.go:768-769](cmd/dcrdata/main.go#L768-L769)
-  - **Data Structures:** chi route, `AddressPathCtx` puts address into `ctxAddress`.
-  - **Transformations:** Two routes share the same middleware — `/address/{address}` → `AddressPage`, `/addresstable/{address}` → `AddressTable`.
+---
 
-- **Location:** [cmd/dcrdata/internal/middleware/apimiddleware.go:818-842](cmd/dcrdata/internal/middleware/apimiddleware.go#L818-L842)
-  - **Data Structures:** `ctxCoin` context key, `uint8` value.
-  - **Transformations:** `CoinCtx` parses `?coin=N` (1-255). Missing/invalid → `dbtypes.CoinTypeAll = 255` sentinel ([db/dbtypes/types.go:47-49](db/dbtypes/types.go#L47-L49)). `GetCoinCtx(r)` returns the value or `CoinTypeAll` if absent.
+## Section 1 — Overview
 
-- **Location:** [cmd/dcrdata/internal/explorer/explorerroutes.go:1535-1648](cmd/dcrdata/internal/explorer/explorerroutes.go#L1535-L1648)
-  - **Data Structures:** Inline `AddressPageData{*CommonPageData, Data: *dbtypes.AddressInfo, Type txhelpers.AddressType, CRLFDownload bool, Pages []pageNumber, FiatBalance interface{}}` (1539-1546). `FiatBalance` is `interface{}` and **always set to `nil`** at 1633 — the fiat row in the template never fires today.
-  - **Transformations:** `parseAddressParams` (1549) extracts `address`, `txntype`, `n`, `start`; coin comes separately via `middleware.GetCoinCtx(r)` (1605, passed into `AddressListData`). Zero/dummy address branch (1593-1603) short-circuits DB reads and builds an empty `AddressBalance` with `Coins: nil` (initialized later in the template path). `calcPages` (1632) builds pagination. `templates.exec("address", pageData)` (1635).
-  - **Note:** Inline payload's `FiatBalance interface{}` and the `nil` assignment carry `TODO: Remove once frontend is updated for multi-coin support`. The `if $.FiatBalance` branch in `address.tmpl:54` is therefore dead code today.
+This traces the **per-coin filter and multi-coin rendering path** for `/address/{addr}`:
+`?coin=N` → `CoinCtx` middleware → `AddressHistory(... coinType)` →
+per-coin balance + coin-filtered paginated rows → `address.tmpl` / `extras.tmpl`
+→ `address_controller.js` (chart + table coin selectors, SKA-string legend).
 
-- **Location:** [cmd/dcrdata/internal/explorer/explorerroutes.go:1652-1704](cmd/dcrdata/internal/explorer/explorerroutes.go#L1652-L1704)
-  - **Data Structures:** XHR response struct `{TxnCount int64, HTML string, Pages []pageNumber}`.
-  - **Transformations:** Same `parseAddressParams` + `middleware.GetCoinCtx(r)` (1656, 1663). Calls `AddressListData` (1663) and renders only the `addresstable` template fragment (1682-1686). Returns JSON `{tx_count: addrData.TxnCount + addrData.NumUnconfirmed, html, pages}`.
+The address page is now **multi-coin end-to-end**: VAR (coin 0) and SKA{n}
+(coins 1–254) are filtered, aggregated, and rendered on both the summary card
+and the transaction table; charts are per-coin. Mempool/unconfirmed activity is
+**confirmed-only for balance** — unconfirmed counts surface separately.
 
-- **Location:** [cmd/dcrdata/internal/explorer/explorerroutes.go:1875-1889](cmd/dcrdata/internal/explorer/explorerroutes.go#L1875-L1889)
-  - **Data Structures:** `AddressListData(ctx, addr, txnType, N, offset, coinType uint8) (*dbtypes.AddressInfo, error)`.
-  - **Transformations:** Thin pass-through to `dataSource.AddressData`. The `coinType` arg is the only addition over the legacy signature.
+---
 
-- **Location:** [db/dcrpg/pgblockchain.go:2533-2917](db/dcrpg/pgblockchain.go#L2533-L2917) (`AddressData`)
-  - **Data Structures:** `*dbtypes.AddressInfo` (`db/dbtypes/types.go:2322`), `*dbtypes.AddressBalance` (`types.go:2392`), `*dbtypes.CoinBalance` (`types.go:2379`).
-  - **Transformations:**
-    1. `AddressHistory` (2547) returns confirmed rows + balance (with `Coins` map populated by either the shortcut path through `ReduceAddressHistory` or the cache miss path through `retrieveAddressBalance`).
-    2. `retrieveAddressCoinTypes` (2553) → SQL `SelectAddressCoinTypes` → `ActiveCoins []uint8` sorted.
-    3. `ReduceAddressHistory` builds the skeleton (2581) — note this populates `Balance` from the **paginated row slice only**; the code at 2601 explicitly **overwrites** with the full `balance` from `AddressHistory` to avoid wrong totals on non-first pages (commit `961bbb0c`).
-    4. Legacy flat-field sync from `Coins[0]` (2610-2615): `balance.TotalSpent = varBal.TotalSpent`, etc. Same sync repeats at 2512-2519 inside `AddressHistory`.
-    5. `KnownTransactions/KnownFundingTxns/KnownSpendingTxns` derived from `Balance.Coins[coinType]` (or summed across all coins when `coinType == CoinTypeAll`) at 2618-2630.
-    6. `TxnCount`: `mergedTxnCount(ctx, addr, txnType, coinType)` for merged views; for `AddrTxnAll` non-merged, uses `CountTransactions(ctx, addr, txnType, coinType)` (real DB count, not balance-derived — commit `7a08c3d3`) with a fallback to `KnownFundingTxns + KnownSpendingTxns`.
-    7. `FillAddressTransactions` (2677) back-fills `Size`, `FormattedSize`, `Total`, `Time`, `Confirmations`, `MatchedTxIndex`.
-    8. `mp.UnconfirmedTxnsForAddress(address)` (2687) returns `(*AddressOutpoints, map[uint8]int64, error)`. The per-coin map populates `NumUnconfirmedByCoin` (2701) and totals into `NumUnconfirmed` (2697).
-    9. Mempool overlay (2712-2871): coin-aware. Funding-side reads `coinType` from `fundingTx.CoinInfo[f.Index]`; spending-side reads `f.CoinType`. Per-coin SKA accumulators (`skaReceivedByType`, `skaSpentByType`) of `*big.Int`, written back to `Balance.Coins[ct].TotalReceivedSKA / TotalSpentSKA / TotalUnspentSKA` (2887-2911).
+## Section 2 — End-to-End Data Flow
 
-- **Location:** [db/dbtypes/types.go:2456-2613](db/dbtypes/types.go#L2456-L2613) (`ReduceAddressHistory`)
-  - **Data Structures:** `AddressInfo`, `AddressBalance{Coins, TotalInputs, TotalOutputs, FromStake, ToStake, +legacy flat fields}`, `CoinBalance{NumSpent, NumUnspent, TotalSpent/TotalUnspent (VAR int64), TotalSpentSKA/TotalUnspentSKA/TotalReceivedSKA (string)}`.
-  - **Transformations:** Walks `addrHist`, switches on `coinType` per row. VAR rows: `receivedVAR += value`, `tx.ReceivedTotal = ToCoin(value)`. SKA rows: `bigAddSKA(receivedSKAByCoin[ct], addrOut.SKAValue)` and `tx.ReceivedTotalSKA = addrOut.SKAValue`. After the loop, materializes `*big.Int` accumulators into `CoinBalance.Total*SKA` strings (2568-2588). Also produces `ActiveCoins` from `coins` map keys, sorted ascending (2593-2597).
-  - **Critical:** Legacy flat-field sync at 2557-2562: `balance.TotalUnspent = coins[0].TotalUnspent`, etc. **Coins[0] only.** If only SKA activity exists, these fields stay at zero.
+```
+?coin=N ─→ m.CoinCtx ─→ GetCoinCtx(r): uint8   (absent|invalid|255 ⇒ CoinTypeAll=255 = no filter; 1–254 = SKA coin)
+  │
+  ├─ HTML page:  AddressPage (explorerroutes.go)
+  │     → AddressData(ctx, addr, N, off, txnType, coinType)        (pgblockchain.go)
+  │       → AddressHistory(ctx, addr, N, off, txnView, coinType)
+  │           ├─ coinType == CoinTypeAll → existing all-coin cache/SQL LIMIT/OFFSET path
+  │           └─ coinType != CoinTypeAll → load FULL per-coin rows (cache or updateAddressRows),
+  │                                        FILTER by r.CoinType, THEN SliceAddressRows,
+  │                                        + always full AddressBalance (Coins map complete)
+  │       → mempool overlay: append unconfirmed rows (coin-filtered), DO NOT touch balance
+  │       → addrData{ Balance.Coins, ActiveCoins, NumUnconfirmed, NumUnconfirmedByCoin }
+  │     → AddressPageData → templates.exec("address")
+  │       → address.tmpl: range .ActiveCoins over Balance.Coins; data-active-coins='[…]' (jsonMarshal)
+  │       → extras.tmpl:  per-row Coin column + SKA/VAR value branch
+  │     → linkTemplate gets &coin=N appended when filtered
+  │
+  ├─ XHR table:  /addresstable/{addr}?txntype=…&n=…&start=…&coin=N
+  │     → AddressTable → same AddressData path; linkTemplate also &coin=N
+  │
+  └─ Charts:     /api/address/{addr}/{amountflow|types}/{bin}?coin=N
+        → re.With(m.ChartGroupingCtx, m.CoinCtx) → getAddressTx*Data → GetCoinCtx(r)
+        → TxHistoryData(...coinType) → retrieveTxHistoryByAmountFlow(...coinType)
+          → MakeSelectAddressAmountFlowByAddress  (dual VAR INT8 / SKA numeric::text columns)
+          → parseRowsSentReceived(rows, coinType) with big.Int cumulative balance accumulator
+        → ChartsData{ Received,Sent,Net,Balance (VAR) | ReceivedAtoms,SentAtoms,NetAtoms,BalanceAtoms (SKA) }
+        → address_controller.js: amountFlowProcessor(data, effectiveCoin(), skaAtomsByTime)
+```
 
-- **Location:** [db/dbtypes/types.go:2252-2273](db/dbtypes/types.go#L2252-L2273) (`AddressTx`)
-  - **Data Structures:** Adds `ReceivedTotalSKA string`, `SentTotalSKA string` (2264-2265), `CoinType uint8`, `SKAValue string` (2271-2272) alongside the existing `ReceivedTotal float64` / `SentTotal float64`.
-  - **Note:** Template (`extras.tmpl:251-284`) still reads only the float fields.
+---
 
-- **Location:** [db/dcrpg/queries.go:1472-1610](db/dcrpg/queries.go#L1472-L1610) (`retrieveAddressBalance`)
-  - **Data Structures:** Same `AddressBalance` shape; SQL is `SelectAddressSpentUnspentCountAndValue`.
-  - **Transformations:** SQL groups by `(tx_type=0, coin_type, is_funding, matching_tx_hash IS NULL)` and emits both `SUM(value)` (VAR atoms) and `COALESCE(SUM(NULLIF(ska_value, '')::numeric), 0)::text AS ska_total` ([addrstmts.go:234-247](db/dcrpg/internal/addrstmts.go#L234-L247)). Go-side: per-row `Scan(&isRegular, &coinType, &count, &totalValue, &skaTotal, &isFunding, &noMatchingTx)`. VAR (`coinType == 0`) goes to `CoinBalance.TotalSpent/TotalUnspent int64`; SKA accumulates into local `skaSpent`/`skaUnspent` `map[uint8]*big.Int`, then materializes into `CoinBalance.Total*SKA` strings (1570+).
+## Section 3 — Per-Layer Breakdown
 
-- **Location:** [db/dcrpg/pgblockchain.go:3323-3397](db/dcrpg/pgblockchain.go#L3323-L3397) (`TxHistoryData`)
-  - **Data Structures:** `TxHistoryData(ctx, address, addrChart dbtypes.HistoryChart, chartGroupings dbtypes.TimeBasedGrouping, coinType uint8) (*dbtypes.ChartsData, error)`.
-  - **Transformations:** Default-coin collapse: `if coinType == CoinTypeAll { coinType = 0 }` (3328-3330) — charts are inherently per-coin. Cache lookup with coin-keyed key: `AddressCache.HistoryChart(addr, chart, grouping, coinType)` (3343). Per-address `CacheLocks.bal.TryLock` singleflight (3354). Dispatch to `retrieveTxHistoryByType` ([queries.go:2054-2089](db/dcrpg/queries.go#L2054-L2089)) or `retrieveTxHistoryByAmountFlow` ([queries.go:2091-2102](db/dcrpg/queries.go#L2091-L2102)). Store result keyed by coin: `StoreHistoryChart(addr, chart, grouping, coinType, cd, blockID)` (3394).
+### 3.1 Coin filter (source of truth) — *unchanged*
 
-- **Location:** [db/cache/addresscache.go:375-486,1143-1199](db/cache/addresscache.go#L375-L1199) (`AddressCache.HistoryChart` / `StoreHistoryChart`)
-  - **Data Structures:** `TxHistory{TypeByInterval [NumIntervals]map[uint8]*ChartsData, AmtFlowByInterval [NumIntervals]map[uint8]*ChartsData}` (378-379) — the coin-type map is the **inner** key, allowing per-coin caching at the same (address, interval).
-  - **Transformations:** `(d *AddressCacheItem).HistoryChart` (461) returns `m[coinType]` if present; `StoreHistoryChart` (1143) lazily allocates the inner map then writes `m[coinType] = cd`.
+- **`db/dbtypes/types.go:49`** — `const CoinTypeAll = uint8(255)`.
+- **`cmd/dcrdata/internal/middleware/apimiddleware.go:821–842`** — `CoinCtx`
+  parses `?coin=` to `uint8`; absent/invalid/`255` ⇒ `CoinTypeAll`; `1–254` ⇒
+  SKA coin; stored under `ctxCoin`. `GetCoinCtx(r)` returns it (default
+  `CoinTypeAll`).
+- Guarded by **`db/dbtypes/coinfilter_test.go::TestCoinTypeAllSentinel`** (new):
+  `CoinTypeAll` must stay `255` and collide with no real coin index.
 
-- **Location:** [db/dcrpg/queries.go:4289-4331](db/dcrpg/queries.go#L4289-L4331) (`parseRowsSentReceived`)
-  - **Data Structures:** Populates `dbtypes.ChartsData` ([types.go:2041-2057](db/dbtypes/types.go#L2041-L2057)) including `BalanceAtoms []string`, `ReceivedAtoms []string`, `SentAtoms []string`, `NetAtoms []string` (new SKA-string parallel fields).
-  - **Transformations:** Scans four sum columns from `selectAddressAmountFlowByAddress`: `receivedVAR, sentVAR uint64` (`value INT8` partitioned by `coin_type = 0` / `is_funding`) and `receivedSKAStr, sentSKAStr string` (`NULLIF(ska_value,'')::numeric::text` partitioned by `coin_type > 0` / `is_funding`). VAR branch (`coinType == 0`): `toCoin = float64(amt) / 1e8` over `receivedVAR`/`sentVAR`, populate `Received/Sent/Net/Balance []float64`. SKA branch: `new(big.Int).SetString(*SKAStr, 10)` for per-row deltas, `*big.Int` accumulators emit `*Atoms []string`.
-  - **✅ SKA precision fix (PR #263, commit `49953185`):** previously the row scanned only `Scan(&blockTime, &received, &sent uint64)` and reused the VAR `uint64`s for SKA — sending the truncated `addresses.value INT8` (which stores `vout.Value` regardless of coin type at [queries.go:2280](db/dcrpg/queries.go#L2280)) through `*big.Int.SetUint64`. SKA atoms (1e18 scale) live in `ska_value TEXT` and were ignored by the old single-pair SUM, so `Received/Sent/Net/Balance Atoms` were zeroed for every SKA coin. The fix added two text columns to the SQL and a four-column `Scan`; the SKA branch now builds `*big.Int` from `SetString(receivedSKAStr, 10)` etc. `COALESCE(..., 0)::text` in the SQL guarantees a valid decimal string. See `charts.impact.md §6.3` for the full before/after.
+### 3.2 DB layer — the major behavioral change (`db/dcrpg/pgblockchain.go`)
 
-- **Location:** [cmd/dcrdata/internal/api/apirouter.go:178-200](cmd/dcrdata/internal/api/apirouter.go#L178-L200) + [apiroutes.go:1827-1896](cmd/dcrdata/internal/api/apiroutes.go#L1827-L1896)
-  - **Data Structures:** `*dbtypes.ChartsData`.
-  - **Transformations:** Routes are scoped by `m.AddressPathCtxN(1)`; chart routes additionally pass through `m.ChartGroupingCtx, m.CoinCtx` (185-186). Handlers `getAddressTxTypesData` (1827) and `getAddressTxAmountFlowData` (1864) call `DataSource.TxHistoryData(ctx, address, TxsType|AmountFlow, interval, coinType)`.
-  - **Data interface:** `DataSource.TxHistoryData(... coinType uint8)`, `DataSource.AddressRowsCompact(... coinType uint8)` ([apiroutes.go:64-71](cmd/dcrdata/internal/api/apiroutes.go#L64-L71)).
+**`AddressHistory` signature** now `(... txnView dbtypes.AddrTxnViewType, coinType uint8)`
+(`:2419-2420`). New filter-before-paginate branch (`:~2427-2480`):
 
-- **Location:** [cmd/dcrdata/internal/api/apirouter.go:313-320](cmd/dcrdata/internal/api/apirouter.go#L313-L320) + [apiroutes.go:1728-1825](cmd/dcrdata/internal/api/apiroutes.go#L1728-L1825) (CSV download)
-  - **Data Structures:** `[]*dbtypes.AddressRowCompact` (with `CoinType uint8` field at [types.go:1314](db/dbtypes/types.go#L1314)).
-  - **Transformations:** `/download/address/io/{address}` and `/download/address/io/{address}/win` are wrapped in `m.CoinCtx` (apirouter.go:318). Handler calls `DataSource.AddressRowsCompact(ctx, address, coinType)` ([pgblockchain.go:2266-2310](db/dcrpg/pgblockchain.go#L2266-L2310)) which filters in-memory by `r.CoinType == coinType` (2303). CSV header: `tx_hash, direction, io_index, valid_mainchain, coin_type, amount, time_stamp, tx_type, matching_tx_hash` (1776-1777). Amount column: VAR → `strconv.FormatFloat(dcrutil.Amount(r.Value).ToCoin(), 'f', 8, 64)`; SKA → `dbtypes.FormatSKAPerVAR(r.SKAValue, r.CoinType)` (1803-1807). **Note:** SKA value is rendered as a human-readable string like `"1.23 SKA1"`, not raw atoms.
+- When `coinType != CoinTypeAll`: get the **full per-coin row set** from
+  `pgb.AddressCache.Rows(address, coinType)` (uncompacted) or, on cache miss,
+  from `updateAddressRows(ctx, address)` filtered by `r.CoinType == coinType`;
+  **then** `dbtypes.SliceAddressRows(fullRows, N, offset, txnView)`.
+  *Filtering happens before LIMIT/OFFSET — never after.*
+- Balance always comes from `pgb.AddressBalance(ctx, address)` (full per-coin),
+  never the row-derived shortcut, so `Balance.Coins` stays complete for the
+  coin selector even under a filter. Legacy flat fields are still synced from
+  `Coins[0]` for back-compat but the template no longer reads them.
+- `CoinTypeAll` path is the prior all-coin cache/SQL path, unchanged.
 
-- **Location:** [cmd/dcrdata/views/address.tmpl](cmd/dcrdata/views/address.tmpl)
-  - **Data Structures:** All `.Data.*` fields are public fields on `dbtypes.AddressInfo`/`AddressBalance`. Pagination links use `?start=`, `?n=`, `?txntype=` (lines 202, 211, 234, 248). **No `?coin=` in any server-rendered URL today.**
-  - **Transformations:** Summary card reads `.Balance.TotalUnspent`/`.Balance.TotalSpent`/`.Balance.NumSpent`/`.Balance.NumUnspent` (lines 15, 48, 63, 70, 77, 83) — the legacy flat fields, kept in sync from `Coins[0]`. Helpers: `amountAsDecimalParts`, `toFloat64Amount` (`dcrutil.Amount.ToCoin() float64`) — VAR-only. Coin label is hard-coded `DCR` at 48, 50, 64, 66, 77, 79. `if $.FiatBalance` block (54-56) is unreachable because handler sets `FiatBalance: nil`. Container `data-address-balance="{{toFloat64Amount .Balance.TotalUnspent}}"` (15) is read by the controller into `ctrl.balance` (230) and unused.
+Codified by **`db/dbtypes/coinfilter_test.go::TestCoinFilterBeforePagination`**
+(new, DB-free): filter-after-paginate leaves coin rows unreachable on page 0.
 
-- **Location:** [cmd/dcrdata/views/extras.tmpl:210-315](cmd/dcrdata/views/extras.tmpl#L210-L315) (`addressTable`)
-  - **Data Structures:** Per-row reads `AddressTx.{TxID, TxType, MergedTxnCount, SentTotal, ReceivedTotal, IsFunding, MatchedTx, MatchedTxIndex, Time, BlockHeight, Confirmations, FormattedSize}`. Headers hard-code `Credit VAR`/`Debit VAR` (222, 227, 230, 231, 233, 235, 236).
-  - **Transformations:** Amounts via `float64AsDecimalParts .SentTotal 8 false` / `.ReceivedTotal 8 false`. **Does not read `.ReceivedTotalSKA`/`.SentTotalSKA`/`.CoinType`/`.SKAValue`.** SKA rows therefore render `0` in the amount cell, except for the `if eq .SentTotal 0.0` debit branch (277) which forces "sstxcommitment" — false-positive for SKA debits.
+**`AddressData` mempool overlay rewritten** (`:~2740-2910`): unconfirmed
+funding/spending rows are appended to `addrData.Transactions` **only when
+`coinTypeFilter == CoinTypeAll || == coinType`**, and the entire
+`received/sent/numReceived/numSent/skaReceivedByType/skaSpentByType`
+accumulator block was **deleted**. Balance is now purely confirmed-DB.
+Unconfirmed activity surfaces only via `NumUnconfirmed` /
+`NumUnconfirmedByCoin` (code comment after the spending loop states this is by
+design — commit `6e92df4c`).
 
-- **Location:** [cmd/dcrdata/public/js/controllers/address_controller.js](cmd/dcrdata/public/js/controllers/address_controller.js)
-  - **Data Structures:** `this.settings` (chart, zoom, bin, flow, n, start, txntype — see line 211-219) backed by `TurboQuery`. `coin` is **not** in the null-template.
-  - **Transformations:** `connect()` (194) seeds `settings` from URL via `query.update` (233). `drawGraph()` (473) short-circuits zoom-only changes (482-488); otherwise `fetchGraphData` (496) hits `/api/address/${addr}/${chartKey}/${bin}` (517-521) with `chartKey = chart === 'balance' ? 'amountflow' : chart`. **No `?coin=` is appended.** `popChartCache → validateZoom` (588 → 610) calls `Zoom.validate` (612) and `setZoom` (613). All URL writes flow through `query.replace(this.settings)` from `setGraphQuery` (635), `setZoom` (683), Dygraph callbacks (738, 749), and `fetchTable` (361). Legend formatter still emits `${series.y} DCR` (84); ylabels `Total (DCR)` (130) / `Balance (DCR)` (140). `amountFlowProcessor` (30-53) integrates `d.net[i]` as JS `Number` — float-only; ignores `BalanceAtoms`/`ReceivedAtoms`/`SentAtoms`/`NetAtoms` in the response.
+`AddressHistoryAll`, `addressInfo`, retry recursion, and `AddressTransactionsAll`
+now pass `dbtypes.CoinTypeAll` explicitly.
 
-### 4. Cross-Layer Dependencies
-- **Template ↔ struct:** every `.Data.*` reference in `views/address.tmpl` and the `addressTable` template in `views/extras.tmpl` is a public field on `dbtypes.AddressInfo`/`AddressBalance`/`AddressTx`; renames break template parsing at runtime.
-- **Dual-field migration shim:** the template reads `Balance.TotalUnspent`/etc. (flat-VAR) but the truth is in `Balance.Coins[*]`. Three Go-side sync points must stay in lockstep:
-  1. `ReduceAddressHistory` ([types.go:2557-2562](db/dbtypes/types.go#L2557-L2562)) — paginated shortcut.
-  2. `AddressHistory` cache-miss path ([pgblockchain.go:2512-2519](db/dcrpg/pgblockchain.go#L2512-L2519)).
-  3. `AddressData` after full balance overwrite ([pgblockchain.go:2610-2615](db/dcrpg/pgblockchain.go#L2610-L2615)).
-- **Pagination URL contract:** `?start=`, `?n=`, `?txntype=` are produced by both server-rendered links (template) and client-side `fetchTable`; both must match `parseAddressParams` keys. `coin` is **only** in the server-side middleware contract; no client-side write today.
-- **Chart URL contract:** `<select>` option `value` (`balance`/`types`/`amountflow`, template 128-130) ↔ `apirouter.go:185-186` URL segment ↔ `address_controller.js:fetchGraphData` (517-521). Renaming silently 404s. `coin=` is a new optional segment but the controller does not emit it.
-- **Shared params parser + middleware:** `AddressPage` (1535) and `AddressTable` (1652) both call `parseAddressParams` and `middleware.GetCoinCtx`; drift between server-rendered initial table and XHR-refreshed table is a class of subtle bugs.
-- **CoinType context propagation:** `CoinTypeAll = 255` flows uniformly from `CoinCtx` → handler → `AddressListData` → `AddressData` → coin-aware SQL (`countMerged*`, `retrieveAddressTxns`, `nonMergedTxnCount`) where each function maps `CoinTypeAll` to the all-coin SQL variant (e.g. `SelectAddressesMergedCountAll` vs `SelectAddressesMergedCount`). For chart endpoints, `CoinTypeAll → 0` (VAR) — different semantics; do not confuse.
-- **Cache key co-dependency:** `AddressCache.HistoryChart` is keyed by `(address, HistoryChart, TimeBasedGrouping, coinType)`. Cache freshness invalidation (`FreshenAddressCaches`) is still global per-address — a reorg invalidates all coin types together.
-- **Co-mounted controllers:** `data-controller="address newblock"` (template line 11) — `newblock` mutates `data-newblock-target="confirmations"` cells; `address._confirmMempoolTxs` (774) walks `pendingTargets` and decrements `numUnconfirmedTargets`. The address controller's `numUnconfirmed` decrement is **single-counter** today; the backend's `NumUnconfirmedByCoin` map is delivered but unread.
+**`retrieveAddressMergedTxns` rewritten** (`db/dcrpg/queries.go:~1890`): now
+`db.QueryContext(ctx, internal.SelectAddressMergedView, address, N, offset)` +
+`scanAddressMergedRows`. Previously routed through `retrieveAddressTxnsStmt(... 0)`,
+which bound `coinType=0` as `$2` = **LIMIT 0** on the merged statement (which has
+no `coin_type` predicate and uses `$2` for LIMIT) → silently zero rows
+(the "merged-view LIMIT-0 bug", commit `be28442e`). Merged view aggregates
+**all coin types**; it must be queried directly.
 
-### 5. Critical Constraints
-- **Backend multi-coin / frontend single-coin asymmetry:** `AddressInfo.Balance.Coins`, `AddressInfo.ActiveCoins`, `AddressTx.ReceivedTotalSKA`/`SentTotalSKA`/`CoinType`/`SKAValue`, `ChartsData.BalanceAtoms`/`ReceivedAtoms`/`SentAtoms`/`NetAtoms`, `AddressInfo.NumUnconfirmedByCoin`, and `AddressRowCompact.CoinType` are all populated end-to-end. The template + JS controller still render exactly one coin (VAR) and label everything `DCR`. This is the "last unconverted surface" the `feat/address-ui` branch is intended to fix.
-- **`CoinTypeAll = 255` sentinel has two meanings:** "no filter — show all coins" everywhere except chart endpoints, where it collapses to `0` (VAR). Documented at [pgblockchain.go:3327-3330](db/dcrpg/pgblockchain.go#L3327-L3330).
-- **SKA precision invariant (C1):** SKA atoms live in `addresses.ska_value TEXT` and `vins.ska_value TEXT`; SKA aggregates must stay as decimal strings backed by `*big.Int`. `dbtypes.BigAddSKA(acc, str)` is the canonical accumulator. The `chart amountflow` SQL + `parseRowsSentReceived` now honor this invariant end-to-end as of PR #263 (formerly the SUM-the-wrong-column violation noted in older revisions of this doc).
-- **Chart endpoints are single-coin:** `TxHistoryData` always operates on one coin; no aggregate-across-coins option. The legacy "coin-agnostic" behavior was replaced.
-- **Dummy/zero address short-circuit (1593-1603):** required because zero addresses have so many outputs that DB queries time out. Removing it is a hard regression.
-- **Zoom encoding:** `Zoom.encode` (`helpers/zoom_helper.js`) is base-36 ms timestamps `"<start>-<end>"`. Stale values across chart-type changes parse cleanly but lie outside the new chart's range, so `Zoom.validate` clamps silently — never throws.
-- **TurboQuery null-template:** every URL key the controller mutates must be declared with a null value in `connect()` settings (`address_controller.js:211-219`); undeclared keys aren't persisted. `coin` is **not** declared today.
-- **`FiatBalance` is wired to `nil`:** `xcBot.Conversion` is no longer called from the address handler. The `if $.FiatBalance` template branch is unreachable. Re-enabling fiat requires a multi-coin price model.
+### 3.3 Interface change — 6 sites
 
-### 6. Mutation Impact
-When modifying the address page or its chart/table state, check:
-- **Direct dependencies:** `dbtypes.AddressInfo`/`AddressBalance`/`CoinBalance`/`AddressTx`/`AddressRowCompact`/`ChartsData` field names — referenced by `views/address.tmpl`, `views/extras.tmpl` (`addressTable`), three handlers in `explorerroutes.go` (`AddressPage`, `AddressTable`, `AddressListData`), DB layer, and four mocks (`explorer_test.go`, `noop_ds_test.go`, `address_api_test.go`, `apiroutes_test.go`).
-- **Indirect dependencies:** `address_controller.js` URL contract (chart kind, group-by bin, pagination keys; **no `coin` today**), `apirouter.go:178-200, 313-320` route segments, `middleware.CoinCtx` semantics (255 = "no filter" vs charts' 255→0 collapse).
-- **Serialization boundaries:** `/api/address/{addr}/{kind}/{bin}?coin=N` JSON shape (`*dbtypes.ChartsData`); `/addresstable/{addr}?...&coin=N` HTML fragment (`{tx_count, html, pages}`); `/download/address/io/{addr}?coin=N` CSV with columns `tx_hash, direction, io_index, valid_mainchain, coin_type, amount, time_stamp, tx_type, matching_tx_hash`; bookmarked URLs with `?zoom=`/`?chart=`/`?bin=`/`?start=`.
-- **Rendering layers:** template precision helpers (DCR-only today), Dygraph zoom validation (`validateZoom` at 610), chart legend/ylabel strings (still `DCR`).
-- **Silent failures:**
-  - SKA balance / amount precision loss in `address.tmpl` and `extras.tmpl` (uses `.TotalUnspent`/`.SentTotal`/`.ReceivedTotal` — all coin-agnostic floats representing VAR only).
-  - (Fixed in PR #263 — formerly: SKA `amountflow` chart silently truncated/zero because the SQL summed `value` not `ska_value::numeric`. Kept as a historical note because tests written against the broken-but-stable backend may still encode the old shape; SQL is now [addrstmts.go:351-359](db/dcrpg/internal/addrstmts.go#L351-L359) and scan in [queries.go:4296-4324](db/dcrpg/queries.go#L4296-L4324).)
-  - Stale `?zoom=` after chart-type change — `setGraphQuery` (635) writes prior chart's zoom into the URL of the new chart; `Zoom.validate` clamps silently. Refresh re-applies the wrong window.
-  - `if eq .SentTotal 0.0` (extras.tmpl:277) classifies every SKA debit row as "sstxcommitment".
-  - `db/cache` desync after a reorg — chart series stale while table is fresh.
-  - Legacy flat-field sync (`balance.TotalUnspent = Coins[0].TotalUnspent`) writes zero for pure-SKA addresses; template renders `0 DCR`.
-- **Hard failures:**
-  - Template parse error if `AddressInfo`/`AddressBalance`/`AddressTx` field is renamed without updating both `address.tmpl` and the `addressTable` block in `extras.tmpl`.
-  - 404 on chart fetch if `<option value>` doesn't match an API route segment.
-  - `txhelpers.AddressValidation` rejection (1556) renders an error page; template never executes.
-  - DataSource interface signature drift — must update production type plus four mocks together.
+`AddressHistory`'s new `coinType` param propagates to:
+`explorer.explorerDataSource` (`explorer.go:105`), `api.DataSource`
+(`apiroutes.go:58`), and mocks `noop_ds_test.go`, `explorer_test.go`,
+`pgblockchain_test.go`.
 
-### 7. Common Pitfalls
-- Adding more `dcrutil.Amount.ToCoin()`/`toFloat64Amount` calls to the address template — locks in SKA precision loss and re-cements the migration shim.
-- Calling `setGraphQuery` without first deciding whether `settings.zoom` is still meaningful for the new chart — exact mechanism behind the stale-zoom defect (`changeGraph` at 620, `changeBin` at 626).
-- Adding a new query param (e.g. `coin`) without declaring a null entry in `connect()` 211-219 — `TurboQuery` won't persist it.
-- Updating `AddressPage` without mirroring the change in `AddressTable` (1652) — XHR refresh diverges from initial render. Both also need the same `middleware.GetCoinCtx(r)` plumbing.
-- Renaming `<select>` chart option values without updating `apirouter.go` and `fetchGraphData` URL construction.
-- Adding a new per-coin field to `AddressBalance` and forgetting to wire one of: `ReduceAddressHistory`, `retrieveAddressBalance`, the mempool overlay in `AddressData`, or the flat-field sync.
-- Writing SKA aggregation in SQL via `SUM(value)` — the `value INT8` column stores `vout.Value`, not SKA atoms. Use `SUM(NULLIF(ska_value,'')::numeric)::text` and scan as string. The dual-column pattern (VAR sums + SKA sums in one query, guarded by `coin_type` `CASE`s) was established by PR #263 for `selectAddressAmountFlowByAddress`; copy that shape rather than the pre-fix single-`SUM(value)` shape.
-- Confusing `CoinTypeAll`'s semantics: 255 = "all coins" for table/CSV/counts, but 255 → 0 (VAR) for chart endpoints.
+### 3.4 Data structures (source of truth — `db/dbtypes/types.go`)
 
-### 8. Evidence
-- **Routes:** [cmd/dcrdata/main.go:768-769](cmd/dcrdata/main.go#L768-L769); `AddressPathCtx` middleware at `cmd/dcrdata/internal/explorer/explorermiddleware.go`.
-- **CoinCtx middleware:** [cmd/dcrdata/internal/middleware/apimiddleware.go:818-842](cmd/dcrdata/internal/middleware/apimiddleware.go#L818-L842).
-- **Page handler:** [cmd/dcrdata/internal/explorer/explorerroutes.go:1535](cmd/dcrdata/internal/explorer/explorerroutes.go#L1535) (`AddressPage`), inline struct at 1539-1546, `parseAddressParams` at 1549, `AddressListData` at 1605, `FiatBalance: nil` at 1633, `templates.exec` at 1635, dummy address branch 1593-1603.
-- **Table XHR handler:** [explorerroutes.go:1652](cmd/dcrdata/internal/explorer/explorerroutes.go#L1652) (`AddressTable`).
-- **AddressListData:** [explorerroutes.go:1875](cmd/dcrdata/internal/explorer/explorerroutes.go#L1875).
-- **DB layer:** [db/dcrpg/pgblockchain.go:2533](db/dcrpg/pgblockchain.go#L2533) (`AddressData`), 2419 (`AddressHistory`), 2389 (`CountTransactions`), 2312 (`retrieveMergedTxnCount`), 2332 (`mergedTxnCount`), 2345 (`nonMergedTxnCount`), 2947 (`FillAddressTransactions`), 2687 (mempool overlay invocation), 3325 (`TxHistoryData`), 2266 (`AddressRowsCompact`).
-- **DB queries:** [db/dcrpg/queries.go:1450](db/dcrpg/queries.go#L1450) (`retrieveAddressCoinTypes`), 1472 (`retrieveAddressBalance`), 1874 (`retrieveAddressTxns`), 1908 (`retrieveAddressCount`), 2054 (`retrieveTxHistoryByType`), 2096 (`retrieveTxHistoryByAmountFlow`), 4289 (`parseRowsSentReceived` — now scans 4 cols; SKA fix per PR #263).
-- **DB SQL:** [db/dcrpg/internal/addrstmts.go:234](db/dcrpg/internal/addrstmts.go#L234) (`SelectAddressSpentUnspentCountAndValue`), 249 (`SelectAddressCoinTypes`), 270 (`SelectAddressLimitNByAddress`), 276 (`...All`), 338 (`selectAddressTxTypesByAddress` — with `coin_type=$2`), 351 (`selectAddressAmountFlowByAddress` — dual VAR/SKA `SUM` columns; PR #263 fix).
-- **Types:** [db/dbtypes/types.go:2322](db/dbtypes/types.go#L2322) (`AddressInfo` — with `Coins`, `ActiveCoins`, `NumUnconfirmedByCoin`), 2375 (`CoinBalance`), 2392 (`AddressBalance` — `Coins map[uint8]*CoinBalance` + legacy flat fields), 2456 (`ReduceAddressHistory`), 2252 (`AddressTx`), 1304 (`AddressRowCompact` with `CoinType`), 2041 (`ChartsData` with `*Atoms` parallel SKA series), 47 (`CoinTypeAll = 255`).
-- **Cache:** [db/cache/addresscache.go:378](db/cache/addresscache.go#L378) (`TxHistory` shape), 461 (`AddressCacheItem.HistoryChart`), 866 (`AddressCache.HistoryChart`), 1143 (`StoreHistoryChart`).
-- **Chart API:** [cmd/dcrdata/internal/api/apirouter.go:178-200](cmd/dcrdata/internal/api/apirouter.go#L178-L200); handlers [apiroutes.go:1827,1864](cmd/dcrdata/internal/api/apiroutes.go#L1827-L1864).
-- **CSV API:** [apirouter.go:313-320](cmd/dcrdata/internal/api/apirouter.go#L313-L320); handler [apiroutes.go:1728-1825](cmd/dcrdata/internal/api/apiroutes.go#L1728-L1825).
-- **DataSource interface + mocks:** [apiroutes.go:64-71](cmd/dcrdata/internal/api/apiroutes.go#L64-L71); [explorer.go:105-106](cmd/dcrdata/internal/explorer/explorer.go#L105-L106); mocks at `cmd/dcrdata/internal/explorer/explorer_test.go`, `cmd/dcrdata/internal/api/noop_ds_test.go:40,53`, `cmd/dcrdata/internal/api/address_api_test.go:15`, `cmd/dcrdata/internal/api/apiroutes_test.go:337,359,383`.
-- **Mempool:** [mempool/monitor.go:481-572](mempool/monitor.go#L481-L572) (`UnconfirmedTxnsForAddress` returns `map[uint8]int64`).
-- **Template:** [cmd/dcrdata/views/address.tmpl](cmd/dcrdata/views/address.tmpl) (DCR labels lines 48, 50, 64, 66, 77, 79; pagination URLs 202, 211, 234, 248; chart options 128-130; group-by buttons 154-158; container `data-` attrs 10-16; `if $.FiatBalance` unreachable today at 54-56).
-- **addressTable:** [cmd/dcrdata/views/extras.tmpl:210-315](cmd/dcrdata/views/extras.tmpl#L210-L315) (Credit/Debit VAR literals at 222, 227, 230, 231, 233, 235, 236; float-only amount rendering at 251, 254, 258, 262, 265, 267, 277, 284).
-- **Frontend controller:** [cmd/dcrdata/public/js/controllers/address_controller.js](cmd/dcrdata/public/js/controllers/address_controller.js) — `connect` 194, settings template 211-219, `query.update` 233, zoom-button-clear 236-240, DCR legend 84, ylabels 130/140, `amountFlowProcessor` 30-53, `makeTableUrl` 319-323, `fetchTable` 361, `drawGraph` 473, `fetchGraphData` 496-527, `popChartCache` 548, `validateZoom` 610, `changeGraph` 620, `changeBin` 626, `setGraphQuery` 635, `onZoom` 666, `setZoom` 683-692, Dygraph callbacks 738/749, `_confirmMempoolTxs` 774.
-- **Zoom helper:** [cmd/dcrdata/public/js/helpers/zoom_helper.js](cmd/dcrdata/public/js/helpers/zoom_helper.js) — `Zoom.encode/decode/validate/mapValue/mapKey`.
+- `AddressInfo` (`:2323-2373`): `NumUnconfirmed int64` (`:2343`),
+  **`NumUnconfirmedByCoin map[uint8]int64`** (`:2345`), `Balance *AddressBalance`
+  (`:2361`), **`ActiveCoins []uint8`** (`:2366`).
+- `CoinBalance` (`:2379-2389`): `CoinType`, `NumSpent/NumUnspent`,
+  `TotalSpent/TotalUnspent int64` (VAR atoms),
+  `TotalSpentSKA/TotalUnspentSKA string` (SKA atoms),
+  **`TotalReceived int64` / `TotalReceivedSKA string`** (precomputed).
+- `AddressBalance` (`:2393-2406`): `Coins map[uint8]*CoinBalance`,
+  `TotalOutputs/TotalInputs`, `FromStake/ToStake`, plus legacy flat
+  `TotalUnspent/TotalSpent/NumSpent/NumUnspent` (synced from `Coins[0]`,
+  back-compat only).
+- `ActiveCoins` populated at `pgblockchain.go:2626` (no confirmed txns) and
+  `:2691` (confirmed txns); `NumUnconfirmedByCoin` at `:2762`.
+
+### 3.5 Transformation 1 — templates
+
+**`address.tmpl`:** summary card `range $ct := .ActiveCoins`, indexes
+`$balance.Coins`, renders VAR via `amountAsDecimalParts` and SKA via
+`skaDecimalParts $cb.TotalUnspentSKA / TotalReceivedSKA / TotalSpentSKA`,
+labelled `{{coinSymbol $ct}}`; `&mdash;` empty state. `Received`/`Spent`
+counts now from `$balance.TotalOutputs`/`TotalInputs`. Unconfirmed block
+ranges `.NumUnconfirmedByCoin` per coin with
+`data-coin-type`/`data-count` attrs. Stake rows gated on `$varCB`
+(VAR-only metric). The container's `data-address-balance` attr was
+**replaced** by `data-active-coins='{{jsonMarshal .ActiveCoins}}'`. Two
+coin `<select>`s added (chart card → `data-address-target="coin"`,
+`address#changeCoin`; table → `data-address-target="coinFilter"`),
+disabled/single-option when `ActiveCoins` ≤ 1; txntype select disabled
+when `not .ActiveCoins`. **`FiatBalance` field + `if $.FiatBalance`
+branch deleted** (and removed from the `AddressPageData` struct in
+`explorerroutes.go`).
+
+**`extras.tmpl`** (address tx table): new `<th>Coin</th>` +
+`<td data-coin-type="{{.CoinType}}">{{coinSymbol .CoinType}}</td>`; every
+value cell branches `{{if eq .CoinType 0}}float64AsDecimalParts …{{else}}
+skaDecimalParts .SKAValue true{{end}}`; `Credit VAR`/`Debit VAR` headers
+renamed to `Credit`/`Debit`; `sstxcommitment` gate now also requires
+`eq .CoinType 0`.
+
+**`templates.go:768-780`** — new `jsonMarshal` func: coerces `[]uint8`→`[]int`
+before `json.Marshal` (else `[]byte` alias renders base64), so `ActiveCoins`
+serializes as a JSON array for `data-active-coins`.
+
+**`explorerroutes.go`** `AddressPage`/`AddressTable`: `linkTemplate` gets
+`&coin=%d` appended when `GetCoinCtx(r) != CoinTypeAll`, so pagination links
+preserve the filter.
+
+### 3.6 Transformation 2 — controller (`address_controller.js`)
+
+- `coin` **added to the TurboQuery null-template** (`:271-275`) and to targets
+  (`coinFilter`, `coin`).
+- New `coinUrlSegment()` (`&coin=` or empty), `normalizeCoinSetting()`
+  (validates against `activeCoins`, syncs both selectors, canonicalizes string
+  form), `effectiveCoin()` (returns the integer coin used for chart fetches —
+  **mirrors backend `CoinTypeAll→0` collapse**: explicit coin, else first
+  `activeCoins`, else 0), `changeCoin(e)` (sets `settings.coin`, resets
+  pagination, forces chart refetch via `state.coin='__force_refetch__'`).
+- `activeCoins` parsed from `data-active-coins` (try/catch → `[]` on bad JSON).
+- Chart cache keys now `${chart}-${bin}-${coin}` (`fetchGraphData :625`,
+  `processData`, `popChartCache :679`); `drawGraph` short-circuit also compares
+  `settings.coin === state.coin`. Chart URL: `?coin=${coin}` appended.
+- `amountFlowProcessor(d, binSize, coinType, atomsByTime)`: VAR reads the
+  **server-precomputed `d.balance[i]`** (old JS `balance += v` accumulator
+  removed — was lossy at high balances); SKA reads `d.received_atoms /
+  sent_atoms / net_atoms / balance_atoms` strings, sign-splits on the string,
+  stores originals in `skaAtomsByTime` Map keyed by `time.getTime()`, uses
+  `Number()` only for pixel positioning.
+- `makeAmountFormatter(coinType, atomsByTime)` builds the legend per-fetch;
+  SKA values rendered from the atom strings via `formatSkaAtoms` →
+  `splitSkaAtomsNoTrailing`; label via `renderCoinType`. `ylabel`/
+  `legendFormatter` are now per-fetch in `popChartCache`, not static.
+- Confirmed-tx handler decrements **only the `numUnconfirmed` target whose
+  `data-coin-type` matches** the row's `data-coin-type`.
+
+### 3.7 Chart serialization (`db/dbtypes/types.go:2041-2057`,
+`db/dcrpg/internal/addrstmts.go:351-359`, `db/dcrpg/queries.go:4301-4343`)
+
+`ChartsData` json tags: `received/sent/net/balance` (VAR float64) and
+`received_atoms/sent_atoms/net_atoms/balance_atoms` (SKA string), all
+`omitempty`. SQL emits VAR via `SUM(... value ...)` for `coin_type=0` and SKA
+via `COALESCE(SUM(... NULLIF(ska_value,'')::numeric ...),0)::text` for
+`coin_type>0`; `WHERE coin_type=$2`. `parseRowsSentReceived` runs a per-row
+cumulative accumulator: `int64 balanceVAR` → `items.Balance`, `big.Int
+balanceSKA` → `items.BalanceAtoms`.
+
+### 3.8 Helpers (`cmd/dcrdata/public/js/helpers/ska_helper.js`)
+
+- `renderCoinType(coinType)` (`:16-23`) → `"VAR"` | `"SKA1".."SKA255"` | `"-"`.
+- `splitSkaAtomsNoTrailing(atomStr,…)` (`:78-81`) → `{intPart,bold,rest,
+  trailingZeros:''}`.
+
+---
+
+## Section 4 — Cross-Layer Dependencies
+
+- **`AddressHistory` signature** — DB ↔ two Go interfaces ↔ four test mocks
+  (6 sites). Any further param change re-touches all six across modules.
+- **`ChartsData` JSON tags ↔ `amountFlowProcessor` string keys** — `omitempty`
+  means a renamed tag silently disappears; SKA chart goes blank, no error.
+- **`effectiveCoin()` (JS) ↔ backend `CoinTypeAll→0` collapse** — the same rule
+  implemented twice; divergence shows the wrong coin's chart silently.
+- **`data-coin-type` SSR attr (`extras.tmpl`) ↔ unconfirmed-decrement compare**
+  — string equality; format/type drift silently stops decrementing.
+- **`jsonMarshal` ↔ `data-active-coins` ↔ controller `activeCoins`** — if the
+  func is removed/changed, base64 reaches `JSON.parse`, which throws and the
+  catch yields `activeCoins=[]` → empty summary card, all selectors disabled.
+- **`linkTemplate &coin=` (Go) ↔ `coinUrlSegment()` (JS)** — both must append
+  the filter or pagination/CSV silently drops scope.
+
+---
+
+## Section 5 — Critical Constraints
+
+1. **Coin filter MUST precede LIMIT/OFFSET.** Enforced invariant
+   (`TestCoinFilterBeforePagination`). Filter-after-paginate ⇒ under-filled,
+   unreachable pages while per-coin counts say rows exist.
+2. **`CoinTypeAll` must stay `255`, distinct from every real coin.**
+   (`TestCoinTypeAllSentinel`.)
+3. **Unconfirmed/mempool MUST NOT affect balance.** Balance is confirmed-DB
+   only by design; mempool surfaces via `NumUnconfirmedByCoin`. Do not
+   reintroduce the deleted accumulator block.
+4. **SKA precision (core constraint C1).** SKA atoms stay strings end-to-end;
+   `Number()` permitted only for chart pixel positioning, never for displayed
+   values — the legend reads the original strings from `skaAtomsByTime`.
+5. **Merged view has no `coin_type` predicate.** It aggregates all coins; query
+   directly with `(address, N, offset)`, never via the coin-injecting stmt
+   helper (LIMIT-0 trap).
+6. **Centralized coin labels (core constraint C7).** Use `coinSymbol`
+   (template) / `renderCoinType` (JS); no hard-coded `DCR`/`VAR` literals.
+
+---
+
+## Section 6 — Mutation Impact
+
+When modifying *the address coin-filter / multi-coin path*, check:
+
+**Direct dependencies**
+- `AddressHistory` 6-site signature (build break across modules if missed).
+- `AddressData` mempool block — don't re-fold mempool into balance.
+- `retrieveAddressMergedTxns` argument order (LIMIT-0 trap).
+- `address.tmpl` `range .ActiveCoins`; `extras.tmpl` Coin column + SKA branch.
+- `address_controller.js` null-template, cache keys, `effectiveCoin`.
+
+**Indirect / derived**
+- `ActiveCoins` / `NumUnconfirmedByCoin` populated only at
+  `pgblockchain.go:2626/2691` and `:2762` — patch *both* branches.
+- `Balance.Coins[0]` legacy-flat sync (drop only when nothing reads it).
+
+**Serialization boundaries**
+- `ChartsData` json tags; `data-active-coins` via `jsonMarshal`;
+  `&coin=N` on `linkTemplate` (HTML + table) and all JS URL builders + CSV.
+
+**Rendering layers**
+- Summary card, Coin column, chart legend/ylabel, coin selectors, unconfirmed
+  badges.
+
+**Silent failures**
+- `effectiveCoin()` vs. backend collapse divergence (wrong coin chart).
+- `ChartsData` tag rename (omitempty hides absence) → blank SKA chart.
+- `data-coin-type` string-compare drift → unconfirmed count never decrements.
+- Stale `?zoom=` carried across coin/chart-type change → `validateZoom`
+  silently clamps (pre-existing latent issue, unchanged).
+
+**Hard failures**
+- `AddressHistory` signature mismatch → compile error (multi-module).
+- `jsonMarshal` removed → base64 in attr → `JSON.parse` throws →
+  `activeCoins=[]` → empty card, disabled selectors (degrades, not crash).
+
+---
+
+## Section 7 — Common Pitfalls
+
+- Editing `AddressHistory` without the 4 mocks → multi-module build break.
+- "Fixing" unconfirmed display by re-adding mempool amounts to balance — that
+  removal was deliberate (confirmed-only).
+- Renaming a `ChartsData` field and missing the JS string key — SKA chart
+  silently blank (`omitempty`).
+- Routing the merged query through the coin-injecting helper — LIMIT-0,
+  zero rows, no error.
+- Trusting the prior wiki's "frontend VAR-only / `coin` not in null-template"
+  — both now false.
+- Populating only one of the two `ActiveCoins` assignment branches.
+
+---
+
+## Section 8 — Evidence
+
+All file:line references verified against working tree at `HEAD`
+(`1b670255`). Diff base for the delta: `a8f641f2` (prior wiki revision,
+2026-05-13). Relevant commits:
+- PR #265: `8cf06854`, `8b5c3a1b`, `9f5d5a7e`, `f3e2d687`, `a4457a7a`,
+  `a9b24127`, `2297e522`.
+- PR #266 / db series: `6e92df4c`, `0c389276`, `d4bf6cff`, `f3231a78`,
+  `61661722`, `be28442e`, `1b670255`.
+- Charts SKA SQL precision (`#263`, still valid): `49953185`, `6837673f`.
+
+Primary files: `db/dcrpg/pgblockchain.go`, `db/dcrpg/queries.go`,
+`db/dcrpg/internal/addrstmts.go`, `db/dbtypes/types.go`,
+`db/dbtypes/coinfilter_test.go`, `cmd/dcrdata/internal/middleware/apimiddleware.go`,
+`cmd/dcrdata/internal/api/apirouter.go`, `…/api/apiroutes.go`,
+`cmd/dcrdata/internal/explorer/explorerroutes.go`, `…/explorer/explorer.go`,
+`…/explorer/templates.go`, `cmd/dcrdata/views/address.tmpl`,
+`cmd/dcrdata/views/extras.tmpl`,
+`cmd/dcrdata/public/js/controllers/address_controller.js`,
+`cmd/dcrdata/public/js/helpers/ska_helper.js`.
+
+---
 
 See also:
-- /wiki/code-analysis/address/flow.compact.md (compact-of: this trace)
-- /wiki/code-analysis/address/patterns.md (shares-pattern-with: dual-field migration shim, `CoinCtx` URL/middleware contract)
-- /wiki/code-analysis/address/summary.impact.md (depends-on: legacy flat-field sync — the surface still reading it)
-- /wiki/code-analysis/address/transactions.impact.md (depends-on: `AddressTx.SKAValue`/`SentTotalSKA` plumbing — already populated, unread)
-- /wiki/code-analysis/address/charts.impact.md (depends-on: chart `?coin=` URL wiring + SKA SQL precision fix in PR #263)
-- /wiki/code-analysis/charts/flow.full.md (shares-pattern-with: TurboQuery URL-state persistence; `Zoom` validation; per-coin chart pipelines)
-- /wiki/code-analysis/transaction/flow.full.md (depends-on: address transaction list rendering)
-- /wiki/code-analysis/mempool/flow.full.md (depends-on: `UnconfirmedTxnsForAddress` now returns per-coin map; address overlay consumes it)
-- /wiki/core/constraints.md#C1 (depends-on: numeric precision & bifurcation — backend honored, template+controller still violate)
-- /wiki/core/constraints.md#C7 (depends-on: centralised coin-type label rendering — `DCR` literals still in `address.tmpl`, `extras.tmpl addressTable`, `address_controller.js`)
+- /wiki/code-analysis/charts/flow.full.md (shares-pattern-with: TurboQuery URL ownership; per-coin chart endpoints; SKA atom string pipeline)
+- /wiki/code-analysis/transaction/flow.full.md (depends-on: address tx-list / Coin-column rendering)
+- /wiki/code-analysis/address/patterns.md (shares-pattern-with: CoinCtx URL contract, coin-aware aggregation, per-coin caching — **needs reconciliation via `Consolidate: address`**)
+- /wiki/code-analysis/address/summary.impact.md (depends-on: summary card — **describes now-completed migration, stale**)
+- /wiki/code-analysis/address/transactions.impact.md (depends-on: Coin column / coin filter — **describes now-completed migration, stale**)
+- /wiki/code-analysis/address/charts.impact.md (depends-on: chart `?coin=` wiring — **frontend now emits `?coin=`, partially stale**)
+- /wiki/core/constraints.md#C1 (depends-on: float64-vs-string SKA precision — now honored in template + controller)
+- /wiki/core/constraints.md#C7 (depends-on: centralized coin labels — now honored via coinSymbol/renderCoinType)

--- a/wiki/code-analysis/address/flow.full.md
+++ b/wiki/code-analysis/address/flow.full.md
@@ -350,6 +350,8 @@ Primary files: `db/dcrpg/pgblockchain.go`, `db/dcrpg/queries.go`,
 ---
 
 See also:
+- /wiki/code-analysis/page-rendering/patterns.md (shares-pattern-with: `*CommonPageData` struct-embedding template injection — `AddressPageData`)
+- /wiki/code-analysis/page-rendering/impact.md (depends-on: `commonData` nil render crash)
 - /wiki/code-analysis/charts/flow.full.md (shares-pattern-with: TurboQuery URL ownership; per-coin chart endpoints; SKA atom string pipeline)
 - /wiki/code-analysis/transaction/flow.full.md (depends-on: address tx-list / Coin-column rendering)
 - /wiki/code-analysis/address/patterns.md (shares-pattern-with: CoinCtx URL contract, coin-aware aggregation, per-coin caching — **needs reconciliation via `Consolidate: address`**)

--- a/wiki/code-analysis/address/transactions.impact.md
+++ b/wiki/code-analysis/address/transactions.impact.md
@@ -4,7 +4,7 @@ Scope of this note: the bottom section of `/address/{address}` (header range / p
 
 ## TL;DR
 
-The backend now ships per-row `CoinType uint8`, `SKAValue string`, `ReceivedTotalSKA string`, and `SentTotalSKA string` on `AddressTx`, supports `?coin=N` filtering through `CoinCtx` middleware on both `/address` HTML and `/addresstable` XHR, and has a fully coin-aware CSV pipeline (`coin_type` column + per-row `FormatSKAPerVAR` for SKA). The `addressTable` template (`extras.tmpl:210-315`) still ignores all per-row coin fields, hard-codes `Credit VAR` / `Debit VAR` headers, and renders `float64AsDecimalParts .SentTotal 8 false` / `.ReceivedTotal 8 false` — so SKA rows render `0` in the amount cell. The `if eq .SentTotal 0.0` heuristic at `extras.tmpl:277` mis-classifies every SKA debit as "sstxcommitment". The frontend controller does not declare `coin` in its TurboQuery null-template (`address_controller.js:211-219`) and does not append `?coin=` to `makeTableUrl` (319-323) — so the `?coin=` filter only flows on hard reload, not via XHR refresh today.
+The backend now ships per-row `CoinType uint8`, `SKAValue string`, `ReceivedTotalSKA string`, and `SentTotalSKA string` on `AddressTx`, supports `?coin=N` filtering through `CoinCtx` middleware on both `/address` HTML and `/addresstable` XHR, and has a fully coin-aware CSV pipeline (`coin_type` column + bare-decimal SKA amounts via `dbtypes.FormatSKACoins`). The `addressTable` template (`extras.tmpl:210-315`) still ignores all per-row coin fields, hard-codes `Credit VAR` / `Debit VAR` headers, and renders `float64AsDecimalParts .SentTotal 8 false` / `.ReceivedTotal 8 false` — so SKA rows render `0` in the amount cell. The `if eq .SentTotal 0.0` heuristic at `extras.tmpl:277` mis-classifies every SKA debit as "sstxcommitment". The frontend controller does not declare `coin` in its TurboQuery null-template (`address_controller.js:211-219`) and does not append `?coin=` to `makeTableUrl` (319-323) — so the `?coin=` filter only flows on hard reload, not via XHR refresh today.
 
 ## 1. Scope
 
@@ -54,7 +54,7 @@ Both `/address` and `/addresstable` go through `explorer.AddressPathCtx` (middle
 - **[db/dcrpg/pgblockchain.go:2312-2343](db/dcrpg/pgblockchain.go#L2312-L2343)** — `retrieveMergedTxnCount(ctx, addr, txnView, coinType)` and `mergedTxnCount(...)` (cache-aware count for `merged` / `merged_credit` / `merged_debit`). Both take `coinType uint8`.
 - **[db/dcrpg/pgblockchain.go:2345-2412](db/dcrpg/pgblockchain.go#L2345-L2412)** — `nonMergedTxnCount(...)` and `CountTransactions(...)`. When `coinType == CoinTypeAll`, dispatches to all-coin SQL variants (`SelectAddressAllCountByAddress`, `SelectAddressesMergedCountAll`); otherwise the coin-filtered variant.
 - **[db/dcrpg/pgblockchain.go:2947-3005](db/dcrpg/pgblockchain.go#L2947-L3005)** — `FillAddressTransactions`. Fills `Size`, `FormattedSize`, `Total`, `Time`, `Confirmations`, and (for matched txns) `MatchedTxIndex`. **`txn.Total = dcrutil.Amount(dbTx.Sent).ToCoin()` (2964) is still VAR-only** — fine for non-amount columns but worth noting.
-- **[db/dcrpg/pgblockchain.go:2266-2310](db/dcrpg/pgblockchain.go#L2266-L2310)** — `AddressRowsCompact(ctx, address, coinType uint8)`. CSV download source; returns `[]*dbtypes.AddressRowCompact`. When `coinType != CoinTypeAll`, filters in-memory after cache hit at 2303 (`if r.CoinType == coinType`).
+- **[db/dcrpg/pgblockchain.go:2266-2310](db/dcrpg/pgblockchain.go#L2266-L2310)** — `AddressRowsCompact(ctx, address, coinType uint8)`. CSV download source; returns `[]*dbtypes.AddressRowCompact`. Honors the `CoinTypeAll = 255` "no filter" sentinel (returns **all** coin rows unfiltered — this is the no-`?coin=N` CSV path); when `coinType != CoinTypeAll`, filters in-memory after cache hit (`if r.CoinType == coinType`). The same sentinel guard applies in `AddressCache.Rows` ([db/cache/addresscache.go](db/cache/addresscache.go)). Regression: `db/cache/addresscache_test.go::TestAddressCacheRows_CoinTypeAll`. (Before this guard, `coinType==255` matched no row and the all-coins CSV was empty.)
 
 ### Mocks (four files)
 
@@ -209,7 +209,7 @@ Per-row population ([apiroutes.go:1785-1823](cmd/dcrdata/internal/api/apiroutes.
 - **`coin_type`** — `strconv.FormatUint(uint64(r.CoinType), 10)`. New column.
 - **`amount`** (renamed from `value`):
   - VAR (`r.CoinType == 0`): `strconv.FormatFloat(dcrutil.Amount(r.Value).ToCoin(), 'f', 8, 64)` — `1.23456789`.
-  - SKA: `dbtypes.FormatSKAPerVAR(r.SKAValue, r.CoinType)` ([types.go:2428-2442](db/dbtypes/types.go#L2428-L2442)) — human-readable string like `"1.23 SKA1"`. **Note:** SKA renders as a labeled coin string, NOT raw atoms. Consumers parsing the CSV for SKA atoms need to know this.
+  - SKA: `dbtypes.FormatSKACoins(r.SKAValue)` ([types.go](db/dbtypes/types.go)) — a **bare decimal** coin amount (atoms ÷ 1e18, e.g. `0.0000000000000005`), no coin label, trailing zeros trimmed. The coin is disambiguated by the separate `coin_type` column, so `amount` is a uniform parseable number across VAR and SKA rows. (Previously `dbtypes.FormatSKAPerVAR` appended a `" SKA{n}"` label, making SKA rows non-numeric and inconsistent with VAR; that misnamed, now-unused helper was deleted. Do not confuse `dbtypes.FormatSKACoins` (atoms→coins) with `txhelpers.FormatSKAAtoms` (raw atom integer string, unchanged).)
 - `time_stamp` — Unix integer (`r.TxBlockTime`).
 - `tx_type` — `txhelpers.TxTypeToString(int(r.TxType))`.
 - `matching_tx_hash` — empty when nil.
@@ -283,8 +283,8 @@ These questions cannot be answered from code alone and must be decided before a 
 4. **CSV column schema decisions** — the choices already shipped:
    - Added `coin_type` column.
    - Renamed `value` → `amount`.
-   - SKA encoded as labeled human string `"1.23 SKA1"` via `FormatSKAPerVAR`, NOT raw atoms.
-   - Should be revisited if external tools want raw SKA atoms (which fit in a string but not float).
+   - SKA encoded as a bare decimal coin amount (atoms ÷ 1e18, no label) via `dbtypes.FormatSKACoins`; coin identified by the `coin_type` column. `amount` is a uniform parseable number across VAR and SKA rows.
+   - Note this is a coin amount, not raw atoms; revisit if external tools want raw SKA atoms (which fit in a string but not float).
 5. **`SentTotal == 0.0` sstxcommitment heuristic** (`extras.tmpl:277`) — float-compare to a magic value. For SKA, the value is always `0.0` because the ReduceAddressHistory branch leaves it zero. Either replace the heuristic with an explicit flag on `AddressTx`, or special-case by `CoinType`.
 6. **Per-coin balance summary** — out of scope for this note (see `summary.impact.md`), but a coin filter without per-coin balance numbers in the summary card will feel inconsistent.
 7. **Fiat conversion** — handler now sets `FiatBalance: nil`; no longer relevant on this surface.

--- a/wiki/code-analysis/block/flow.full.md
+++ b/wiki/code-analysis/block/flow.full.md
@@ -82,4 +82,6 @@ When modifying **`BlockData` (or Multi-Coin Extraction logic)**, you MUST check 
 - **Presentation State Duplication:** `cmd/dcrdata/internal/explorer/explorer.go` (~line 750) and `pubsub/pubsubhub.go` (~line 650) both run identical loops transforming `map[uint8]string` into sorted `[]PoWSKAReward`.
 
 See also:
+- /wiki/code-analysis/page-rendering/patterns.md (shares-pattern-with: out-of-band shared page state via `BlockDataSaver` fan-out; shared-state lock discipline)
+- /wiki/code-analysis/page-rendering/impact.md (depends-on: saver writer/reader drift — HTML flashes stale data before WS overwrite)
 - /wiki/core/constraints.md (depends-on: C1 numeric precision & bifurcation; C2 dual pipeline mutation; C3 template + WebSocket parity; C4 perimeter flattening & array stability; shares-pattern-with: C8 dual-transport shape asymmetry — REST `map[uint8]string` vs WebSocket sorted-array form for multi-coin amounts)

--- a/wiki/code-analysis/charts/flow.full.md
+++ b/wiki/code-analysis/charts/flow.full.md
@@ -137,5 +137,7 @@ When modifying chart data structures or pipelines, check ALL of:
 - **Key commits:** `538d5cd1` initial SKA chart support; `3e6d14cf` per-SKA endpoints; `19a114c1` cumulative + height alignment; `a9db4b3b` `h` field on time-axis; `ddf17358` frontend integration & default-case logging; `4af1009f` test/mock additions.
 
 See also:
+- /wiki/code-analysis/page-rendering/patterns.md (shares-pattern-with: out-of-band shared page state — handler reads `pageData.HomeInfo.SKACoinSupply`; `*CommonPageData` embedding)
+- /wiki/code-analysis/page-rendering/impact.md (depends-on: `commonData` nil render crash)
 - /wiki/core/constraints.md (depends-on: C1 numeric precision & bifurcation — applies to the SKA pipeline `string`-end-to-end rule; C2 dual pipeline — VAR delta+`accumulate` vs SKA `*big.Int` cumulation; C7 centralized coin-type label rendering — `renderCoinType` / `coinSymbol`)
 - /wiki/code-analysis/address/flow.full.md (shares-pattern-with: TurboQuery URL state, `Zoom` validation; the address chart endpoint reuses the same controller patterns. Note: charts controller calls `Zoom.project` across data-range changes (line 901); the address controller does not — see address/flow.full.md §5.)

--- a/wiki/code-analysis/mempool/flow.full.md
+++ b/wiki/code-analysis/mempool/flow.full.md
@@ -252,6 +252,8 @@ When adding a **new saver**:
 - `txhelpers/txhelpers.go:1305-1329` — `SKATotalsFromMsgTx`; nil-return for VAR-only txs.
 
 See also:
+- [/wiki/code-analysis/page-rendering/patterns.md](../page-rendering/patterns.md) (shares-pattern-with: out-of-band shared page state; shared-state lock discipline; block-scoped ETag cache)
+- [/wiki/code-analysis/page-rendering/impact.md](../page-rendering/impact.md) (depends-on: saver writer/reader drift; lock-order inversion against `Store`)
 - [/wiki/code-analysis/mempool/patterns.md](patterns.md) — patterns extracted from this flow.
 - [/wiki/code-analysis/mempool/impact.md](impact.md) — mutation impact entries.
 - [/wiki/code-analysis/visualblocks/patterns.md](../visualblocks/patterns.md) (shares-pattern-with: **dual-transport WS** for mempool signals).

--- a/wiki/code-analysis/page-rendering/impact.md
+++ b/wiki/code-analysis/page-rendering/impact.md
@@ -1,0 +1,100 @@
+# Page-Rendering Impact (Cross-Domain Consolidation)
+
+> Mode-4 consolidation of mutation risks whose failure mode or propagation path
+> is shared by **2+ page-flow traces**. Domain flows link here via
+> `depends-on`. Pairs with [patterns.md](patterns.md).
+
+---
+
+## Risk: `commonData` Nil Render Crash
+
+**Trigger:**
+`GetTip(ctx)` (Postgres) fails inside `exp.commonData(r)` — DB down, migration,
+or tip query error. `commonData` logs and returns `nil`.
+
+**Affected flows:**
+
+- /wiki/code-analysis/parameters/flow.full.md (grounded: nil `.ChainParams` deref → `StatusPage`)
+- /wiki/code-analysis/visualblocks/flow.full.md
+- /wiki/code-analysis/charts/flow.full.md
+- /wiki/code-analysis/address/flow.full.md
+- /wiki/code-analysis/mempool/flow.full.md
+
+(Every page using the `*CommonPageData` embedding pattern is exposed; only
+parameters traces the concrete deref path today.)
+
+**Failure mode:** loud (HTTP error page).
+
+**Description:**
+The nil `*CommonPageData` is still embedded in the page payload. Any template
+that dereferences a common field (`.ChainParams.*`, `.Version`, `.NetName` —
+effectively all pages) fails template execution → handler falls to
+`StatusPage(defaultErrorCode, …, ExpStatusError)`. A single DB tip failure
+takes down **every** server-rendered page simultaneously, not just one. A
+handler that adds a new common-field deref without a nil guard widens nothing
+(already total) but confirms there is no per-page isolation here.
+
+---
+
+## Risk: Saver Writer/Reader Drift (HTML ≠ WebSocket)
+
+**Trigger:**
+A computed field is added/changed in `(*explorerUI).Store` /
+`(*explorerUI).StoreMPData` (HTTP path) without the matching change in
+`PubSubHub.Store` / the WS encoders — or vice versa.
+
+**Affected flows:**
+
+- /wiki/code-analysis/block/flow.full.md ("update WebSocket only" → page flashes stale data before WS overwrite)
+- /wiki/code-analysis/mempool/flow.full.md (derived view written into two call sites / two fields)
+- /wiki/code-analysis/visualblocks/flow.full.md (`Store` + `StoreMPData` both update `pageData`/`invs`)
+
+**Failure mode:** silent.
+
+**Description:**
+Each saver transforms the fan-out independently (no shared layer). When only
+one saver is updated, the server-rendered HTML and the subsequent WebSocket
+payload disagree: the page loads with one value, then the WS frame overwrites
+it with another (visible "flash"), or per-coin fields render in HTML but are
+absent from JSON snapshots. Propagation crosses Go→template and Go→JS
+boundaries with no compile-time check. The mempool `CoinFills` case is the
+sharpest: it is written into **two struct fields** (`inv.CoinFills` legacy +
+`inv.MempoolShort.CoinFills` JSON) from **two call sites** (`Store` and
+`StoreMPData`); missing any one desyncs HTTP pages from WS snapshots.
+
+---
+
+## Risk: Lock-Order Inversion Against `Store`
+
+**Trigger:**
+New code acquires `invsMtx` (or the embedded `MempoolInfo` lock) and **then**
+waits on `pageData.Lock()`.
+
+**Affected flows:**
+
+- /wiki/code-analysis/visualblocks/flow.full.md (§4 explicit deadlock rule)
+- /wiki/code-analysis/mempool/flow.full.md (reversing lock order risks deadlock)
+
+**Failure mode:** loud (deadlock / hung request goroutine).
+
+**Description:**
+`(*explorerUI).Store` is the only path that nests `pageData.Lock()` →
+`invsMtx.Lock()`. Any other goroutine holding `invsMtx` while blocking on
+`pageData.Lock()` forms the classic AB/BA cycle with `Store` and hangs both —
+manifesting as the page (and the block-processing pipeline) freezing on the
+next block. Current code paths are safe because readers take the locks
+sequentially (non-nested) and `StoreMPData` releases `pageData.RLock` before
+taking `invsMtx`. The invariant is fragile: it is enforced by convention, not
+structure.
+
+---
+
+## Cross-Domain Observation
+
+These three risks share one root: **page handlers are pure readers of
+background-written shared state behind a hand-maintained multi-lock, multi-saver
+fan-out with no shared transformation layer.** Drift (silent) and lock
+inversion (loud) are both consequences of "no shared layer"; the `commonData`
+crash is the blast-radius amplifier (one shared dependency, every page). Any
+refactor that introduces a shared transformation/render layer should treat all
+three as a single design constraint, not three separate fixes.

--- a/wiki/code-analysis/page-rendering/patterns.md
+++ b/wiki/code-analysis/page-rendering/patterns.md
@@ -1,0 +1,148 @@
+# Page-Rendering Patterns (Cross-Domain Consolidation)
+
+> Mode-4 consolidation of architectural behaviors that recur across **2+
+> page-flow traces**. These are the shared mechanics of every server-rendered
+> HTML page in `cmd/dcrdata/internal/explorer`. Domain flows link here via
+> `shares-pattern-with`; do not re-describe these per domain.
+
+---
+
+## Out-of-Band Shared Page State (`explorerUI.pageData` / `exp.invs`)
+
+**Appears in:**
+
+- /wiki/code-analysis/block/flow.full.md
+- /wiki/code-analysis/mempool/flow.full.md
+- /wiki/code-analysis/visualblocks/flow.full.md
+- /wiki/code-analysis/parameters/flow.full.md
+- /wiki/code-analysis/charts/flow.full.md
+
+**Description:**
+HTTP page handlers do **not** fetch live chain state themselves. They read
+`exp.pageData` (block/blockchain/`HomeInfo`) and `exp.invs`
+(`*MempoolInfo`), which are populated **out-of-band** by the saver fan-out:
+
+- `(*explorerUI).Store` is a `BlockDataSaver` hook — registered alongside
+  `pgb` and `psHub` in `cmd/dcrdata/main.go`. On every block it rewrites
+  `pageData.{BlockInfo,BlockchainInfo,HomeInfo}` (`explorer.go` `Store`).
+- `(*explorerUI).StoreMPData` is a `MempoolDataSaver` hook. On every mempool
+  change it recomputes `CoinFills` and swaps `exp.invs`.
+
+Each saver (`ChainDB`, `explorerUI`, `PubSubHub`) processes the fan-out
+independently with no shared transformation layer. The page handler is a
+**pure reader** of a snapshot last written by a background goroutine.
+
+**Constraints:**
+
+- A handler reading `pageData`/`invs` must assume the value is from the *last*
+  block/mempool tick, not the request instant. `BlockchainInfo` is `nil` for
+  non-tip states by design — every reader needs a fallback.
+- New per-page data that derives from chain state belongs in the page handler's
+  own struct, **not** in `pageData` (shared by all pages) and **not** computed
+  inside `commonData`.
+- Any computed field added to `Store`/`StoreMPData` must be added to **all**
+  savers that expose it, or the HTTP path and WS path diverge (see
+  `impact.md` → *Saver Writer/Reader Drift*).
+
+---
+
+## Shared-State Lock Discipline (`pageData.RWMutex` + `invsMtx`)
+
+**Appears in:**
+
+- /wiki/code-analysis/visualblocks/flow.full.md (§4 lock map)
+- /wiki/code-analysis/mempool/flow.full.md (inventory locking)
+- /wiki/code-analysis/parameters/flow.full.md
+- /wiki/code-analysis/block/flow.compact.md
+
+**Description:**
+Three distinct locks guard the shared page state, and they are **not** a
+single hierarchy:
+
+- `pageData.RWMutex` — guards `pageData` struct contents.
+- `invsMtx` on `explorerUI` — guards the `exp.invs` **pointer**.
+- `MempoolInfo.RWMutex` (embedded) — guards inventory **contents**.
+
+Writers: `Store` is the only path that *nests* two locks —
+`pageData.Lock()` then `invsMtx.Lock()`
+([explorer.go:547,608-614](../../../cmd/dcrdata/internal/explorer/explorer.go#L547-L614)).
+`StoreMPData` takes `pageData.RLock`, releases it, *then* takes `invsMtx.Lock`
+— not nested. Readers (page handlers) acquire `invsMtx.RLock` →
+`MempoolInfo.RLock` → `pageData.RLock` **sequentially**, never nested.
+
+**Constraints:**
+
+- Reading any `pageData` field (e.g. `BlockchainInfo.MaxBlockSize` in
+  `ParametersPage`) **must** be under `pageData.RLock()`. Unlocked reads race
+  against `Store`.
+- The narrow deadlock rule: code that holds `invsMtx` (or the inventory lock)
+  and then waits on `pageData.Lock()` deadlocks against `Store`. Acquire
+  `pageData` first or not-nested.
+- `DeepCopy`/`Trim` already lock internally — do not wrap them in an outer lock
+  of the same instance.
+
+---
+
+## `*CommonPageData` Struct-Embedding Template Injection
+
+**Appears in:**
+
+- /wiki/code-analysis/parameters/flow.full.md (`{*CommonPageData, ExtendedParams}`)
+- /wiki/code-analysis/visualblocks/flow.full.md (anonymous struct embedding `*CommonPageData`)
+- /wiki/code-analysis/charts/flow.full.md (`{*CommonPageData, Premine, TargetPoolSize, ActiveSKATypes}`)
+- /wiki/code-analysis/address/flow.full.md (`AddressPageData → templates.exec`)
+- /wiki/code-analysis/mempool/flow.full.md
+
+**Description:**
+Every server-rendered page builds its template payload by **Go struct
+embedding**: an anonymous struct embeds `*CommonPageData` (from
+`exp.commonData(r)`) alongside a page-specific struct. The template addresses
+both via dotted paths (`.ChainParams.*` from common, `.ExtendedParams.*` /
+`.Premine` / etc. from the page struct). There is no merge step — embedding
+*is* the merge at the `templates.exec(...)` call.
+
+`commonData` is **shared by every page**: it injects static `exp.ChainParams`,
+`Version`, `NetName`, cookies, and calls `GetTip(ctx)` (Postgres) for the
+header tip. On `GetTip` failure it logs and **returns `nil`**.
+
+**Constraints:**
+
+- Template field names must resolve to a field on the embedded common struct
+  **or** the page struct. Adding a row requires knowing which source owns it.
+- Page-specific computed values go in the page struct, never in `commonData`
+  (changing `commonData` touches every page).
+- `commonData` returning `nil` makes the embedded pointer nil; templates that
+  deref `.ChainParams` (effectively all) then fail — see `impact.md` →
+  *commonData Nil Render Crash*.
+- `exp.ChainParams` is captured **once at startup**; node config changes need
+  an explorer restart to surface in any page.
+
+---
+
+## Block-Scoped ETag / Last-Modified Page Cache
+
+**Appears in:**
+
+- /wiki/code-analysis/parameters/flow.full.md (`withCache` / `ETagAndLastModifiedIntercept`)
+- /wiki/code-analysis/mempool/flow.full.md (`Store` resets the page ETag/Last-Modified)
+
+**Description:**
+Pages whose content depends only on block/mempool state are registered under
+`withCache = r.With(explore.ETagAndLastModifiedIntercept)` in
+`cmd/dcrdata/main.go`. The middleware
+([explorermiddleware.go:193](../../../cmd/dcrdata/internal/explorer/explorermiddleware.go#L193))
+sets `ETag`/`Last-Modified`; the cache key is **reset by `Store` /
+`StoreMPData`** on every new block/mempool tick. Between ticks the response is
+served from cache.
+
+**Constraints:**
+
+- Any handler placed under `withCache` must be a pure function of
+  `pageData`/`invs` at the last tick. A handler that varies per-request on
+  anything *other* than block/mempool state (e.g. a query param affecting
+  output) will serve stale cached bytes — do **not** put it under `withCache`.
+- New invalidation triggers must reset the ETag in the same place `Store` does;
+  a new state source that doesn't reset it is silently stale until the next
+  block.
+- Stale-looking content between blocks (e.g. `/parameters` `MaxBlockSize`) is
+  expected and intentional, not a bug.

--- a/wiki/code-analysis/parameters/flow.compact.md
+++ b/wiki/code-analysis/parameters/flow.compact.md
@@ -1,0 +1,41 @@
+chaincfg.Params (static, launch-time) ──► ChainDB.chainParams ──► exp.ChainParams
+RPC GetBlockChainInfo (per block, tip-only) ──► blockdata ──► pageData.BlockchainInfo
+GET /parameters → ETag cache → ParametersPage → {CommonPageData + ExtendedParams} → parameters.tmpl
+
+Key Patterns:
+
+- **~95% static page:** only `MaximumBlockSize` is dynamic; rest is immutable `chaincfg.Params`
+- **Dual param injection:** template merges `.ChainParams` (commonData) + `.ExtendedParams` (handler) via struct embedding
+- **`exp.ChainParams` captured once at startup** — node config change needs explorer restart
+- **Block-scoped ETag cache** (`ETagAndLastModifiedIntercept`) — intentional
+
+Critical Constraints:
+
+- Read `pageData.BlockchainInfo` only under `RLock` (writer `Store` holds `Lock`)
+- `BlockchainInfo` is `nil` for non-tip blocks by design → handler falls back to `params.MaximumBlockSizes[0]`
+- VAR-only page: subsidy/reward rows are scalar `chaincfg.Params`, NOT per-coin maps (see REWARDS_LOGIC.md)
+- `AddressPrefixes` hardcoded to mainnet/testnet*/simnet → `nil` otherwise
+- `commonData` is shared by ALL pages; page-specific data → `ExtendedParams`
+
+Mutation Checklist:
+
+- new template row → put computed value in `ExtendedParams`, never `commonData`
+- changing `BlockchainInfo`/`Store` → also affects home page + `StoreMPData`
+- changing `GetChainParams`/`commonData` → affects every page
+- keep `AddressPrefixes` Name/Descriptions/prefix arrays index-aligned
+- preserve the `BlockchainInfo == nil` fallback
+
+Silent Risks:
+
+- unknown `params.Name` → empty address-prefix table, no error
+- `BlockchainInfo == nil` → `MaxBlockSize` silently uses stale `MaximumBlockSizes[0]`
+- empty `MaximumBlockSizes` → index panic (no bounds check) [INFERRED]
+
+Hard Failures:
+
+- template exec error / `commonData` nil (DB down) → `StatusPage(ExpStatusError)`
+
+See also:
+- code-analysis/block/flow.compact.md (shares-pattern-with: pageData RWMutex + blockdata.Store fan-out)
+- code-analysis/mempool/flow.compact.md (shares-pattern-with: ETag block-scoped caching)
+- core/staking-rewards.md (depends-on: VAR subsidy/reward proportions)

--- a/wiki/code-analysis/parameters/flow.full.md
+++ b/wiki/code-analysis/parameters/flow.full.md
@@ -1,0 +1,260 @@
+# Parameters Page — Data Flow (Full)
+
+> Code-grounded trace of `/parameters`. Verified at branch `feat/address-page`.
+> The page is **~95% static chain config**; exactly **one field is dynamic**
+> (`MaximumBlockSize`) plus the shared `commonData` header.
+
+---
+
+## Section 1 — Overview
+
+`/parameters` renders the active network's consensus parameters: PoW/PoS
+constants, subsidy/reward proportions, ticket economics, and address prefixes.
+Almost every row is read directly off the immutable `chaincfg.Params` captured
+at process start. The handler adds three derived values (`ExtendedParams`) and
+the shared `commonData` header. Caching is intentional and block-scoped.
+
+---
+
+## Section 2 — End-to-End Data Flow
+
+```
+monetarium-node
+ ├─ chaincfg.Params (static, launch-time) ──► ChainDB.chainParams ──► GetChainParams()
+ │                                                                        │
+ │                                              explorerUI.New: exp.ChainParams = params
+ │                                                                        │
+ └─ RPC GetBlockChainInfo (per block) ──► blockdata.BlockData.BlockchainInfo
+                                                                          │
+                                            explorerUI.Store: p.BlockchainInfo = ...
+                                                                          │
+   GET /parameters ──► ETagAndLastModifiedIntercept ──► ParametersPage ◄──┘
+                                                          │
+                    ┌─────────────────────────────────────┤
+                    │ commonData(r): GetTip() [Postgres]   │ derive ExtendedParams
+                    │   + exp.ChainParams                   │   + AddressPrefixes(params)
+                    └─────────────────────────────────────┤
+                                                          ▼
+                                      templates.exec("parameters", {CommonPageData + ExtendedParams})
+                                                          ▼
+                                                parameters.tmpl ──► HTML
+```
+
+---
+
+## Section 3 — Per-Layer Breakdown
+
+### Node / static config
+
+- **Location:** `db/dcrpg/pgblockchain.go:6408-6410`
+- **Data structures:** `*chaincfg.Params` (from `monetarium-node`)
+- **Transformations:** none — `GetChainParams()` returns `pgb.chainParams` verbatim.
+
+### Capture at startup
+
+- **Location:** `cmd/dcrdata/internal/explorer/explorer.go:369-371`
+- **Data structures:** `exp.ChainParams *chaincfg.Params`, `exp.NetName`
+- **Transformations:** `exp.ChainParams = exp.dataSource.GetChainParams()` once;
+  `exp.NetName = netName(exp.ChainParams)`. **Process-lifetime constant.**
+
+### Dynamic field source (RPC)
+
+- **Location:** `blockdata/blockdata.go:332-357`
+- **Data structures:** `chainjson.GetBlockChainInfoResult` (field
+  `BlockData.BlockchainInfo`, defined `blockdata/blockdata.go:38`)
+- **Transformations:** `chainInfo, err := t.dcrdChainSvr.GetBlockChainInfo(ctx)`.
+  Critically, `blockdata.go:339-341` **nulls** `chainInfo` unless
+  `chainInfo.BestBlockHash == hash.String()` — `GetBlockChainInfo` is only
+  valid at the chain tip.
+
+### Store into pageData
+
+- **Location:** `cmd/dcrdata/internal/explorer/explorer.go:536-572`
+- **Data structures:** `pageData` (struct `explorer.go:230-233`,
+  `RWMutex`-guarded), field `BlockchainInfo *chainjson.GetBlockChainInfoResult`
+- **Transformations:** under `p.Lock()`: `p.BlockchainInfo = blockData.BlockchainInfo`.
+
+### Handler
+
+- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go:2144-2184`
+- **Data structures:** anonymous `struct{ *CommonPageData; ExtendedParams }`;
+  `ExtendedParams{ MaximumBlockSize int64; ActualTicketPoolSize int64; AddressPrefix []types.AddrPrefix }`
+- **Transformations:**
+  - `addrPrefix := types.AddressPrefixes(params)`
+  - `actualTicketPoolSize := int64(params.TicketPoolSize * params.TicketsPerBlock)`
+  - `maxBlockSize`: under `pageData.RLock()`, `BlockchainInfo.MaxBlockSize` if
+    non-nil, else `int64(params.MaximumBlockSizes[0])` (`:2150-2156`)
+
+### commonData (shared header)
+
+- **Location:** `explorerroutes.go:2534-2572`
+- **Data structures:** `*CommonPageData{ Tip, Version, ChainParams, BlockTimeUnix, NetName, … }`
+- **Transformations:** `GetTip(ctx)` → `exptypes.WebBasicBlock` (Postgres,
+  `db/dcrpg/pgblockchain.go:7319-7348`). On error logs and **returns `nil`**
+  (`:2540`). Re-injects `exp.ChainParams` and
+  `BlockTimeUnix = int64(exp.ChainParams.TargetTimePerBlock.Seconds())`.
+
+### AddressPrefixes transform
+
+- **Location:** `explorer/types/explorertypes.go:1508-1549`
+- **Data structures:** `[]AddrPrefix{ Name, Prefix, Description }`
+- **Transformations:** index-aligned `Name`/`Descriptions` arrays selected
+  against a **hardcoded** network prefix table keyed by `params.Name`
+  (`mainnet` / `testnet*` / `simnet`). **Returns `nil` for any other name** (`:1549`).
+
+### Template
+
+- **Location:** `cmd/dcrdata/views/parameters.tmpl` (392 lines)
+- **Data structures:** consumes `.ChainParams.*` (~40 rows) from the embedded
+  `CommonPageData`, and `.ExtendedParams.{MaximumBlockSize,ActualTicketPoolSize,AddressPrefix}`.
+- **Transformations:** template helpers `amountAsDecimalParts`,
+  `durationToShortDurationString`, `uint16Mul` (e.g. `WorkRewardProportion`).
+
+### Route
+
+- **Location:** `cmd/dcrdata/main.go:810`
+- `withCache.Get("/parameters", explore.ParametersPage)` where
+  `withCache = r.With(explore.ETagAndLastModifiedIntercept)`
+  (`explorermiddleware.go:193`).
+
+---
+
+## Section 4 — Cross-Layer Dependencies
+
+- **Dual param injection (brittle):** the template binds `.ChainParams` from
+  `CommonPageData` (via `commonData`) **and** `.ExtendedParams` from the
+  handler's anonymous struct, merged by Go struct embedding at the
+  `templates.exec` call (`explorerroutes.go:2164-2174`). Adding a template row
+  requires knowing which of the two sources owns the field.
+- **`commonData` is shared by every page**, not just `/parameters`. Changing it
+  to satisfy this page risks all pages. Page-specific data belongs in
+  `ExtendedParams`.
+- **`GetChainParams` is broad**: it seeds `exp.ChainParams` once at startup and
+  feeds `commonData` for every page render.
+- **`BlockchainInfo` is shared state**: also read by `StoreMPData`
+  (`explorer.go:506`) and other pages — not isolated to `/parameters`.
+- **Tip↔nil coupling:** `commonData` returning `nil` (DB tip fetch failure)
+  makes the embedded `*CommonPageData` nil; the template then dereferences
+  `.ChainParams` off nil → template execute error.
+
+---
+
+## Section 5 — Critical Constraints
+
+- **Lock discipline:** `pageData.BlockchainInfo` must be read under
+  `pageData.RLock()` (`explorerroutes.go:2149-2156`); writer `Store` holds
+  `p.Lock()` (`explorer.go:568`). Reading outside the RLock is a data race.
+- **Tip-only RPC validity:** `BlockchainInfo` is intentionally `nil` for
+  non-tip blocks (`blockdata.go:339-341`); the handler fallback to
+  `params.MaximumBlockSizes[0]` exists precisely for this.
+- **Multi-coin / VAR-only page:** subsidy and reward rows (`BaseSubsidy`,
+  `WorkRewardProportion`, `StakeRewardProportion`, `BlockTaxProportion`,
+  `MinimumStakeDiff` — `parameters.tmpl:119-168`) are VAR-only scalars from
+  `chaincfg.Params`. SKA coins are **not** represented here. Do not inject
+  per-coin maps without confirming the param model (see `REWARDS_LOGIC.md`).
+- **Static for process lifetime:** `exp.ChainParams` is never refreshed after
+  startup; a node config change requires an explorer restart to reflect here.
+- **Network-name coupling:** `AddressPrefixes` has hardcoded prefix strings and
+  only recognizes `mainnet`/`testnet*`/`simnet` (`explorertypes.go:1540-1549`).
+- **Cache is block-scoped & intentional:** served under
+  `ETagAndLastModifiedIntercept`; ETag/Last-Modified reset on new block/mempool.
+  Stale-looking content between blocks is expected (only `MaxBlockSize` moves).
+
+---
+
+## Section 6 — Mutation Impact
+
+When modifying `/parameters` data, check:
+
+**Direct dependencies**
+
+- `parameters.tmpl` field names must exist on `*chaincfg.Params` (via
+  `.ChainParams`) or on `ExtendedParams` (`explorerroutes.go:2158-2162`).
+- `AddressPrefixes` callers: only `ParametersPage` (`explorerroutes.go:2146`) —
+  low blast radius, but `Name`/`Descriptions`/prefix arrays must stay
+  index-aligned (`explorertypes.go:1517-1538`).
+
+**Indirect dependencies**
+
+- `commonData` → every page. `GetChainParams` → every page.
+- `BlockchainInfo` type/`Store` assignment → home page, `StoreMPData`.
+
+**Serialization boundaries**
+
+- RPC: `GetBlockChainInfo` → `chainjson.GetBlockChainInfoResult`
+  (`blockdata.go:334`).
+- DB: `GetTip` → `retrieveLatestBlockSummary` SQL
+  (`pgblockchain.go:7319-7348`).
+
+**Rendering layers**
+
+- `parameters.tmpl` + helpers (`amountAsDecimalParts`,
+  `durationToShortDurationString`, `uint16Mul`).
+
+### Hard failures (HTTP error page)
+
+- `templates.exec("parameters", …)` error →
+  `StatusPage(defaultErrorCode, …, ExpStatusError)`
+  (`explorerroutes.go:2176-2179`). Causes: missing template field; `commonData`
+  nil (DB down) → nil `*CommonPageData` → nil `.ChainParams` deref.
+- `GetTip` DB error → nil `CommonPageData` → cascades to the above.
+
+### Silent failures (HTTP 200, wrong/blank data)
+
+- Unrecognized `params.Name` → `AddressPrefixes` returns `nil` → empty address
+  table, no error (`explorertypes.go:1549`).
+- `BlockchainInfo == nil` (between blocks, or RPC warn-and-continue at
+  `blockdata.go:335-337`) → `MaximumBlockSize` silently falls back to
+  `params.MaximumBlockSizes[0]`, which may differ from live consensus.
+- Empty `params.MaximumBlockSizes` → `params.MaximumBlockSizes[0]` panics
+  (no bounds check at `explorerroutes.go:2154`). **INFERRED** — relies on the
+  node always populating this; true for known nets.
+
+---
+
+## Section 7 — Common Pitfalls
+
+- Adding a template row and putting the computed value in `commonData`
+  ("it's convenient") — pollutes every page. Use `ExtendedParams`.
+- Assuming `BlockchainInfo` is always present → forgetting the nil fallback,
+  or removing it and crashing on non-tip / RPC-warn states.
+- Reading `pageData.BlockchainInfo` without `RLock` — silent data race.
+- "Multi-coin-ifying" the subsidy rows — these are VAR consensus params, not a
+  per-coin map; the page is intentionally VAR-only.
+- Adding a new network without extending the hardcoded `AddressPrefixes`
+  tables → address section silently blank.
+- Expecting param edits at the node to appear without restarting the explorer
+  (`exp.ChainParams` is captured once).
+
+---
+
+## Section 8 — Evidence
+
+- Route: `cmd/dcrdata/main.go:810`
+- Handler: `cmd/dcrdata/internal/explorer/explorerroutes.go:2143-2184`
+- `commonData`: `explorerroutes.go:2534-2572`
+- `AddressPrefixes`: `explorer/types/explorertypes.go:1508-1549`
+- ChainParams capture: `cmd/dcrdata/internal/explorer/explorer.go:369-371`
+- `pageData` struct: `explorer.go:230-233`
+- `Store` (writes `BlockchainInfo`): `explorer.go:536-572` (assignment `:572`)
+- `StoreMPData` (other reader): `explorer.go:504-506`
+- RPC source / tip-nil gate: `blockdata/blockdata.go:38,332-357` (`:339-341`)
+- `GetChainParams`: `db/dcrpg/pgblockchain.go:6408-6410`
+- `GetTip`: `db/dcrpg/pgblockchain.go:7319-7348`
+- ETag middleware: `cmd/dcrdata/internal/explorer/explorermiddleware.go:193`
+- Template: `cmd/dcrdata/views/parameters.tmpl` (rows e.g.
+  `:9,30,41,61,119-168,173`)
+
+---
+
+## See also
+
+- `wiki/code-analysis/page-rendering/patterns.md`
+  (shares-pattern-with: out-of-band shared page state; `*CommonPageData`
+  embedding; shared-state lock discipline; block-scoped ETag cache)
+- `wiki/code-analysis/page-rendering/impact.md`
+  (depends-on: `commonData` nil render crash)
+- `wiki/core/staking-rewards.md`
+  (depends-on: VAR subsidy/reward proportion semantics)
+- `REWARDS_LOGIC.md`
+  (depends-on: multi-coin reward model — why this page stays VAR-only)

--- a/wiki/code-analysis/visualblocks/flow.full.md
+++ b/wiki/code-analysis/visualblocks/flow.full.md
@@ -134,6 +134,8 @@ When modifying `/visualblocks` data:
 - `cmd/dcrdata/public/scss/visualblocks.scss` and `cmd/dcrdata/public/scss/application.scss:49`.
 
 See also:
+- /wiki/code-analysis/page-rendering/patterns.md (shares-pattern-with: out-of-band shared page state; shared-state lock discipline; `*CommonPageData` embedding)
+- /wiki/code-analysis/page-rendering/impact.md (depends-on: saver writer/reader drift; lock-order inversion against `Store`; `commonData` nil render crash)
 - /wiki/code-analysis/visualblocks/patterns.md — domain patterns (cross-pipeline tile rendering, JS-side server-filter mirror, Subsidy struct asymmetry, triple-enforced 30-cap, memoized BlockInfo, shared page state, WS subsidy patch).
 - /wiki/code-analysis/visualblocks/impact.md — mutation impact, loud/silent failure modes, safe-change checklist.
 - /wiki/code-analysis/block/flow.full.md (shares-pattern-with: fan-out BlockDataSaver, dual transport shape REST vs WebSocket, multi-coin big.Int→string precision)

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -98,3 +98,17 @@ _The `/visualblocks` page: latest-N blocks plus mempool rendered as flex-grow ti
 - flow (full): code-analysis/visualblocks/flow.full.md — detailed, step-by-step function trace covering handler, DB memo, WS encoder, JS controller, and template
 - patterns: code-analysis/visualblocks/patterns.md — cross-pipeline tile rendering, JS-side server-filter mirror, Subsidy struct asymmetry, triple-enforced 30-cap, memoized BlockInfo, lock order, WS subsidy patch
 - impact: code-analysis/visualblocks/impact.md — mutation impact across HTTP/WS/JS/DB layers, loud and silent failure modes, safe-change checklist
+
+### Parameters
+
+_The `/parameters` page: active-network consensus config. ~95% static `chaincfg.Params` captured once at startup; only `MaximumBlockSize` is dynamic (tip-only RPC `GetBlockChainInfo`). Dual param injection (`commonData.ChainParams` + handler `ExtendedParams`), block-scoped ETag cache, VAR-only subsidy rows._
+
+- flow (compact): code-analysis/parameters/flow.compact.md — high-level summary of the static-vs-dynamic split, dual injection, and silent/hard failure modes
+- flow (full): code-analysis/parameters/flow.full.md — detailed, step-by-step trace from node config/RPC → pageData → handler → template, with cross-layer deps and mutation impact
+
+### Page-Rendering (cross-domain consolidation)
+
+_Mode-4 consolidation of the shared mechanics behind every server-rendered HTML page (block, mempool, visualblocks, parameters, charts, address). Not a flow — read alongside the per-domain flows it links. Covers out-of-band shared `pageData`/`invs` state, the multi-lock discipline, `*CommonPageData` struct-embedding template injection, and block-scoped ETag caching._
+
+- patterns: code-analysis/page-rendering/patterns.md — out-of-band shared page state via saver fan-out, `pageData`/`invsMtx` lock discipline, `*CommonPageData` embedding, block-scoped ETag cache
+- impact: code-analysis/page-rendering/impact.md — `commonData` nil render crash (all pages), saver writer/reader drift (HTML≠WS), lock-order inversion against `Store`

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -51,14 +51,14 @@ _End-to-end pipeline for transaction processing, decoding, and rendering inputs/
 
 ### Address
 
-_Address page rendering: paginated transaction table, chart endpoints, CSV download, multi-coin backend (`?coin=` via `CoinCtx` middleware) with frontend still rendering VAR-only, and TurboQuery-driven URL state (chart kind, zoom, group-by, pagination)._
+_Address page rendering: paginated transaction table, chart endpoints, CSV download, **multi-coin end-to-end** (`?coin=` via `CoinCtx` middleware; filter-before-paginate; confirmed-only balance), per-coin summary card + Coin column, and TurboQuery-driven URL state (chart kind, zoom, group-by, pagination, `coin`). Revised at `HEAD=1b670255` (PR #265/#266 + db coin-filter series)._
 
-- flow (compact): code-analysis/address/flow.compact.md — high-level summary of the address page data path, URL contract, and the dual-field migration shim
-- flow (full): code-analysis/address/flow.full.md — detailed function trace covering handler, DB layer with per-coin `Coins` map, cache, chart API, CSV, frontend controller (stale-zoom-param failure mode + confirmed SKA SQL precision bug)
-- patterns: code-analysis/address/patterns.md — `CoinCtx` URL contract, dual-field migration shim, coin-aware aggregation pipelines, per-coin caching, SKA decimal-string atom pipeline, TurboQuery URL ownership
-- impact (summary card): code-analysis/address/summary.impact.md — left-top card; backend per-coin complete, template still reads legacy flat fields and labels everything `DCR`; `FiatBalance` now `nil`
-- impact (transactions): code-analysis/address/transactions.impact.md — bottom section + `/addresstable` XHR + CSV; per-row coin fields populated but unread by template; CSV is multi-coin complete (`coin_type` column added, `value`→`amount` renamed)
-- impact (charts): code-analysis/address/charts.impact.md — chart API now `?coin=N`-aware end-to-end on backend; frontend doesn't emit `?coin=`; **confirmed SKA SQL precision bug** in `selectAddressAmountFlowByAddress`
+- flow (compact): code-analysis/address/flow.compact.md — current data path, `?coin=` contract, filter-before-paginate + confirmed-only-balance invariants, and a stale-claim delta table vs. the prior revision
+- flow (full): code-analysis/address/flow.full.md — current function trace: coin-filtered `AddressHistory`, rewritten mempool overlay, merged-view LIMIT-0 fix, per-coin templates, coin-aware controller, chart serialization
+- patterns: code-analysis/address/patterns.md — `CoinCtx` URL contract, coin-aware aggregation, per-coin caching, SKA decimal-string pipeline, TurboQuery URL ownership ⚠️ **stale (pre-#265/#266: dual-field shim) — reconcile via `Consolidate: address`**
+- impact (summary card): code-analysis/address/summary.impact.md ⚠️ **stale** — describes the now-completed VAR-only→multi-coin summary migration (`FiatBalance` removed, per-coin card shipped)
+- impact (transactions): code-analysis/address/transactions.impact.md ⚠️ **stale** — per-row coin fields are now read by the template (Coin column + SKA branches shipped)
+- impact (charts): code-analysis/address/charts.impact.md ⚠️ **partially stale** — frontend now emits `?coin=`; SKA SQL precision bug fixed (PR #263)
 
 ### Windows
 


### PR DESCRIPTION
## Summary

Finishes the multi-coin work on the address page and hardens the related
data path, plus consolidates the wiki code-analysis traces. Eight commits,
three buckets:

### Bug fixes (address page, multi-coin)

- **Empty address-io CSV with no `?coin=`** — `AddressCache.Rows` /
  `AddressRowsCompact` filtered on `r.CoinType == coinType`, but no real
  coin equals the `CoinTypeAll` sentinel (255), so the all-coins download
  matched zero rows. Both now short-circuit on `CoinTypeAll`.
- **CSV SKA amount format** — was a labeled string (`"1.23 SKA1"`),
  redundant with the `coin_type` column and non-numeric. Now a bare
  decimal via the new `dbtypes.FormatSKACoins`. Removed the misnamed,
  unused `dbtypes.FormatSKAPerVAR`.
- **Merged rows dropped coin type + SKA atoms** — `AddressRowMerged` had
  no coin field and only summed the VAR `int64` Value, so merged rows
  rendered as VAR/0 when a SKA coin was selected (Type=Merged + Coin=SKA1).
  Added `CoinType` and `SKAAtomsCredit/Debit` (`*big.Int`), coin-aware
  `add()`/`IsFunding()`/`Value()`/`SKAValueStr()`, folded through all four
  `Merge*` builders and `UncompactMergedRows`.
- **Amount-flow chart crash on flow toggle** — per-index `setVisibility`
  calls let Dygraph hit a transient all-invisible state, throwing in
  `computeCombinedSeriesAndLimits_`. Now applies the whole visibility map
  in one `setVisibility(object)` call via a new pure `flowVisibility(bitmap)`
  export.

### Tests

Regression coverage added/updated: `TestAddressCacheRows_CoinTypeAll`,
`TestFormatSKACoins`, `TestAddressCSV_CoinFiltering`,
`TestMergedRowsPreserveCoinAndSKA`, `TestMergedCompactMixedCoins`,
`address_controller.test.js` (flow-toggle mapping + reported regression),
and a per-coin unconfirmed-count test in `mempool` (#247).

### Wiki / code-analysis

- Rewrote the `address/` flow docs for the now multi-coin end-to-end
  state; documented the CSV full-export and merged-row coin invariants.
- New `parameters/` trace and a consolidated `page-rendering/` domain
  (shared pageData/invs state, multi-lock discipline, ETag cache);
  cross-linked and registered in `wiki/index.md`.

### Chore

- `.gitignore`: ignore `.github/scripts/tasks.json` (local scratch input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
