### PR TITLE
wiki: add attack-cost code-analysis trace

### DIFF
--- a/wiki/code-analysis/attack-cost/flow.compact.md
+++ b/wiki/code-analysis/attack-cost/flow.compact.md
@@ -1,0 +1,36 @@
+# Attack-Cost Page — Compact Knowledge (LLM-Optimized)
+
+**One-line flow:** node RPC → `blockdata` → `explorer.Store()` → `pageData.HomeInfo`
+(in-mem, RWMutex) → `AttackCost` handler (RLock snapshot, **no compute**) →
+`attackcost.tmpl` `data-attackcost-*` attributes → `attackcost_controller.js`
+(`parseInt`/`parseFloat`) → **all PoW/PoS math in the browser**.
+
+**Key architectural patterns:**
+- **No-compute handler:** `explorerroutes.go:2693-2742` only copies 6 fields from a
+  shared snapshot; no DB/RPC/XHR. Math lives entirely in JS.
+- **VAR-only legacy snapshot:** consumes flat `HomeInfo.CoinSupply int64` /
+  `TicketPoolInfo` (`explorertypes.go:811,1375`); never `VARCoinSupply`/`SKACoinSupply`.
+  Every "DCR" label = legacy VAR naming.
+- **Untyped Go→JS contract:** `data-attackcost-*` keys + `static targets` array
+  (`attackcost_controller.js:121-185`) are an exact string contract.
+- **Vendored-Dygraphs coupling:** monkey-patches private `doZoomY_`
+  (`attackcost_controller.js:252`).
+
+**Critical constraints:**
+- Precision: `parseInt`/`÷1e8` safe for 8-decimal VAR only; **breaks for 18-decimal SKA**
+  (exceeds `float64`). Not portable to SKA without BigInt rewrite.
+- Price: `exchanges` `Conversion` returns `nil` only if bot nil; bot-but-no-state →
+  `Value:0`, so effective price is **0, not the `24.42` literal** (`bot.go:1056`).
+- Snapshot is process-global, possibly stale; pre-first-`Store()` → `tpSize=0` →
+  `NaN`/`Infinity`.
+- `HomeInfo`/`TicketPoolInfo` are JSON-tagged, shared with HTTP API + home page.
+
+**Mutation checklist:**
+- Touch `HomeInfo.CoinSupply`/`TicketPoolInfo` types/units → handler `:2713-2731` + JS
+  `:203-209,602` + API JSON + home page.
+- Rename a `data-attackcost-*` **key** → silent `parseInt(null)=NaN` cascade.
+- Rename/remove a `data-attackcost-target` → JS throws in `connect()`, controller dead.
+- Add SKA → precision-corrupts via `parseInt`/`÷1e8`; needs BigInt path, not this one.
+- Remove/replace `xcBot` → price defaults; verify it's not silently `0`.
+- Upgrade Dygraphs → re-verify `doZoomY_` private override.
+- Loud failure only on template-exec error (`StatusPage`); JS-side failures are silent.

--- a/wiki/code-analysis/attack-cost/flow.full.md
+++ b/wiki/code-analysis/attack-cost/flow.full.md
@@ -1,0 +1,180 @@
+# Attack-Cost Page — Full Flow
+
+## Section 1 — Overview
+
+The `/attack-cost` page is a **51%-style majority-attack cost calculator** (PoW + PoS).
+It is unusual in this codebase: the Go side does **no computation** — the handler reads a
+process-global in-memory snapshot, renders six numbers into HTML `data-*` attributes, and
+**all attack math runs in the browser** (`attackcost_controller.js`). There is no DB query,
+no RPC call, and no XHR for this page.
+
+Critical framing: the page is **single-coin / VAR-only by construction**. It consumes the
+legacy flat `HomeInfo.CoinSupply int64` and never touches `HomeInfo.VARCoinSupply` /
+`HomeInfo.SKACoinSupply`. Every "DCR" label in the template is legacy naming for VAR.
+
+## Section 2 — End-to-End Data Flow
+
+```
+monetarium-node RPC ──► blockdata collector ──► explorer.Store() ──► pageData.HomeInfo (in-mem, RWMutex)
+  GetCoinSupply           blockData.ExtraInfo.CoinSupply        (written under p.Lock())
+  GetStakeDifficulty      blockData.CurrentStakeDiff
+  ticket pool             blockData.PoolInfo
+                                                                         │
+                                         AttackCost handler (RLock snapshot, no compute)
+                                                                         │
+                             attackcost.tmpl  data-attackcost-* attributes (Go number → string)
+                                                                         │
+                             attackcost_controller.connect(): parseInt / parseFloat
+                                                                         │
+                             all PoW/PoS attack math in the browser (Dygraphs + Decred formula)
+```
+
+## Section 3 — Per-Layer Breakdown
+
+### Layer A — Chain → in-memory snapshot
+
+- **Location:** `blockdata/blockdata.go:207` (`GetCoinSupply`); `cmd/dcrdata/internal/explorer/explorer.go:574-649` (`(*explorerUI).Store`).
+- **Data structures:** `blockData.ExtraInfo.CoinSupply`, `blockData.CurrentStakeDiff`,
+  `blockData.PoolInfo` → copied into `explorer/types/explorertypes.go:811` `HomeInfo`
+  (`CoinSupply int64`, `StakeDiff float64`, `HashRate float64`) and `:1375` `TicketPoolInfo`
+  (`Size uint32`, `Value float64`).
+- **Transformations:** `explorer.go:562-564` computes `stakePerc` using VAR `CoinSupply` via
+  `dcrutil.Amount(...).ToCoin()` (8-decimal float). `HomeInfo` is written under `p.Lock()`;
+  attack-cost reads under `RLock` — a snapshot, not request- or block-scoped.
+
+### Layer B — HTTP handler
+
+- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go:2693-2742`
+  (`(*explorerUI).AttackCost`); route registered `cmd/dcrdata/main.go:817`.
+- **Data structures:** anonymous struct embedding `*CommonPageData` with
+  `HashRate float64`, `Height int64`, `DCRPrice float64`, `TicketPrice float64`,
+  `TicketPoolSize int64`, `TicketPoolValue float64`, `CoinSupply int64`.
+- **Transformations:**
+  - `price := 24.42`; overwritten whenever `exp.xcBot != nil` via
+    `exp.xcBot.Conversion(1.0)` (`exchanges/bot.go:1045`). `Conversion` returns `nil`
+    **only** when `bot == nil`; with the bot present but no exchange state yet it returns
+    `Value: 0` (`bot.go:1056-1057`) — so the effective price becomes **0, not 24.42**.
+  - Reads six fields from `exp.pageData` under `RLock`, no math performed.
+  - Renders via `execTemplateToString("attackcost", …)`; template error →
+    `StatusPage(..., ExpStatusError)`.
+
+### Layer C — Template (Go number → HTML string)
+
+- **Location:** `cmd/dcrdata/views/attackcost.tmpl:7-17` (the `data-attackcost-*` attribute
+  block); template registered in the set at `explorer.go:424`.
+- **Data structures:** `data-attackcost-height`, `-hashrate`, `-dcrprice`, `-ticket-price`,
+  `-ticket-pool-value`, `-ticket-pool-size`, `-coin-supply`. `CoinSupply int64` is emitted
+  as a raw VAR-atom integer string.
+- **Transformations:** Go numeric → attribute string. ~90 `data-attackcost-target` hooks
+  feed the controller; the attribute key set and the `targets` array are an **untyped
+  contract**.
+
+### Layer D — Stimulus controller (string → Number → all math)
+
+- **Location:** `cmd/dcrdata/public/js/controllers/attackcost_controller.js`.
+- **Data structures / globals:** `height, dcrPrice, hashrate, tpSize, tpValue, tpPrice,
+  graphData, currentPoint, coinSupply` (module-level, line 47); `deviceList` (lines 63-80,
+  hardcoded `DCR5`/`D1` ASIC specs + a `medium.com/decred` citation).
+- **Transformations:**
+  - `connect()` lines 203-209: `parseInt(this.data.get('height'))`,
+    `parseFloat(this.data.get('ticketPrice'))`, `parseInt(this.data.get('coinSupply'))`, …
+  - `rateCalculation(y)` lines 49-61: Decred hybrid PoW/PoS deterrence formula
+    `(6x⁵−15x⁴+10x³)/(6y⁵−15y⁴+10y³)`.
+  - `calculate()` lines 503-579: device count, electricity, PoS DCR-need, projected ticket
+    price, totals.
+  - `showPosCostWarning()` lines 601-611: `coinSupply / 100000000` — hardcoded 1e8 divisor
+    (8-decimal assumption); if `DCRNeed > totalDCRInCirculation` it flags
+    "Attack not possible".
+  - TurboQuery URL state: `attack_time, target_pow, kwh_rate, other_costs, target_pos,
+    price, device, attack_type` (lines 189-198, 324-331).
+
+## Section 4 — Cross-Layer Dependencies
+
+- **Handler ↔ shared `HomeInfo`:** the handler does not own its data; it reads whatever
+  `Store()` last wrote. `HomeInfo`/`TicketPoolInfo` are **shared structs** (JSON-tagged,
+  `explorertypes.go:812`) also serialized by the HTTP API and consumed by the home page —
+  a field type/units change ripples far beyond this page.
+- **Template ↔ controller (brittle):** the `data-attackcost-*` attribute keys
+  (`this.data.get(...)`) and the `static targets` array (lines 121-185) form an exact,
+  untyped string contract. A renamed *data key* yields `parseInt(null) = NaN` silently; a
+  renamed/removed *target* throws in `connect()` and kills the controller.
+- **Price ↔ exchange bot:** `DCRPrice` depends on `exchanges` bot state at request time;
+  no state → `$0` everywhere, no error.
+- **Dygraphs:** `attackcost_controller.js:252` monkey-patches the private
+  `Dygraph.prototype.doZoomY_` — version-fragile coupling to the vendored Dygraphs build.
+
+## Section 5 — Critical Constraints
+
+- **VAR-only / single-coin:** consumes legacy flat `HomeInfo.CoinSupply`; ignores
+  `VARCoinSupply`/`SKACoinSupply` entirely. SKA coins are absent from the attack model;
+  "Total attack cost" reflects VAR only. (See `wiki/core/constraints.md` C1.)
+- **Precision (hard rule):** `parseInt(coinSupply)` + `coinSupply / 100000000` are safe
+  *only* because VAR has 8 decimals and fits `float64`. SKA has 18 decimals and exceeds the
+  `float64` significand — this pipeline silently corrupts any SKA-scale value. The whole
+  client-side `Number` math model is not portable to SKA without a BigInt rewrite.
+- **Snapshot semantics:** process-global `pageData` guarded by an RWMutex; before the first
+  `Store()` all fields are zero (`tpSize = 0` → divisions produce `NaN`/`Infinity`).
+- **Misleading price fallback:** the literal `24.42` is *not* the no-exchange value; with
+  the bot present and no state the effective price is `0`.
+
+## Section 6 — Mutation Impact
+
+When modifying this page, check:
+
+- **Direct dependencies:** `explorerroutes.go:2713-2731` struct fields;
+  `attackcost.tmpl:7-17` attribute keys; `attackcost_controller.js:203-209` parse calls.
+- **Indirect dependencies:** `HomeInfo`/`TicketPoolInfo` shared with HTTP API + home page;
+  `explorer.go:574-649` `Store()` population; `exchanges` bot `Conversion`.
+- **Serialization boundary:** Go numeric → `data-*` string → JS `parseInt/parseFloat`
+  (and the JSON-tagged shared struct used elsewhere).
+- **Rendering layers:** Dygraphs (`doZoomY_` patch), ~90 `data-attackcost-target` hooks.
+
+**Silent failures (no error, wrong output):**
+- Bot present, no exchange state → `price = 0` → all USD figures `$0`.
+- `pageData` not yet populated (startup) → `tpSize = 0` → `NaN`/`Infinity` outputs.
+- Routing SKA atoms through this path → `parseInt` precision loss, wrong `/1e8` divisor.
+- Mistyped/renamed `data-*` key → `NaN` propagation through every output.
+
+**Hard failures (visible):**
+- Template execution error → `StatusPage(..., ExpStatusError)`
+  (`explorerroutes.go:2733-2736`).
+- Renamed/removed Stimulus *target* → JS exception in `connect()`, controller dead, page
+  shows static `0`s.
+
+## Section 7 — Common Pitfalls
+
+1. Assuming "DCR"/`coin_supply` here means total network value — it is **VAR only**; SKA is
+   silently excluded.
+2. Multi-coin-ifying the page by piping SKA atoms through the existing
+   `data-*`/`parseInt`/`/1e8` path — violates the 18-decimal `big.Int` rule, corrupts
+   values with no error.
+3. Treating `24.42` as the no-exchange fallback — the real no-data price is `0`.
+4. Assuming the handler fetches fresh chain data — it reads a possibly-stale shared
+   snapshot under `RLock`.
+5. Refactoring `HomeInfo`/`TicketPoolInfo` field types "just for this page" — the structs
+   feed the API JSON and the home page.
+6. Renaming template attributes for cleanliness — the `data.get()` keys and `targets`
+   array are an exact, untyped contract; mismatches fail silently or kill the controller.
+7. Upgrading Dygraphs without re-checking the private `doZoomY_` override.
+
+## Section 8 — Evidence
+
+- `cmd/dcrdata/main.go:817` — route registration.
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:2693-2742` — `AttackCost` handler;
+  `:2696-2700` price logic; `:2733-2736` template-error path.
+- `cmd/dcrdata/internal/explorer/explorer.go:562-564, 574-649` — `Store()` → `HomeInfo`.
+- `explorer/types/explorertypes.go:811-837` (`HomeInfo`), `:1375-1382` (`TicketPoolInfo`).
+- `blockdata/blockdata.go:207` — `GetCoinSupply`.
+- `exchanges/bot.go:1045-1058` — `Conversion` (nil only when bot nil; `Value:0` when no state).
+- `cmd/dcrdata/views/attackcost.tmpl:7-17` — `data-*` contract; `:2731`-equivalent int64 emit.
+- `cmd/dcrdata/public/js/controllers/attackcost_controller.js:47` (globals),
+  `:49-61` (formula), `:63-80` (devices), `:121-185` (targets), `:203-209` (data parse),
+  `:252` (Dygraph hack), `:503-579` (calculate), `:601-611` (supply gate).
+
+See also:
+- /wiki/code-analysis/attack-cost/patterns.md (shares-pattern-with: VAR-only legacy snapshot, untyped `data-*`↔Stimulus contract, client-side-only math)
+- /wiki/code-analysis/attack-cost/impact.md (depends-on: shared `HomeInfo` struct, exchange-bot price, snapshot staleness)
+- /wiki/code-analysis/address/summary.impact.md (shares-pattern-with: legacy flat fields read while everything is labelled `DCR`)
+- /wiki/code-analysis/visualblocks/patterns.md (shares-pattern-with: untyped Go→JS contract, vendored Dygraphs coupling)
+- /wiki/core/constraints.md (depends-on: C1 numeric precision — float64 VAR vs big.Int SKA)
+- /wiki/core/pages.md (depends-on: `/attack-cost` route registry entry)

--- a/wiki/code-analysis/attack-cost/impact.md
+++ b/wiki/code-analysis/attack-cost/impact.md
@@ -1,0 +1,85 @@
+# Attack-Cost Page — Mutation Impact
+
+Explicitly identified risks for changing the `/attack-cost` page. Failure mode noted as
+**silent** (wrong output, no error) or **loud** (visible error).
+
+## Risk: SKA routed through the VAR-only pipeline
+
+**Trigger:** Attempting to multi-coin-ify the page, or feeding any SKA-scale value into
+`data-attackcost-coin-supply` / ticket fields.
+
+**Failure mode:** silent.
+
+**Description:** `attackcost_controller.js:209` `parseInt(coinSupply)` and `:602`
+`coinSupply / 100000000` assume 8-decimal VAR fitting `float64`. SKA has 18 decimals,
+exceeding the `float64` significand — values are silently truncated/rounded, and the
+"Attack not possible" gate (`:601-611`) compares corrupted magnitudes. Requires a BigInt
+path, not this one. (See `wiki/core/constraints.md` C1.)
+
+## Risk: Shared `HomeInfo` / `TicketPoolInfo` type or units change
+
+**Trigger:** Changing `HomeInfo.CoinSupply` (`int64`→string, atoms→coins),
+`TicketPoolInfo.Size`/`Value` types, or `HomeInfo.StakeDiff` semantics.
+
+**Failure mode:** silent (math), with cross-page blast radius.
+
+**Description:** `explorertypes.go:811,1375` structs are JSON-tagged
+(`json:"coin_supply"`) and consumed by the HTTP API and home page in addition to
+`explorerroutes.go:2713-2731` and `attackcost_controller.js:203-209,602`. A units change
+breaks the JS `/1e8` divisor and `tpSize`/`tpValue` divisions with no error here and
+mis-serializes the API elsewhere.
+
+## Risk: Exchange-bot price is silently zero
+
+**Trigger:** Exchange bot present but no state yet (startup, upstream outage), or removing
+`xcBot`.
+
+**Failure mode:** silent.
+
+**Description:** `exchanges/bot.go:1045-1058` `Conversion` returns `nil` **only** when
+`bot == nil`; with the bot present and no state it returns `Value: 0`. The handler guard
+`if rate := exp.xcBot.Conversion(1.0); rate != nil` (`explorerroutes.go:2696-2700`) then
+sets `price = 0`, **not** the `24.42` literal — every USD figure renders `$0`.
+
+## Risk: Stale / unpopulated snapshot
+
+**Trigger:** Request before the first `explorer.Store()` (startup), or `Store()` failing.
+
+**Failure mode:** silent.
+
+**Description:** Handler reads process-global `pageData` under `RLock`
+(`explorerroutes.go:2702-2711`). Zero-valued `tpSize` makes `val * tpSize`,
+`getRowForX`, and `DCRNeed / tpSize` produce `NaN`/`Infinity`; the page renders alive but
+with garbage numbers.
+
+## Risk: Untyped Go→JS contract drift
+
+**Trigger:** Renaming a `data-attackcost-*` attribute key or a `data-attackcost-target`.
+
+**Failure mode:** key → silent; target → loud.
+
+**Description:** A renamed *data key* yields `parseInt(null)=NaN` propagating through every
+output. A renamed/removed *target* throws in `connect()` (`attackcost_controller.js`),
+killing the controller so the page shows static `0`s.
+
+## Risk: Dygraphs upgrade breaks private override
+
+**Trigger:** Bumping the vendored Dygraphs build.
+
+**Failure mode:** loud (JS exception) or silent (Y-zoom re-enabled).
+
+**Description:** `attackcost_controller.js:252` overrides private
+`Dygraph.prototype.doZoomY_`; a renamed/removed private member silently restores Y-zoom or
+throws on assignment.
+
+## Loud-failure summary
+
+The only Go-side loud failure is a template execution error →
+`StatusPage(..., ExpStatusError)` (`explorerroutes.go:2733-2736`). Nearly every other
+failure on this page is **silent** — the calculator renders but produces wrong numbers.
+
+See also:
+- /wiki/code-analysis/attack-cost/flow.full.md (depends-on)
+- /wiki/code-analysis/attack-cost/patterns.md (depends-on)
+- /wiki/code-analysis/address/summary.impact.md (shares-pattern-with: legacy flat fields, `DCR` labelling)
+- /wiki/core/constraints.md (depends-on: C1 numeric precision — float64 VAR vs big.Int SKA)

--- a/wiki/code-analysis/attack-cost/patterns.md
+++ b/wiki/code-analysis/attack-cost/patterns.md
@@ -1,0 +1,53 @@
+# Attack-Cost Page — Patterns
+
+Domain-local patterns observed in this flow. These recur elsewhere in the wiki; global
+normalization is left to a future `Consolidate:` pass.
+
+## No-Compute Handler / Client-Side Math
+
+**Description:** The Go handler performs **zero domain computation** — it copies a fixed
+set of scalars from a shared snapshot into template `data-*` attributes; every attack
+calculation (PoW device cost, electricity, PoS DCR-need, Decred hybrid deterrence formula,
+projected ticket price) runs in `attackcost_controller.js`.
+
+**Constraints:**
+- All numeric correctness lives in JS `Number`; the Go side cannot enforce precision.
+- Any value that must stay exact (SKA atoms) cannot pass through this pattern unchanged.
+- Source: `explorerroutes.go:2693-2742`; `attackcost_controller.js:49-61, 503-611`.
+
+## VAR-Only Legacy Snapshot
+
+**Description:** Reads the legacy flat `HomeInfo.CoinSupply int64` / `TicketPoolInfo`
+(`explorertypes.go:811,1375`) and never the multi-coin `VARCoinSupply`/`SKACoinSupply`.
+All "DCR" labels are legacy VAR naming. Shared with `address/summary.impact.md`
+(template still reads legacy flat fields, labels everything `DCR`).
+
+**Constraints:**
+- Treat "coin supply" / "DCR" on this page as VAR-only; SKA is out of scope by design.
+- `HomeInfo`/`TicketPoolInfo` are JSON-tagged and shared with the HTTP API + home page —
+  field changes are cross-page.
+
+## Untyped Go → Stimulus String Contract
+
+**Description:** Two coupled string sets — `data-attackcost-*` attribute keys read via
+`this.data.get(...)` and the `static targets` array (`attackcost_controller.js:121-185`).
+Same pattern as `visualblocks/patterns.md` (untyped Go→JS contract).
+
+**Constraints:**
+- Renaming a *data key* → `parseInt(null)=NaN`, silent.
+- Renaming/removing a *target* → exception in `connect()`, controller dead (loud).
+- Keep template attribute names and the `targets` array in lockstep.
+
+## Vendored-Dygraphs Private Override
+
+**Description:** `attackcost_controller.js:252` monkey-patches the private
+`Dygraph.prototype.doZoomY_` to disable Y-axis zoom. Shares the vendored-Dygraphs coupling
+seen in the charts/visualblocks flows.
+
+**Constraints:** any Dygraphs upgrade must re-verify the private method name still exists.
+
+See also:
+- /wiki/code-analysis/attack-cost/flow.full.md (shares-pattern-with)
+- /wiki/code-analysis/visualblocks/patterns.md (shares-pattern-with: untyped Go→JS contract, vendored Dygraphs)
+- /wiki/code-analysis/address/summary.impact.md (shares-pattern-with: legacy flat-field / `DCR` labelling)
+- /wiki/core/constraints.md (depends-on: C1 numeric precision)

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -98,3 +98,12 @@ _The `/visualblocks` page: latest-N blocks plus mempool rendered as flex-grow ti
 - flow (full): code-analysis/visualblocks/flow.full.md — detailed, step-by-step function trace covering handler, DB memo, WS encoder, JS controller, and template
 - patterns: code-analysis/visualblocks/patterns.md — cross-pipeline tile rendering, JS-side server-filter mirror, Subsidy struct asymmetry, triple-enforced 30-cap, memoized BlockInfo, lock order, WS subsidy patch
 - impact: code-analysis/visualblocks/impact.md — mutation impact across HTTP/WS/JS/DB layers, loud and silent failure modes, safe-change checklist
+
+### Attack-Cost
+
+_The `/attack-cost` majority-attack calculator: a no-compute Go handler reads a shared VAR-only `HomeInfo` snapshot into `data-*` attributes; all PoW/PoS math runs client-side in `attackcost_controller.js`. VAR-only by construction (legacy flat `CoinSupply`/`DCR` labels); not portable to SKA without a BigInt rewrite._
+
+- flow (compact): code-analysis/attack-cost/flow.compact.md — high-level summary of the no-compute handler, VAR-only snapshot, untyped Go→JS contract, and client-side math
+- flow (full): code-analysis/attack-cost/flow.full.md — detailed trace: node→Store→HomeInfo→handler→template→Stimulus, exchange-bot price-zero trap, snapshot staleness, SKA precision boundary
+- patterns: code-analysis/attack-cost/patterns.md — no-compute handler, VAR-only legacy snapshot, untyped `data-*`↔Stimulus contract, vendored-Dygraphs private override
+- impact: code-analysis/attack-cost/impact.md — SKA-through-VAR-pipeline corruption, shared `HomeInfo` blast radius, silently-zero exchange price, stale snapshot, Go→JS drift; mostly silent failure modes


### PR DESCRIPTION
## Summary

Adds a new `attack-cost` domain to the code-analysis wiki, documenting the `/attack-cost` majority-attack calculator.

Key knowledge preserved:
- **No-compute handler**: `explorerroutes.go:2693-2742` does zero math — all PoW/PoS attack calculation runs client-side in `attackcost_controller.js`. No DB/RPC/XHR.
- **VAR-only by construction**: consumes legacy flat `HomeInfo.CoinSupply`; never `VARCoinSupply`/`SKACoinSupply`. All "DCR" labels are legacy VAR naming.
- **SKA precision boundary**: `parseInt` + `/1e8` silently corrupts 18-decimal SKA (exceeds `float64`); not portable without a BigInt rewrite.
- **Price-zero trap**: the `24.42` literal is *not* the no-exchange fallback — `Conversion` returns `Value:0` when the bot has no state, so price silently becomes `$0`.
- Mostly **silent** failure modes; only loud Go-side failure is a template-exec error.

## Files

- `wiki/code-analysis/attack-cost/flow.full.md` — §1–8 detailed trace
- `wiki/code-analysis/attack-cost/flow.compact.md` — §9 LLM-optimized summary
- `wiki/code-analysis/attack-cost/patterns.md` — recurring patterns (typed `shares-pattern-with` links; not globally consolidated)
- `wiki/code-analysis/attack-cost/impact.md` — 6 explicitly-identified mutation risks, silent/loud tagged
- `wiki/index.md` — registers the new domain under 🤖 Code Traces

Docs-only; no code changes. Produced via the mutation-analyzer skill (`Synthesize: attack-cost`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)