### PR TITLE
.claude/skills: add mutation-analyzer project skill; align wiki maintenance

### DIFF
--- a/.claude/skills/mutation-analyzer/SKILL.md
+++ b/.claude/skills/mutation-analyzer/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: mutation-analyzer
+description: >
+  Extracts structured, code-grounded knowledge from the Monetarium Explorer codebase to safely
+  modify existing code. Acts as an investigative staff engineer focused on mutation safety and
+  cross-layer dependencies. Use heavily whenever the user is tracking down dependencies across
+  layers, tracing data flow, or asking what breaks if they change something. Trigger explicitly
+  for phrases like "Trace how X flows", "I want to modify X, what do I check?", "Where is X
+  used?", "What breaks if I change X?", or "How does data move from backend to frontend for X?".
+  DO NOT trigger for general learning questions or high-level architecture overviews — for those,
+  redirect to Interview Mode to scope first. Strictly for mutation-oriented analysis anchored in
+  actual code paths. Produces/updates files under wiki/code-analysis/<domain>/.
+---
+
+# Mutation Analyzer
+
+You are acting as a senior staff engineer analyzing this complex, legacy-derived system. Your
+goal is to help the user safely modify existing code by producing code-grounded analysis of data
+flows, cross-layer dependencies, and hidden constraints — and to **persist that analysis to the
+wiki without being asked twice**.
+
+---
+
+## Project Invariants (assume these; do not rediscover them every run)
+
+This is the Monetarium Explorer (a multi-coin block explorer derived from `decred/dcrdata`,
+**no git upstream, no sync** — standalone codebase). The canonical, human-curated constraint
+list lives in [wiki/core/constraints.md](../../../wiki/core/constraints.md) (C1…Cn) — read it
+before any Synthesize and link applicable constraints with `depends-on: core/constraints.md C#`.
+
+Hard invariants that dominate mutation risk here:
+
+- **Precision bifurcation.** VAR uses 8 decimals → safe in `float64` (`dcrutil.Amount.ToCoin()`
+  is used for VAR everywhere). SKA uses 18 decimals → **exceeds float64 significand**; SKA atoms
+  must stay `big.Int`-derived strings end-to-end, no float conversion before the template
+  boundary. Any flow that funnels SKA through a VAR/float pipeline is a silent-corruption site.
+- **Single-coin transactions.** A tx is always single-coin; every input/output shares one coin
+  type. There is no mixed-coin tx.
+- **Fees follow the tx coin.** A VAR tx pays fees in VAR; a SKA tx pays fees in SKA. Never
+  assume fees are VAR.
+- **Multi-coin maps.** Many places where dcrdata had a single value now carry per-coin-type
+  maps/structs (VAR + up to 255 `SKA{n}`). Legacy flat fields / `DCR` labels still exist and
+  are load-bearing — flag them, don't rename them.
+- **10-module workspace.** Build/test/lint run from inside the relevant module's directory; a
+  low-level change (e.g. `txhelpers`) cascades `go mod tidy` through dependents.
+
+The wiki governance rules (domain naming, update-vs-create, index conventions, lint schedule)
+live in [wiki/core/maintenance.md](../../../wiki/core/maintenance.md). Load it before any
+Synthesize/Consolidate/Lint session that touches existing wiki files.
+
+---
+
+## Rules
+
+- NEVER produce generic summaries of files or architecture.
+- ALWAYS ground statements in actual code. Provide explicit file paths and relevant snippets.
+- Prioritize mutation safety ("if I change X, what breaks?") and tracing data flow end-to-end.
+- Explicitly identify critical constraints (precision, multi-coin, fee-coin) and implicit
+  assumptions. Anchor them to `core/constraints.md` rather than reinventing them.
+- Every non-trivial claim MUST be traceable to code.
+- If no direct evidence is found, mark it explicitly as **INFERRED** or **ASSUMPTION**. NEVER
+  present assumptions as facts.
+- Always prioritize tracing data FLOW over describing structure.
+- Treat patterns and impact as first-class knowledge derived from flows, not optional additions.
+
+**Good:** showing how data moves through modules.
+**Bad:** describing what a module does without flow context.
+
+---
+
+## Operating Modes
+
+You operate in **five** explicit modes. Default mode: **Interview**.
+
+The core pipeline is **auto-chaining**: Interview → Explore → **Synthesize (automatic)**.
+Synthesize is NOT a mode the user must remember to trigger. As soon as an Explore pass
+satisfies its mandatory checklist, you proceed to Synthesize and **write the wiki files**
+in the same turn, then report what you wrote. The explicit `Synthesize:` trigger only exists
+to re-run synthesis on an already-explored topic.
+
+To stop before files are written, the user must explicitly say so (e.g. "explore only",
+"don't write yet", "no wiki"). Absent that, generated files are the expected outcome.
+
+---
+
+### Mode 1 — Interview
+
+Define scope and surface unknowns before code exploration.
+
+- Ask 5–12 targeted questions focused on data flow across layers.
+- Stop when you can identify: data origin, main transformation points, main consumption points.
+- Then proceed to Explore (do not wait for a trigger word once scope is clear and the user
+  has answered enough; confirm scope in one line and continue).
+
+Good questions: where the same data is consumed in multiple layers; where a change propagates
+backend → API → UI; where silent corruption could occur (esp. SKA-through-float).
+Bad questions: exact struct definitions without flow context; internals unrelated to movement.
+
+---
+
+### Mode 2 — Explore
+
+**Trigger:** `Explore: <question>` — or automatically, once Interview scope is settled.
+
+Deeply analyze the code and return code-grounded answers.
+
+**Required analysis (ALL mandatory):**
+
+1. Where the entity is defined (source of truth).
+2. Where it is used (≥3 distinct usage points).
+3. ≥2 transformation points.
+4. ≥1 serialization boundary (DB or API).
+5. ≥1 domain-specific constraint (link to `core/constraints.md` when applicable).
+
+**For every entity, answer (do not defer to synthesis):** what depends on it directly; what
+depends on derived data; where a **silent failure** occurs; where a **hard failure** occurs.
+
+If any checklist item is missing: ⚠️ **INCOMPLETE** — state the missing evidence, and do not
+auto-proceed to Synthesize until resolved or the user accepts the gap.
+
+**On completion:** if the checklist is satisfied and the user has not asked to stop, continue
+directly into Mode 3 — Synthesize, in the same turn.
+
+---
+
+### Mode 3 — Synthesize (auto-runs after Explore)
+
+**Trigger:** automatic after a complete Explore pass; or explicit `Synthesize: <topic>` to
+re-synthesize.
+
+Produce a structured knowledge document from Explore findings **and write it to disk**.
+
+**Pre-generation:**
+
+- Read [wiki/index.md](../../../wiki/index.md) and any existing files for the target domain.
+- Read [wiki/core/constraints.md](../../../wiki/core/constraints.md) and reuse its C-numbers
+  instead of re-deriving precision/multi-coin rules.
+- State the target file(s) (create / update / extend) in ONE sentence before writing.
+- NEVER duplicate an existing knowledge file — extend or merge instead.
+
+**Files this mode writes (per-domain is allowed and expected):**
+
+| File | When |
+|---|---|
+| `wiki/code-analysis/<domain>/flow.full.md` | Always (Sections 1–8). |
+| `wiki/code-analysis/<domain>/flow.compact.md` | Always (Section 9). |
+| `wiki/code-analysis/<domain>/flow.<name>.full.md` | When the domain has genuinely distinct flows (e.g. `flow.reward-calculation.full.md`); pair with a matching `.compact.md`. |
+| `wiki/code-analysis/<domain>/patterns.md` | When this flow reveals reusable architectural behavior — **single-domain is sufficient; no 2+ requirement**. Create or extend. |
+| `wiki/code-analysis/<domain>/impact.md` | When this flow reveals non-trivial mutation risk — single-domain is sufficient. Create or extend. |
+| `wiki/code-analysis/<domain>/<subarea>.impact.md` | When a domain has distinct sub-areas with separate blast radii (e.g. `summary.impact.md`, `transactions.impact.md`, `charts.impact.md`). |
+
+Patterns and impact are produced **here, at synthesis time, per domain**. Mode 4 — Consolidate
+does NOT own their creation; it only normalizes recurrence *across* domains afterward.
+
+**Index:** every file created, extended, or merged requires a matching `wiki/index.md` update
+in the same turn. The index is the source of truth for what knowledge exists.
+
+**Cross-links:** typed and bidirectional when applicable. Types: `depends-on`, `derived-from`,
+`shares-pattern-with`. Place them in a `See also:` block at the bottom of the file. Use
+repo-root-relative `/wiki/...` paths to match the existing corpus, e.g.:
+
+```text
+See also:
+- /wiki/code-analysis/transaction/impact.md (depends-on: transaction serialization)
+- /wiki/core/constraints.md (depends-on: C1 numeric precision — float64 VAR vs big.Int SKA)
+```
+
+If evidence is missing: ⚠️ **INCOMPLETE** — list missing code references.
+
+Follow the **Synthesis Template (STRICT FORMAT)** below. After writing, report exactly which
+files were created/updated and the one-line index entries added.
+
+---
+
+### Mode 4 — Consolidate
+
+**Trigger:** `Consolidate: <scope>` (e.g. `Consolidate: transaction`, `Consolidate: var-ska`,
+`Consolidate: entire wiki`). Operates on existing wiki files, NOT raw code.
+
+**Purpose:** normalize knowledge that recurs across **2+ domains**. Per-domain `patterns.md` /
+`impact.md` already exist (Synthesize creates them). Consolidate's job is to prevent drift and
+duplication between domains:
+
+- When the same architectural behavior is independently documented in 2+ domains, pick a single
+  canonical home (the most upstream domain, or `core/constraints.md` if it is a cross-domain
+  invariant), trim the duplicates to a reference, and wire `shares-pattern-with` links.
+- When the same mutation risk / failure mode recurs across 2+ domains, do the same for impact:
+  one canonical statement, `depends-on` / `shares-pattern-with` links from the others.
+- Merge near-duplicate entries; prefer normalization over many narrow entries; keep entries
+  domain-specific unless they are clearly cross-domain.
+
+**Output (entry shapes):**
+
+```markdown
+## <Pattern Name>
+**Appears in:**
+- /wiki/code-analysis/<domain-a>/flow.full.md
+- /wiki/code-analysis/<domain-b>/flow.full.md
+**Description:** <what it is and why it recurs>
+**Constraints:** <rules that must hold wherever this pattern is used>
+```
+
+```markdown
+## Risk: <Short Name>
+**Trigger:** <what change causes this>
+**Affected flows:**
+- /wiki/code-analysis/<domain-a>/flow.full.md
+- /wiki/code-analysis/<domain-b>/flow.full.md
+**Failure mode:** silent / loud
+**Description:** <what breaks, where, how it propagates>
+```
+
+After extraction: add `shares-pattern-with` / `depends-on` links from each participating flow,
+keep links consistent and non-duplicated, update `wiki/index.md` if file roles change.
+
+---
+
+### Mode 5 — Lint
+
+**Trigger:** `Lint: <scope>` (e.g. `Lint: transaction`, `Lint: var-ska`, `Lint: entire wiki`).
+
+Scan [wiki/index.md](../../../wiki/index.md) and related files to detect: contradictions,
+duplication, missing links, incomplete flows, constraint violations, **a domain whose flow
+documents a reusable pattern but has no `patterns.md`**, **a domain whose flow documents a
+non-trivial risk but has no `impact.md`/`<subarea>.impact.md`**, and cross-domain recurrence
+not yet normalized by Consolidate.
+
+**Knowledge gaps:**
+
+- Flow reveals reusable behavior but domain has no `patterns.md` → Action: extend that domain
+  via Synthesize (or write the missing `patterns.md` directly if the flow is already complete).
+- Same behavior/risk across 2+ domains, un-normalized → Action: `Consolidate: <scope>`.
+
+**Output:**
+
+- **Issues Found** — per issue: Type (Contradiction / Duplication / Missing Link / Incomplete
+  Flow / Constraint Violation / Missing Pattern / Missing Impact); Location (file paths);
+  Description; Severity (Critical / High / Medium / Low); Action (Immediate / Next Refactor /
+  Optional).
+- **Suggested Fixes** — exact corrective actions.
+- **Critical Observations** — systemic risks across domains.
+
+All findings grounded in actual files. Mark assumptions as **INFERRED**.
+
+---
+
+## Synthesis Template (STRICT FORMAT)
+
+Every synthesis MUST follow this structure exactly.
+
+### Section 1 — Overview
+Short description of what is being traced or modified.
+
+### Section 2 — End-to-End Data Flow
+Step-by-step, e.g. `RPC → blockdata → db/dcrpg → internal/api → views/*.tmpl → public/js`.
+
+### Section 3 — Per-Layer Breakdown
+For each layer: **Location** (file paths/modules), **Data Structures** (exact structs/types),
+**Transformations** (how data is modified).
+
+### Section 4 — Cross-Layer Dependencies
+How layers are coupled; identify brittle connections (esp. Go→JS untyped `data-*`/WS contracts).
+
+### Section 5 — Critical Constraints
+Precision rules, multi-coin logic, fee-coin, hidden assumptions. Cite `core/constraints.md` C#.
+
+### Section 6 — Mutation Impact
+When modifying [X], check: direct deps, indirect deps, serialization boundaries, rendering
+layers. Define **silent failures** and **hard failures** explicitly.
+
+### Section 7 — Common Pitfalls
+Typical mistakes by developers or LLMs (e.g. SKA via float64, editing one of a duplicated calc).
+
+### Section 8 — Evidence
+File paths, code references, snippets supporting claims.
+
+### Section 9 — Compact Knowledge (LLM-Optimized)
+Max 200–300 words, no repetition, high density. Structure: one-line Flow; Key Architectural
+Patterns (2–4); Critical Constraints; Mutation Checklist.
+
+### Section 10 — Export (paths are exact — write these)
+
+```text
+📄 wiki/code-analysis/<domain>/flow.full.md      ← Sections 1–8
+📄 wiki/code-analysis/<domain>/flow.compact.md   ← Section 9
+📄 wiki/code-analysis/<domain>/patterns.md       ← if reusable behavior found (create/extend)
+📄 wiki/code-analysis/<domain>/impact.md         ← if non-trivial risk found (create/extend)
+📄 wiki/code-analysis/<domain>/<subarea>.impact.md ← if a sub-area has its own blast radius
+📄 wiki/index.md                                 ← MANDATORY: add/refresh entries for every
+                                                   file created, extended, or merged
+```
+
+Domain naming: name after the **feature area** being modified, not an abstract layer
+(`mempool/`, `voting-rewards/`, `block-table/`). If a feature touches an existing domain,
+extend that domain's files — never create a parallel file for an existing flow. If a new
+domain is required, add its entries to `wiki/index.md` (no justification needed).

--- a/.claude/skills/mutation-analyzer/evals/evals.json
+++ b/.claude/skills/mutation-analyzer/evals/evals.json
@@ -1,0 +1,100 @@
+{
+  "skill_name": "mutation-analyzer",
+  "evals": [
+    {
+      "id": "interview-block-flow",
+      "prompt": "Start interview for: Trace how block data flows from RPC to frontend rendering.",
+      "expected_output": "8-12 targeted questions focused on data flow, transformations, and cross-layer dependencies. No generic architecture questions."
+    },
+    {
+      "id": "explore-block-origin",
+      "prompt": "Explore: Where is block data initially constructed and what structures represent it?",
+      "expected_output": "Code-grounded answer with file paths and references to blockdata or RPC-related structures. Must include where data originates and how it is represented."
+    },
+    {
+      "id": "explore-block-usage",
+      "prompt": "Explore: Where is block data used in API responses and explorer rendering?",
+      "expected_output": "Answer must include multiple usage points (API handlers, explorer handlers, templates). Must show cross-layer usage, not just a single file."
+    },
+    {
+      "id": "synthesize-block-flow",
+      "prompt": "Synthesize: Trace how block data flows from RPC to frontend rendering.",
+      "expected_output": "Structured markdown document following the 10-section template. Must include end-to-end flow, per-layer breakdown, mutation impact, and evidence with file paths. Must include Compact Knowledge section."
+    },
+    {
+      "id": "interview-mutation-block-table",
+      "prompt": "Start interview for: I want to add SKA-related fields to the block table.",
+      "expected_output": "Questions must focus on data flow, UI rendering, precision handling, and where SKA data is introduced. Must avoid generic questions."
+    },
+    {
+      "id": "explore-ska-handling",
+      "prompt": "Explore: How are SKA token amounts handled and formatted across the system?",
+      "expected_output": "Must identify precision handling, data structures, and formatting logic. Must include references to relevant code and highlight high-risk areas."
+    },
+    {
+      "id": "synthesize-mutation-impact",
+      "prompt": "Synthesize: I want to add SKA-related fields to the block table. What do I need to check?",
+      "expected_output": "Structured document focused on mutation impact. Must explicitly list backend, DB, API, template, and frontend dependencies, plus potential breakage scenarios. Must include the 10-section template."
+    },
+    {
+      "id": "explore-api-impact",
+      "prompt": "Explore: If block data structure changes, which API responses depend on it?",
+      "expected_output": "Must identify API types, handlers, and serialization boundaries. Must include multiple dependency points and not stop at a single file."
+    },
+    {
+      "id": "synthesize-api-breakage",
+      "prompt": "Synthesize: If I change the structure of block data, what API responses and frontend parts will break?",
+      "expected_output": "Structured output emphasizing cross-layer dependencies and mutation risks. Must include both direct and indirect breakage."
+    },
+    {
+      "id": "lint-wiki-entire",
+      "prompt": "Lint: entire wiki",
+      "expected_output": "Issues Found section with Type, Location, Description, Severity, and Action. Suggested Fixes section. Critical Observations section. Must identify contradictions or missing links in the wiki."
+    },
+    {
+      "id": "interview-mempool-flow",
+      "prompt": "Start interview for: Trace how mempool transactions flow from RPC ingestion to live frontend updates.",
+      "expected_output": "Targeted questions about WebSocket vs HTTP paths, PubSubHub involvement, and how the frontend (Stimulus controllers) receives updates."
+    },
+    {
+      "id": "explore-mempool-bifurcation",
+      "prompt": "Explore: How does the system distinguish and separate mempool transactions from on-chain block transactions in the codebase?",
+      "expected_output": "Must identify specific flags, separate processing queues, or database tables. Must show the branching point in the backend logic."
+    },
+    {
+      "id": "explore-precision-enforcement",
+      "prompt": "Explore: Where exactly is the 18-decimal precision for SKA tokens enforced? Check DB schema, API serialization, and UI formatting.",
+      "expected_output": "Must identify exact code lines in SQL/Postgres, Go API structs, and JS formatting helpers. Must flag where precision loss could occur."
+    },
+    {
+      "id": "synthesize-mempool-impact",
+      "prompt": "Synthesize: I want to change how mempool transactions are aggregated before being sent to the UI. What is the impact?",
+      "expected_output": "10-section synthesis document. Must focus on the PubSub/WebSocket layer as a critical dependency and potential for UI lag or out-of-order updates."
+    },
+    {
+      "id": "synthesize-writes-correct-path",
+      "prompt": "Synthesize: Trace how the visualblocks page renders tiles from HTTP and WebSocket.",
+      "expected_output": "Synthesis must write files under wiki/code-analysis/visualblocks/ (NOT wiki/visualblocks/). Section 10 export and reported paths must use the wiki/code-analysis/<domain>/ prefix, and the run must update wiki/index.md."
+    },
+    {
+      "id": "synthesize-single-domain-patterns-impact",
+      "prompt": "Synthesize: Trace the attack-cost calculator from HomeInfo snapshot to client-side math.",
+      "expected_output": "Must produce per-domain patterns.md and impact.md for attack-cost even though only one flow exists (single-domain creation is allowed). Must NOT defer patterns/impact creation to Consolidate or claim a 2+ flow requirement."
+    },
+    {
+      "id": "explore-auto-chains-to-synthesize",
+      "prompt": "Explore: How does address page chart data flow from the DB per-coin Coins map to Dygraphs?",
+      "expected_output": "After the mandatory Explore checklist is satisfied, the run must automatically continue into Synthesize and write the wiki files in the same turn without the user issuing a separate Synthesize: trigger. Stopping is only acceptable if the checklist is INCOMPLETE or the user asked to explore only."
+    },
+    {
+      "id": "synthesize-links-core-constraints",
+      "prompt": "Synthesize: Trace how SKA atom amounts move from DB to the transaction template.",
+      "expected_output": "Critical Constraints section and See also block must reference wiki/core/constraints.md by C-number (e.g. depends-on: core/constraints.md C1) rather than re-deriving the float64/big.Int precision rule from scratch."
+    },
+    {
+      "id": "synthesize-multiple-impact-files",
+      "prompt": "Synthesize: Trace the address page across its summary card, transactions table, and charts sub-areas.",
+      "expected_output": "Must support multiple sub-area impact files (e.g. summary.impact.md, transactions.impact.md, charts.impact.md) under wiki/code-analysis/address/ when sub-areas have distinct blast radii, and update wiki/index.md for each."
+    }
+  ]
+}

--- a/wiki/core/maintenance.md
+++ b/wiki/core/maintenance.md
@@ -1,22 +1,33 @@
 # Wiki Maintenance Instructions
 
-This file defines conventions for maintaining the `/wiki/` knowledge base produced by the
-mutation-analyzer skill. It is a reference for the human and for LLMs working on wiki
-housekeeping — not part of the analysis skill itself.
+This file defines conventions for maintaining the **`wiki/code-analysis/`** knowledge base
+produced by the mutation-analyzer skill. It is a reference for the human and for LLMs working on
+wiki housekeeping — not part of the analysis skill itself.
 
-The wiki grows incrementally — one feature at a time. There is no pre-defined structure to
-fill in. Domains and files are created only when a real implementation session produces
-knowledge worth preserving.
+**Scope.** The mutation-analyzer skill produces and maintains only `wiki/code-analysis/`. The
+sibling trees are NOT produced by the skill and are out of scope here:
+
+- `wiki/core/` — human-curated architecture, domain rules, and the canonical constraint list
+  (`core/constraints.md`, C1…Cn). Hand-maintained.
+- `wiki/specs/` — human-curated feature requirements and page specs. Hand-maintained.
+- `wiki/index.md` — shared index covering all three trees. The skill updates only the
+  `code-analysis` entries in it; the core/specs sections are maintained by humans.
+
+The `code-analysis` tree grows incrementally — one feature at a time. There is no pre-defined
+structure to fill in. Domains and files are created only when a real implementation session
+produces knowledge worth preserving.
 
 ---
 
 ## Growth Model
 
-The wiki is feature-driven, not domain-driven. When starting work on a new feature:
+`wiki/code-analysis/` is feature-driven, not domain-driven. When starting work on a new feature:
 
-1. Run Interview + Explore + Synthesize using the mutation-analyzer skill.
-2. The synthesis output becomes the first (or updated) wiki file for that area.
-3. Add the file to `index.md`.
+1. Run Interview + Explore using the mutation-analyzer skill.
+2. Explore auto-chains into Synthesize, which writes the wiki file(s) for that area — you do
+   not need to issue a separate `Synthesize:` trigger; generated files are the expected outcome
+   of a completed Explore pass.
+3. The skill updates the `code-analysis` entries in `wiki/index.md` in the same run.
 4. Repeat for the next feature.
 
 The directory structure emerges from this process. Do not create domains speculatively.
@@ -26,20 +37,25 @@ The directory structure emerges from this process. Do not create domains specula
 ## Directory Structure
 
 ```
-/wiki/
-  index.md        ← source of truth; always update when adding files
-  <domain>/       ← created when the first synthesis for that area is saved
-    flow.full.md
-    flow.compact.md
-    patterns.md     (optional — only when a pattern appears across 2+ flows)
-    impact.md       (optional — only when mutation risks are explicitly identified)
+wiki/
+  index.md            ← shared index; code-analysis section is skill-maintained
+  core/               ← human-curated (NOT produced by the skill)
+  specs/              ← human-curated (NOT produced by the skill)
+  code-analysis/      ← produced and maintained by the mutation-analyzer skill
+    <domain>/         ← created when the first synthesis for that area is saved
+      flow.full.md
+      flow.compact.md
+      flow.<name>.full.md / flow.<name>.compact.md  (optional — genuinely distinct flows)
+      patterns.md       (created at Synthesize time when reusable behavior is found)
+      impact.md         (created at Synthesize time when mutation risk is found)
+      <subarea>.impact.md (optional — a sub-area with its own blast radius,
+                            e.g. summary.impact.md / transactions.impact.md / charts.impact.md)
 ```
 
 **Domain naming:** name it after the feature area being modified, not after an abstract
 architectural layer. Examples: `mempool/`, `voting-rewards/`, `supply-section/`, `block-table/`.
-If a feature touches an existing domain, extend that domain's files rather than creating a new one.
-
-Adding a new domain requires no justification — just add it to the index.
+If a feature touches an existing domain, extend that domain's files rather than creating a new
+one. Adding a new domain requires no justification — just add it to the index.
 
 ---
 
@@ -49,33 +65,42 @@ Adding a new domain requires no justification — just add it to the index.
 |---|---|---|
 | `flow.full.md` | Sections 1–8 from synthesis. Source of truth for this flow. | Synthesize |
 | `flow.compact.md` | Section 9 from synthesis. For LLM context injection. | Synthesize |
-| `patterns.md` | Reusable architectural behavior extracted from 2+ flows. | Consolidate |
-| `impact.md` | Mutation risks consolidated from 2+ flows. | Consolidate |
+| `patterns.md` | Reusable architectural behavior observed in this domain's flow(s). | Synthesize (per-domain); Consolidate normalizes cross-domain recurrence |
+| `impact.md` / `<subarea>.impact.md` | Mutation risks for this domain (or a sub-area). | Synthesize (per-domain); Consolidate normalizes cross-domain recurrence |
 
 Rules:
-- Every Synthesize session always produces `flow.full.md` and `flow.compact.md`. It may
-  mention observed patterns and risks inline but does not extract them into separate files.
-- `patterns.md` and `impact.md` are created or updated only by Consolidate, which operates
-  across existing flow files — not during a single-flow Synthesize session.
-- Lint detects missing `patterns.md` and `impact.md` entries but does not generate them —
-  it flags the gap and the human triggers a Consolidate session to address it.
-- A domain can have multiple named flow files if the flows are genuinely distinct
-  (e.g. `flow.reward-calculation.full.md`).
+
+- Every Synthesize session always produces `flow.full.md` and `flow.compact.md`.
+- Synthesize **also** creates or extends `patterns.md` / `impact.md` for the domain whenever
+  the flow reveals reusable behavior or non-trivial mutation risk. **Single-domain is
+  sufficient — there is no "appears in 2+ flows" precondition for creating these files.**
+- A domain may have multiple impact files when distinct sub-areas have distinct blast radii
+  (e.g. `summary.impact.md`, `transactions.impact.md`, `charts.impact.md`).
+- A domain may have multiple named flow files if the flows are genuinely distinct
+  (e.g. `flow.reward-calculation.full.md` + `flow.reward-calculation.compact.md`).
+- Consolidate does NOT own creation of `patterns.md` / `impact.md`. It operates across the
+  already-written per-domain files to normalize behavior/risks that recur in **2+ domains**:
+  pick one canonical home, trim duplicates to references, and wire cross-links.
+- Lint detects gaps (a flow that documents reusable behavior/risk but the domain lacks a
+  `patterns.md` / `impact.md`, or un-normalized cross-domain recurrence) and flags them; the
+  human decides whether to extend via Synthesize or run a Consolidate session.
 
 ---
 
-## Index Conventions (`index.md`)
+## Index Conventions (`wiki/index.md`)
 
-Start with an empty index and add entries as files are created. Each entry follows this format:
+`wiki/index.md` indexes all three trees. The skill maintains only the **Code Traces**
+(`code-analysis`) section; the Core and Specs sections are human-maintained. Each code-analysis
+entry follows this format (paths are repo-root-relative, including the `code-analysis/` prefix):
 
 ```markdown
 ### mempool/
-- [mempool flow](mempool/flow.full.md) — transaction table, block-fill indicators, WebSocket data
-- [mempool impact](mempool/impact.md) — mutation risks: WebSocket payload, coin type handling
+- [mempool flow](code-analysis/mempool/flow.full.md) — transaction table, fill indicators, WS data
+- [mempool impact](code-analysis/mempool/impact.md) — mutation risks: WS payload, coin handling
 ```
 
-Update the index every time a file is created, extended, or merged. The index is what the
-LLM reads to understand what knowledge already exists — keep it accurate.
+Update the index every time a code-analysis file is created, extended, or merged. The index is
+what the LLM reads to understand what knowledge already exists — keep it accurate.
 
 ---
 
@@ -83,13 +108,14 @@ LLM reads to understand what knowledge already exists — keep it accurate.
 
 | Situation | Action |
 |---|---|
-| Working on a feature in an existing domain | Read existing flow files, then extend or update via Synthesize |
-| Working on a feature with no existing domain | Create new domain folder and flow files via Synthesize, add to index |
-| New findings extend an existing flow | Edit the existing `flow.full.md` and `flow.compact.md` |
+| Working on a feature in an existing domain | Read existing flow files, then extend/update via Synthesize |
+| Working on a feature with no existing domain | Synthesize creates the new `code-analysis/<domain>/` folder + files and adds them to the index |
+| New findings extend an existing flow | Edit the existing `flow.full.md` / `flow.compact.md` (and `patterns.md` / `impact.md` if affected) |
 | New findings contradict existing knowledge | Flag the conflict explicitly, then update |
-| Same behavior appears in 2+ flow files | Run `Consolidate: <scope>` to extract into `patterns.md` |
-| Same mutation risk appears in 2+ flow files | Run `Consolidate: <scope>` to extract into `impact.md` |
-| Lint flags a missing pattern or impact entry | Human triggers `Consolidate: <scope>` to address it |
+| This domain's flow reveals reusable behavior | Synthesize writes/extends `code-analysis/<domain>/patterns.md` (no 2+ requirement) |
+| This domain's flow reveals a non-trivial risk | Synthesize writes/extends `code-analysis/<domain>/impact.md` (or a `<subarea>.impact.md`) |
+| Same behavior/risk recurs across 2+ domains | Run `Consolidate: <scope>` to normalize to one canonical home + cross-links |
+| Lint flags a gap or un-normalized recurrence | Human triggers Synthesize (extend) or `Consolidate: <scope>` |
 
 Never create a parallel file for a flow that already exists. Merge instead.
 
@@ -97,20 +123,21 @@ Never create a parallel file for a flow that already exists. Merge instead.
 
 ## Cross-Linking Format
 
-Links are optional at the start. Add them when a genuine dependency between domains becomes
-apparent during synthesis or lint.
+Links are optional at the start. Add them when a genuine dependency between domains (or to
+`core/constraints.md`) becomes apparent during synthesis or lint.
 
-When adding links, place them in a `See also:` block at the bottom of the file:
+Place them in a `See also:` block at the bottom of the file, using repo-root-relative `/wiki/`
+paths (matching the existing corpus):
 
 ```markdown
 See also:
-- /wiki/block-table/flow.full.md (shares-pattern-with: SKA aggregation logic)
-- /wiki/voting-rewards/impact.md (depends-on: ticket price precision handling)
+- /wiki/code-analysis/block-table/flow.full.md (shares-pattern-with: SKA aggregation logic)
+- /wiki/code-analysis/voting-rewards/impact.md (depends-on: ticket price precision)
+- /wiki/core/constraints.md (depends-on: C1 numeric precision — float64 VAR vs big.Int SKA)
 ```
 
-Link types: `depends-on`, `derived-from`, `shares-pattern-with`
-
-If A links to B, check whether B should reference A.
+Link types: `depends-on`, `derived-from`, `shares-pattern-with`. If A links to B, check whether
+B should reference A.
 
 ---
 
@@ -120,19 +147,22 @@ Run `Lint: <scope>` using the mutation-analyzer skill when:
 
 - You are about to modify a domain you haven't touched in several sessions.
 - A synthesis produces results that feel inconsistent with existing knowledge.
-- The wiki has grown enough that cross-domain dependencies are plausible (typically after 4–6 domains exist).
+- The wiki has grown enough that cross-domain dependencies are plausible (typically after 4–6
+  domains exist).
 
-Lint detects problems and flags missing `patterns.md` or `impact.md` entries — it does not
-generate files itself. When Lint flags a gap, the human decides whether to run
-`Consolidate: <scope>` to address it.
+Lint detects problems and flags gaps — it does not generate files itself. When Lint flags a
+gap, the human decides whether to extend via Synthesize or run `Consolidate: <scope>`.
 
-Lint is not automated — the human decides when to run it. Early in the project, lint is rarely needed.
+Lint is not automated — the human decides when to run it. Early in the project, lint is rarely
+needed.
 
 ---
 
 ## What This File Is NOT
 
-- It does not define how analysis works — that is the mutation-analyzer skill.
+- It does not define how analysis works — that is the mutation-analyzer skill
+  (`.claude/skills/mutation-analyzer/SKILL.md`).
 - It does not enforce rules during Explore or Interview mode.
-- It is not read automatically by the LLM. Load it into context when doing wiki housekeeping
-  or before a synthesis session where existing wiki files are relevant.
+- It does not govern `wiki/core/` or `wiki/specs/` — those are human-curated.
+- It is not read automatically by the LLM. Load it into context when doing `code-analysis`
+  housekeeping or before a synthesis session where existing wiki files are relevant.


### PR DESCRIPTION
## What

Adds a **project-local** `mutation-analyzer` skill (`.claude/skills/mutation-analyzer/`) and realigns `wiki/core/maintenance.md` to match it.

## Why we want this in the repo

The mutation-analyzer skill is already load-bearing for this codebase, but it has been living **only as a personal global skill** in individual contributors' `~/.claude/`. That's a problem:

- **It's de-facto project infrastructure, untracked.** `CLAUDE.md` mandates reading the code-analysis traces before modifying a covered area; the entire `wiki/code-analysis/` tree (11 domains) is *produced by this skill*; `wiki/core/maintenance.md` exists specifically to govern it. The thing that generates and maintains a checked-in part of the repo should itself be checked in and reviewable.
- **The global copy had drifted from reality.** It wrote to the wrong wiki paths (`/wiki/<domain>/` instead of `wiki/code-analysis/<domain>/`), miscounted its own modes, contradicted `maintenance.md` on how `patterns.md`/`impact.md` are produced, had no project anchoring (VAR/SKA precision, single-coin tx, etc.), and required a manual `Synthesize:` trigger so generated files were easy to forget. These defects shipped silently through many sessions because nothing versioned or tested the skill.
- **No consistency across contributors.** Every person's global copy could differ. A project skill is shared, versioned, and **overrides the global one for this repo**, so everyone (and Claude) uses the same, correct behavior automatically — no setup step.
- **Co-location keeps it honest.** Skill + its governance doc (`maintenance.md`) + its regression suite (`evals/evals.json`) now evolve together in one PR-reviewable place, so future edits can't silently re-introduce the path/mode/process drift.

Net: this converts an ad-hoc personal tool into shared, reviewable project infrastructure that actually matches how the wiki is built.

## What changed

Fixes baked into the project skill vs. the old global one:

- Output paths corrected to `wiki/code-analysis/<domain>/`; removed the nonexistent `var-ska-data` example.
- Mode count fixed (five, not four).
- Per-domain `patterns.md`/`impact.md` (and multiple `<subarea>.impact.md`) produced at **Synthesize** time with no "2+ flows" precondition; **Consolidate** redefined as cross-domain normalization only — matching how the wiki is actually structured.
- **Explore auto-chains into Synthesize**, so wiki files get written without a manual trigger.
- Added a "Project Invariants" preamble and a pre-generation anchor requiring `wiki/core/constraints.md` (constraints linked by C-number).
- `evals/evals.json` extended with 5 regression cases pinning each fix.
- `wiki/core/maintenance.md` realigned: scoped to `wiki/code-analysis/` only (`core/` and `specs/` are human-curated), paths corrected, process model reconciled.

## Impact / risk

Tooling + documentation only. **Zero effect on the explorer binary, build, or runtime** — no Go/JS/SQL touched. The skill governs how analysis docs are produced, not application behavior.

## Validation

- All 5 fixes verified by static inspection of `SKILL.md`.
- Before/after spot-checked: the old global skill reproduced the auto-chain and patterns/impact defects; the new skill behaved correctly (wrote under `wiki/code-analysis/`, produced per-domain `patterns.md`/`impact.md` in one pass, anchored constraints by C-number).
- No changes to `wiki/code-analysis/` content in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
