### PR TITLE
docs/scripts: make contract-the-seam the default issue decomposition

### DIFF
--- a/.claude/skills/generate-tasks-json/SKILL.md
+++ b/.claude/skills/generate-tasks-json/SKILL.md
@@ -5,107 +5,76 @@ description: Generate a tasks.json file for the Monetarium Explorer issue-creati
 
 # Generate tasks.json for create-issues.js
 
-This project drives bulk GitHub issue creation through a single Node.js script (`.github/scripts/create-issues.js`) that consumes a `tasks.json` file. Your job in this skill is to turn the user's high-level intent (a feature, an epic, a chunk of refactoring work) into a valid `tasks.json` that the script will accept on the first try, while honoring the team's hierarchy, naming, and assignment conventions.
+This project drives bulk GitHub issue creation through a single Node.js script (`.github/scripts/create-issues.js`) that consumes a `tasks.json` file. This skill covers **how to execute** that task: where the file goes, the script's schema, validation, and the safe run procedure. It does **not** restate the team's planning rules — those live in one place (below).
 
-The authoritative rule document is [`.github/scripts/GITHUB_ISSUES_AND_PROJECT_BOARD.md`](../../../.github/scripts/GITHUB_ISSUES_AND_PROJECT_BOARD.md). The notes below are the working summary you actually need while drafting — read the full doc only if a question comes up that this skill doesn't answer.
+## Authoritative rules — read this first, every time
+
+[`.github/scripts/GITHUB_ISSUES_AND_PROJECT_BOARD.md`](../../../.github/scripts/GITHUB_ISSUES_AND_PROJECT_BOARD.md) is the **single source of truth** for all issue-planning policy. **Read it in full before drafting** — not "only if a question comes up". It is binding; if anything in this skill ever appears to conflict with it, the doc wins and this skill should be fixed.
+
+It owns, and this skill deliberately does **not** duplicate:
+
+- the **two-level hierarchy** and the **contract-is-the-seam default decomposition** (§6.2.1, §6.3) — when to emit a single `issue` vs. one `parent` + exactly two contract-aligned sub-issues, the >2 exception, no childless `parent`;
+- **sub-issue prefixes** and the one-dominant-prefix / splitting rules (§6.4–§6.7);
+- **assignment** mapping and load-balancing (§7);
+- the **allowed label set** (§7.6).
+
+Apply those rules from the doc. The rest of this skill is mechanics.
+
+## Sourcing issue content from the wiki
+
+The repo ships a curated `wiki/` (`wiki/index.md`). Use it to fill issue bodies instead of re-deriving scope — this is drafting technique, not policy:
+
+- **If `wiki/specs/<area>/spec.md` exists, that spec is the Feature.** Link it from the `parent` description; **lift the spec's own acceptance checklist verbatim** into the consumer (`[UI]`) sub-issue rather than paraphrasing.
+- **If `wiki/code-analysis/<area>/` exists, mine it for the producer sub-issue.** Put `patterns.md` invariants and `impact.md` failure modes into the `[DATA]`/`[WS]` issue as explicit "must preserve" acceptance items (memoized-pointer no-mutate, lock order, the doc-mandated both-transports parity gate, etc.).
+- The producer side may cascade across several Go modules (10-module workspace) — that is still **one** sub-issue (the contract), never one-per-module.
+- The routine `[DOCS]` third refreshes those exact code-analysis files (`flow.compact.md`, `patterns.md`, `impact.md`) after the other two land.
 
 ## Workflow
 
-1. **Understand the feature.** Ask the user enough to identify: the user-visible functionality (the Feature), the rough system layers it touches (DB, DATA, API, WS, UI), and any constraints (single PR? small enough to skip sub-issues?).
-2. **Decide the shape.** A small Feature can be a single `parent` issue with checkbox steps in its description. A normal Feature is one `parent` plus several `sub-issue` children, one per system boundary that requires its own PR.
-3. **Draft the JSON** in memory or directly into the file, following the schema and rules below.
-4. **Validate locally** by running the script in dry-run mode before doing anything live (see "Validate" below). Never invoke a non-dry run yourself — that creates real issues on GitHub. Hand the dry-run output to the user and let them run the live command.
+1. **Read the authoritative doc** (above), then understand the feature: the user-visible functionality, the system layers it touches, and any constraints.
+2. **Decide the shape per the doc's §6.2.1** — no contract → a single `issue`; a contract → one `parent` + two contract-aligned sub-issues; exceed two only with the doc's stated justification.
+3. **Draft the JSON** following the schema below, sourcing content from the wiki.
+4. **Validate locally** in dry-run mode (see "Validate"). Never invoke a live run yourself.
 
 ## File location and shape
 
-By default the script reads `./tasks.json` from the current working directory, but it accepts `--file <path>`. Unless the user says otherwise, write to `.github/scripts/tasks.json` so it sits next to the script and is easy to commit alongside any related changes.
-
-The top-level structure is a single object with a `tasks` array:
+The script defaults to `./tasks.json` in the cwd but accepts `--file <path>`. Unless told otherwise, write to `.github/scripts/tasks.json` so it sits next to the script.
 
 ```json
 {
-  "tasks": [ /* task objects */ ]
+  "tasks": [
+    /* task objects */
+  ]
 }
 ```
 
 ## Task object fields
 
-Each task is one of three `type` values. The script's validator (in `create-issues.js`) enforces:
+This is the `create-issues.js` schema (a script contract, not team policy). The validator enforces:
 
-- `id` — required, unique string. Used internally to wire `parent` ↔ `sub-issue`. Use stable, kebab-case slugs like `feature-blocks-list`, `blocks-api-endpoint`. The id is **not** posted to GitHub; it is purely a local key.
-- `title` — required, what appears on GitHub.
+- `id` — required, unique string. Wires `parent` ↔ `sub-issue` locally; not posted to GitHub. Use stable kebab-case slugs (`feature-blocks-list`).
+- `title` — required, what appears on GitHub. Sub-issue titles take a prefix per the doc.
 - `type` — one of `parent`, `sub-issue`, `issue`. Anything else fails validation.
-- `parent` — required when `type` is `sub-issue`; must reference an existing `id` whose task has `type: parent`.
-- `issue_type` — `Feature` for parents, `Task` for sub-issues and standalone issues. The script defaults to `Feature`/`Task` if omitted, but set it explicitly so the file is self-documenting.
-- `description` — markdown body. For sub-issues the script automatically appends `\n\nPart of #<parent-number>` at create time, so do not include that yourself.
-- `assignee` — exactly one GitHub login (see "Assignment" below).
-- `labels` — array. Use only the approved set; `enhancement` is the safe default. Omit entirely if no label adds value — over-labeling is discouraged.
-
-## Hierarchy rules
-
-- Only **two levels**: Feature (`parent`) → Sub-issues (`sub-issue`). No nested sub-tasks.
-- A sub-issue should be **one PR's worth of work** and self-contained enough that the assignee doesn't need deep context from sibling issues to start.
-- If a Feature is genuinely small, emit a single `parent` (or a single `issue`) with a checkbox list in `description` instead of inventing thin sub-issues.
-- A standalone task (bug fix, infra tweak) that has no parent uses `type: issue`.
-
-## Sub-issue title prefixes
-
-Every sub-issue title must start with exactly one prefix in square brackets. The prefix marks the **dominant** area of responsibility — where the main work happens — not every layer the change touches.
-
-| Prefix    | Use it when the primary work is…                 |
-| --------- | ------------------------------------------------ |
-| `[API]`   | Adding/changing an HTTP endpoint or data contract |
-| `[DB]`    | SQL queries, indexing, schema, perf in `db/dcrpg`|
-| `[UI]`    | Templates, SCSS, Stimulus controllers, frontend  |
-| `[WS]`    | WebSocket / pubsub real-time push                |
-| `[DATA]`  | Aggregation, transformation, internal Go logic   |
-| `[DOCS]`  | Wiki pages, READMEs, CLAUDE.md, in-repo guides   |
-
-Hard rules:
-
-- **One prefix per title.** Never combine (`[API][UI] …` is invalid).
-- **Pick the dominant prefix** — the one reflecting the primary area of responsibility, where the main work is performed. Prefixes do not enumerate every layer the change touches; they mark the initiator of the change. An endpoint change that incidentally requires a UI tweak stays `[API]` because the contract is the dominant work — do not split it.
-- **Only split when two domains carry genuinely equal weight.** Splitting is the fallback for the rare case where neither domain dominates, not the default response to multi-layer work — over-splitting produces churn and many tiny issues. When it is the right call:
-  - ❌ `[API][UI] Add sorting to blocks list`
-  - ✅ `[API] Add sorting support to blocks endpoint` + `[UI] Implement sorting in blocks table`
-
-The parent (Feature) title does **not** take a prefix — it names the user-visible functionality (e.g. `Blocks List Page`).
-
-## Assignment
-
-Each issue gets exactly one assignee. The team's preferred mapping:
-
-- `[DB]`, `[DATA]`, `[WS]`, `[API]` → **yanchenko-igor**
-- `[UI]` → **edshav**
-- `[DOCS]` → no fixed default; assign to whichever developer has the most context on the area being documented.
-- Feature (`parent`) assignee is the Feature Owner — typically the developer doing the bulk of the work, often the backend lead for backend-heavy features.
-
-This is a **guideline, not a hard rule**. If following it would pile every sub-issue on one person, rebalance: load balancing beats specialization. Do not invent extra sub-issues just to redistribute work, and do not split a sub-issue purely because of who would own it.
-
-## Labels
-
-Allowed values, and only these:
-
-- `enhancement` (default for new functionality)
-- `bug`
-- `infrastructure`
-- `documentation`
-- `refactoring` — only when behavior does not change
-
-The script will fail if a label doesn't already exist on the repo, so do not invent new ones. Generic labels (`duplicate`, `invalid`, `wontfix`, `question`, `good first issue`, `help wanted`) are explicitly disallowed by team policy. When in doubt, omit `labels` rather than add noise.
+- `parent` — required when `type` is `sub-issue`; must reference an existing `id` whose task is `type: parent`.
+- `issue_type` — `Feature` for parents, `Task` otherwise. Defaults apply if omitted; set it explicitly.
+- `description` — markdown body. The script auto-appends `\n\nPart of #<parent-number>` to sub-issues — do not write that yourself.
+- `assignee` — exactly one GitHub login (mapping is in the doc, §7).
+- `labels` — array from the doc's allowed set only (§7.6); omit if none adds value. There is **no** per-task `milestone` field — the script applies the milestone globally.
 
 ## Validation cheat-sheet (what the script enforces)
 
-The validator in `create-issues.js` will reject the file if any of these are true — check before handing the file to the user:
+`create-issues.js` rejects the file if any of these hold — check before handing it over:
 
-- A task is missing `id` or `title`.
-- Two tasks share an `id`.
-- `type` is anything other than `parent`, `sub-issue`, or `issue`.
-- A `sub-issue` has no `parent`, or its `parent` id does not exist, or the referenced parent's `type` is not `parent`.
+- a task missing `id` or `title`;
+- two tasks sharing an `id`;
+- `type` not in `parent` / `sub-issue` / `issue`;
+- a `sub-issue` with no `parent`, a non-existent `parent`, or a `parent` whose `type` is not `parent`.
 
-Sanity-check the JSON yourself against these before declaring done.
+Sanity-check the JSON against these yourself first.
 
 ## Skeleton to start from
+
+The default shape (one `parent` + the two contract sides). A canonical worked example with a routine `[DOCS]` third is in the authoritative doc §8.4.
 
 ```json
 {
@@ -115,17 +84,17 @@ Sanity-check the JSON yourself against these before declaring done.
       "type": "parent",
       "issue_type": "Feature",
       "title": "<User-visible feature name>",
-      "description": "<Scope, motivation, acceptance criteria>",
+      "description": "<scope, motivation, link to wiki/specs/<area>/spec.md>",
       "assignee": "<github-login>",
       "labels": ["enhancement"]
     },
     {
-      "id": "<slug>-data",
+      "id": "<slug>-contract",
       "type": "sub-issue",
       "parent": "feature-<slug>",
       "issue_type": "Task",
-      "title": "[DATA] <what this sub-issue does>",
-      "description": "<concrete implementation scope>",
+      "title": "[DATA] <producer side — deliver the contract shape>",
+      "description": "<contract as acceptance criteria + both-transports parity gate + code-analysis invariants>",
       "assignee": "yanchenko-igor",
       "labels": ["enhancement"]
     },
@@ -134,8 +103,8 @@ Sanity-check the JSON yourself against these before declaring done.
       "type": "sub-issue",
       "parent": "feature-<slug>",
       "issue_type": "Task",
-      "title": "[UI] <what this sub-issue does>",
-      "description": "<concrete implementation scope>",
+      "title": "[UI] <consumer side — render against the contract>",
+      "description": "<spec acceptance checklist, lifted verbatim>",
       "assignee": "edshav",
       "labels": ["enhancement"]
     }
@@ -143,25 +112,23 @@ Sanity-check the JSON yourself against these before declaring done.
 }
 ```
 
-A fuller worked example (Blocks List Page) lives in [`.github/scripts/GITHUB_ISSUES_AND_PROJECT_BOARD.md`](../../../.github/scripts/GITHUB_ISSUES_AND_PROJECT_BOARD.md) §8.4 — open it if you need a reference for how a real Feature decomposes into 4–6 sub-issues.
-
 ## Validate
 
-After writing the file, run the script in dry-run mode. It validates structure, prints what would be created, and makes **no** GitHub API calls:
+After writing the file, run dry-run mode — it validates, prints what would be created, and makes **no** GitHub API calls:
 
 ```bash
 cd .github/scripts && node create-issues.js --dry-run
 ```
 
-If the user wrote the file somewhere else, point the script at it: `node create-issues.js --dry-run --file <path>`.
+If the file is elsewhere: `node create-issues.js --dry-run --file <path>`.
 
-Read the dry-run output for any `❌` lines and fix the file before reporting done. Do **not** run the live command (`node create-issues.js` without `--dry-run`) yourself — that creates real GitHub issues, which is a write action that requires explicit user approval per the project's GitHub CLI rules. Show the user the dry-run output and the live command, and let them invoke it.
+Fix any `❌` lines before reporting done. Do **not** run the live command (`node create-issues.js` without `--dry-run`) yourself — that creates real GitHub issues, a write action requiring explicit user approval per the project's GitHub CLI rules. Show the user the dry-run output and the live command and let them invoke it.
 
-## Common mistakes to avoid
+## Common mistakes (mechanics)
 
-- **Putting `Part of #N` in a sub-issue description.** The script appends this automatically — duplicating it produces ugly output.
-- **Inventing prefixes** (`[BACKEND]`, `[FE]`, `[TEST]`). Only the six listed prefixes are valid.
-- **Multi-prefix titles.** Pick the single dominant prefix — the area where the main work is performed — instead of combining. Only split into separate sub-issues when two domains carry genuinely equal weight; otherwise a one-prefix title with a brief note in the description about incidental cross-layer changes is correct.
-- **Assigning a sub-issue to multiple people** via comma or array. The field takes one login.
-- **Putting CI/dev-tooling work under `enhancement`.** Use `infrastructure`.
-- **Reusing an `id` across runs after partial success.** If the user is resuming a previous run with `--resume`, the script reads `.create_issues_state.json` keyed by `id`; renaming an id mid-flight breaks resume linkage.
+Planning mistakes (over-decomposition, childless `parent`, wrong prefix/assignment/label) are governed by the authoritative doc — follow it. The script-mechanics traps:
+
+- **Writing `Part of #N` into a sub-issue description.** The script appends it automatically; duplicating produces ugly output.
+- **Adding a `milestone` field to a task.** The milestone is applied globally (script config default, e.g. `v1`, or the `MILESTONE=` env override) — a per-task field is noise.
+- **Reusing or renaming an `id` across runs after partial success.** With `--resume` the script keys `.create_issues_state.json` by `id`; changing ids mid-flight breaks resume linkage.
+- **Running the live command to "just check".** Dry-run is the only thing you run; the live run is the user's.

--- a/.github/scripts/GITHUB_ISSUES_AND_PROJECT_BOARD.md
+++ b/.github/scripts/GITHUB_ISSUES_AND_PROJECT_BOARD.md
@@ -66,8 +66,6 @@ To support scalable and realistic development workflows, we use a **two-level is
 
 ### 6.2. Sub-issues (Implementation Tasks)
 
-- A Feature can have **any number of sub-issues** (no fixed limit).
-
 - Each sub-issue represents a **concrete, executable unit of work**:
   - should be completable in a single PR
   - should not require deep implicit knowledge from other issues
@@ -86,6 +84,22 @@ To support scalable and realistic development workflows, we use a **two-level is
 
 ---
 
+### 6.2.1. The contract is the seam (default decomposition)
+
+Almost every Feature here is a **backend producing data** and a **frontend rendering it**. The work splits cleanly along the **data contract between them**, and that is the _only_ split made by default.
+
+- **No contract** (pure backend or pure frontend, no handoff) → a **single `issue`**, with checkbox steps in its description for internal planning. No sub-issues.
+- **There is a contract** → **1 Feature (`parent`) + exactly 2 sub-issues**: one for the side that **produces** the contract (`[DATA]`/`[WS]`/`[API]`/`[DB]`) and one for the side that **consumes** it (`[UI]`).
+- **More than two sub-issues is the exception**, allowed only when one side is genuinely several independent PRs (e.g. a schema migration that must land before the aggregation depending on it). A `[DOCS]` follow-up is the one routine third.
+
+**Where the contract lives for page Features:** pages have no JSON API behind them — they are rendered by two pipelines that must emit identical DOM (the Go template on the HTTP path and a Stimulus controller on the live WebSocket path). The contract is therefore the **view-model struct whose field set is identical across the template context and the WebSocket JSON** ("present on both transports"). The producer sub-issue's acceptance gate is a **both-transports parity test**. For a real HTTP endpoint the contract is the JSON response itself — that is `[API]`.
+
+**Keep the contract fat, not raw:** push computation and all precision/format-sensitive values (e.g. 18-decimal SKA, which must stay `big.Int`-derived strings server-side) behind the contract; the frontend renders, it does not compute. This also balances workload between the two sub-issues — balance volume via contract fatness, never by padding the issue count.
+
+Over-decomposition (many thin issues) is the most common planning failure. Fewer, contract-aligned issues are preferred every time.
+
+---
+
 ### 6.3. Structure Constraints
 
 - Only **two levels are allowed**:
@@ -93,9 +107,9 @@ To support scalable and realistic development workflows, we use a **two-level is
 
 - ❌ No nested sub-tasks or deeper hierarchies
 
-- If a Feature is small:
-  - it may consist of a **single issue without sub-issues**
-  - internal steps can be described using checkboxes
+- **A `parent` must have sub-issues — a childless `parent` is invalid.** A Feature too small to split, or with no backend↔frontend contract, is created as a single `type: issue` (with checkbox steps in its description), **not** as a `parent` with nothing under it.
+
+- The default is **exactly two sub-issues** (see §6.2.1); deviating in either direction requires the reasoning stated in §6.2.1.
 
 ---
 
@@ -133,6 +147,7 @@ Prefixes do **not** represent all affected parts of the system. They must reflec
 - Do **not** combine prefixes (e.g., ❌ `[API][DB][UI]`)
 - If a task spans multiple domains equally:
   - split it into multiple sub-issues
+  - in practice this is the single backend↔frontend contract split of §6.2.1 (producer vs. consumer); splitting further, per touched layer, is the exception, not the default
 
 ---
 
@@ -163,6 +178,8 @@ Do:
 [API] Add sorting support to blocks endpoint
 [UI] Implement sorting in blocks table
 ```
+
+This is the backend↔frontend contract split of §6.2.1 — the producer side and the consumer side. Do **not** split further by layer (DB vs. DATA vs. WS) unless one side is genuinely several independent PRs.
 
 ---
 
@@ -311,6 +328,7 @@ Your `tasks.json` must declare an array of task objects. Each task requires a un
 
 - Sub-issues must follow the **prefix naming convention**
 - Issue structure must follow the **two-level hierarchy**
+- Default to **one Feature + two contract-aligned sub-issues** (§6.2.1); a childless `parent` is invalid (§6.3)
 - Do **not** split tasks based on developer specialization
 - Sub-issues should reflect **system boundaries** (API, DB, UI, etc.), not roles
 - Assignment should follow the **Prefix-Based Assignment rule**, but may be adjusted for balance
@@ -318,6 +336,8 @@ Your `tasks.json` must declare an array of task objects. Each task requires a un
 ---
 
 ### 8.4. Example `tasks.json`
+
+The canonical shape: one Feature + the two contract sides (+ a routine `[DOCS]` refresh when a wiki code-analysis trace exists for the area):
 
 ```json
 {
@@ -327,63 +347,45 @@ Your `tasks.json` must declare an array of task objects. Each task requires a un
       "type": "parent",
       "issue_type": "Feature",
       "title": "Blocks List Page",
-      "description": "Display a paginated list of blocks with VAR and SKA{n} metrics.",
+      "description": "Display a paginated list of blocks with VAR and SKA{n} metrics. Spec: wiki/specs/blocks-list/spec.md.",
       "assignee": "yanchenko-igor",
       "labels": ["enhancement"]
     },
     {
-      "id": "blocks-data-aggregation",
+      "id": "blocks-list-contract",
       "type": "sub-issue",
       "parent": "feature-blocks-list",
       "issue_type": "Task",
-      "title": "[DATA] Aggregate block data for list page",
-      "description": "Prepare structured block data including VAR and SKA{n} values.",
+      "title": "[DATA] Blocks list backend↔frontend data contract",
+      "description": "Deliver the per-block VAR + SKA{n} view-model, identical on both transports (HTTP template context and WebSocket JSON). Implementation is free; acceptance gate is a both-transports parity test plus the invariants in the area's wiki/code-analysis patterns.md.",
       "assignee": "yanchenko-igor",
       "labels": ["enhancement"]
     },
     {
-      "id": "blocks-db-query",
+      "id": "blocks-list-ui",
       "type": "sub-issue",
       "parent": "feature-blocks-list",
       "issue_type": "Task",
-      "title": "[DB] Optimize blocks query for list page",
-      "description": "Ensure efficient retrieval of block data from PostgreSQL.",
-      "assignee": "yanchenko-igor",
-      "labels": ["enhancement"]
-    },
-    {
-      "id": "blocks-api-endpoint",
-      "type": "sub-issue",
-      "parent": "feature-blocks-list",
-      "issue_type": "Task",
-      "title": "[API] Blocks list endpoint",
-      "description": "Expose aggregated block data via API endpoint.",
-      "assignee": "yanchenko-igor",
-      "labels": ["enhancement"]
-    },
-    {
-      "id": "blocks-ui-table",
-      "type": "sub-issue",
-      "parent": "feature-blocks-list",
-      "issue_type": "Task",
-      "title": "[UI] Blocks table rendering",
-      "description": "Render blocks table using templates and Stimulus controllers.",
+      "title": "[UI] Blocks list rendering",
+      "description": "Render the blocks table (template + Stimulus controller + SCSS) against the agreed contract; acceptance criteria are the spec's own acceptance checklist.",
       "assignee": "edshav",
       "labels": ["enhancement"]
     },
     {
-      "id": "blocks-ui-pagination",
+      "id": "blocks-list-docs",
       "type": "sub-issue",
       "parent": "feature-blocks-list",
       "issue_type": "Task",
-      "title": "[UI] Implement pagination for blocks table",
-      "description": "Add pagination controls and behavior to the blocks list page.",
+      "title": "[DOCS] Refresh blocks-list code-analysis",
+      "description": "After the two implementation issues land, update wiki/code-analysis/blocks-list/{flow.compact,patterns,impact}.md to match the shipped contract.",
       "assignee": "edshav",
-      "labels": ["enhancement"]
+      "labels": ["documentation"]
     }
   ]
 }
 ```
+
+**Exception (more than two implementation sub-issues):** only when one contract side is genuinely several independent PRs — e.g. a DB schema migration that must merge before the aggregation depending on it, justifying a separate `[DB]` issue ahead of `[DATA]`. This is the documented exception of §6.2.1, not the template.
 
 ---
 


### PR DESCRIPTION
## Summary

Rework the issue-planning guide and the `generate-tasks-json` skill around a single default decomposition: **one Feature (`parent`) + exactly two contract-aligned sub-issues** — the side that produces the data contract and the side that consumes it.

## Changes

- **`.github/scripts/GITHUB_ISSUES_AND_PROJECT_BOARD.md`**
  - New §6.2.1 "The contract is the seam (default decomposition)": no contract → single `issue`; contract → 1 `parent` + 2 sub-issues; >2 is the documented exception.
  - Forbid childless `parent` (§6.3); a too-small Feature is a `type: issue`, not an empty parent.
  - Tie the prefix-split rule to the single backend↔frontend split rather than per-layer splitting.
  - Rewrite the §8.4 example to the canonical shape (producer `[DATA]` + consumer `[UI]` + routine `[DOCS]`), with the >2 exception called out explicitly.

- **`.claude/skills/generate-tasks-json/SKILL.md`**
  - Stop duplicating planning policy; point to the authoritative doc as the single source of truth (doc wins on conflict).
  - Add wiki-sourcing guidance (lift spec acceptance checklists; mine code-analysis for producer invariants).
  - Trim schema/validation/mechanics notes; clarify there is no per-task `milestone` field.

Docs-only; no code or script behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)