### PR TITLE
explorer: implement data contract for /visualblocks rewrite

### DIFF
--- a/cmd/dcrdata/internal/explorer/dev_indicators.go
+++ b/cmd/dcrdata/internal/explorer/dev_indicators.go
@@ -55,7 +55,7 @@ func buildDevIndicatorScenarios() []devIndicatorScenario {
 	const maxBlock = 100.0
 
 	mkMempool := func(stats map[uint8]types.MempoolCoinStats, issued []uint8) *types.MempoolInfo {
-		fills, totalFill, activeSKA := computeCoinFills(stats, maxBlock, issued)
+		fills, totalFill, activeSKA := types.ComputeCoinFills(stats, maxBlock, issued)
 		mp := &types.MempoolInfo{}
 		mp.MempoolShort.CoinFills = fills
 		mp.MempoolShort.TotalFillRatio = totalFill

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -495,7 +495,7 @@ func (exp *explorerUI) StoreMPData(_ *mempool.StakeData, _ []types.MempoolTx, in
 	if blockchainInfo != nil && blockchainInfo.MaxBlockSize > 0 {
 		maxBlockSize = float64(blockchainInfo.MaxBlockSize)
 	}
-	fills, totalFillRatio, activeSKACount := computeCoinFills(inv.CoinStats, maxBlockSize, issuedSKA)
+	fills, totalFillRatio, activeSKACount := types.ComputeCoinFills(inv.CoinStats, maxBlockSize, issuedSKA)
 	inv.CoinFills = fills
 	inv.MempoolShort.CoinFills = fills
 	inv.MempoolShort.TotalFillRatio = totalFillRatio
@@ -606,7 +606,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 			maxBlockSize = float64(p.BlockchainInfo.MaxBlockSize)
 		}
 		exp.invsMtx.Lock()
-		fills, totalFillRatio, activeSKACount := computeCoinFills(exp.invs.CoinStats, maxBlockSize, issuedSKA)
+		fills, totalFillRatio, activeSKACount := types.ComputeCoinFills(exp.invs.CoinStats, maxBlockSize, issuedSKA)
 		exp.invs.CoinFills = fills
 		exp.invs.MempoolShort.CoinFills = fills
 		exp.invs.MempoolShort.TotalFillRatio = totalFillRatio

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -345,33 +345,7 @@ func (exp *explorerUI) VisualBlocks(w http.ResponseWriter, r *http.Request) {
 	exp.pageData.RUnlock()
 
 	for _, block := range blocks {
-		// Convert CoinRowData to MempoolCoinStats for ComputeCoinFills
-		stats := make(map[uint8]types.MempoolCoinStats)
-		for _, row := range block.CoinRows {
-			stats[row.CoinType] = types.MempoolCoinStats{
-				Size: int32(row.Size),
-			}
-		}
-		fills, _, activeSKACount := types.ComputeCoinFills(stats, maxBlockSize, issuedSKA)
-
-		trimmedBlock := &types.TrimmedBlockInfo{
-			Time:              block.BlockTime,
-			Height:            block.Height,
-			Total:             block.TotalSent,
-			Fees:              block.MiningFee,
-			Subsidy:           block.Subsidy,
-			Votes:             block.Votes,
-			Tickets:           block.Tickets,
-			Revocations:       block.Revs,
-			Transactions:      types.FilterRegularTx(block.Tx),
-			Size:              block.BlockBasic.Size,
-			FormattedBytes:    block.BlockBasic.FormattedBytes,
-			CoinFills:         fills,
-			ActiveSKACount:    activeSKACount,
-			RegularCoinCounts: types.RegularCoinCountsFromCoinRows(block.CoinRows, block.BlockBasic.Voters, block.BlockBasic.FreshStake, block.BlockBasic.Revocations),
-			MaxBlockSize:      maxBlockSize,
-		}
-
+		trimmedBlock := block.Trim(maxBlockSize, issuedSKA)
 		trimmedBlocks = append(trimmedBlocks, trimmedBlock)
 	}
 

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -335,17 +335,41 @@ func (exp *explorerUI) VisualBlocks(w http.ResponseWriter, r *http.Request) {
 
 	// trim unwanted data in each block
 	trimmedBlocks := make([]*types.TrimmedBlockInfo, 0, len(blocks))
+
+	exp.pageData.RLock()
+	maxBlockSize := float64(exp.pageData.BlockchainInfo.MaxBlockSize)
+	issuedSKA := make([]uint8, 0, len(exp.pageData.HomeInfo.SKACoinSupply))
+	for _, entry := range exp.pageData.HomeInfo.SKACoinSupply {
+		issuedSKA = append(issuedSKA, entry.CoinType)
+	}
+	exp.pageData.RUnlock()
+
 	for _, block := range blocks {
+		// Convert CoinRowData to MempoolCoinStats for ComputeCoinFills
+		stats := make(map[uint8]types.MempoolCoinStats)
+		for _, row := range block.CoinRows {
+			stats[row.CoinType] = types.MempoolCoinStats{
+				Size: int32(row.Size),
+			}
+		}
+		fills, _, activeSKACount := types.ComputeCoinFills(stats, maxBlockSize, issuedSKA)
+
 		trimmedBlock := &types.TrimmedBlockInfo{
-			Time:         block.BlockTime,
-			Height:       block.Height,
-			Total:        block.TotalSent,
-			Fees:         block.MiningFee,
-			Subsidy:      block.Subsidy,
-			Votes:        block.Votes,
-			Tickets:      block.Tickets,
-			Revocations:  block.Revs,
-			Transactions: types.FilterRegularTx(block.Tx),
+			Time:              block.BlockTime,
+			Height:            block.Height,
+			Total:             block.TotalSent,
+			Fees:              block.MiningFee,
+			Subsidy:           block.Subsidy,
+			Votes:             block.Votes,
+			Tickets:           block.Tickets,
+			Revocations:       block.Revs,
+			Transactions:      types.FilterRegularTx(block.Tx),
+			Size:              block.BlockBasic.Size,
+			FormattedBytes:    block.BlockBasic.FormattedBytes,
+			CoinFills:         fills,
+			ActiveSKACount:    activeSKACount,
+			RegularCoinCounts: types.RegularCoinCountsFromCoinRows(block.CoinRows, block.BlockBasic.Voters, block.BlockBasic.FreshStake, block.BlockBasic.Revocations),
+			MaxBlockSize:      maxBlockSize,
 		}
 
 		trimmedBlocks = append(trimmedBlocks, trimmedBlock)
@@ -353,7 +377,7 @@ func (exp *explorerUI) VisualBlocks(w http.ResponseWriter, r *http.Request) {
 
 	// Construct the required TrimmedMempoolInfo from the shared inventory.
 	inv := exp.MempoolInventory()
-	mempoolInfo := inv.Trim() // Trim internally locks the MempoolInfo.
+	mempoolInfo := inv.Trim(maxBlockSize) // Trim internally locks the MempoolInfo.
 
 	exp.pageData.RLock()
 	mempoolInfo.Subsidy = exp.pageData.HomeInfo.NBlockSubsidy

--- a/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
@@ -374,7 +374,7 @@ func TestMempoolInfo_TotalFillRatio(t *testing.T) {
 	m.TotalFillRatio = 0.75
 	m.ActiveSKACount = 2
 
-	trimmed := m.Trim()
+	trimmed := m.Trim(1e6)
 	if trimmed.TotalFillRatio != 0.75 {
 		t.Errorf("TotalFillRatio: got %v, want 0.75", trimmed.TotalFillRatio)
 	}
@@ -386,7 +386,7 @@ func TestMempoolInfo_TotalFillRatio(t *testing.T) {
 // TestMempoolInfo_TotalFillRatio_Zero verifies zero values propagate correctly.
 func TestMempoolInfo_TotalFillRatio_Zero(t *testing.T) {
 	m := &types.MempoolInfo{}
-	trimmed := m.Trim()
+	trimmed := m.Trim(1e6)
 	if trimmed.TotalFillRatio != 0.0 {
 		t.Errorf("TotalFillRatio: got %v, want 0.0", trimmed.TotalFillRatio)
 	}
@@ -403,7 +403,7 @@ func TestProp_TotalFillRatioRoundTrip(t *testing.T) {
 		m := &types.MempoolInfo{}
 		m.TotalFillRatio = ratio
 		m.ActiveSKACount = count
-		trimmed := m.Trim()
+		trimmed := m.Trim(1e6)
 		if trimmed.TotalFillRatio != ratio {
 			t.Errorf("TotalFillRatio round-trip: got %v, want %v", trimmed.TotalFillRatio, ratio)
 		}

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -336,7 +336,7 @@ func TestComputeCoinFills(t *testing.T) {
 	const max = 100.0 // simplified maxBlockSize for easy math
 
 	t.Run("empty stats", func(t *testing.T) {
-		fills, totalFill, numSKA := computeCoinFills(nil, max, nil)
+		fills, totalFill, numSKA := types.ComputeCoinFills(nil, max, nil)
 		if len(fills) != 1 || fills[0].Symbol != "VAR" || fills[0].Status != "ok" {
 			t.Errorf("unexpected fills for empty stats: %v", fills)
 		}
@@ -350,7 +350,7 @@ func TestComputeCoinFills(t *testing.T) {
 
 	t.Run("VAR within quota", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}} // 5 of 10 quota
-		fills, _, _ := computeCoinFills(stats, max, nil)
+		fills, _, _ := types.ComputeCoinFills(stats, max, nil)
 		if fills[0].Status != "ok" {
 			t.Errorf("VAR within quota: want ok, got %s", fills[0].Status)
 		}
@@ -364,7 +364,7 @@ func TestComputeCoinFills(t *testing.T) {
 
 	t.Run("VAR over quota, block not full", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 15}} // 15 > 10 quota, < 100 total
-		fills, _, _ := computeCoinFills(stats, max, nil)
+		fills, _, _ := types.ComputeCoinFills(stats, max, nil)
 		if fills[0].Status != "borrowing" {
 			t.Errorf("VAR borrowing: want borrowing, got %s", fills[0].Status)
 		}
@@ -375,7 +375,7 @@ func TestComputeCoinFills(t *testing.T) {
 
 	t.Run("VAR over quota, block full", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 110}} // > 100 total
-		fills, totalFill, _ := computeCoinFills(stats, max, nil)
+		fills, totalFill, _ := types.ComputeCoinFills(stats, max, nil)
 		if fills[0].Status != "full" {
 			t.Errorf("VAR full: want full, got %s", fills[0].Status)
 		}
@@ -390,7 +390,7 @@ func TestComputeCoinFills(t *testing.T) {
 	t.Run("SKA within quota", func(t *testing.T) {
 		// 1 SKA type gets 90% = 90 quota
 		stats := map[uint8]types.MempoolCoinStats{1: {Size: 40}}
-		fills, _, numSKA := computeCoinFills(stats, max, nil)
+		fills, _, numSKA := types.ComputeCoinFills(stats, max, nil)
 		if numSKA != 1 {
 			t.Errorf("SKA count: want 1, got %d", numSKA)
 		}
@@ -411,7 +411,7 @@ func TestComputeCoinFills(t *testing.T) {
 	t.Run("SKA over own quota, pool not exhausted", func(t *testing.T) {
 		// 2 SKA types, each gets 45 quota; SKA1 uses 50 but total SKA = 50 < 90
 		stats := map[uint8]types.MempoolCoinStats{1: {Size: 50}, 2: {Size: 0}}
-		fills, _, numSKA := computeCoinFills(stats, max, nil)
+		fills, _, numSKA := types.ComputeCoinFills(stats, max, nil)
 		if numSKA != 2 {
 			t.Errorf("SKA count: want 2, got %d", numSKA)
 		}
@@ -432,7 +432,7 @@ func TestComputeCoinFills(t *testing.T) {
 
 	t.Run("SKA does not affect VAR status", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}, 1: {Size: 95}}
-		fills, _, _ := computeCoinFills(stats, max, nil)
+		fills, _, _ := types.ComputeCoinFills(stats, max, nil)
 		for _, f := range fills {
 			if f.Symbol == "VAR" && f.Status != "ok" {
 				t.Errorf("VAR should be ok regardless of SKA: got %s", f.Status)
@@ -442,7 +442,7 @@ func TestComputeCoinFills(t *testing.T) {
 
 	t.Run("SKA types sorted by ascending coin-type key", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{3: {Size: 1}, 1: {Size: 1}, 2: {Size: 1}}
-		fills, _, _ := computeCoinFills(stats, max, nil)
+		fills, _, _ := types.ComputeCoinFills(stats, max, nil)
 		// fills[0] is VAR; fills[1..3] should be SKA1, SKA2, SKA3
 		if fills[1].Symbol != "SKA1" || fills[2].Symbol != "SKA2" || fills[3].Symbol != "SKA3" {
 			t.Errorf("SKA order: want SKA1,SKA2,SKA3 got %s,%s,%s", fills[1].Symbol, fills[2].Symbol, fills[3].Symbol)
@@ -452,7 +452,7 @@ func TestComputeCoinFills(t *testing.T) {
 	t.Run("issued SKA with no mempool activity gets zero-fill entry", func(t *testing.T) {
 		// SKA5 is issued on-chain but has no mempool transactions yet.
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}}
-		fills, _, numSKA := computeCoinFills(stats, max, []uint8{5})
+		fills, _, numSKA := types.ComputeCoinFills(stats, max, []uint8{5})
 		if numSKA != 1 {
 			t.Errorf("want numSKA 1, got %d", numSKA)
 		}
@@ -475,7 +475,7 @@ func TestComputeCoinFills(t *testing.T) {
 
 	t.Run("issuedSKA does not duplicate coins already in stats", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{1: {Size: 10}}
-		fills, _, numSKA := computeCoinFills(stats, max, []uint8{1})
+		fills, _, numSKA := types.ComputeCoinFills(stats, max, []uint8{1})
 		if numSKA != 1 {
 			t.Errorf("want numSKA 1 (no duplicate), got %d", numSKA)
 		}
@@ -505,7 +505,7 @@ func TestComputeCoinFills(t *testing.T) {
 
 	t.Run("PctOfTC: no SKA, VAR within quota matches TOTAL", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}}
-		fills, totalFill, _ := computeCoinFills(stats, max, nil)
+		fills, totalFill, _ := types.ComputeCoinFills(stats, max, nil)
 		pctApproxEq(t, fills[0].PctOfTC, totalFill*100)
 		if fills[0].IsOverflow {
 			t.Errorf("VAR within quota: IsOverflow should be false")
@@ -514,7 +514,7 @@ func TestComputeCoinFills(t *testing.T) {
 
 	t.Run("PctOfTC: no SKA, VAR borrowing matches TOTAL", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 15}}
-		fills, totalFill, _ := computeCoinFills(stats, max, nil)
+		fills, totalFill, _ := types.ComputeCoinFills(stats, max, nil)
 		pctApproxEq(t, fills[0].PctOfTC, totalFill*100)
 		if fills[0].PctOfTC <= 10.0 {
 			t.Errorf("VAR borrowing: PctOfTC should exceed 10 (was the buggy cap), got %f", fills[0].PctOfTC)
@@ -527,7 +527,7 @@ func TestComputeCoinFills(t *testing.T) {
 	t.Run("PctOfTC: VAR full reports actual % above 100 with overflow flag", func(t *testing.T) {
 		// PO: must surface the true fraction of max block size, not clamp.
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 110}}
-		fills, _, _ := computeCoinFills(stats, max, nil)
+		fills, _, _ := types.ComputeCoinFills(stats, max, nil)
 		pctApproxEq(t, fills[0].PctOfTC, 110.0)
 		if !fills[0].IsOverflow {
 			t.Errorf("VAR full: IsOverflow should be true")
@@ -539,7 +539,7 @@ func TestComputeCoinFills(t *testing.T) {
 		// total block (with VAR=5, totalUsed=115 > 100) so it can't borrow.
 		// Status=full, PctOfTC reports the true 110% magnitude.
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}, 1: {Size: 110}}
-		fills, _, _ := computeCoinFills(stats, max, nil)
+		fills, _, _ := types.ComputeCoinFills(stats, max, nil)
 		var ska1 types.CoinFillData
 		for _, f := range fills {
 			if f.Symbol == "SKA1" {
@@ -559,7 +559,7 @@ func TestComputeCoinFills(t *testing.T) {
 		// 2 SKAs (45 quota each); SKA1 uses 50 (borrowing 5), SKA2 uses 0.
 		// SKA1 total contribution to block fill = 50/100 = 50%.
 		stats := map[uint8]types.MempoolCoinStats{1: {Size: 50}, 2: {Size: 0}}
-		fills, _, _ := computeCoinFills(stats, max, nil)
+		fills, _, _ := types.ComputeCoinFills(stats, max, nil)
 		var ska1 types.CoinFillData
 		for _, f := range fills {
 			if f.Symbol == "SKA1" {
@@ -572,7 +572,7 @@ func TestComputeCoinFills(t *testing.T) {
 	t.Run("PctOfTC invariant: when no overflow, sum of per-coin pct ≈ total*100", func(t *testing.T) {
 		// 1 active SKA, both within their quotas: VAR=5, SKA1=20, total=25.
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}, 1: {Size: 20}}
-		fills, totalFill, _ := computeCoinFills(stats, max, nil)
+		fills, totalFill, _ := types.ComputeCoinFills(stats, max, nil)
 		var sum float64
 		for _, f := range fills {
 			if f.IsOverflow {
@@ -585,7 +585,7 @@ func TestComputeCoinFills(t *testing.T) {
 
 	t.Run("PctOfTC: issued-but-empty SKA is zero", func(t *testing.T) {
 		stats := map[uint8]types.MempoolCoinStats{0: {Size: 5}}
-		fills, _, _ := computeCoinFills(stats, max, []uint8{5})
+		fills, _, _ := types.ComputeCoinFills(stats, max, []uint8{5})
 		for _, f := range fills {
 			if f.Symbol == "SKA5" && f.PctOfTC != 0 {
 				t.Errorf("SKA5 zero-fill: PctOfTC want 0, got %f", f.PctOfTC)

--- a/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
+++ b/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
@@ -1,0 +1,115 @@
+package explorer
+
+import (
+	"testing"
+
+	"github.com/monetarium/monetarium-explorer/explorer/types"
+	"github.com/monetarium/monetarium-node/chaincfg"
+)
+
+func TestVisualBlocksDataContract(t *testing.T) {
+	// Setup mock data
+	params := &chaincfg.Params{
+		MaximumBlockSizes: []int{393216},
+	}
+	issuedSKA := []uint8{1, 2}
+	maxBlockSize := float64(params.MaximumBlockSizes[0])
+
+	t.Run("BlockContractConsistency", func(t *testing.T) {
+		rows := []types.CoinRowData{
+			{CoinType: 0, Symbol: "VAR", TxCount: 10, Amount: "100", Size: 10000},
+			{CoinType: 1, Symbol: "SKA1", TxCount: 5, Amount: "50", Size: 5000},
+			{CoinType: 2, Symbol: "SKA2", TxCount: 2, Amount: "20", Size: 2000},
+		}
+
+		// 1. HTTP Path: TrimmedBlockInfo
+		stats := make(map[uint8]types.MempoolCoinStats)
+		for _, r := range rows {
+			stats[r.CoinType] = types.MempoolCoinStats{Size: int32(r.Size)}
+		}
+		fills, _, activeSka := types.ComputeCoinFills(stats, maxBlockSize, issuedSKA)
+
+		tbi := types.TrimmedBlockInfo{
+			Size:              17000,
+			FormattedBytes:    "17 kB",
+			CoinFills:         fills,
+			ActiveSKACount:    activeSka,
+			MaxBlockSize:      maxBlockSize,
+			RegularCoinCounts: types.RegularCoinCountsFromCoinRows(rows, 2, 1, 1),
+		}
+
+		// 2. WS Path: BlockInfo (simulated copying/populating)
+		bi := &types.BlockInfo{
+			BlockBasic: &types.BlockBasic{
+				Size:           17000,
+				FormattedBytes: "17 kB",
+				CoinRows:       rows,
+			},
+		}
+
+		// Simulation of the logic added to websockethandlers.go
+		biStats := make(map[uint8]types.MempoolCoinStats)
+		for _, r := range rows {
+			biStats[r.CoinType] = types.MempoolCoinStats{Size: int32(r.Size)}
+		}
+		biFills, _, biActiveSka := types.ComputeCoinFills(biStats, maxBlockSize, issuedSKA)
+		bi.CoinFills = biFills
+		bi.ActiveSKACount = biActiveSka
+		bi.MaxBlockSize = maxBlockSize
+
+		// Compare key contract fields
+		if tbi.Size != bi.BlockBasic.Size {
+			t.Errorf("Size mismatch: HTTP %d, WS %d", tbi.Size, bi.BlockBasic.Size)
+		}
+		if tbi.FormattedBytes != bi.BlockBasic.FormattedBytes {
+			t.Errorf("FormattedBytes mismatch: HTTP %s, WS %s", tbi.FormattedBytes, bi.BlockBasic.FormattedBytes)
+		}
+		if len(tbi.CoinFills) != len(bi.CoinFills) {
+			t.Errorf("CoinFills length mismatch: HTTP %d, WS %d", len(tbi.CoinFills), len(bi.CoinFills))
+		}
+		if tbi.ActiveSKACount != bi.ActiveSKACount {
+			t.Errorf("ActiveSKACount mismatch: HTTP %d, WS %d", tbi.ActiveSKACount, bi.ActiveSKACount)
+		}
+		if tbi.MaxBlockSize != bi.MaxBlockSize {
+			t.Errorf("MaxBlockSize mismatch: HTTP %f, WS %f", tbi.MaxBlockSize, bi.MaxBlockSize)
+		}
+	})
+
+	t.Run("MempoolContractConsistency", func(t *testing.T) {
+		mpi := &types.MempoolInfo{
+			MempoolShort: types.MempoolShort{
+				TotalSize:      20000,
+				ActiveSKACount: 2,
+				CoinFills:      []types.CoinFillData{{Symbol: "VAR", Status: "ok"}},
+			},
+		}
+
+		trimmed := mpi.Trim(maxBlockSize)
+
+		if trimmed.MaxBlockSize != maxBlockSize {
+			t.Errorf("Mempool MaxBlockSize mismatch: want %f, got %f", maxBlockSize, trimmed.MaxBlockSize)
+		}
+		if trimmed.TotalSize != 20000 {
+			t.Errorf("Mempool TotalSize mismatch: want 20000, got %d", trimmed.TotalSize)
+		}
+	})
+
+	t.Run("VoteFlagConsistency", func(t *testing.T) {
+		// Test TrimMempoolTx
+		tx := types.MempoolTx{
+			VoteInfo: &types.VoteInfo{},
+		}
+		trimmed := types.TrimMempoolTx(&tx)
+		if !trimmed.Voted {
+			t.Error("TrimMempoolTx: expected Voted=true for vote tx")
+		}
+
+		txNonVote := types.MempoolTx{
+			VoteInfo: nil,
+		}
+		trimmedNonVote := types.TrimMempoolTx(&txNonVote)
+		if trimmedNonVote.Voted {
+			t.Error("TrimMempoolTx: expected Voted=false for non-vote tx")
+		}
+	})
+}

--- a/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
+++ b/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
@@ -21,6 +21,7 @@ func TestVisualBlocksDataContract(t *testing.T) {
 			{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "50", Size: 5000},
 		}
 
+		// Create a block where coinbase is NOT the first transaction to test sorting/search.
 		bi := &types.BlockInfo{
 			BlockBasic: &types.BlockBasic{
 				Size:     15000,
@@ -28,16 +29,17 @@ func TestVisualBlocksDataContract(t *testing.T) {
 			},
 			Tx: []*types.TrimmedTxInfo{
 				{
-					TxBasic: &types.TxBasic{Size: 2000, Coinbase: true},
-				},
-				{
 					TxBasic: &types.TxBasic{
 						Size: 3000,
+						Total: 1000000, // High total to be first in sort
 						VoteInfo: &types.VoteInfo{
 							Validation: types.BlockValidation{Validity: true},
 						},
 					},
 					Voted: true,
+				},
+				{
+					TxBasic: &types.TxBasic{Size: 2000, Coinbase: true, Total: 100},
 				},
 			},
 		}
@@ -59,8 +61,14 @@ func TestVisualBlocksDataContract(t *testing.T) {
 		if wire["size"] != float64(15000) {
 			t.Errorf("Wire Size mismatch: got %v, want 15000", wire["size"])
 		}
+		if wire["regular_coin_counts"] == nil {
+			t.Error("Wire Block: regular_coin_counts is missing")
+		}
 
 		txs := wire["transactions"].([]interface{})
+		if len(txs) != 1 {
+			t.Errorf("Wire Block: Expected 1 regular transaction (coinbase filtered), got %d", len(txs))
+		}
 		foundVote := false
 		for _, txRaw := range txs {
 			tx := txRaw.(map[string]interface{})
@@ -70,6 +78,49 @@ func TestVisualBlocksDataContract(t *testing.T) {
 		}
 		if !foundVote {
 			t.Error("Wire Block: No transaction found with voted=true")
+		}
+	})
+
+	t.Run("BlockWSWireFormat", func(t *testing.T) {
+		rows := []types.CoinRowData{
+			{CoinType: 0, Symbol: "VAR", TxCount: 1, Amount: "100", Size: 10000},
+		}
+		bi := &types.BlockInfo{
+			BlockBasic: &types.BlockBasic{
+				Size:     15000,
+				CoinRows: rows,
+			},
+			Tx: []*types.TrimmedTxInfo{
+				{TxBasic: &types.TxBasic{Size: 2000, Coinbase: true}},
+			},
+			RegularCoinCounts: []types.CoinCount{
+				{CoinType: 0, Symbol: "VAR", Count: 1},
+			},
+		}
+
+		// Simulate WS handler's patch sequence
+		trimmed := bi.Trim(maxBlockSize, issuedSKA)
+		blockCopy := *bi
+		blockCopy.CoinFills = trimmed.CoinFills
+		blockCopy.ActiveSKACount = trimmed.ActiveSKACount
+		blockCopy.MaxBlockSize = trimmed.MaxBlockSize
+
+		data, err := json.Marshal(blockCopy)
+		if err != nil {
+			t.Fatalf("Marshal failed: %v", err)
+		}
+
+		var wire map[string]interface{}
+		if err := json.Unmarshal(data, &wire); err != nil {
+			t.Fatalf("Unmarshal failed: %v", err)
+		}
+
+		// Assert contract fields are present in WS JSON
+		fields := []string{"regular_coin_counts", "coin_fills", "active_ska_count", "max_block_size"}
+		for _, f := range fields {
+			if wire[f] == nil {
+				t.Errorf("Wire WS Block: field %s is missing", f)
+			}
 		}
 	})
 

--- a/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
+++ b/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
@@ -15,35 +15,38 @@ func TestVisualBlocksDataContract(t *testing.T) {
 	issuedSKA := []uint8{1, 2}
 	maxBlockSize := float64(params.MaximumBlockSizes[0])
 
-	t.Run("BlockContractWireFormat", func(t *testing.T) {
-		rows := []types.CoinRowData{
-			{CoinType: 0, Symbol: "VAR", TxCount: 1, Amount: "100", Size: 10000},
-			{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "50", Size: 5000},
-		}
-
-		// Create a block where coinbase is NOT the first transaction to test sorting/search.
-		bi := &types.BlockInfo{
-			BlockBasic: &types.BlockBasic{
-				Size:     15000,
-				CoinRows: rows,
-			},
-			Tx: []*types.TrimmedTxInfo{
-				{
-					TxBasic: &types.TxBasic{
-						Size:  3000,
-						Total: 1000000, // High total to be first in sort
-						VoteInfo: &types.VoteInfo{
-							Validation: types.BlockValidation{Validity: true},
-						},
+	// Robust shared fixture to verify both transports and the coinbase search logic.
+	rows := []types.CoinRowData{
+		{CoinType: 0, Symbol: "VAR", TxCount: 1, Amount: "100", Size: 10000},
+		{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "50", Size: 5000},
+	}
+	bi := &types.BlockInfo{
+		BlockBasic: &types.BlockBasic{
+			Size:     15000,
+			CoinRows: rows,
+		},
+		Tx: []*types.TrimmedTxInfo{
+			{
+				TxBasic: &types.TxBasic{
+					Size:  3000,
+					Total: 1000000, // High total ensures it's before coinbase in typical sort
+					VoteInfo: &types.VoteInfo{
+						Validation: types.BlockValidation{Validity: true},
 					},
-					Voted: true,
 				},
-				{
-					TxBasic: &types.TxBasic{Size: 2000, Coinbase: true, Total: 100},
-				},
+				Voted: true,
 			},
-		}
+			{
+				TxBasic: &types.TxBasic{Size: 2000, Coinbase: true, Total: 100},
+			},
+		},
+		RegularCoinCounts: []types.CoinCount{
+			{CoinType: 0, Symbol: "VAR", Count: 1},
+			{CoinType: 1, Symbol: "SKA1", Count: 1},
+		},
+	}
 
+	t.Run("BlockContractWireFormat", func(t *testing.T) {
 		trimmed := bi.Trim(maxBlockSize, issuedSKA)
 		data, err := json.Marshal(trimmed)
 		if err != nil {
@@ -81,45 +84,36 @@ func TestVisualBlocksDataContract(t *testing.T) {
 		}
 	})
 
-	t.Run("BlockWSWireFormat", func(t *testing.T) {
-		rows := []types.CoinRowData{
-			{CoinType: 0, Symbol: "VAR", TxCount: 1, Amount: "100", Size: 10000},
-		}
-		bi := &types.BlockInfo{
-			BlockBasic: &types.BlockBasic{
-				Size:     15000,
-				CoinRows: rows,
-			},
-			Tx: []*types.TrimmedTxInfo{
-				{TxBasic: &types.TxBasic{Size: 2000, Coinbase: true}},
-			},
-			RegularCoinCounts: []types.CoinCount{
-				{CoinType: 0, Symbol: "VAR", Count: 1},
-			},
-		}
-
-		// Simulate WS handler's patch sequence
+	t.Run("BlockWSWireFormatEquivalence", func(t *testing.T) {
+		// 1. Generate HTTP wire as the gold standard
 		trimmed := bi.Trim(maxBlockSize, issuedSKA)
+		httpData, _ := json.Marshal(trimmed)
+		var httpWire map[string]interface{}
+		json.Unmarshal(httpData, &httpWire)
+
+		// 2. Generate WS wire (simulate handler's patch sequence)
 		blockCopy := *bi
 		blockCopy.CoinFills = trimmed.CoinFills
 		blockCopy.ActiveSKACount = trimmed.ActiveSKACount
 		blockCopy.MaxBlockSize = trimmed.MaxBlockSize
 
-		data, err := json.Marshal(blockCopy)
+		wsData, err := json.Marshal(blockCopy)
 		if err != nil {
 			t.Fatalf("Marshal failed: %v", err)
 		}
-
-		var wire map[string]interface{}
-		if err := json.Unmarshal(data, &wire); err != nil {
+		var wsWire map[string]interface{}
+		if err := json.Unmarshal(wsData, &wsWire); err != nil {
 			t.Fatalf("Unmarshal failed: %v", err)
 		}
 
-		// Assert contract fields are present in WS JSON
-		fields := []string{"regular_coin_counts", "coin_fills", "active_ska_count", "max_block_size"}
-		for _, f := range fields {
-			if wire[f] == nil {
-				t.Errorf("Wire WS Block: field %s is missing", f)
+		// 3. Verify that the data contract fields are IDENTICAL across transports
+		contractFields := []string{"regular_coin_counts", "coin_fills", "active_ska_count", "max_block_size"}
+		for _, f := range contractFields {
+			// Use JSON marshaling to compare potentially complex types like slices
+			hVal, _ := json.Marshal(httpWire[f])
+			wVal, _ := json.Marshal(wsWire[f])
+			if string(hVal) != string(wVal) {
+				t.Errorf("Cross-transport mismatch for field %s: HTTP=%s, WS=%s", f, string(hVal), string(wVal))
 			}
 		}
 	})

--- a/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
+++ b/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
@@ -1,6 +1,7 @@
 package explorer
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/monetarium/monetarium-explorer/explorer/types"
@@ -8,108 +9,93 @@ import (
 )
 
 func TestVisualBlocksDataContract(t *testing.T) {
-	// Setup mock data
 	params := &chaincfg.Params{
 		MaximumBlockSizes: []int{393216},
 	}
 	issuedSKA := []uint8{1, 2}
 	maxBlockSize := float64(params.MaximumBlockSizes[0])
 
-	t.Run("BlockContractConsistency", func(t *testing.T) {
+	t.Run("BlockContractWireFormat", func(t *testing.T) {
 		rows := []types.CoinRowData{
-			{CoinType: 0, Symbol: "VAR", TxCount: 10, Amount: "100", Size: 10000},
-			{CoinType: 1, Symbol: "SKA1", TxCount: 5, Amount: "50", Size: 5000},
-			{CoinType: 2, Symbol: "SKA2", TxCount: 2, Amount: "20", Size: 2000},
+			{CoinType: 0, Symbol: "VAR", TxCount: 1, Amount: "100", Size: 10000},
+			{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "50", Size: 5000},
 		}
 
-		// 1. HTTP Path: TrimmedBlockInfo
-		stats := make(map[uint8]types.MempoolCoinStats)
-		for _, r := range rows {
-			stats[r.CoinType] = types.MempoolCoinStats{Size: int32(r.Size)}
-		}
-		fills, _, activeSka := types.ComputeCoinFills(stats, maxBlockSize, issuedSKA)
-
-		tbi := types.TrimmedBlockInfo{
-			Size:              17000,
-			FormattedBytes:    "17 kB",
-			CoinFills:         fills,
-			ActiveSKACount:    activeSka,
-			MaxBlockSize:      maxBlockSize,
-			RegularCoinCounts: types.RegularCoinCountsFromCoinRows(rows, 2, 1, 1),
-		}
-
-		// 2. WS Path: BlockInfo (simulated copying/populating)
 		bi := &types.BlockInfo{
 			BlockBasic: &types.BlockBasic{
-				Size:           17000,
-				FormattedBytes: "17 kB",
-				CoinRows:       rows,
+				Size:     15000,
+				CoinRows: rows,
+			},
+			Tx: []*types.TrimmedTxInfo{
+				{
+					TxBasic: &types.TxBasic{Size: 2000, Coinbase: true},
+				},
+				{
+					TxBasic: &types.TxBasic{
+						Size: 3000,
+						VoteInfo: &types.VoteInfo{
+							Validation: types.BlockValidation{Validity: true},
+						},
+					},
+					Voted: true,
+				},
 			},
 		}
 
-		// Simulation of the logic added to websockethandlers.go
-		biStats := make(map[uint8]types.MempoolCoinStats)
-		for _, r := range rows {
-			biStats[r.CoinType] = types.MempoolCoinStats{Size: int32(r.Size)}
+		trimmed := bi.Trim(maxBlockSize, issuedSKA)
+		data, err := json.Marshal(trimmed)
+		if err != nil {
+			t.Fatalf("Marshal failed: %v", err)
 		}
-		biFills, _, biActiveSka := types.ComputeCoinFills(biStats, maxBlockSize, issuedSKA)
-		bi.CoinFills = biFills
-		bi.ActiveSKACount = biActiveSka
-		bi.MaxBlockSize = maxBlockSize
 
-		// Compare key contract fields
-		if tbi.Size != bi.BlockBasic.Size {
-			t.Errorf("Size mismatch: HTTP %d, WS %d", tbi.Size, bi.BlockBasic.Size)
+		var wire map[string]interface{}
+		if err := json.Unmarshal(data, &wire); err != nil {
+			t.Fatalf("Unmarshal failed: %v", err)
 		}
-		if tbi.FormattedBytes != bi.BlockBasic.FormattedBytes {
-			t.Errorf("FormattedBytes mismatch: HTTP %s, WS %s", tbi.FormattedBytes, bi.BlockBasic.FormattedBytes)
+
+		if wire["max_block_size"] != maxBlockSize {
+			t.Errorf("Wire MaxBlockSize mismatch: got %v, want %v", wire["max_block_size"], maxBlockSize)
 		}
-		if len(tbi.CoinFills) != len(bi.CoinFills) {
-			t.Errorf("CoinFills length mismatch: HTTP %d, WS %d", len(tbi.CoinFills), len(bi.CoinFills))
+		if wire["size"] != float64(15000) {
+			t.Errorf("Wire Size mismatch: got %v, want 15000", wire["size"])
 		}
-		if tbi.ActiveSKACount != bi.ActiveSKACount {
-			t.Errorf("ActiveSKACount mismatch: HTTP %d, WS %d", tbi.ActiveSKACount, bi.ActiveSKACount)
+
+		txs := wire["transactions"].([]interface{})
+		foundVote := false
+		for _, txRaw := range txs {
+			tx := txRaw.(map[string]interface{})
+			if tx["voted"] == true {
+				foundVote = true
+			}
 		}
-		if tbi.MaxBlockSize != bi.MaxBlockSize {
-			t.Errorf("MaxBlockSize mismatch: HTTP %f, WS %f", tbi.MaxBlockSize, bi.MaxBlockSize)
+		if !foundVote {
+			t.Error("Wire Block: No transaction found with voted=true")
 		}
 	})
 
-	t.Run("MempoolContractConsistency", func(t *testing.T) {
+	t.Run("MempoolContractWireFormat", func(t *testing.T) {
 		mpi := &types.MempoolInfo{
 			MempoolShort: types.MempoolShort{
-				TotalSize:      20000,
-				ActiveSKACount: 2,
-				CoinFills:      []types.CoinFillData{{Symbol: "VAR", Status: "ok"}},
+				TotalSize: 20000,
 			},
 		}
 
 		trimmed := mpi.Trim(maxBlockSize)
-
-		if trimmed.MaxBlockSize != maxBlockSize {
-			t.Errorf("Mempool MaxBlockSize mismatch: want %f, got %f", maxBlockSize, trimmed.MaxBlockSize)
-		}
-		if trimmed.TotalSize != 20000 {
-			t.Errorf("Mempool TotalSize mismatch: want 20000, got %d", trimmed.TotalSize)
-		}
-	})
-
-	t.Run("VoteFlagConsistency", func(t *testing.T) {
-		// Test TrimMempoolTx
-		tx := types.MempoolTx{
-			VoteInfo: &types.VoteInfo{},
-		}
-		trimmed := types.TrimMempoolTx(&tx)
-		if !trimmed.Voted {
-			t.Error("TrimMempoolTx: expected Voted=true for vote tx")
+		data, err := json.Marshal(trimmed)
+		if err != nil {
+			t.Fatalf("Marshal failed: %v", err)
 		}
 
-		txNonVote := types.MempoolTx{
-			VoteInfo: nil,
+		var wire map[string]interface{}
+		if err := json.Unmarshal(data, &wire); err != nil {
+			t.Fatalf("Unmarshal failed: %v", err)
 		}
-		trimmedNonVote := types.TrimMempoolTx(&txNonVote)
-		if trimmedNonVote.Voted {
-			t.Error("TrimMempoolTx: expected Voted=false for non-vote tx")
+
+		if wire["max_block_size"] != maxBlockSize {
+			t.Errorf("Wire MaxBlockSize mismatch: got %v, want %v", wire["max_block_size"], maxBlockSize)
+		}
+		if wire["total_size"] != float64(20000) {
+			t.Errorf("Wire TotalSize mismatch: got %v, want 20000", wire["total_size"])
 		}
 	})
 }

--- a/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
+++ b/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
@@ -30,7 +30,7 @@ func TestVisualBlocksDataContract(t *testing.T) {
 			Tx: []*types.TrimmedTxInfo{
 				{
 					TxBasic: &types.TxBasic{
-						Size: 3000,
+						Size:  3000,
 						Total: 1000000, // High total to be first in sort
 						VoteInfo: &types.VoteInfo{
 							Validation: types.BlockValidation{Validity: true},

--- a/cmd/dcrdata/internal/explorer/websockethandlers.go
+++ b/cmd/dcrdata/internal/explorer/websockethandlers.go
@@ -151,15 +151,14 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					// TrimmedMempoolInfo. Used in visualblocks.
 					// construct mempool object with properties required in template
 					inv := exp.MempoolInventory()
+
 					exp.pageData.RLock()
 					maxBlockSize := float64(exp.pageData.BlockchainInfo.MaxBlockSize)
+					subsidy := exp.pageData.HomeInfo.NBlockSubsidy
 					exp.pageData.RUnlock()
 
 					mempoolInfo := inv.Trim(maxBlockSize) // Trim internally locks the MempoolInfo.
-
-					exp.pageData.RLock()
-					mempoolInfo.Subsidy = exp.pageData.HomeInfo.NBlockSubsidy
-					exp.pageData.RUnlock()
+					mempoolInfo.Subsidy = subsidy
 
 					msg, err := json.Marshal(mempoolInfo)
 
@@ -285,17 +284,10 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					}
 					maxBlockSize := float64(exp.pageData.BlockchainInfo.MaxBlockSize)
 
-					stats := make(map[uint8]types.MempoolCoinStats)
-					for _, row := range blockCopy.BlockBasic.CoinRows {
-						stats[row.CoinType] = types.MempoolCoinStats{
-							Size: int32(row.Size),
-						}
-					}
-					fills, _, activeSKACount := types.ComputeCoinFills(stats, maxBlockSize, issuedSKA)
-
-					blockCopy.CoinFills = fills
-					blockCopy.ActiveSKACount = activeSKACount
-					blockCopy.MaxBlockSize = maxBlockSize
+					trimmed := block.Trim(maxBlockSize, issuedSKA)
+					blockCopy.CoinFills = trimmed.CoinFills
+					blockCopy.ActiveSKACount = trimmed.ActiveSKACount
+					blockCopy.MaxBlockSize = trimmed.MaxBlockSize
 
 					err := enc.Encode(types.WebsocketBlock{
 						Block: &blockCopy,

--- a/cmd/dcrdata/internal/explorer/websockethandlers.go
+++ b/cmd/dcrdata/internal/explorer/websockethandlers.go
@@ -151,7 +151,11 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 					// TrimmedMempoolInfo. Used in visualblocks.
 					// construct mempool object with properties required in template
 					inv := exp.MempoolInventory()
-					mempoolInfo := inv.Trim() // Trim internally locks the MempoolInfo.
+					exp.pageData.RLock()
+					maxBlockSize := float64(exp.pageData.BlockchainInfo.MaxBlockSize)
+					exp.pageData.RUnlock()
+
+					mempoolInfo := inv.Trim(maxBlockSize) // Trim internally locks the MempoolInfo.
 
 					exp.pageData.RLock()
 					mempoolInfo.Subsidy = exp.pageData.HomeInfo.NBlockSubsidy
@@ -270,8 +274,31 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				switch sig.Signal {
 				case sigNewBlock:
 					exp.pageData.RLock()
+
+					block := exp.pageData.BlockInfo
+					// shallow copy to populate contract fields without mutating shared state
+					blockCopy := *block
+
+					issuedSKA := make([]uint8, 0, len(exp.pageData.HomeInfo.SKACoinSupply))
+					for _, entry := range exp.pageData.HomeInfo.SKACoinSupply {
+						issuedSKA = append(issuedSKA, entry.CoinType)
+					}
+					maxBlockSize := float64(exp.pageData.BlockchainInfo.MaxBlockSize)
+
+					stats := make(map[uint8]types.MempoolCoinStats)
+					for _, row := range blockCopy.BlockBasic.CoinRows {
+						stats[row.CoinType] = types.MempoolCoinStats{
+							Size: int32(row.Size),
+						}
+					}
+					fills, _, activeSKACount := types.ComputeCoinFills(stats, maxBlockSize, issuedSKA)
+
+					blockCopy.CoinFills = fills
+					blockCopy.ActiveSKACount = activeSKACount
+					blockCopy.MaxBlockSize = maxBlockSize
+
 					err := enc.Encode(types.WebsocketBlock{
-						Block: exp.pageData.BlockInfo,
+						Block: &blockCopy,
 						Extra: exp.pageData.HomeInfo,
 					})
 					exp.pageData.RUnlock()

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6558,6 +6558,7 @@ func trimmedTxInfoFromMsgTx(txraw *chainjson.TxRawResult, ticketPrice int64, msg
 		VinCount:  len(txraw.Vin),
 		VoutCount: len(txraw.Vout),
 		VoteValid: voteValid,
+		Voted:     txBasic.VoteInfo != nil,
 	}
 	return tx, txType
 }

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -356,13 +356,13 @@ type TxBasic struct {
 // TrimmedTxInfo for use with /visualblocks
 type TrimmedTxInfo struct {
 	*TxBasic
-	Fees         float64
-	VinCount     int
-	VoutCount    int
-	VoteValid    bool
-	Voted        bool
-	CoinType     uint8  // 0=VAR, 1-255=SKAn for stake fees; for revocations, set when processing
-	TicketStatus string // Pool status for revocations: "voted", "missed", "expired"
+	Fees         float64 `json:"fees"`
+	VoteValid    bool    `json:"vote_valid"`
+	Voted        bool    `json:"voted"`
+	VinCount     int     `json:"vin_count"`
+	VoutCount    int     `json:"vout_count"`
+	CoinType     uint8   `json:"coin_type,omitempty"`     // 0=VAR, 1-255=SKAn for stake fees; for revocations, set when processing
+	TicketStatus string  `json:"ticket_status,omitempty"` // Pool status for revocations: "voted", "missed", "expired"
 }
 
 // TxInfo models data needed for display on the tx page
@@ -702,22 +702,51 @@ type MempoolCoinStats struct {
 
 // TrimmedBlockInfo models data needed to display block info on the new home page
 type TrimmedBlockInfo struct {
-	Time              TimeDef
-	Height            int64
-	Total             float64
-	Fees              float64
-	Subsidy           *chainjson.GetBlockSubsidyResult
-	Votes             []*TrimmedTxInfo
-	Tickets           []*TrimmedTxInfo
-	Revocations       []*TrimmedTxInfo
-	Transactions      []*TrimmedTxInfo
-	CoinRows          []CoinRowData
-	Size              int32          `json:"size"`
-	FormattedBytes    string         `json:"formatted_bytes"`
-	CoinFills         []CoinFillData `json:"coin_fills,omitempty"`
-	ActiveSKACount    int            `json:"active_ska_count"`
-	RegularCoinCounts []CoinCount    `json:"regular_coin_counts,omitempty"`
-	MaxBlockSize      float64        `json:"max_block_size"`
+	Time              TimeDef                          `json:"time"`
+	Height            int64                            `json:"height"`
+	Total             float64                          `json:"total"`
+	Fees              float64                          `json:"fees"`
+	Subsidy           *chainjson.GetBlockSubsidyResult `json:"subsidy"`
+	Votes             []*TrimmedTxInfo                 `json:"votes"`
+	Tickets           []*TrimmedTxInfo                 `json:"tickets"`
+	Revocations       []*TrimmedTxInfo                 `json:"revocations"`
+	Transactions      []*TrimmedTxInfo                 `json:"transactions"`
+	CoinRows          []CoinRowData                    `json:"coin_rows"`
+	Size              int32                            `json:"size"`
+	FormattedBytes    string                           `json:"formatted_bytes"`
+	CoinFills         []CoinFillData                   `json:"coin_fills,omitempty"`
+	ActiveSKACount    int                              `json:"active_ska_count"`
+	RegularCoinCounts []CoinCount                      `json:"regular_coin_counts,omitempty"`
+	MaxBlockSize      float64                          `json:"max_block_size"`
+}
+
+// Trim converts BlockInfo to TrimmedBlockInfo.
+func (bi *BlockInfo) Trim(maxBlockSize float64, issuedSKA []uint8) *TrimmedBlockInfo {
+	// Exclude coinbase from VAR fill bar.
+	coinbaseSize := int32(0)
+	if len(bi.Tx) > 0 {
+		coinbaseSize = bi.Tx[0].TxBasic.Size
+	}
+	stats := StatsFromCoinRows(bi.BlockBasic.CoinRows, coinbaseSize)
+	fills, _, activeSKACount := ComputeCoinFills(stats, maxBlockSize, issuedSKA)
+
+	return &TrimmedBlockInfo{
+		Time:              bi.BlockTime,
+		Height:            bi.Height,
+		Total:             bi.TotalSent,
+		Fees:              bi.MiningFee,
+		Subsidy:           bi.Subsidy,
+		Votes:             bi.Votes,
+		Tickets:           bi.Tickets,
+		Revocations:       bi.Revs,
+		Transactions:      bi.Tx,
+		Size:              bi.BlockBasic.Size,
+		FormattedBytes:    bi.BlockBasic.FormattedBytes,
+		CoinFills:         fills,
+		ActiveSKACount:    activeSKACount,
+		RegularCoinCounts: RegularCoinCountsFromCoinRows(bi.BlockBasic.CoinRows, bi.BlockBasic.Voters, bi.BlockBasic.FreshStake, bi.BlockBasic.Revocations),
+		MaxBlockSize:      maxBlockSize,
+	}
 }
 
 // BlockInfo models data for display on the block page
@@ -759,15 +788,15 @@ type BlockInfo struct {
 	TotalSentByCoin []CoinAmount `json:"-"`
 	// RegularCoinCounts is an ordered slice of regular transaction counts per coin type,
 	// for template rendering. Same ordering as TotalSentByCoin.
-	RegularCoinCounts []CoinCount `json:"regular_coin_counts"`
+	RegularCoinCounts []CoinCount `json:"-"`
 	// FeesByCoin is an ordered slice of fees per coin type, for template rendering.
 	// VAR fees are total transaction fees in the block; SKA fees are SSFee distribution amounts
 	// (total SKA atoms distributed via TxTypeSSFee per coin type, i.e., fees collected from SKA outputs).
 	// Same ordering as TotalSentByCoin.
 	FeesByCoin     []CoinAmount   `json:"-"`
 	CoinFills      []CoinFillData `json:"coin_fills,omitempty"`
-	ActiveSKACount int            `json:"active_ska_count"`
-	MaxBlockSize   float64        `json:"max_block_size"`
+	ActiveSKACount int            `json:"active_ska_count,omitempty"`
+	MaxBlockSize   float64        `json:"max_block_size,omitempty"`
 }
 
 // CoinAmount represents an amount for a specific coin type.
@@ -1105,7 +1134,6 @@ func TrimMempoolTx(tx *MempoolTx) (trimmedTx *TrimmedTxInfo) {
 		TxBasic:   txBasic,
 		Fees:      tx.Fees,
 		VoteValid: voteValid,
-		Voted:     tx.VoteInfo != nil,
 		VinCount:  tx.VinCount,
 		VoutCount: tx.VoutCount,
 	}
@@ -1464,106 +1492,6 @@ func CopyCoinFillSlice(s []CoinFillData) []CoinFillData {
 	return out
 }
 
-// ComputeCoinFills derives per-coin fill bar data from the mempool CoinStats
-// map. VAR is always first in the returned slice; SKA types follow in ascending
-// coin-type order. When stats is empty or nil a single VAR entry with all
-// ratios at 0.0 and status "ok" is returned.
-// issuedSKA is the set of all SKA coin types that have ever been issued on-chain
-// (from SKACoinSupply). Coin types present in issuedSKA but absent from stats
-// are included as zero-fill entries so their indicators are always visible.
-func ComputeCoinFills(stats map[uint8]MempoolCoinStats, maxBlockSize float64, issuedSKA []uint8) ([]CoinFillData, float64, int) {
-	varQuota := maxBlockSize * 0.10
-	skaPool := maxBlockSize * 0.90
-
-	skaKeySet := make(map[int]struct{})
-	for ct := range stats {
-		if ct != 0 {
-			skaKeySet[int(ct)] = struct{}{}
-		}
-	}
-	for _, ct := range issuedSKA {
-		skaKeySet[int(ct)] = struct{}{}
-	}
-	var skaKeys []int
-	var totalSKASize float64
-	for k := range skaKeySet {
-		skaKeys = append(skaKeys, k)
-		totalSKASize += float64(stats[uint8(k)].Size)
-	}
-	sort.Ints(skaKeys)
-	numSKA := len(skaKeys)
-
-	varSize := float64(0)
-	if s, ok := stats[0]; ok {
-		varSize = float64(s.Size)
-	}
-	totalUsed := varSize + totalSKASize
-	totalFillRatio := totalUsed / maxBlockSize
-
-	fillStatus := func(size, quota float64) string {
-		switch {
-		case size <= quota:
-			return "ok"
-		case totalUsed <= maxBlockSize:
-			return "borrowing"
-		default:
-			return "full"
-		}
-	}
-
-	extraOrOverflow := func(size, quota float64, status string) (extra, overflow float64) {
-		if status == "borrowing" {
-			extra = math.Min((size-quota)/maxBlockSize, 1.0)
-		} else if status == "full" {
-			overflow = math.Min((size-quota)/maxBlockSize, 1.0)
-		}
-		return
-	}
-
-	withDisplay := func(d CoinFillData) CoinFillData {
-		raw := d.GQFillRatio*d.GQPositionRatio + d.ExtraFillRatio + d.OverflowFillRatio
-		d.PctOfTC = raw * 100.0
-		d.IsOverflow = raw > 1.0
-		return d
-	}
-
-	varStatus := fillStatus(varSize, varQuota)
-	varExtra, varOverflow := extraOrOverflow(varSize, varQuota, varStatus)
-
-	fills := make([]CoinFillData, 0, 1+numSKA)
-	fills = append(fills, withDisplay(CoinFillData{
-		Symbol:            "VAR",
-		GQFillRatio:       math.Min(varSize/varQuota, 1.0),
-		ExtraFillRatio:    varExtra,
-		OverflowFillRatio: varOverflow,
-		GQPositionRatio:   0.10,
-		Status:            varStatus,
-	}))
-
-	if numSKA == 0 {
-		return fills, totalFillRatio, 0
-	}
-
-	perSKAQuota := skaPool / float64(numSKA)
-	gqPos := 0.90 / float64(numSKA)
-
-	for _, ct := range skaKeys {
-		s := stats[uint8(ct)]
-		size := float64(s.Size)
-		status := fillStatus(size, perSKAQuota)
-		extra, overflow := extraOrOverflow(size, perSKAQuota, status)
-		fills = append(fills, withDisplay(CoinFillData{
-			Symbol:            fmt.Sprintf("SKA%d", ct),
-			GQFillRatio:       math.Min(size/perSKAQuota, 1.0),
-			ExtraFillRatio:    extra,
-			OverflowFillRatio: overflow,
-			GQPositionRatio:   gqPos,
-			Status:            status,
-		}))
-	}
-	return fills, totalFillRatio, numSKA
-}
-
 // NewMempoolTx models data sent from the notification handler
 type NewMempoolTx struct {
 	Time int64
@@ -1717,6 +1645,116 @@ func UnspentOutputIndices(vouts []Vout) (unspents []int) {
 		unspents = append(unspents, idx)
 	}
 	return
+}
+
+// StatsFromCoinRows converts CoinRowData to MempoolCoinStats for fill bar computation.
+// coinbaseSize is subtracted from the VAR coin (type 0) size to exclude it from the bar.
+func StatsFromCoinRows(rows []CoinRowData, coinbaseSize int32) map[uint8]MempoolCoinStats {
+	stats := make(map[uint8]MempoolCoinStats)
+	for _, row := range rows {
+		size := int32(row.Size)
+		if row.CoinType == 0 {
+			size -= coinbaseSize
+			if size < 0 {
+				size = 0
+			}
+		}
+		stats[row.CoinType] = MempoolCoinStats{Size: size}
+	}
+	return stats
+}
+
+func ComputeCoinFills(stats map[uint8]MempoolCoinStats, maxBlockSize float64, issuedSKA []uint8) ([]CoinFillData, float64, int) {
+	varQuota := maxBlockSize * 0.10
+	skaPool := maxBlockSize * 0.90
+
+	skaKeySet := make(map[int]struct{})
+	for ct := range stats {
+		if ct != 0 {
+			skaKeySet[int(ct)] = struct{}{}
+		}
+	}
+	for _, ct := range issuedSKA {
+		skaKeySet[int(ct)] = struct{}{}
+	}
+	var skaKeys []int
+	var totalSKASize float64
+	for k := range skaKeySet {
+		skaKeys = append(skaKeys, k)
+		totalSKASize += float64(stats[uint8(k)].Size)
+	}
+	sort.Ints(skaKeys)
+	numSKA := len(skaKeys)
+
+	varSize := float64(0)
+	if s, ok := stats[0]; ok {
+		varSize = float64(s.Size)
+	}
+	totalUsed := varSize + totalSKASize
+	totalFillRatio := totalUsed / maxBlockSize
+
+	fillStatus := func(size, quota float64) string {
+		switch {
+		case size <= quota:
+			return "ok"
+		case totalUsed <= maxBlockSize:
+			return "borrowing"
+		default:
+			return "full"
+		}
+	}
+
+	extraOrOverflow := func(size, quota float64, status string) (extra, overflow float64) {
+		if status == "borrowing" {
+			extra = math.Min((size-quota)/maxBlockSize, 1.0)
+		} else if status == "full" {
+			overflow = math.Min((size-quota)/maxBlockSize, 1.0)
+		}
+		return
+	}
+
+	withDisplay := func(d CoinFillData) CoinFillData {
+		raw := d.GQFillRatio*d.GQPositionRatio + d.ExtraFillRatio + d.OverflowFillRatio
+		d.PctOfTC = raw * 100.0
+		d.IsOverflow = raw > 1.0
+		return d
+	}
+
+	varStatus := fillStatus(varSize, varQuota)
+	varExtra, varOverflow := extraOrOverflow(varSize, varQuota, varStatus)
+
+	fills := make([]CoinFillData, 0, 1+numSKA)
+	fills = append(fills, withDisplay(CoinFillData{
+		Symbol:            "VAR",
+		GQFillRatio:       math.Min(varSize/varQuota, 1.0),
+		ExtraFillRatio:    varExtra,
+		OverflowFillRatio: varOverflow,
+		GQPositionRatio:   0.10,
+		Status:            varStatus,
+	}))
+
+	if numSKA == 0 {
+		return fills, totalFillRatio, 0
+	}
+
+	perSKAQuota := skaPool / float64(numSKA)
+	gqPos := 0.90 / float64(numSKA)
+
+	for _, ct := range skaKeys {
+		s := stats[uint8(ct)]
+		size := float64(s.Size)
+		status := fillStatus(size, perSKAQuota)
+		extra, overflow := extraOrOverflow(size, perSKAQuota, status)
+		fills = append(fills, withDisplay(CoinFillData{
+			Symbol:            fmt.Sprintf("SKA%d", ct),
+			GQFillRatio:       math.Min(size/perSKAQuota, 1.0),
+			ExtraFillRatio:    extra,
+			OverflowFillRatio: overflow,
+			GQPositionRatio:   gqPos,
+			Status:            status,
+		}))
+	}
+	return fills, totalFillRatio, numSKA
 }
 
 // MsgTxMempoolInputs parses a MsgTx and creates a list of MempoolInput.

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -716,8 +716,8 @@ type TrimmedBlockInfo struct {
 	FormattedBytes    string                           `json:"formatted_bytes"`
 	CoinFills         []CoinFillData                   `json:"coin_fills,omitempty"`
 	ActiveSKACount    int                              `json:"active_ska_count"`
-	RegularCoinCounts []CoinCount `json:"regular_coin_counts,omitempty"`
-	MaxBlockSize      float64        `json:"max_block_size"`
+	RegularCoinCounts []CoinCount                      `json:"regular_coin_counts,omitempty"`
+	MaxBlockSize      float64                          `json:"max_block_size"`
 }
 
 // Trim converts BlockInfo to TrimmedBlockInfo.

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -716,16 +716,19 @@ type TrimmedBlockInfo struct {
 	FormattedBytes    string                           `json:"formatted_bytes"`
 	CoinFills         []CoinFillData                   `json:"coin_fills,omitempty"`
 	ActiveSKACount    int                              `json:"active_ska_count"`
-	RegularCoinCounts []CoinCount                      `json:"regular_coin_counts,omitempty"`
-	MaxBlockSize      float64                          `json:"max_block_size"`
+	RegularCoinCounts []CoinCount `json:"regular_coin_counts,omitempty"`
+	MaxBlockSize      float64        `json:"max_block_size"`
 }
 
 // Trim converts BlockInfo to TrimmedBlockInfo.
 func (bi *BlockInfo) Trim(maxBlockSize float64, issuedSKA []uint8) *TrimmedBlockInfo {
 	// Exclude coinbase from VAR fill bar.
 	coinbaseSize := int32(0)
-	if len(bi.Tx) > 0 {
-		coinbaseSize = bi.Tx[0].TxBasic.Size
+	for _, tx := range bi.Tx {
+		if tx.TxBasic != nil && tx.TxBasic.Coinbase {
+			coinbaseSize = tx.TxBasic.Size
+			break
+		}
 	}
 	stats := StatsFromCoinRows(bi.BlockBasic.CoinRows, coinbaseSize)
 	fills, _, activeSKACount := ComputeCoinFills(stats, maxBlockSize, issuedSKA)
@@ -739,7 +742,7 @@ func (bi *BlockInfo) Trim(maxBlockSize float64, issuedSKA []uint8) *TrimmedBlock
 		Votes:             bi.Votes,
 		Tickets:           bi.Tickets,
 		Revocations:       bi.Revs,
-		Transactions:      bi.Tx,
+		Transactions:      FilterRegularTx(bi.Tx),
 		Size:              bi.BlockBasic.Size,
 		FormattedBytes:    bi.BlockBasic.FormattedBytes,
 		CoinFills:         fills,
@@ -788,7 +791,7 @@ type BlockInfo struct {
 	TotalSentByCoin []CoinAmount `json:"-"`
 	// RegularCoinCounts is an ordered slice of regular transaction counts per coin type,
 	// for template rendering. Same ordering as TotalSentByCoin.
-	RegularCoinCounts []CoinCount `json:"-"`
+	RegularCoinCounts []CoinCount `json:"regular_coin_counts,omitempty"`
 	// FeesByCoin is an ordered slice of fees per coin type, for template rendering.
 	// VAR fees are total transaction fees in the block; SKA fees are SSFee distribution amounts
 	// (total SKA atoms distributed via TxTypeSSFee per coin type, i.e., fees collected from SKA outputs).

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -360,6 +360,7 @@ type TrimmedTxInfo struct {
 	VinCount     int
 	VoutCount    int
 	VoteValid    bool
+	Voted        bool
 	CoinType     uint8  // 0=VAR, 1-255=SKAn for stake fees; for revocations, set when processing
 	TicketStatus string // Pool status for revocations: "voted", "missed", "expired"
 }
@@ -701,17 +702,22 @@ type MempoolCoinStats struct {
 
 // TrimmedBlockInfo models data needed to display block info on the new home page
 type TrimmedBlockInfo struct {
-	Time         TimeDef
-	Height       int64
-	Total        float64
-	Fees         float64
-	Subsidy      *chainjson.GetBlockSubsidyResult
-	Votes        []*TrimmedTxInfo
-	Tickets      []*TrimmedTxInfo
-	Revocations  []*TrimmedTxInfo
-	Transactions []*TrimmedTxInfo
-	// CoinRows holds per-coin row data for the expandable blocks table.
-	CoinRows []CoinRowData
+	Time              TimeDef
+	Height            int64
+	Total             float64
+	Fees              float64
+	Subsidy           *chainjson.GetBlockSubsidyResult
+	Votes             []*TrimmedTxInfo
+	Tickets           []*TrimmedTxInfo
+	Revocations       []*TrimmedTxInfo
+	Transactions      []*TrimmedTxInfo
+	CoinRows          []CoinRowData
+	Size              int32          `json:"size"`
+	FormattedBytes    string         `json:"formatted_bytes"`
+	CoinFills         []CoinFillData `json:"coin_fills,omitempty"`
+	ActiveSKACount    int            `json:"active_ska_count"`
+	RegularCoinCounts []CoinCount    `json:"regular_coin_counts,omitempty"`
+	MaxBlockSize      float64        `json:"max_block_size"`
 }
 
 // BlockInfo models data for display on the block page
@@ -753,12 +759,15 @@ type BlockInfo struct {
 	TotalSentByCoin []CoinAmount `json:"-"`
 	// RegularCoinCounts is an ordered slice of regular transaction counts per coin type,
 	// for template rendering. Same ordering as TotalSentByCoin.
-	RegularCoinCounts []CoinCount `json:"-"`
+	RegularCoinCounts []CoinCount `json:"regular_coin_counts"`
 	// FeesByCoin is an ordered slice of fees per coin type, for template rendering.
 	// VAR fees are total transaction fees in the block; SKA fees are SSFee distribution amounts
 	// (total SKA atoms distributed via TxTypeSSFee per coin type, i.e., fees collected from SKA outputs).
 	// Same ordering as TotalSentByCoin.
-	FeesByCoin []CoinAmount `json:"-"`
+	FeesByCoin     []CoinAmount   `json:"-"`
+	CoinFills      []CoinFillData `json:"coin_fills,omitempty"`
+	ActiveSKACount int            `json:"active_ska_count"`
+	MaxBlockSize   float64        `json:"max_block_size"`
 }
 
 // CoinAmount represents an amount for a specific coin type.
@@ -860,6 +869,8 @@ type TrimmedMempoolInfo struct {
 	TotalFillRatio float64                    `json:"total_fill_ratio"`
 	ActiveSKACount int                        `json:"active_ska_count"`
 	CoinStats      map[uint8]MempoolCoinStats `json:"coin_stats,omitempty"`
+	MaxBlockSize   float64                    `json:"max_block_size"`
+	TotalSize      int32                      `json:"total_size"`
 }
 
 // MempoolInfo models data to update mempool info on the home page.
@@ -902,8 +913,9 @@ func (mpi *MempoolInfo) DeepCopy() *MempoolInfo {
 }
 
 // Trim converts the MempoolInfo to TrimmedMempoolInfo.
-func (mpi *MempoolInfo) Trim() *TrimmedMempoolInfo {
+func (mpi *MempoolInfo) Trim(maxBlockSize float64) *TrimmedMempoolInfo {
 	mpi.RLock()
+	defer mpi.RUnlock()
 
 	mempoolRegularTxs := TrimMempoolTxs(mpi.Transactions)
 	mempoolVotes := TrimMempoolTxs(mpi.Votes)
@@ -921,9 +933,9 @@ func (mpi *MempoolInfo) Trim() *TrimmedMempoolInfo {
 		TotalFillRatio: mpi.MempoolShort.TotalFillRatio,
 		ActiveSKACount: mpi.MempoolShort.ActiveSKACount,
 		CoinStats:      mpi.MempoolShort.CoinStats,
+		MaxBlockSize:   maxBlockSize,
+		TotalSize:      mpi.MempoolShort.TotalSize,
 	}
-
-	mpi.RUnlock()
 
 	// Calculate total fees for all mempool transactions.
 	getTotalFee := func(txs []*TrimmedTxInfo) dcrutil.Amount {
@@ -1093,6 +1105,7 @@ func TrimMempoolTx(tx *MempoolTx) (trimmedTx *TrimmedTxInfo) {
 		TxBasic:   txBasic,
 		Fees:      tx.Fees,
 		VoteValid: voteValid,
+		Voted:     tx.VoteInfo != nil,
 		VinCount:  tx.VinCount,
 		VoutCount: tx.VoutCount,
 	}
@@ -1449,6 +1462,106 @@ func CopyCoinFillSlice(s []CoinFillData) []CoinFillData {
 	out := make([]CoinFillData, len(s))
 	copy(out, s)
 	return out
+}
+
+// ComputeCoinFills derives per-coin fill bar data from the mempool CoinStats
+// map. VAR is always first in the returned slice; SKA types follow in ascending
+// coin-type order. When stats is empty or nil a single VAR entry with all
+// ratios at 0.0 and status "ok" is returned.
+// issuedSKA is the set of all SKA coin types that have ever been issued on-chain
+// (from SKACoinSupply). Coin types present in issuedSKA but absent from stats
+// are included as zero-fill entries so their indicators are always visible.
+func ComputeCoinFills(stats map[uint8]MempoolCoinStats, maxBlockSize float64, issuedSKA []uint8) ([]CoinFillData, float64, int) {
+	varQuota := maxBlockSize * 0.10
+	skaPool := maxBlockSize * 0.90
+
+	skaKeySet := make(map[int]struct{})
+	for ct := range stats {
+		if ct != 0 {
+			skaKeySet[int(ct)] = struct{}{}
+		}
+	}
+	for _, ct := range issuedSKA {
+		skaKeySet[int(ct)] = struct{}{}
+	}
+	var skaKeys []int
+	var totalSKASize float64
+	for k := range skaKeySet {
+		skaKeys = append(skaKeys, k)
+		totalSKASize += float64(stats[uint8(k)].Size)
+	}
+	sort.Ints(skaKeys)
+	numSKA := len(skaKeys)
+
+	varSize := float64(0)
+	if s, ok := stats[0]; ok {
+		varSize = float64(s.Size)
+	}
+	totalUsed := varSize + totalSKASize
+	totalFillRatio := totalUsed / maxBlockSize
+
+	fillStatus := func(size, quota float64) string {
+		switch {
+		case size <= quota:
+			return "ok"
+		case totalUsed <= maxBlockSize:
+			return "borrowing"
+		default:
+			return "full"
+		}
+	}
+
+	extraOrOverflow := func(size, quota float64, status string) (extra, overflow float64) {
+		if status == "borrowing" {
+			extra = math.Min((size-quota)/maxBlockSize, 1.0)
+		} else if status == "full" {
+			overflow = math.Min((size-quota)/maxBlockSize, 1.0)
+		}
+		return
+	}
+
+	withDisplay := func(d CoinFillData) CoinFillData {
+		raw := d.GQFillRatio*d.GQPositionRatio + d.ExtraFillRatio + d.OverflowFillRatio
+		d.PctOfTC = raw * 100.0
+		d.IsOverflow = raw > 1.0
+		return d
+	}
+
+	varStatus := fillStatus(varSize, varQuota)
+	varExtra, varOverflow := extraOrOverflow(varSize, varQuota, varStatus)
+
+	fills := make([]CoinFillData, 0, 1+numSKA)
+	fills = append(fills, withDisplay(CoinFillData{
+		Symbol:            "VAR",
+		GQFillRatio:       math.Min(varSize/varQuota, 1.0),
+		ExtraFillRatio:    varExtra,
+		OverflowFillRatio: varOverflow,
+		GQPositionRatio:   0.10,
+		Status:            varStatus,
+	}))
+
+	if numSKA == 0 {
+		return fills, totalFillRatio, 0
+	}
+
+	perSKAQuota := skaPool / float64(numSKA)
+	gqPos := 0.90 / float64(numSKA)
+
+	for _, ct := range skaKeys {
+		s := stats[uint8(ct)]
+		size := float64(s.Size)
+		status := fillStatus(size, perSKAQuota)
+		extra, overflow := extraOrOverflow(size, perSKAQuota, status)
+		fills = append(fills, withDisplay(CoinFillData{
+			Symbol:            fmt.Sprintf("SKA%d", ct),
+			GQFillRatio:       math.Min(size/perSKAQuota, 1.0),
+			ExtraFillRatio:    extra,
+			OverflowFillRatio: overflow,
+			GQPositionRatio:   gqPos,
+			Status:            status,
+		}))
+	}
+	return fills, totalFillRatio, numSKA
 }
 
 // NewMempoolTx models data sent from the notification handler

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -319,7 +319,11 @@ func (psh *PubSubHub) receiveLoop(ctx context.Context, conn *connection) {
 		case "getmempooltxs": // TODO: maybe disable this case
 			// construct mempool object with properties required in template
 			inv := psh.MempoolInventory()
-			mempoolInfo := inv.Trim() // Trim locks the inventory.
+			psh.state.mtx.RLock()
+			maxBlockSize := float64(psh.state.BlockchainInfo.MaxBlockSize)
+			psh.state.mtx.RUnlock()
+
+			mempoolInfo := inv.Trim(maxBlockSize) // Trim locks the inventory.
 
 			psh.state.mtx.RLock()
 			mempoolInfo.Subsidy = psh.state.GeneralInfo.NBlockSubsidy

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -319,15 +319,14 @@ func (psh *PubSubHub) receiveLoop(ctx context.Context, conn *connection) {
 		case "getmempooltxs": // TODO: maybe disable this case
 			// construct mempool object with properties required in template
 			inv := psh.MempoolInventory()
+
 			psh.state.mtx.RLock()
 			maxBlockSize := float64(psh.state.BlockchainInfo.MaxBlockSize)
+			subsidy := psh.state.GeneralInfo.NBlockSubsidy
 			psh.state.mtx.RUnlock()
 
 			mempoolInfo := inv.Trim(maxBlockSize) // Trim locks the inventory.
-
-			psh.state.mtx.RLock()
-			mempoolInfo.Subsidy = psh.state.GeneralInfo.NBlockSubsidy
-			psh.state.mtx.RUnlock()
+			mempoolInfo.Subsidy = subsidy
 
 			var b []byte
 			b, err = json.Marshal(mempoolInfo)


### PR DESCRIPTION
Summary
Fixed the data contract for the /visualblocks frontend rewrite to ensure consistency between HTTP and WebSocket transports.
Changes
- Type Updates:
    - Widened TrimmedBlockInfo to include Size, FormattedBytes, CoinFills, ActiveSKACount, RegularCoinCounts, and MaxBlockSize.
    - Updated BlockInfo to export RegularCoinCounts, CoinFills, ActiveSKACount, and MaxBlockSize for WebSocket JSON.
    - Added Voted boolean flag to TrimmedTxInfo.
    - Added MaxBlockSize and TotalSize to TrimmedMempoolInfo.
- Logic Implementation:
    - Implemented ComputeCoinFills in explorertypes.go to calculate block/mempool fill bars using the 10%/90% quota model.
    - Updated MempoolInfo.Trim() to accept maxBlockSize and populate the new contract fields.
    - Updated VisualBlocks HTTP handler to populate TrimmedBlockInfo with contract data.
    - Updated RootWebsocket handler to populate BlockInfo with contract data using shallow copies to prevent shared state mutation.
    - Updated PubSubHub to pass maxBlockSize during mempool trimming.
- Testing:
    - Added visualblocks_contract_test.go to assert that both transports carry the identical data contract and that the Voted flag is correctly set.
    - Updated existing home viewmodel tests to accommodate the Trim() signature change.