### PR TITLE
cmd/dcrdata/views/parameters: align /parameters with Monetarium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ go.work
 go.work.sum
 .claude/settings.local.json
 .github/scripts/tasks.json
+.playwright-mcp/

--- a/cmd/dcrdata/go.mod
+++ b/cmd/dcrdata/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/monetarium/monetarium-node/blockchain/standalone v1.1.0
 	github.com/monetarium/monetarium-node/chaincfg v1.1.0
 	github.com/monetarium/monetarium-node/chaincfg/chainhash v1.1.0
+	github.com/monetarium/monetarium-node/cointype v1.0.14
 	github.com/monetarium/monetarium-node/dcrutil v1.1.0
 	github.com/monetarium/monetarium-node/rpc/jsonrpc/types v1.1.0
 	github.com/monetarium/monetarium-node/rpcclient v1.1.0
@@ -181,7 +182,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
-	github.com/monetarium/monetarium-node/cointype v1.0.14 // indirect
 	github.com/monetarium/monetarium-node/crypto/blake256 v1.0.14 // indirect
 	github.com/monetarium/monetarium-node/crypto/rand v1.0.14 // indirect
 	github.com/monetarium/monetarium-node/crypto/ripemd160 v1.0.14 // indirect

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -171,7 +171,7 @@ var explorerLinks = &links{
 	InsightAPIDocs:  "https://github.com/decred/dcrdata/blob/master/docs/Insight_API_documentation.md",
 	Github:          "https://github.com/monetarium/monetarium-explorer",
 	License:         "https://github.com/monetarium/monetarium-explorer/blob/main/LICENSE",
-	NetParams:       "https://github.com/decred/dcrd/blob/master/chaincfg/params.go",
+	NetParams:       "https://github.com/monetarium/monetarium-node/blob/master/chaincfg/params.go",
 	DownloadLink:    "https://decred.org/wallets/",
 }
 

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -2159,6 +2159,7 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 		MaximumBlockSize     int64
 		ActualTicketPoolSize int64
 		AddressPrefix        []types.AddrPrefix
+		SKACoins             []types.SKACoinParam
 	}
 
 	str, err := exp.templates.exec("parameters", struct {
@@ -2170,6 +2171,7 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 			MaximumBlockSize:     maxBlockSize,
 			AddressPrefix:        addrPrefix,
 			ActualTicketPoolSize: actualTicketPoolSize,
+			SKACoins:             buildSKACoinParams(params),
 		},
 	})
 

--- a/cmd/dcrdata/internal/explorer/parameters.go
+++ b/cmd/dcrdata/internal/explorer/parameters.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2025, The Monetarium developers
+// See LICENSE for details.
+
+package explorer
+
+import (
+	"math/big"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/monetarium/monetarium-explorer/explorer/types"
+	"github.com/monetarium/monetarium-node/chaincfg"
+	"github.com/monetarium/monetarium-node/cointype"
+)
+
+// buildSKACoinParams walks chaincfg.Params.SKACoins in CoinType order and
+// returns a pre-formatted view-model slice for the /parameters template. All
+// 18-decimal SKA atom values are converted to plain decimal strings via
+// formatAtomsAsCoinString; no *big.Int crosses the template boundary (see
+// wiki/core/constraints.md#C1).
+func buildSKACoinParams(params *chaincfg.Params) []types.SKACoinParam {
+	if len(params.SKACoins) == 0 {
+		return nil
+	}
+
+	initial := make(map[cointype.CoinType]struct{}, len(params.InitialSKATypes))
+	for _, ct := range params.InitialSKATypes {
+		initial[ct] = struct{}{}
+	}
+
+	coinTypes := make([]cointype.CoinType, 0, len(params.SKACoins))
+	for ct := range params.SKACoins {
+		coinTypes = append(coinTypes, ct)
+	}
+	sort.Slice(coinTypes, func(i, j int) bool { return coinTypes[i] < coinTypes[j] })
+
+	out := make([]types.SKACoinParam, 0, len(coinTypes))
+	for _, ct := range coinTypes {
+		c := params.SKACoins[ct]
+		if c == nil {
+			continue
+		}
+		_, initiallyActive := initial[ct]
+
+		emissionAmounts := make([]string, len(c.EmissionAmounts))
+		for i, amt := range c.EmissionAmounts {
+			emissionAmounts[i] = formatBigIntAsSKAString(amt)
+		}
+
+		out = append(out, types.SKACoinParam{
+			CoinType:          uint8(ct),
+			Label:             "SKA" + strconv.Itoa(int(ct)),
+			Name:              c.Name,
+			Symbol:            c.Symbol,
+			Description:       c.Description,
+			Active:            c.Active,
+			InitiallyActive:   initiallyActive,
+			MaxSupply:         formatBigIntAsSKAString(c.MaxSupply),
+			AtomsPerCoin:      formatBigIntWithCommas(c.AtomsPerCoin),
+			MinRelayTxFee:     formatBigIntAsSKAString(c.MinRelayTxFee),
+			MaxFeeMultiplier:  c.MaxFeeMultiplier,
+			EmissionHeight:    c.EmissionHeight,
+			EmissionWindow:    c.EmissionWindow,
+			EmissionAddresses: append([]string(nil), c.EmissionAddresses...),
+			EmissionAmounts:   emissionAmounts,
+		})
+	}
+	return out
+}
+
+// formatBigIntAsSKAString renders an SKA atom *big.Int as a full-precision
+// 18-decimal coin string with thousands separators, no rounding and no
+// scientific notation. Whole-coin values render without a trailing decimal
+// point. nil renders as "0".
+func formatBigIntAsSKAString(n *big.Int) string {
+	if n == nil {
+		return "0"
+	}
+	// formatAtomsAsCoinString switches on coinType: 0 → VAR (8 dec), any other
+	// → SKA (18 dec). Use CoinTypeMax to make the SKA intent obvious.
+	s := formatAtomsAsCoinString(n.String(), uint8(cointype.CoinTypeMax), 0)
+	// With minDecimals=0 and a whole-coin value, formatAtomsAsCoinString
+	// trims the fractional digits down to "" and still appends a stray "."
+	// (e.g. "900,000,000,000,000."). Strip that trailing dot.
+	return strings.TrimSuffix(s, ".")
+}
+
+// formatBigIntWithCommas renders a *big.Int as a base-10 integer with
+// thousands separators. Used for AtomsPerCoin (the per-coin atomic scale,
+// meaningful as an integer, not a coin amount).
+func formatBigIntWithCommas(n *big.Int) string {
+	if n == nil {
+		return "0"
+	}
+	s := n.String()
+	prefix := ""
+	if strings.HasPrefix(s, "-") {
+		prefix = "-"
+		s = s[1:]
+	}
+	if len(s) <= 3 {
+		return prefix + s
+	}
+	var out []byte
+	for i := 0; i < len(s); i++ {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, s[i])
+	}
+	return prefix + string(out)
+}

--- a/cmd/dcrdata/internal/explorer/parameters_test.go
+++ b/cmd/dcrdata/internal/explorer/parameters_test.go
@@ -4,11 +4,95 @@
 package explorer
 
 import (
+	"math/big"
 	"strings"
 	"testing"
 
 	"github.com/monetarium/monetarium-node/chaincfg"
 )
+
+func TestFormatBigIntAsSKAString(t *testing.T) {
+	mustBig := func(s string) *big.Int {
+		n, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			t.Fatalf("bad bigint literal %q", s)
+		}
+		return n
+	}
+
+	cases := []struct {
+		name string
+		in   *big.Int
+		want string
+	}{
+		{"nil", nil, "0"},
+		{"zero", big.NewInt(0), "0"},
+		{"one atom (smallest unit)", big.NewInt(1), "0.000000000000000001"},
+		{"sub-coin", big.NewInt(500_000_000_000_000_000), "0.5"},
+		{"one whole coin", mustBig("1000000000000000000"), "1"},
+		{"four whole coins (MinRelayTxFee mainnet)", mustBig("4000000000000000000"), "4"},
+		{"five million coins (SKA-2 MaxSupply)", mustBig("5000000000000000000000000"), "5,000,000"},
+		{
+			"nine hundred trillion coins (SKA-1 MaxSupply)",
+			mustBig("900000000000000000000000000000000"),
+			"900,000,000,000,000",
+		},
+		{"non-integer coin amount", mustBig("1234500000000000000"), "1.2345"},
+		{"sub-coin with leading fractional zeros", mustBig("100000000000000"), "0.0001"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatBigIntAsSKAString(tc.in)
+			if got != tc.want {
+				t.Errorf("formatBigIntAsSKAString(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+			// Anti-regression guards on the whole class of formatter glitches:
+			if strings.HasSuffix(got, ".") {
+				t.Errorf("trailing decimal point in %q", got)
+			}
+			if strings.HasPrefix(got, ".") {
+				t.Errorf("leading decimal point in %q", got)
+			}
+			if strings.ContainsAny(got, "eE") {
+				t.Errorf("scientific notation in %q", got)
+			}
+		})
+	}
+}
+
+func TestFormatBigIntWithCommas(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *big.Int
+		want string
+	}{
+		{"nil", nil, "0"},
+		{"zero", big.NewInt(0), "0"},
+		{"single digit", big.NewInt(7), "7"},
+		{"three digits", big.NewInt(123), "123"},
+		{"four digits", big.NewInt(1234), "1,234"},
+		{"seven digits", big.NewInt(1_000_000), "1,000,000"},
+		{
+			"AtomsPerCoin (1e18)",
+			new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+			"1,000,000,000,000,000,000",
+		},
+		{"negative", big.NewInt(-1234567), "-1,234,567"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatBigIntWithCommas(tc.in)
+			if got != tc.want {
+				t.Errorf("formatBigIntWithCommas(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.Contains(got, ".") {
+				t.Errorf("integer formatter emitted a decimal point in %q", got)
+			}
+		})
+	}
+}
 
 func TestBuildSKACoinParams_Mainnet(t *testing.T) {
 	got := buildSKACoinParams(chaincfg.MainNetParams())

--- a/cmd/dcrdata/internal/explorer/parameters_test.go
+++ b/cmd/dcrdata/internal/explorer/parameters_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2025, The Monetarium developers
+// See LICENSE for details.
+
+package explorer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/monetarium/monetarium-node/chaincfg"
+)
+
+func TestBuildSKACoinParams_Mainnet(t *testing.T) {
+	got := buildSKACoinParams(chaincfg.MainNetParams())
+	if len(got) < 2 {
+		t.Fatalf("expected >=2 SKA entries on mainnet, got %d", len(got))
+	}
+
+	// Entries must be sorted by CoinType.
+	for i := 1; i < len(got); i++ {
+		if got[i-1].CoinType >= got[i].CoinType {
+			t.Fatalf("SKA entries not sorted by CoinType: %d before %d", got[i-1].CoinType, got[i].CoinType)
+		}
+	}
+
+	first := got[0]
+	if first.CoinType != 1 {
+		t.Errorf("first CoinType=%d, want 1", first.CoinType)
+	}
+	if first.Label != "SKA1" {
+		t.Errorf("first Label=%q, want %q (no dash)", first.Label, "SKA1")
+	}
+	if !first.InitiallyActive {
+		t.Error("SKA1 should be in InitialSKATypes")
+	}
+	if !first.Active {
+		t.Error("SKA1 should be Active")
+	}
+	if !strings.Contains(first.MaxSupply, ",") {
+		t.Errorf("MaxSupply=%q has no thousands separators", first.MaxSupply)
+	}
+	if strings.ContainsAny(first.MaxSupply, "eE") {
+		t.Errorf("MaxSupply=%q must not use scientific notation", first.MaxSupply)
+	}
+	if strings.HasSuffix(first.MaxSupply, ".") {
+		t.Errorf("MaxSupply=%q must not have a trailing decimal point for whole-coin values", first.MaxSupply)
+	}
+
+	const wantAtomsPerCoin = "1,000,000,000,000,000,000"
+	if first.AtomsPerCoin != wantAtomsPerCoin {
+		t.Errorf("AtomsPerCoin=%q, want %q", first.AtomsPerCoin, wantAtomsPerCoin)
+	}
+
+	if len(first.EmissionAddresses) == 0 {
+		t.Error("SKA1 should have at least one EmissionAddress")
+	}
+	if len(first.EmissionAmounts) != len(first.EmissionAddresses) {
+		t.Errorf("EmissionAmounts len=%d != EmissionAddresses len=%d",
+			len(first.EmissionAmounts), len(first.EmissionAddresses))
+	}
+
+	// SKA2 on mainnet is configured but inactive and not in InitialSKATypes.
+	second := got[1]
+	if second.CoinType != 2 {
+		t.Errorf("second CoinType=%d, want 2", second.CoinType)
+	}
+	if second.Label != "SKA2" {
+		t.Errorf("second Label=%q, want %q", second.Label, "SKA2")
+	}
+	if second.InitiallyActive {
+		t.Error("SKA2 should NOT be in InitialSKATypes on mainnet")
+	}
+	if second.Active {
+		t.Error("SKA2 should be inactive on mainnet")
+	}
+}
+
+func TestBuildSKACoinParams_OtherNets(t *testing.T) {
+	// Must not panic and must produce non-empty output where SKACoins are
+	// configured. simnet/testnet/regnet may differ in coin sets but the
+	// builder should work uniformly.
+	for _, p := range []*chaincfg.Params{
+		chaincfg.SimNetParams(),
+		chaincfg.TestNet3Params(),
+		chaincfg.RegNetParams(),
+	} {
+		got := buildSKACoinParams(p)
+		_ = got // existence + no panic is the contract; SKACoins may be empty.
+	}
+}

--- a/cmd/dcrdata/views/parameters.tmpl
+++ b/cmd/dcrdata/views/parameters.tmpl
@@ -137,19 +137,14 @@
                                 <td>Reduction interval in blocks</td>
                             </tr>
                             <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">WorkRewardProportion</td>
-                                <td class="mono">{{uint16Mul .ChainParams.WorkRewardProportion 10}}%</td>
-                                <td>Comparative amount of the subsidy given for creating a block</td>
+                                <td class="mono text-start pe-2 nowrap p03rem0">WorkRewardProportionV2</td>
+                                <td class="mono">{{uint16Mul .ChainParams.WorkRewardProportionV2 10}}%</td>
+                                <td>Comparative amount of the subsidy given for creating a block (Monetarium fixes PoW/PoS at 50% / 50%)</td>
                             </tr>
                             <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">StakeRewardProportion</td>
-                                <td class="mono">{{uint16Mul .ChainParams.StakeRewardProportion 10}}%</td>
+                                <td class="mono text-start pe-2 nowrap p03rem0">StakeRewardProportionV2</td>
+                                <td class="mono">{{uint16Mul .ChainParams.StakeRewardProportionV2 10}}%</td>
                                 <td>Comparative amount of the subsidy given for casting stake votes (collectively, per block)</td>
-                            </tr>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">BlockTaxProportion</td>
-                                <td class="mono">{{uint16Mul .ChainParams.BlockTaxProportion 10}}%</td>
-                                <td>Inverse of the percentage of funds for each block to allocate to the developer organization</td>
                             </tr>
                         </tbody>
                     </table>
@@ -255,63 +250,6 @@
                             </tr>
                         </tbody>
                     </table>
-                    <h4><span>Treasury parameters</span></h4>
-                    <table class="table table-mono-cells table-sm f15">
-                        <thead>
-                          <tr>
-                            <th width="20%">Parameter</th>
-                            <th>Value</th>
-                            <th width="60%">Description</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">TreasuryVoteInterval</td>
-                                <td class="mono">{{.ChainParams.TreasuryVoteInterval}}</td>
-                                <td>How frequently a TSpend transaction is allowed in a block (see standalone.IsTreasuryVoteInterval)</td>
-                            </tr>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">TreasuryVoteIntervalMultiplier</td>
-                                <td class="mono">{{.ChainParams.TreasuryVoteIntervalMultiplier}}</td>
-                                <td>Multiplier to TreasuryVoteInterval to calculate Expiry (see standalone.CalcTSpendWindow)</td>
-                            </tr>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">TreasuryVoteQuorumMultiplier</td>
-                                <td class="mono">{{.ChainParams.TreasuryVoteQuorumMultiplier}}</td>
-                                <td>Numerator of the TSpend vote quorum percentage (see CheckTSpendHasVotes)</td>
-                            </tr>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">TreasuryVoteQuorumDivisor</td>
-                                <td class="mono">{{.ChainParams.TreasuryVoteQuorumDivisor}}</td>
-                                <td>Divisor of the TSpend vote quorum percentage (see CheckTSpendHasVotes)</td>
-                            </tr>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">TreasuryVoteRequiredMultiplier</td>
-                                <td class="mono">{{.ChainParams.TreasuryVoteRequiredMultiplier}}</td>
-                                <td>Numerator of the required votes percentage (see CheckTSpendHasVotes)</td>
-                            </tr>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">TreasuryVoteRequiredDivisor</td>
-                                <td class="mono">{{.ChainParams.TreasuryVoteRequiredDivisor}}</td>
-                                <td>Divisor of the required votes vote quorum percentage (see CheckTSpendHasVotes)</td>
-                            </tr>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">TreasuryExpenditureWindow</td>
-                                <td class="mono">{{.ChainParams.TreasuryExpenditureWindow}}</td>
-                                <td>The number of TreasuryVoteInterval*TreasuryVoteIntervalMultiplier windows that define a single expenditure window (see maxTreasuryExpenditure)</td>
-                            </tr>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">TreasuryExpenditurePolicy</td>
-                                <td class="mono">{{.ChainParams.TreasuryExpenditurePolicy}}</td>
-                                <td>The number of previous TreasuryExpenditureWindows that defines how far back to calculate the average expenditure of the treasury for an expenditure policy check (see maxTreasuryExpenditure)</td>
-                            </tr>
-                            <tr>
-                                <td class="mono text-start pe-2 nowrap p03rem0">TreasuryExpenditureBootstrap</td>
-                                <td class="mono">{{.ChainParams.TreasuryExpenditureBootstrap}}</td>
-                                <td>Default previous average expenditure when there are no treasury spends inside the entire window defined by TreasuryExpenditurePolicy</td>
-                            </tr>
-                        </tbody>
-                    </table>
                     <h4><span>Rule change parameters</span></h4>
                     <table class="table table-mono-cells table-sm f15">
                         <thead>
@@ -383,6 +321,77 @@
                             {{end}}
                         </tbody>
                     </table>
+                    <h4><span>SKA coin parameters</span></h4>
+                    {{range $coin := .ExtendedParams.SKACoins}}
+                    <h5 class="mt-3">
+                        <span class="mono">{{$coin.Label}}</span>
+                        <span class="fs14 text-secondary">— {{$coin.Name}}{{if $coin.Symbol}} ({{$coin.Symbol}}){{end}}</span>
+                        {{if not $coin.Active}}<span class="badge bg-secondary ms-2 fs12">inactive</span>{{else if not $coin.InitiallyActive}}<span class="badge bg-info ms-2 fs12">activated post-genesis</span>{{end}}
+                    </h5>
+                    <table class="table table-mono-cells table-sm">
+                        <thead>
+                          <tr>
+                            <th width="20%">Parameter</th>
+                            <th>Value</th>
+                            <th width="60%">Description</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="mono text-start pe-2 nowrap p03rem0">Description</td>
+                                <td colspan="2">{{$coin.Description}}</td>
+                            </tr>
+                            <tr>
+                                <td class="mono text-start pe-2 nowrap p03rem0">Active</td>
+                                <td class="mono">{{$coin.Active}}</td>
+                                <td>Whether this coin type is currently active and can be used in transactions</td>
+                            </tr>
+                            <tr>
+                                <td class="mono text-start pe-2 nowrap p03rem0">MaxSupply</td>
+                                <td class="mono">{{$coin.MaxSupply}} <span class="unit lh15rem">{{$coin.Label}}</span></td>
+                                <td>Maximum number of coins that can ever be emitted for this coin type</td>
+                            </tr>
+                            <tr>
+                                <td class="mono text-start pe-2 nowrap p03rem0">AtomsPerCoin</td>
+                                <td class="mono">{{$coin.AtomsPerCoin}}</td>
+                                <td>Atomic scale: number of atoms in one whole coin</td>
+                            </tr>
+                            <tr>
+                                <td class="mono text-start pe-2 nowrap p03rem0">MinRelayTxFee</td>
+                                <td class="mono">{{$coin.MinRelayTxFee}} <span class="unit lh15rem">{{$coin.Label}}</span> / KB</td>
+                                <td>Minimum fee rate for transactions of this coin type</td>
+                            </tr>
+                            <tr>
+                                <td class="mono text-start pe-2 nowrap p03rem0">MaxFeeMultiplier</td>
+                                <td class="mono">{{$coin.MaxFeeMultiplier}}x</td>
+                                <td>Multiplier applied to MinRelayTxFee to determine the maximum allowed fee</td>
+                            </tr>
+                            <tr>
+                                <td class="mono text-start pe-2 nowrap p03rem0">EmissionHeight</td>
+                                <td class="mono"><a href="/block/{{$coin.EmissionHeight}}">{{$coin.EmissionHeight}}</a></td>
+                                <td>Block height at which this coin type is/was initially emitted</td>
+                            </tr>
+                            <tr>
+                                <td class="mono text-start pe-2 nowrap p03rem0">EmissionWindow</td>
+                                <td class="mono">{{$coin.EmissionWindow}} blocks</td>
+                                <td>Number of blocks after EmissionHeight during which emission is allowed</td>
+                            </tr>
+                            <tr>
+                                <td class="mono text-start pe-2 nowrap p03rem0">EmissionAddresses</td>
+                                <td colspan="2">
+                                    {{range $i, $addr := $coin.EmissionAddresses}}
+                                    <div class="mono">
+                                        <a href="/address/{{$addr}}">{{$addr}}</a>
+                                        {{if (index $coin.EmissionAmounts $i)}} — {{index $coin.EmissionAmounts $i}} <span class="unit lh15rem">{{$coin.Label}}</span>{{end}}
+                                    </div>
+                                    {{end}}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    {{else}}
+                    <p class="text-secondary">No SKA coins configured for this network.</p>
+                    {{end}}
                 </div>
             </div>
         </div>

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -5,6 +5,7 @@
 package types
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -1512,52 +1513,116 @@ type AddrPrefix struct {
 	Description string
 }
 
-// AddressPrefixes generates an array AddrPrefix by using chaincfg.Params
+// addrPrefixSet captures the textual base58 prefix that every address of each
+// type begins with on a given network. These are the values documented in
+// `monetarium-node/chaincfg/{mainnet,testnet,simnet,regnet}params.go` as the
+// "starts with X" comments next to each magic-byte field. We hardcode the
+// table per network because the textual prefix is a property of typical
+// real-world hash160 / BIP32 payloads, not a deterministic function of the
+// magic bytes alone (the leading base58 digit shifts with the payload).
+type addrPrefixSet struct {
+	pubKeyAddrID, pubKeyHashAddrID, pkhEdwardsAddrID, pkhSchnorrAddrID string
+	scriptHashAddrID, privateKeyID, hdPrivateKeyID, hdPublicKeyID      string
+}
+
+var (
+	mainnetAddrPrefixes = addrPrefixSet{
+		pubKeyAddrID: "Mk", pubKeyHashAddrID: "Ms", pkhEdwardsAddrID: "Me",
+		pkhSchnorrAddrID: "MS", scriptHashAddrID: "Mc", privateKeyID: "Pm",
+		hdPrivateKeyID: "dprv", hdPublicKeyID: "dpub",
+	}
+	testnetAddrPrefixes = addrPrefixSet{
+		pubKeyAddrID: "Tk", pubKeyHashAddrID: "Ts", pkhEdwardsAddrID: "Te",
+		pkhSchnorrAddrID: "TS", scriptHashAddrID: "Tc", privateKeyID: "Pt",
+		hdPrivateKeyID: "tprv", hdPublicKeyID: "tpub",
+	}
+	simnetAddrPrefixes = addrPrefixSet{
+		pubKeyAddrID: "Sk", pubKeyHashAddrID: "Ss", pkhEdwardsAddrID: "Se",
+		pkhSchnorrAddrID: "SS", scriptHashAddrID: "Sc", privateKeyID: "Ps",
+		hdPrivateKeyID: "sprv", hdPublicKeyID: "spub",
+	}
+	regnetAddrPrefixes = addrPrefixSet{
+		pubKeyAddrID: "Rk", pubKeyHashAddrID: "Rs", pkhEdwardsAddrID: "Re",
+		pkhSchnorrAddrID: "RS", scriptHashAddrID: "Rc", privateKeyID: "Pr",
+		hdPrivateKeyID: "rprv", hdPublicKeyID: "rpub",
+	}
+)
+
+// AddressPrefixes returns the textual address prefixes for the active network
+// on /parameters. Recognised nets (mainnet/testnet*/simnet/regnet) return the
+// documented textual prefixes; any other network falls back to the magic-byte
+// hex representation so the table is never silently empty.
 func AddressPrefixes(params *chaincfg.Params) []AddrPrefix {
-	Descriptions := []string{"P2PK address",
-		"P2PKH address prefix. Standard wallet address. 1 public key -> 1 private key",
-		"Ed25519 P2PKH address prefix",
-		"secp256k1 Schnorr P2PKH address prefix",
-		"P2SH address prefix",
-		"WIF private key prefix",
-		"HD extended private key prefix",
-		"HD extended public key prefix",
+	set, recognised := lookupAddrPrefixSet(params.Name)
+
+	prefix2 := func(known string, magic [2]byte) string {
+		if recognised {
+			return known
+		}
+		return "0x" + hex.EncodeToString(magic[:])
 	}
-	Name := []string{"PubKeyAddrID",
-		"PubKeyHashAddrID",
-		"PKHEdwardsAddrID",
-		"PKHSchnorrAddrID",
-		"ScriptHashAddrID",
-		"PrivateKeyID",
-		"HDPrivateKeyID",
-		"HDPublicKeyID",
+	prefix4 := func(known string, magic [4]byte) string {
+		if recognised {
+			return known
+		}
+		return "0x" + hex.EncodeToString(magic[:])
 	}
 
-	MainnetPrefixes := []string{"Dk", "Ds", "De", "DS", "Dc", "Pm", "dprv", "dpub"}
-	TestnetPrefixes := []string{"Tk", "Ts", "Te", "TS", "Tc", "Pt", "tprv", "tpub"}
-	SimnetPrefixes := []string{"Sk", "Ss", "Se", "SS", "Sc", "Ps", "sprv", "spub"}
-
-	name := params.Name
-	var netPrefixes []string
-	if name == "mainnet" {
-		netPrefixes = MainnetPrefixes
-	} else if strings.HasPrefix(name, "testnet") {
-		netPrefixes = TestnetPrefixes
-	} else if name == "simnet" {
-		netPrefixes = SimnetPrefixes
-	} else {
-		return nil
+	return []AddrPrefix{
+		{Name: "PubKeyAddrID", Prefix: prefix2(set.pubKeyAddrID, params.PubKeyAddrID),
+			Description: "P2PK address"},
+		{Name: "PubKeyHashAddrID", Prefix: prefix2(set.pubKeyHashAddrID, params.PubKeyHashAddrID),
+			Description: "P2PKH address prefix. Standard wallet address. 1 public key -> 1 private key"},
+		{Name: "PKHEdwardsAddrID", Prefix: prefix2(set.pkhEdwardsAddrID, params.PKHEdwardsAddrID),
+			Description: "Ed25519 P2PKH address prefix"},
+		{Name: "PKHSchnorrAddrID", Prefix: prefix2(set.pkhSchnorrAddrID, params.PKHSchnorrAddrID),
+			Description: "secp256k1 Schnorr P2PKH address prefix"},
+		{Name: "ScriptHashAddrID", Prefix: prefix2(set.scriptHashAddrID, params.ScriptHashAddrID),
+			Description: "P2SH address prefix"},
+		{Name: "PrivateKeyID", Prefix: prefix2(set.privateKeyID, params.PrivateKeyID),
+			Description: "WIF private key prefix"},
+		{Name: "HDPrivateKeyID", Prefix: prefix4(set.hdPrivateKeyID, params.HDPrivateKeyID),
+			Description: "HD extended private key prefix"},
+		{Name: "HDPublicKeyID", Prefix: prefix4(set.hdPublicKeyID, params.HDPublicKeyID),
+			Description: "HD extended public key prefix"},
 	}
+}
 
-	addrPrefix := make([]AddrPrefix, 0, len(Descriptions))
-	for i, desc := range Descriptions {
-		addrPrefix = append(addrPrefix, AddrPrefix{
-			Name:        Name[i],
-			Description: desc,
-			Prefix:      netPrefixes[i],
-		})
+func lookupAddrPrefixSet(netName string) (addrPrefixSet, bool) {
+	switch {
+	case netName == "mainnet":
+		return mainnetAddrPrefixes, true
+	case strings.HasPrefix(netName, "testnet"):
+		return testnetAddrPrefixes, true
+	case netName == "simnet":
+		return simnetAddrPrefixes, true
+	case netName == "regnet":
+		return regnetAddrPrefixes, true
+	default:
+		return addrPrefixSet{}, false
 	}
-	return addrPrefix
+}
+
+// SKACoinParam is the per-coin view-model for the SKA coin parameters table
+// on /parameters. All 18-decimal SKA amounts are pre-formatted to plain
+// decimal strings server-side; no *big.Int / atoms cross the template
+// boundary (see wiki/core/constraints.md#C1).
+type SKACoinParam struct {
+	CoinType          uint8
+	Label             string // "SKA1", "SKA2" — no dash, see wiki/core/product.md
+	Name              string
+	Symbol            string
+	Description       string
+	Active            bool // SKACoinConfig.Active
+	InitiallyActive   bool // present in chaincfg.Params.InitialSKATypes
+	MaxSupply         string
+	AtomsPerCoin      string
+	MinRelayTxFee     string
+	MaxFeeMultiplier  int64
+	EmissionHeight    int32
+	EmissionWindow    int32
+	EmissionAddresses []string
+	EmissionAmounts   []string // parallel to EmissionAddresses
 }
 
 // StatsInfo represents all of the data for the stats page.

--- a/explorer/types/explorertypes_test.go
+++ b/explorer/types/explorertypes_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/monetarium/monetarium-node/chaincfg"
 )
 
 func TestTimeDefMarshal(t *testing.T) {
@@ -452,4 +454,93 @@ func TestBytesString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddressPrefixes(t *testing.T) {
+	cases := []struct {
+		name   string
+		params *chaincfg.Params
+		want   map[string]string // AddrPrefix.Name -> AddrPrefix.Prefix
+	}{
+		{
+			name:   "mainnet",
+			params: chaincfg.MainNetParams(),
+			want: map[string]string{
+				"PubKeyAddrID":     "Mk",
+				"PubKeyHashAddrID": "Ms",
+				"PKHEdwardsAddrID": "Me",
+				"PKHSchnorrAddrID": "MS",
+				"ScriptHashAddrID": "Mc",
+				"PrivateKeyID":     "Pm",
+				"HDPrivateKeyID":   "dprv",
+				"HDPublicKeyID":    "dpub",
+			},
+		},
+		{
+			name:   "testnet",
+			params: chaincfg.TestNet3Params(),
+			want: map[string]string{
+				"PubKeyAddrID":     "Tk",
+				"PubKeyHashAddrID": "Ts",
+				"PKHEdwardsAddrID": "Te",
+				"PKHSchnorrAddrID": "TS",
+				"ScriptHashAddrID": "Tc",
+				"PrivateKeyID":     "Pt",
+				"HDPrivateKeyID":   "tprv",
+				"HDPublicKeyID":    "tpub",
+			},
+		},
+		{
+			name:   "simnet",
+			params: chaincfg.SimNetParams(),
+			want: map[string]string{
+				"PubKeyAddrID":     "Sk",
+				"PubKeyHashAddrID": "Ss",
+				"PKHEdwardsAddrID": "Se",
+				"PKHSchnorrAddrID": "SS",
+				"ScriptHashAddrID": "Sc",
+				"PrivateKeyID":     "Ps",
+				"HDPrivateKeyID":   "sprv",
+				"HDPublicKeyID":    "spub",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AddressPrefixes(tc.params)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len(AddressPrefixes)=%d, want %d", len(got), len(tc.want))
+			}
+			for _, ap := range got {
+				want, ok := tc.want[ap.Name]
+				if !ok {
+					t.Errorf("unexpected entry %q", ap.Name)
+					continue
+				}
+				if ap.Prefix != want {
+					t.Errorf("%s: prefix=%q, want %q", ap.Name, ap.Prefix, want)
+				}
+				if ap.Description == "" {
+					t.Errorf("%s: empty description", ap.Name)
+				}
+			}
+		})
+	}
+
+	// Unknown / custom network must never produce an empty table. We use a
+	// shallow clone of mainnet with a renamed Name to exercise the fallback.
+	t.Run("unknown-net-fallback", func(t *testing.T) {
+		clone := *chaincfg.MainNetParams()
+		clone.Name = "custom-devnet-xyz"
+		got := AddressPrefixes(&clone)
+		if len(got) == 0 {
+			t.Fatal("AddressPrefixes returned empty slice for unrecognised net")
+		}
+		for _, ap := range got {
+			if ap.Prefix == "" {
+				t.Errorf("%s: empty prefix on unrecognised net", ap.Name)
+			}
+		}
+	})
 }

--- a/wiki/code-analysis/parameters/flow.compact.md
+++ b/wiki/code-analysis/parameters/flow.compact.md
@@ -4,17 +4,20 @@ GET /parameters → ETag cache → ParametersPage → {CommonPageData + Extended
 
 Key Patterns:
 
-- **~95% static page:** only `MaximumBlockSize` is dynamic; rest is immutable `chaincfg.Params`
+- **Near-static page:** only `MaximumBlockSize` is dynamic; rest is immutable `chaincfg.Params`
 - **Dual param injection:** template merges `.ChainParams` (commonData) + `.ExtendedParams` (handler) via struct embedding
 - **`exp.ChainParams` captured once at startup** — node config change needs explorer restart
 - **Block-scoped ETag cache** (`ETagAndLastModifiedIntercept`) — intentional
+- **VAR scalar subsidy rows + dedicated SKA section:** subsidy/stake rows are VAR scalar `chaincfg.Params` fields; the SKA coin parameters table is the only multi-coin content, fed by a pre-formatted view-model
+- **`WorkRewardProportionV2` / `StakeRewardProportionV2`** are the actual 50/50 fields read by the template (not the legacy V1 60/30 fields, and not the deprecated `WorkSubsidyProportion()` helper which still returns V1)
 
 Critical Constraints:
 
 - Read `pageData.BlockchainInfo` only under `RLock` (writer `Store` holds `Lock`)
 - `BlockchainInfo` is `nil` for non-tip blocks by design → handler falls back to `params.MaximumBlockSizes[0]`
-- VAR-only page: subsidy/reward rows are scalar `chaincfg.Params`, NOT per-coin maps (see REWARDS_LOGIC.md)
-- `AddressPrefixes` hardcoded to mainnet/testnet*/simnet → `nil` otherwise
+- VAR-only subsidy/stake rows: scalar `chaincfg.Params`, NOT per-coin maps (see REWARDS_LOGIC.md). SKA coins live only in the SKA section.
+- `AddressPrefixes` returns documented per-net textual prefixes for mainnet/testnet*/simnet/regnet and falls back to magic-byte hex for any other `params.Name` — never returns `nil`.
+- SKA atom values (`MaxSupply`, `MinRelayTxFee`, `EmissionAmounts`) MUST be pre-formatted server-side via `formatAtomsAsCoinString`; no `*big.Int` crosses the template boundary.
 - `commonData` is shared by ALL pages; page-specific data → `ExtendedParams`
 
 Mutation Checklist:
@@ -22,14 +25,15 @@ Mutation Checklist:
 - new template row → put computed value in `ExtendedParams`, never `commonData`
 - changing `BlockchainInfo`/`Store` → also affects home page + `StoreMPData`
 - changing `GetChainParams`/`commonData` → affects every page
-- keep `AddressPrefixes` Name/Descriptions/prefix arrays index-aligned
+- new address-prefix kind → add an inline literal row inside `AddressPrefixes`; new recognised network → add an `addrPrefixSet` var and a case in `lookupAddrPrefixSet`
+- new SKA field on the page → extend `types.SKACoinParam` AND `buildSKACoinParams` AND the template; SKA atom values must go through `formatAtomsAsCoinString` (or `formatBigIntAsSKAString`)
 - preserve the `BlockchainInfo == nil` fallback
 
 Silent Risks:
 
-- unknown `params.Name` → empty address-prefix table, no error
 - `BlockchainInfo == nil` → `MaxBlockSize` silently uses stale `MaximumBlockSizes[0]`
 - empty `MaximumBlockSizes` → index panic (no bounds check) [INFERRED]
+- bypassing `buildSKACoinParams` and rendering a SKA `*big.Int` directly → precision loss / scientific notation
 
 Hard Failures:
 

--- a/wiki/code-analysis/parameters/flow.full.md
+++ b/wiki/code-analysis/parameters/flow.full.md
@@ -76,14 +76,20 @@ monetarium-node
 
 ### Handler
 
-- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go:2144-2184`
+- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go:2144-2186`
 - **Data structures:** anonymous `struct{ *CommonPageData; ExtendedParams }`;
-  `ExtendedParams{ MaximumBlockSize int64; ActualTicketPoolSize int64; AddressPrefix []types.AddrPrefix }`
+  `ExtendedParams{ MaximumBlockSize int64; ActualTicketPoolSize int64; AddressPrefix []types.AddrPrefix; SKACoins []types.SKACoinParam }`
 - **Transformations:**
   - `addrPrefix := types.AddressPrefixes(params)`
   - `actualTicketPoolSize := int64(params.TicketPoolSize * params.TicketsPerBlock)`
   - `maxBlockSize`: under `pageData.RLock()`, `BlockchainInfo.MaxBlockSize` if
     non-nil, else `int64(params.MaximumBlockSizes[0])` (`:2150-2156`)
+  - `SKACoins := buildSKACoinParams(params)` — walks `params.SKACoins` in
+    `CoinType` order, cross-references `params.InitialSKATypes`, and
+    pre-formats all 18-decimal SKA atom amounts (`MaxSupply`,
+    `MinRelayTxFee`, `EmissionAmounts[]`) to plain decimal strings via
+    `formatAtomsAsCoinString` so no `*big.Int` crosses the template
+    boundary (`cmd/dcrdata/internal/explorer/parameters.go`).
 
 ### commonData (shared header)
 
@@ -96,19 +102,49 @@ monetarium-node
 
 ### AddressPrefixes transform
 
-- **Location:** `explorer/types/explorertypes.go:1508-1549`
+- **Location:** `explorer/types/explorertypes.go` (function plus
+  `addrPrefixSet` per-net tables for mainnet / testnet* / simnet / regnet).
 - **Data structures:** `[]AddrPrefix{ Name, Prefix, Description }`
-- **Transformations:** index-aligned `Name`/`Descriptions` arrays selected
-  against a **hardcoded** network prefix table keyed by `params.Name`
-  (`mainnet` / `testnet*` / `simnet`). **Returns `nil` for any other name** (`:1549`).
+- **Transformations:** picks the per-net `addrPrefixSet` by `params.Name`
+  (Monetarium values: mainnet `Mk Ms Me MS Mc Pm dprv dpub`, testnet `Tk Ts
+  Te TS Tc Pt tprv tpub`, simnet `Sk Ss Se SS Sc Ps sprv spub`, regnet `Rk
+  Rs Re RS Rc Pr rprv rpub`). For any other `params.Name` the function
+  **does not return nil** — it falls back to the magic-byte hex
+  representation of each `chaincfg.Params` ID field so the table is never
+  silently empty. Description / Name columns are produced inline per row
+  (no parallel slices to keep aligned).
+
+### SKACoinParams transform
+
+- **Location:** `cmd/dcrdata/internal/explorer/parameters.go`
+  (`buildSKACoinParams`, `formatBigIntAsSKAString`, `formatBigIntWithCommas`).
+- **Data structures:** `[]types.SKACoinParam` (defined in
+  `explorer/types/explorertypes.go`; view-model: pre-formatted strings only,
+  no `*big.Int`).
+- **Transformations:** sort `params.SKACoins` by `cointype.CoinType`,
+  cross-reference `params.InitialSKATypes` for the `InitiallyActive` flag,
+  and pre-format every 18-decimal SKA atom value via
+  `formatAtomsAsCoinString(s, uint8(cointype.CoinTypeMax), 0)` — exact
+  `big.Int` division, no rounding, no scientific notation, thousands
+  commas. `AtomsPerCoin` is rendered as a plain comma-separated integer
+  scale (e.g. `1,000,000,000,000,000,000`). `EmissionKey` is deliberately
+  omitted (spec §9 — dev-stub).
 
 ### Template
 
-- **Location:** `cmd/dcrdata/views/parameters.tmpl` (392 lines)
-- **Data structures:** consumes `.ChainParams.*` (~40 rows) from the embedded
-  `CommonPageData`, and `.ExtendedParams.{MaximumBlockSize,ActualTicketPoolSize,AddressPrefix}`.
+- **Location:** `cmd/dcrdata/views/parameters.tmpl`
+- **Data structures:** consumes `.ChainParams.*` (~35 rows) from the embedded
+  `CommonPageData`, and
+  `.ExtendedParams.{MaximumBlockSize,ActualTicketPoolSize,AddressPrefix,SKACoins}`.
+  No Treasury section, no `BlockTaxProportion` row — Monetarium has no
+  treasury. PoW/PoS subsidy rows render `.ChainParams.WorkRewardProportionV2` /
+  `.ChainParams.StakeRewardProportionV2` (the actual 50% / 50% fields), not the
+  legacy 60 / 30 fields.
 - **Transformations:** template helpers `amountAsDecimalParts`,
-  `durationToShortDurationString`, `uint16Mul` (e.g. `WorkRewardProportion`).
+  `durationToShortDurationString`, `uint16Mul`. The SKA coin section renders
+  the pre-formatted strings from `ExtendedParams.SKACoins` directly — no
+  formatter helper invoked in-template for SKA amounts, ensuring the
+  `*big.Int → string` precision contract is enforced at the handler boundary.
 
 ### Route
 
@@ -147,15 +183,26 @@ monetarium-node
 - **Tip-only RPC validity:** `BlockchainInfo` is intentionally `nil` for
   non-tip blocks (`blockdata.go:339-341`); the handler fallback to
   `params.MaximumBlockSizes[0]` exists precisely for this.
-- **Multi-coin / VAR-only page:** subsidy and reward rows (`BaseSubsidy`,
-  `WorkRewardProportion`, `StakeRewardProportion`, `BlockTaxProportion`,
-  `MinimumStakeDiff` — `parameters.tmpl:119-168`) are VAR-only scalars from
-  `chaincfg.Params`. SKA coins are **not** represented here. Do not inject
-  per-coin maps without confirming the param model (see `REWARDS_LOGIC.md`).
+- **Subsidy/Stake rows stay VAR-only scalar:** `BaseSubsidy`,
+  `WorkRewardProportionV2`, `StakeRewardProportionV2`, `MinimumStakeDiff`,
+  etc. are scalar `chaincfg.Params` fields and use the VAR 8-decimal
+  `amountAsDecimalParts` / `float64` path. Do **not** multi-coin-ify them
+  into per-coin maps — these are VAR consensus constants (see
+  `REWARDS_LOGIC.md`). The new SKA section is the only multi-coin content on
+  the page; it lives in its own table.
+- **SKA precision boundary:** every 18-decimal SKA atom value on this page
+  must be pre-formatted to a plain decimal string in the handler
+  (`buildSKACoinParams` via `formatAtomsAsCoinString`). Never pass `*big.Int`
+  or atom integers into the template — they exceed `float64` precision and
+  break the spec §9 "no rounding, no scientific notation" contract
+  ([core/constraints.md#C1](../../core/constraints.md#C1)).
 - **Static for process lifetime:** `exp.ChainParams` is never refreshed after
   startup; a node config change requires an explorer restart to reflect here.
-- **Network-name coupling:** `AddressPrefixes` has hardcoded prefix strings and
-  only recognizes `mainnet`/`testnet*`/`simnet` (`explorertypes.go:1540-1549`).
+- **Network-name coupling (soft):** `AddressPrefixes` picks documented
+  textual prefixes per `params.Name` (`mainnet`/`testnet*`/`simnet`/`regnet`)
+  and falls back to the magic-byte hex for any other name. The table is
+  never silently empty; adding a new recognised net means extending the
+  `addrPrefixSet` table, not avoiding a crash.
 - **Cache is block-scoped & intentional:** served under
   `ETagAndLastModifiedIntercept`; ETag/Last-Modified reset on new block/mempool.
   Stale-looking content between blocks is expected (only `MaxBlockSize` moves).
@@ -169,10 +216,16 @@ When modifying `/parameters` data, check:
 **Direct dependencies**
 
 - `parameters.tmpl` field names must exist on `*chaincfg.Params` (via
-  `.ChainParams`) or on `ExtendedParams` (`explorerroutes.go:2158-2162`).
-- `AddressPrefixes` callers: only `ParametersPage` (`explorerroutes.go:2146`) —
-  low blast radius, but `Name`/`Descriptions`/prefix arrays must stay
-  index-aligned (`explorertypes.go:1517-1538`).
+  `.ChainParams`) or on `ExtendedParams` (`explorerroutes.go:2158-2164`).
+- `AddressPrefixes` callers: only `ParametersPage` (`explorerroutes.go:2146`).
+  Adding a new address kind = one row inline in the literal; adding a new
+  recognised network = one entry in `lookupAddrPrefixSet` plus the
+  corresponding `addrPrefixSet` var. There are no longer any parallel
+  slices to keep index-aligned.
+- `buildSKACoinParams` callers: only `ParametersPage`
+  (`explorerroutes.go:2173`). The `types.SKACoinParam` shape is consumed by
+  `parameters.tmpl` only — changing a field name there means updating both
+  the type and the template.
 
 **Indirect dependencies**
 
@@ -201,14 +254,20 @@ When modifying `/parameters` data, check:
 
 ### Silent failures (HTTP 200, wrong/blank data)
 
-- Unrecognized `params.Name` → `AddressPrefixes` returns `nil` → empty address
-  table, no error (`explorertypes.go:1549`).
 - `BlockchainInfo == nil` (between blocks, or RPC warn-and-continue at
   `blockdata.go:335-337`) → `MaximumBlockSize` silently falls back to
   `params.MaximumBlockSizes[0]`, which may differ from live consensus.
 - Empty `params.MaximumBlockSizes` → `params.MaximumBlockSizes[0]` panics
   (no bounds check at `explorerroutes.go:2154`). **INFERRED** — relies on the
   node always populating this; true for known nets.
+- (Eliminated) Unrecognised `params.Name` no longer produces a silent blank
+  address-prefix table — `AddressPrefixes` now falls back to a magic-byte
+  hex representation. Prefix textual values for an unrecognised net will be
+  hex (`0x1fc5` etc.) rather than the documented two-letter form, but the
+  rows are present.
+- (Eliminated) `AddressPrefixes` no longer uses parallel slices —
+  misaligned-row bug class is gone. New address kinds are added as inline
+  literal rows.
 
 ---
 
@@ -221,8 +280,14 @@ When modifying `/parameters` data, check:
 - Reading `pageData.BlockchainInfo` without `RLock` — silent data race.
 - "Multi-coin-ifying" the subsidy rows — these are VAR consensus params, not a
   per-coin map; the page is intentionally VAR-only.
-- Adding a new network without extending the hardcoded `AddressPrefixes`
-  tables → address section silently blank.
+- Adding a new recognised network without extending `lookupAddrPrefixSet` +
+  the corresponding `addrPrefixSet` var → address section shows magic-byte
+  hex instead of the documented two-letter prefixes (degrades gracefully,
+  but still less informative than the per-net table).
+- Passing a `*big.Int` or atom integer directly into the SKA section of the
+  template instead of going through `buildSKACoinParams` →
+  precision loss / scientific notation in the rendered amount, violating
+  spec §9.
 - Expecting param edits at the node to appear without restarting the explorer
   (`exp.ChainParams` is captured once).
 
@@ -231,9 +296,13 @@ When modifying `/parameters` data, check:
 ## Section 8 — Evidence
 
 - Route: `cmd/dcrdata/main.go:810`
-- Handler: `cmd/dcrdata/internal/explorer/explorerroutes.go:2143-2184`
+- Handler: `cmd/dcrdata/internal/explorer/explorerroutes.go:2143-2186`
 - `commonData`: `explorerroutes.go:2534-2572`
-- `AddressPrefixes`: `explorer/types/explorertypes.go:1508-1549`
+- `AddressPrefixes` (+ per-net `addrPrefixSet` table):
+  `explorer/types/explorertypes.go`
+- `SKACoinParam` view-model: `explorer/types/explorertypes.go`
+- `buildSKACoinParams` (+ `formatBigIntAsSKAString`,
+  `formatBigIntWithCommas`): `cmd/dcrdata/internal/explorer/parameters.go`
 - ChainParams capture: `cmd/dcrdata/internal/explorer/explorer.go:369-371`
 - `pageData` struct: `explorer.go:230-233`
 - `Store` (writes `BlockchainInfo`): `explorer.go:536-572` (assignment `:572`)
@@ -242,8 +311,12 @@ When modifying `/parameters` data, check:
 - `GetChainParams`: `db/dcrpg/pgblockchain.go:6408-6410`
 - `GetTip`: `db/dcrpg/pgblockchain.go:7319-7348`
 - ETag middleware: `cmd/dcrdata/internal/explorer/explorermiddleware.go:193`
-- Template: `cmd/dcrdata/views/parameters.tmpl` (rows e.g.
-  `:9,30,41,61,119-168,173`)
+- Template: `cmd/dcrdata/views/parameters.tmpl` (Chain / Subsidy / Stake /
+  Rule-change / Address / SKA coin sections)
+- V2 reward proportion fields on chaincfg:
+  `github.com/monetarium/monetarium-node/chaincfg` `params.go:517-535`
+- `SKACoinConfig` + `SKACoins` + `InitialSKATypes`:
+  `github.com/monetarium/monetarium-node/chaincfg` `params.go:249-305,759,764`
 
 ---
 

--- a/wiki/code-analysis/parameters/impact.md
+++ b/wiki/code-analysis/parameters/impact.md
@@ -44,58 +44,66 @@ class.
 
 ---
 
-## Risk: Silent Blank Address-Prefix Table
+## Risk: Degraded (Hex) Address-Prefix Rows On Unrecognised Net
 
 **Trigger:**
 The active network's `params.Name` is not `"mainnet"`, does not start with
-`"testnet"`, and is not `"simnet"` (a new/renamed network, a custom regtest
-name).
+`"testnet"`, is not `"simnet"`, and is not `"regnet"` (a new/renamed
+network, a custom dev-net name).
 
-**Failure mode:** silent (HTTP 200, missing section).
+**Failure mode:** silent-but-visible (HTTP 200, rows present, prefixes
+shown as `0x` + hex magic bytes instead of the documented two-letter form).
 
 **Affected flows:**
 
-- /wiki/code-analysis/parameters/flow.full.md (§5 network-name coupling)
+- /wiki/code-analysis/parameters/flow.full.md (§3 AddressPrefixes transform)
 
 **Description:**
-`types.AddressPrefixes(params)` hits the final `else { return nil }`
-([explorer/types/explorertypes.go:1549](../../../explorer/types/explorertypes.go#L1549)).
-The handler assigns this `nil` straight into
-`ExtendedParams.AddressPrefix`
-([explorerroutes.go:2146,2171](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L2146))
-with no error check. The template ranges over an empty slice → the entire
-address-prefix table renders blank while the page returns 200 OK. A new
-network requires extending **all three** hardcoded prefix arrays
-([:1536-1538](../../../explorer/types/explorertypes.go#L1536)) and the
-selection switch ([:1540-1550](../../../explorer/types/explorertypes.go#L1540));
-forgetting any one silently drops the section. (Note: flow.full.md cites this
-function at `:1508-1549`; it is actually `:1516-1559`, **+8 line drift**, nil
-return still at `:1549`.)
+`types.AddressPrefixes(params)` calls `lookupAddrPrefixSet(params.Name)`,
+which returns `(zero, false)` for any unrecognised network name. The
+function then renders each row with `"0x" + hex.EncodeToString(magic[:])`
+as the `Prefix` cell. The rows are visible and informative (a custom net
+operator can read the magic bytes), but they are no longer the documented
+human-readable two-letter prefix. To restore the documented prefixes for a
+new net, add an `addrPrefixSet` package var (with the textual prefixes
+copied verbatim from the chaincfg comments) and a case in
+`lookupAddrPrefixSet`.
+
+**Eliminated risks (do not reintroduce):**
+
+- Previously, an unrecognised net produced a silent blank section — that
+  bug class is removed; the fallback ensures the rows are always present.
+- Previously, the function zipped four parallel slices by index, so adding
+  an address kind required four matching edits — that bug class is also
+  removed; rows are now declared as inline struct literals.
 
 ---
 
-## Risk: Misaligned Address-Prefix Rows
+## Risk: SKA `*big.Int` Crossing Template Boundary
 
 **Trigger:**
-Adding or removing an address kind by editing only some of the four parallel
-slices in `AddressPrefixes` (`Descriptions`, `Name`, and the three
-`<Net>Prefixes`).
+A new SKA amount field is added to the page without routing it through
+`buildSKACoinParams` / `formatBigIntAsSKAString` — e.g. exposing the
+`*big.Int` directly on `types.SKACoinParam`, or rendering an atom integer
+in the template.
 
-**Failure mode:** silent (HTTP 200, wrong prefix/name pairing).
+**Failure mode:** silent (HTTP 200, wrong-but-plausible amount text).
 
 **Affected flows:**
 
-- /wiki/code-analysis/parameters/flow.full.md (§6 direct dependencies)
+- /wiki/code-analysis/parameters/flow.full.md (§3 SKACoinParams transform,
+  §5 SKA precision boundary)
 
 **Description:**
-The build loop zips the slices by positional index:
-`AddrPrefix{Name: Name[i], Description: desc, Prefix: netPrefixes[i]}`
-([explorer/types/explorertypes.go:1552-1559](../../../explorer/types/explorertypes.go#L1552)).
-There is no length assertion across the four slices. An off-by-one (e.g.
-adding a description without the matching `Name` and prefix entries) silently
-pairs the wrong prefix string with the wrong field name; if the prefix slice
-is *shorter* than `Descriptions`, `netPrefixes[i]` panics at request time
-(loud) instead. All four slices must be edited at the same index.
+SKA atoms are 18-decimal values that routinely exceed `float64`'s 15-17
+significand digits. The existing VAR formatting path (`amountAsDecimalParts`
+→ `float64`) silently loses precision and can serialise in scientific
+notation for large values, both of which violate spec §9 ("show fully,
+without rounding and without exponential notation"). The fix is structural:
+`*big.Int` SKA values must be converted to plain decimal strings via
+`formatAtomsAsCoinString` (or `formatBigIntAsSKAString`) at the handler
+boundary, and the template must only see those pre-formatted strings.
+`buildSKACoinParams` is the chokepoint; bypassing it is the failure path.
 
 ---
 
@@ -186,17 +194,26 @@ Before committing changes that touch the `/parameters` data path:
       struct (edit both the `type` block and the literal), never `commonData`.
 - [ ] New raw-param row → `.ChainParams.X` in the template only; confirm `X`
       exists on `*chaincfg.Params`.
-- [ ] Touching `AddressPrefixes` → all four parallel slices
-      (`Descriptions`, `Name`, `Mainnet/Testnet/SimnetPrefixes`) edited at the
-      same index; selection switch covers any new `params.Name`.
+- [ ] Touching `AddressPrefixes` → new address kind = an inline struct
+      literal row inside the function; new recognised network = a new
+      `addrPrefixSet` var plus a case in `lookupAddrPrefixSet`.
 - [ ] `BlockchainInfo != nil` branch and the `MaximumBlockSizes[0]` fallback
       preserved together; new params variant populates `MaximumBlockSizes`.
 - [ ] Any new `pageData` field read is inside an `RLock()`/`RUnlock()` window;
       no code holds `invsMtx` then waits on `pageData.Lock` (deadlocks against
       `Store` — see page-rendering impact).
-- [ ] No SKA / per-coin value injected into the VAR-only subsidy rows; new
-      amount rows are VAR via `amountAsDecimalParts`
+- [ ] No SKA / per-coin value injected into the VAR-only subsidy/stake
+      rows; new SKA rows live only in the dedicated SKA coin section, with
+      atom values pre-formatted via `formatAtomsAsCoinString` (or
+      `formatBigIntAsSKAString`) at the handler boundary
       (see [core/constraints.md#C1](../../core/constraints.md#C1)).
+- [ ] No Treasury content reintroduced — Monetarium has no treasury,
+      `BlockTaxProportion` is always zero, the section was deliberately
+      removed (spec §4).
+- [ ] PoW/PoS subsidy rows continue to read
+      `WorkRewardProportionV2`/`StakeRewardProportionV2`, not the legacy V1
+      fields and not `WorkSubsidyProportion()`/`StakeSubsidyProportion()`
+      (both return V1 = legacy 60/30).
 - [ ] Handler stays a pure function of startup `ChainParams` + last-tick
       `pageData` (it is registered under `withCache`; per-request variation
       serves stale cached bytes).

--- a/wiki/code-analysis/parameters/patterns.md
+++ b/wiki/code-analysis/parameters/patterns.md
@@ -72,7 +72,7 @@ is a derived value that is *not* a `chaincfg.Params` field — it must live in
 
 ---
 
-## Hardcoded Network-Name Address-Prefix Table
+## Per-Net Address-Prefix Table With Magic-Byte Fallback
 
 **Appears in:**
 
@@ -80,63 +80,106 @@ is a derived value that is *not* a `chaincfg.Params` field — it must live in
 
 **Description:**
 `types.AddressPrefixes(params)`
-([explorer/types/explorertypes.go:1516-1559](../../../explorer/types/explorertypes.go#L1516)
-— flow.full.md cites `:1508-1549`; the function is actually at `:1516`,
-**+8 line drift**) builds the address-prefix table from **four parallel
-index-aligned slices**: `Descriptions` and `Name`
-([:1517-1534](../../../explorer/types/explorertypes.go#L1517)) plus one of
-three hardcoded prefix arrays — `MainnetPrefixes` / `TestnetPrefixes` /
-`SimnetPrefixes`
-([:1536-1538](../../../explorer/types/explorertypes.go#L1536)). Selection is a
-literal string switch on `params.Name`: `== "mainnet"`,
-`strings.HasPrefix(name, "testnet")`, `== "simnet"`, else **`return nil`**
-([:1540-1550](../../../explorer/types/explorertypes.go#L1540)). The only caller
-is `ParametersPage`
-([explorerroutes.go:2146](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L2146))
+([explorer/types/explorertypes.go](../../../explorer/types/explorertypes.go))
+returns a `[]AddrPrefix` literal in which each row is declared inline: name,
+description, and the textual base58 prefix for that address kind on the
+active network. The prefix string comes from one of four package-level
+`addrPrefixSet` constants — mainnet (`Mk Ms Me MS Mc Pm dprv dpub`), testnet
+(`Tk Ts Te TS Tc Pt tprv tpub`), simnet (`Sk Ss Se SS Sc Ps sprv spub`),
+regnet (`Rk Rs Re RS Rc Pr rprv rpub`) — selected by `params.Name` via
+`lookupAddrPrefixSet`. For an **unrecognised** `params.Name` the function
+falls back to a `0x` + hex.EncodeToString of the magic-byte field on
+`chaincfg.Params`, so the rendered table is never silently empty. The only
+caller is `ParametersPage` —
+[explorerroutes.go:2146](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L2146)
 — blast radius is one page.
 
 **Constraints:**
 
-- The four slices (`Descriptions`, `Name`, `<Net>Prefixes`) are zipped by
-  positional index in the build loop
-  ([:1552-1559](../../../explorer/types/explorertypes.go#L1552)). Adding/removing
-  an address kind requires editing **all four** slices at the same index, or
-  rows misalign (wrong prefix paired with wrong name) with no error.
-- A new network whose `params.Name` is not `mainnet`/`testnet*`/`simnet`
-  returns `nil` → the address section renders blank with HTTP 200 (see
-  `impact.md` → *Silent Blank Address-Prefix Table*).
+- Rows are an inline struct literal — no parallel slices to keep aligned.
+  Adding a new address kind = one row inline in `AddressPrefixes`. There is
+  no longer a bug class of misaligned rows.
+- Adding a new **recognised** network requires both a new `addrPrefixSet`
+  var with the documented per-net textual prefixes *and* a case in
+  `lookupAddrPrefixSet`. Forgetting either means the new net falls into the
+  magic-byte hex fallback — degraded display, but still non-empty.
+- The textual prefix strings cannot be derived deterministically from the
+  magic-byte fields alone: chaincfg's "starts with X" comments describe the
+  typical real-world hash160 outcome, not a guarantee for arbitrary
+  payloads. The hardcoded table is the source of truth.
+- The `NetworkAddressPrefix` row remains a direct `.ChainParams` template
+  read and is intentionally outside this function.
 
 ---
 
-## VAR-Only Consensus-Param Rows
+## VAR-Only Consensus-Param Rows + Dedicated SKA Section
 
 **Appears in:**
 
 - /wiki/code-analysis/parameters/flow.full.md (§5, §7)
 
 **Description:**
-The subsidy/reward rows — `BaseSubsidy`
-([parameters.tmpl:117-119](../../../cmd/dcrdata/views/parameters.tmpl)),
-`MulSubsidy`/`DivSubsidy`/`SubsidyReductionInterval` (`:126-136`),
-`WorkRewardProportion`/`StakeRewardProportion`/`BlockTaxProportion`
-(`:140-151`, rendered via `{{uint16Mul .ChainParams.X 10}}%`), and
-`MinimumStakeDiff` (`:167-168`, hardcoded `VAR` literal in the template) — are
-**scalar `chaincfg.Params` fields**, not per-coin maps. `BaseSubsidy` and
-`MinimumStakeDiff` go through `amountAsDecimalParts` (VAR's 8-decimal
-`float64` path). SKA coins are deliberately absent: these are VAR consensus
-constants, and the multi-coin reward model (see `REWARDS_LOGIC.md`) does not
-parameterize them per coin.
+The subsidy/stake rows — `BaseSubsidy`,
+`MulSubsidy`/`DivSubsidy`/`SubsidyReductionInterval`,
+`WorkRewardProportionV2`/`StakeRewardProportionV2` (rendered via
+`{{uint16Mul .ChainParams.X 10}}%` to produce the actual 50% / 50% Monetarium
+consensus split, not the legacy V1 60 / 30 fields), and `MinimumStakeDiff`
+(hardcoded `VAR` unit in the template) — are **scalar `chaincfg.Params`
+fields**, not per-coin maps. `BaseSubsidy` and `MinimumStakeDiff` go through
+`amountAsDecimalParts` (VAR's 8-decimal `float64` path). SKA coins live
+**only** in a dedicated section fed by `ExtendedParams.SKACoins`
+(`[]types.SKACoinParam`, pre-formatted via `buildSKACoinParams`); they do
+not parameterise the subsidy/stake rows. The legacy `BlockTaxProportion`
+row is **absent** — Monetarium has no treasury.
 
 **Constraints:**
 
-- Do not "multi-coin-ify" these rows into per-coin maps; they are not a
-  `map[uint8]...` anywhere in the param model. The page is intentionally
-  VAR-only.
-- Any new amount row sourced from `chaincfg.Params` is VAR and may use
-  `amountAsDecimalParts` (float64-safe at 8 decimals). A SKA-denominated value
-  would violate the precision split — see
-  [core/constraints.md#C1](../../core/constraints.md#C1) — and has no
-  `chaincfg.Params` source anyway.
+- Do not "multi-coin-ify" the subsidy/stake rows. They are not a
+  `map[uint8]...` in the param model, and Monetarium's per-coin behaviour
+  is captured by the consensus rule `SSVMonetarium` (see
+  `REWARDS_LOGIC.md`), not by per-coin subsidy parameters.
+- Subsidy/stake amount rows are VAR (8 decimals, `float64`-safe) and use
+  `amountAsDecimalParts`. SKA-denominated values do not appear in these
+  rows.
+- The SKA coin section is the page's only multi-coin content. Adding a new
+  per-coin field there means extending `types.SKACoinParam` *and*
+  `buildSKACoinParams` *and* the template — pre-format any SKA atom values
+  via `formatAtomsAsCoinString` (or `formatBigIntAsSKAString`) so the
+  template only sees plain strings (see
+  [core/constraints.md#C1](../../core/constraints.md#C1)).
+
+---
+
+## Pre-Formatted SKA View-Model In `ExtendedParams`
+
+**Appears in:**
+
+- /wiki/code-analysis/parameters/flow.full.md (§3, §5)
+
+**Description:**
+SKA atom values on `chaincfg.SKACoinConfig` are `*big.Int` (`MaxSupply`,
+`AtomsPerCoin`, `MinRelayTxFee`, `EmissionAmounts[]`) — they exceed
+`float64` precision and cannot survive the existing VAR `amountAsDecimalParts`
+path. `buildSKACoinParams`
+([cmd/dcrdata/internal/explorer/parameters.go](../../../cmd/dcrdata/internal/explorer/parameters.go))
+converts each `*big.Int` to a plain decimal string server-side, using
+`formatAtomsAsCoinString` (exact `big.Int` division, no rounding, no
+scientific notation, thousands commas) for coin amounts and a small
+`formatBigIntWithCommas` helper for the atomic-scale `AtomsPerCoin` field.
+The resulting `[]types.SKACoinParam` is consumed by the template as plain
+strings — no `*big.Int` crosses the template boundary.
+
+**Constraints:**
+
+- Every new SKA amount-shaped field added to `SKACoinParam` must be
+  formatted at the handler boundary; never expose a `*big.Int` or atom
+  integer to the template.
+- The `Label` field uses the canonical `SKA{n}` form (no dash), matching
+  [core/product.md](../../core/product.md). Do not introduce a `SKA-{n}`
+  variant — the `Symbol` field on `SKACoinConfig` is the dashed form for
+  display alongside the label, not in place of it.
+- The view-model must be a pure function of the startup-immutable
+  `exp.ChainParams`; the builder reads no shared state and needs no lock.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #286. Bring the `/parameters` page in line with Monetarium:

- Drop the **Treasury parameters** section and the `BlockTaxProportion` row (Monetarium has no treasury).
- Fix the PoW/PoS subsidy split: the template now reads `WorkRewardProportionV2` / `StakeRewardProportionV2`, rendering the actual **50% / 50%** (the legacy V1 fields and the deprecated `WorkSubsidyProportion()` helpers still return the Decred-era 60/30 and are explicitly avoided).
- Repoint the **"from chaincfg/params.go"** link from `decred/dcrd` to [`monetarium/monetarium-node`](https://github.com/monetarium/monetarium-node/blob/master/chaincfg/params.go).
- Replace the hardcoded Decred address-prefix table with Monetarium per-net tables (mainnet `Mk Ms Me MS Mc Pm dprv dpub`, testnet `Tk Ts Te TS Tc Pt tprv tpub`, simnet `Sk Ss Se SS Sc Ps sprv spub`, regnet `Rk Rs Re RS Rc Pr rprv rpub`), with a **magic-byte hex fallback** for unknown nets so the table is never silently blank.
- Add a new **SKA coin parameters** section listing every coin in `chaincfg.Params.SKACoins` in `CoinType` order. Active vs inactive coins carry distinct badges, `EmissionHeight` links to the block page, each `EmissionAddresses` entry links to its `/address/{addr}` page, and all 18-decimal SKA amounts are pre-formatted to plain decimal strings server-side via `formatAtomsAsCoinString` so no `*big.Int` crosses the template boundary (spec §9 / `core/constraints.md#C1`).
- Refresh the four `wiki/code-analysis/parameters/` files to describe the shipped page (eliminate the *Silent Blank Address-Prefix Table* and *Misaligned Address-Prefix Rows* risks; add the SKA precision boundary pattern + risk).

Must-preserve invariants kept untouched: the `*CommonPageData` + `ExtendedParams` split, the `pageData.RLock()` window, the `BlockchainInfo == nil → params.MaximumBlockSizes[0]` fallback, the `NetworkAddressPrefix` row, and the VAR-only subsidy/stake rows (the SKA section is the page's only multi-coin content).

Plan / spec / code-analysis references:
- [wiki/specs/parameters/spec.md](wiki/specs/parameters/spec.md)
- [wiki/code-analysis/parameters/](wiki/code-analysis/parameters/)

## Test plan

- [x] `cd cmd/dcrdata && npm run check` — pre-existing warnings only, no errors.
- [x] `cd cmd/dcrdata && npm test` — 286/286 vitest tests pass.
- [x] `cd cmd/dcrdata && npm run build` — webpack build succeeds.
- [x] `go test ./...` from the repo root **and** from `cmd/dcrdata` — green. New tests:
  - `TestAddressPrefixes` (mainnet / testnet / simnet documented values + unknown-net fallback).
  - `TestBuildSKACoinParams_Mainnet` (ordering, `SKA{n}` label (no dash), `InitiallyActive`/`Active` flags, full-precision `MaxSupply`, no scientific notation, no trailing dot, `AtomsPerCoin = 1,000,000,000,000,000,000`).
  - `TestBuildSKACoinParams_OtherNets` (no panic on simnet/testnet/regnet).
- [x] `go build -o monetarium-explorer .` in `cmd/dcrdata` — binary builds.
- [x] **Manual browser pass on testnet3** via Playwright against a live `monetarium-explorer`:
  - No `DCR` label anywhere; no `Treasury` / `BlockTaxProportion` / `TreasuryVote*` content.
  - `chaincfg/params.go` link → `https://github.com/monetarium/monetarium-node/blob/master/chaincfg/params.go`.
  - `WorkRewardProportionV2 = 50%`, `StakeRewardProportionV2 = 50%`.
  - Rule change parameters section present and unchanged.
  - Address parameters: `NetworkAddressPrefix T` + 8 derived rows (`Tk / Ts / Te / TS / Tc / Pt / tprv / tpub`).
  - SKA section shows `SKA1 — Skarb-1 (SKA-1)` and `SKA2 — Skarb-2 (SKA-2) inactive`; `MaxSupply` renders as `900,000,000,000,000 SKA1` and `5,000,000 SKA2` (full 18-decimal exact, no rounding, no scientific notation, no trailing dot); `AtomsPerCoin = 1,000,000,000,000,000,000`; `EmissionHeight` and `EmissionAddresses` links work.
  - Dark theme renders cleanly.

## Deviation from the original plan

The spec preferred deriving address prefixes from `chaincfg.Params` magic bytes via base58. I confirmed that's not actually feasible: the chaincfg "starts with X" comments describe the typical real-world hash160 outcome, not a deterministic function of the magic bytes (low-byte magics like `0x0b` are stable but high-byte magics like `0x1f`/`0x22` flip the leading base58 char with the payload). Pragmatic landing: per-net hardcoded tables with Monetarium-correct values, plus a magic-byte hex fallback so the silent-blank-table risk is still eliminated. Code-analysis notes updated to reflect this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)