### PR TITLE
cmd/dcrdata: align /attack-cost page with Monetarium model

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -2692,13 +2692,6 @@ func calcPages(rows, pageSize, offset int, link string) pageNumbers {
 
 // AttackCost is the page handler for the "/attack-cost" path.
 func (exp *explorerUI) AttackCost(w http.ResponseWriter, r *http.Request) {
-	price := 24.42
-	if exp.xcBot != nil {
-		if rate := exp.xcBot.Conversion(1.0); rate != nil {
-			price = rate.Value
-		}
-	}
-
 	exp.pageData.RLock()
 
 	height := exp.pageData.BlockInfo.Height
@@ -2714,7 +2707,6 @@ func (exp *explorerUI) AttackCost(w http.ResponseWriter, r *http.Request) {
 		*CommonPageData
 		HashRate        float64
 		Height          int64
-		DCRPrice        float64
 		TicketPrice     float64
 		TicketPoolSize  int64
 		TicketPoolValue float64
@@ -2723,7 +2715,6 @@ func (exp *explorerUI) AttackCost(w http.ResponseWriter, r *http.Request) {
 		CommonPageData:  exp.commonData(r),
 		HashRate:        HashRate,
 		Height:          height,
-		DCRPrice:        price,
 		TicketPrice:     ticketPrice,
 		TicketPoolSize:  int64(ticketPoolSize),
 		TicketPoolValue: ticketPoolValue,

--- a/cmd/dcrdata/public/js/controllers/attackcost_controller.js
+++ b/cmd/dcrdata/public/js/controllers/attackcost_controller.js
@@ -44,43 +44,28 @@ function removeTrailingZeros(value) {
 }
 
 let Dygraph // lazy loaded on connect
-let height, dcrPrice, hashrate, tpSize, tpValue, tpPrice, graphData, currentPoint, coinSupply
+let height, varPrice, hashrate, tpSize, tpValue, tpPrice, graphData, currentPoint, coinSupply
+let deviceHashrate, devicePower, devicePrice
 
 function rateCalculation(y) {
   y = y || 0.99 // 0.99 TODO confirm why 0.99 is used as default instead of 1
   const x = 1 - y
 
-  // equation to determine hashpower requirement based on percentage of live stake
-  // https://medium.com/decred/decreds-hybrid-protocol-a-superior-deterrent-to-majority-attacks-9421bf486292
-  // (6 (1-f_s)⁵ -15(1-f_s) + 10(1-f_s)³) / (6f_s⁵-15f_s⁴ + 10f_s³)
-  // (6x⁵-15x⁴ +10x³) / (6y⁵-15y⁴ +10y³) where y = this.value and x = 1-y
+  // Hybrid PoW + PoS deterrence formula for the fixed 50/50 reward split.
+  // (6x⁵-15x⁴ +10x³) / (6y⁵-15y⁴ +10y³) where y = stake fraction and x = 1-y
   return (
     (6 * Math.pow(x, 5) - 15 * Math.pow(x, 4) + 10 * Math.pow(x, 3)) /
     (6 * Math.pow(y, 5) - 15 * Math.pow(y, 4) + 10 * Math.pow(y, 3))
   )
 }
 
-const deviceList = {
-  0: {
-    hashrate: 34, // Th/s
-    units: 'Th/s',
-    power: 1610, // W
-    cost: 1282, // $
-    name: 'DCR5',
-    link: 'https://www.cryptocompare.com/mining/bitmain/antminer-dr5-blake256r14-34ths/'
-  },
-  1: {
-    hashrate: 44, // Th/s
-    units: 'Th/s',
-    power: 2200, // W
-    cost: 4199, // $
-    name: 'D1',
-    link: 'https://www.cryptocompare.com/mining/crypto-drilling/microbt-whatsminer-d1-plus-psu-dcr-44ths/'
-  }
-}
-
 const externalAttackType = 'external'
 const internalAttackType = 'internal'
+
+const defaultDeviceHashrate = 50 // Th/s
+const defaultDevicePower = 1500 // W
+const defaultDevicePrice = 1500 // USD
+const defaultExchangeRate = 1 // USD/VAR
 
 function legendFormatter(data) {
   let html = ''
@@ -125,10 +110,9 @@ export default class extends Controller {
       'attackPeriod',
       'blockHeight',
       'countDevice',
-      'device',
-      'deviceCost',
-      'deviceDesc',
-      'deviceName',
+      'deviceHashrate',
+      'devicePower',
+      'devicePrice',
       'devicePronoun',
       'deviceSuffix',
       'external',
@@ -138,12 +122,12 @@ export default class extends Controller {
       'kwhRateLabel',
       'otherCosts',
       'otherCostsValue',
-      'priceDCR',
+      'exchangeRate',
       'internalAttackText',
       'targetHashRate',
       'externalAttackText',
       'externalAttackPosText',
-      'additionalDcr',
+      'additionalVar',
       'newTicketPoolValue',
       'internalAttackPosText',
       'additionalHashRate',
@@ -161,7 +145,7 @@ export default class extends Controller {
       'durationUnit',
       'durationLongDesc',
       'total',
-      'totalDCRPos',
+      'totalVarPos',
       'totalDeviceCost',
       'totalElectricity',
       'totalExtraCostRate',
@@ -175,8 +159,8 @@ export default class extends Controller {
       'projectedTicketPriceSign',
       'attackType',
       'attackPosPercentAmountLabel',
-      'dcrPriceLabel',
-      'totalDCRPosLabel',
+      'varPriceLabel',
+      'totalVarPosLabel',
       'projectedPriceDiv',
       'attackNotPossibleWrapperDiv',
       'coinSupply',
@@ -193,7 +177,9 @@ export default class extends Controller {
       'other_costs',
       'target_pos',
       'price',
-      'device',
+      'device_hashrate',
+      'device_power',
+      'device_price',
       'attack_type'
     ])
 
@@ -202,11 +188,15 @@ export default class extends Controller {
 
     height = parseInt(this.data.get('height'))
     hashrate = parseInt(this.data.get('hashrate'))
-    dcrPrice = parseFloat(this.data.get('dcrprice'))
+    varPrice = defaultExchangeRate
     tpPrice = parseFloat(this.data.get('ticketPrice'))
     tpValue = parseFloat(this.data.get('ticketPoolValue'))
     tpSize = parseInt(this.data.get('ticketPoolSize'))
     coinSupply = parseInt(this.data.get('coinSupply'))
+
+    deviceHashrate = defaultDeviceHashrate
+    devicePower = defaultDevicePower
+    devicePrice = defaultDevicePrice
 
     this.defaultSettings = {
       attack_time: 1,
@@ -214,8 +204,10 @@ export default class extends Controller {
       kwh_rate: 0.1,
       other_costs: 5,
       target_pos: 51,
-      price: dcrPrice,
-      device: 0,
+      price: defaultExchangeRate,
+      device_hashrate: defaultDeviceHashrate,
+      device_power: defaultDevicePower,
+      device_price: defaultDevicePrice,
       attack_type: externalAttackType
     }
 
@@ -230,8 +222,24 @@ export default class extends Controller {
     if (this.settings.target_pos) {
       this.setAllInputs(this.targetPosTargets, parseFloat(this.settings.target_pos))
     }
-    if (this.settings.price) this.priceDCRTarget.value = parseFloat(this.settings.price)
-    if (this.settings.device) this.setDevice(this.settings.device)
+    if (this.settings.price) {
+      varPrice = parseFloat(this.settings.price)
+      this.exchangeRateTarget.value = varPrice
+    } else {
+      this.exchangeRateTarget.value = defaultExchangeRate
+    }
+    if (this.settings.device_hashrate) {
+      deviceHashrate = parseFloat(this.settings.device_hashrate)
+      this.deviceHashrateTarget.value = deviceHashrate
+    }
+    if (this.settings.device_power) {
+      devicePower = parseFloat(this.settings.device_power)
+      this.devicePowerTarget.value = devicePower
+    }
+    if (this.settings.device_price) {
+      devicePrice = parseFloat(this.settings.device_price)
+      this.devicePriceTarget.value = devicePrice
+    }
     if (this.settings.attack_type) this.attackTypeTarget.value = this.settings.attack_type
     if (this.settings.target_pos) {
       this.attackPercentTarget.value = parseFloat(this.targetPosTarget.value) / 100
@@ -240,7 +248,6 @@ export default class extends Controller {
     if (this.settings.attack_type !== internalAttackType) {
       this.settings.attack_type = externalAttackType
     }
-    this.setDevicesDesc()
     this.updateSliderData()
 
     Dygraph = await getDefault(
@@ -363,8 +370,27 @@ export default class extends Controller {
     this.updateSliderData()
   }
 
-  chooseDevice() {
-    this.settings.device = this.selectedDevice()
+  updateDeviceHashrate() {
+    const v = parseFloat(this.deviceHashrateTarget.value)
+    if (!isFinite(v) || v <= 0) return
+    deviceHashrate = v
+    this.settings.device_hashrate = this.deviceHashrateTarget.value
+    this.updateSliderData()
+  }
+
+  updateDevicePower() {
+    const v = parseFloat(this.devicePowerTarget.value)
+    if (!isFinite(v) || v <= 0) return
+    devicePower = v
+    this.settings.device_power = this.devicePowerTarget.value
+    this.updateSliderData()
+  }
+
+  updateDevicePrice() {
+    const v = parseFloat(this.devicePriceTarget.value)
+    if (!isFinite(v) || v <= 0) return
+    devicePrice = v
+    this.settings.device_price = this.devicePriceTarget.value
     this.updateSliderData()
   }
 
@@ -393,43 +419,15 @@ export default class extends Controller {
   }
 
   updatePrice() {
-    this.settings.price = this.priceDCRTarget.value
-    dcrPrice = this.priceDCRTarget.value
+    const v = parseFloat(this.exchangeRateTarget.value)
+    if (!isFinite(v) || v <= 0) return
+    varPrice = v
+    this.settings.price = this.exchangeRateTarget.value
     this.updateSliderData()
-  }
-
-  selectedDevice() {
-    return this.deviceTarget.value
   }
 
   selectedAttackType() {
     return this.attackTypeTarget.value
-  }
-
-  selectOption(options) {
-    let val = '0'
-    options.forEach((n) => {
-      if (n.selected) val = n.value
-    })
-    return val
-  }
-
-  setDevicesDesc() {
-    this.deviceDescTargets.forEach((n) => {
-      const info = deviceList[n.value]
-      if (!info) return
-      n.innerHTML = `${info.name} (${info.hashrate} ${info.units}, ${info.power} W, $${digitformat(info.cost)} ea.)`
-    })
-  }
-
-  setDevice(selectedVal) {
-    return this.setOption(this.deviceTargets, selectedVal)
-  }
-
-  setOption(options, selectedVal) {
-    options.forEach((n) => {
-      n.selected = n.value === selectedVal
-    })
   }
 
   setActivePoint() {
@@ -504,26 +502,24 @@ export default class extends Controller {
     if (!disableHashRateUpdate) this.updateTargetHashRate()
 
     this.updateQueryString()
-    const deviceInfo = deviceList[this.selectedDevice()]
-    const deviceCount = Math.ceil((this.targetHashRate * 1000) / deviceInfo.hashrate)
-    const totalDeviceCost = deviceCount * deviceInfo.cost
-    const totalKwh =
-      (deviceCount * deviceInfo.power * parseFloat(this.attackPeriodTarget.value)) / 1000
+    const deviceCount = Math.ceil((this.targetHashRate * 1000) / deviceHashrate)
+    const totalDeviceCost = deviceCount * devicePrice
+    const totalKwh = (deviceCount * devicePower * parseFloat(this.attackPeriodTarget.value)) / 1000
     const totalElectricity = totalKwh * parseFloat(this.kwhRateTarget.value)
     const extraCost =
       (parseFloat(this.otherCostsTarget.value) / 100) * (totalDeviceCost + totalElectricity)
     const totalPow = extraCost + totalDeviceCost + totalElectricity
-    let ticketAttackSize, DCRNeed
+    let ticketAttackSize, varNeed
     if (this.settings.attack_type === externalAttackType) {
-      DCRNeed = tpValue / (1 - parseFloat(this.targetPosTarget.value) / 100)
-      this.setAllValues(this.newTicketPoolValueTargets, digitformat(DCRNeed, 2))
-      this.setAllValues(this.additionalDcrTargets, digitformat(DCRNeed - tpValue, 2))
+      varNeed = tpValue / (1 - parseFloat(this.targetPosTarget.value) / 100)
+      this.setAllValues(this.newTicketPoolValueTargets, digitformat(varNeed, 2))
+      this.setAllValues(this.additionalVarTargets, digitformat(varNeed - tpValue, 2))
     } else {
       ticketAttackSize = (tpSize * parseFloat(this.targetPosTarget.value)) / 100
-      DCRNeed = tpValue * (parseFloat(this.targetPosTarget.value) / 100)
-      this.setAllValues(this.ticketPoolAttackTargets, digitformat(DCRNeed))
+      varNeed = tpValue * (parseFloat(this.targetPosTarget.value) / 100)
+      this.setAllValues(this.ticketPoolAttackTargets, digitformat(varNeed))
     }
-    const projectedTicketPrice = DCRNeed / tpSize
+    const projectedTicketPrice = varNeed / tpSize
     this.projectedTicketPriceIncreaseTarget.innerHTML = digitformat(
       (100 * Math.abs(projectedTicketPrice - tpPrice)) / tpPrice,
       2
@@ -532,11 +528,11 @@ export default class extends Controller {
       projectedTicketPrice > tpPrice ? 'increase' : 'decrease'
     this.ticketPoolValueTarget.innerHTML = digitformat(hashrate, 3)
 
-    const totalDCRPos =
+    const totalVarPos =
       this.settings.attack_type === externalAttackType
-        ? DCRNeed - tpValue
+        ? varNeed - tpValue
         : ticketAttackSize * projectedTicketPrice
-    const totalPos = totalDCRPos * dcrPrice
+    const totalPos = totalVarPos * varPrice
     const timeStr = this.attackPeriodTarget.value
     const hourStr = timeStr > 1 ? 'hours' : 'hour'
     const timeHourStr = `${timeStr} ${hourStr}`
@@ -544,7 +540,7 @@ export default class extends Controller {
     const deviceSuffixStr = deviceCount > 1 ? 's' : ''
     this.ticketPoolSizeLabelTarget.innerHTML = digitformat(tpSize, 2)
     this.setAllValues(this.actualHashRateTargets, digitformat(hashrate, 4))
-    this.priceDCRTarget.value = digitformat(dcrPrice, 2)
+    this.exchangeRateTarget.value = digitformat(varPrice, 2)
     this.setAllInputs(this.targetPosTargets, digitformat(parseFloat(this.targetPosTarget.value), 2))
     this.ticketPriceTarget.innerHTML = digitformat(tpPrice, 4)
     this.setAllValues(this.targetHashRateTargets, digitformat(this.targetHashRate, 4))
@@ -554,28 +550,23 @@ export default class extends Controller {
     this.setAllValues(this.countDeviceTargets, digitformat(deviceCount))
     this.devicePronounTarget.innerHTML = devicePronounStr
     this.deviceSuffixTarget.innerHTML = deviceSuffixStr
-    this.setAllValues(
-      this.deviceNameTargets,
-      `<a href="${deviceInfo.link}">${deviceInfo.name}</a>${deviceSuffixStr}`
-    )
     this.setAllValues(this.totalDeviceCostTargets, digitformat(totalDeviceCost))
     this.setAllValues(this.totalKwhTargets, digitformat(totalKwh, 2))
     this.setAllValues(this.totalElectricityTargets, digitformat(totalElectricity, 2))
     this.setAllValues(this.otherCostsValueTargets, digitformat(extraCost, 2))
     this.setAllValues(this.totalPowTargets, digitformat(totalPow, 2))
     this.setAllValues(this.ticketSizeAttackTargets, digitformat(ticketAttackSize))
-    this.setAllValues(this.totalDCRPosTargets, digitformat(totalDCRPos, 2))
+    this.setAllValues(this.totalVarPosTargets, digitformat(totalVarPos, 2))
     this.setAllValues(this.totalPosTargets, digitformat(totalPos))
     this.setAllValues(this.ticketPoolValueTargets, digitformat(tpValue))
     this.setAllValues(this.ticketPoolSizeTargets, digitformat(tpSize))
     this.blockHeightTarget.innerHTML = digitformat(height)
     this.totalTarget.innerHTML = digitformat(totalPow + totalPos, 2)
     this.projectedTicketPriceTarget.innerHTML = digitformat(projectedTicketPrice, 2)
-    // this.attackPosPercentNeededLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
     this.attackPosPercentAmountLabelTarget.innerHTML = digitformat(this.targetPosTarget.value, 2)
-    this.setAllValues(this.totalDCRPosLabelTargets, digitformat(totalDCRPos, 2))
-    this.setAllValues(this.dcrPriceLabelTargets, digitformat(dcrPrice, 2))
-    this.showPosCostWarning(DCRNeed)
+    this.setAllValues(this.totalVarPosLabelTargets, digitformat(totalVarPos, 2))
+    this.setAllValues(this.varPriceLabelTargets, digitformat(varPrice, 2))
+    this.showPosCostWarning(varNeed)
   }
 
   setAllValues(targets, data) {
@@ -598,10 +589,10 @@ export default class extends Controller {
     targets.forEach((el) => el.classList.remove('d-none'))
   }
 
-  showPosCostWarning(DCRNeed) {
-    const totalDCRInCirculation = coinSupply / 100000000
-    if (DCRNeed > totalDCRInCirculation) {
-      this.coinSupplyTarget.textContent = digitformat(totalDCRInCirculation, 2)
+  showPosCostWarning(varNeed) {
+    const totalVarInCirculation = coinSupply / 100000000
+    if (varNeed > totalVarInCirculation) {
+      this.coinSupplyTarget.textContent = digitformat(totalVarInCirculation, 2)
       this.totalAttackCostContainerTarget.style.cssText = 'color: #f12222 !important'
       this.showAll(this.attackNotPossibleWrapperDivTargets)
     } else {

--- a/cmd/dcrdata/views/attackcost.tmpl
+++ b/cmd/dcrdata/views/attackcost.tmpl
@@ -9,11 +9,10 @@
       data-controller="attackcost"
       data-attackcost-height="{{.Height}}"
       data-attackcost-hashrate="{{.HashRate}}"
-      data-attackcost-dcrprice="{{.DCRPrice}}"
       data-attackcost-ticket-price="{{.TicketPrice}}"
       data-attackcost-ticket-pool-value="{{.TicketPoolValue}}"
       data-attackcost-ticket-pool-size="{{.TicketPoolSize}}"
-     data-attackcost-coin-supply="{{.CoinSupply}}"
+      data-attackcost-coin-supply="{{.CoinSupply}}"
     >
     <div class="col-md-24 p-0">
       <div class="bg-white mb-1 py-2 px-3 my-0">
@@ -99,7 +98,7 @@
                   <span class="text-secondary fs13">Ticket Price</span>
                   <br>
                   <span class="h4" data-attackcost-target="ticketPrice">0</span>
-                  <span class="text-secondary">DCR</span>
+                  <span class="text-secondary">VAR</span>
                 </div>
               </div>
             </div>
@@ -162,15 +161,15 @@
                   <span class="h4">
                     <input
                       type="number"
-                      data-attackcost-target="priceDCR"
+                      data-attackcost-target="exchangeRate"
                       data-action="change->attackcost#updatePrice"
                       step="0.01"
                       min="0.01"
-                      value="20"
-                      max="1000"
+                      value="1"
+                      max="10000"
                       size="7"
                     >
-                  </span> <span class="text-secondary fs13">USD/DCR</span>
+                  </span> <span class="text-secondary fs13">USD/VAR</span>
                 </div>
               </div>
               <div class="col-12 text-center">
@@ -199,19 +198,51 @@
           </div>
           <div class="ms-4">
               <div class="mt-1 ms-2">
-                <div class="d-flex w-100">
-                  <span class="align-self-center me-1 text-nowrap">Mining Device:</span>
-                  <select
-                    class="form-control chart-form-control text-truncate min-w-0 dropdown"
-                    data-action="attackcost#chooseDevice"
-                    data-attackcost-target="device"
-                  >
-                    <option data-attackcost-target="deviceDesc" value="0">DCR5</option>
-                    <option data-attackcost-target="deviceDesc" value="1">D1</option>
-                  </select>
+                <div class="row gx-3">
+                  <div class="col-auto">
+                    <span class="text-secondary fs13 d-block">Device Hashrate</span>
+                    <input
+                      type="number"
+                      data-attackcost-target="deviceHashrate"
+                      data-action="change->attackcost#updateDeviceHashrate"
+                      step="0.01"
+                      min="0.01"
+                      max="100000"
+                      value="50"
+                      size="7"
+                    >
+                    <span class="text-secondary fs11">Th/s</span>
+                  </div>
+                  <div class="col-auto">
+                    <span class="text-secondary fs13 d-block">Device Power</span>
+                    <input
+                      type="number"
+                      data-attackcost-target="devicePower"
+                      data-action="change->attackcost#updateDevicePower"
+                      step="1"
+                      min="1"
+                      max="100000"
+                      value="1500"
+                      size="7"
+                    >
+                    <span class="text-secondary fs11">W</span>
+                  </div>
+                  <div class="col-auto">
+                    <span class="text-secondary fs13 d-block">Device Price</span>
+                    <input
+                      type="number"
+                      data-attackcost-target="devicePrice"
+                      data-action="change->attackcost#updateDevicePrice"
+                      step="1"
+                      min="1"
+                      max="10000000"
+                      value="1500"
+                      size="9"
+                    >
+                    <span class="text-secondary fs11">USD</span>
+                  </div>
                 </div>
               </div>
-            </row>
             <div class="mt-1 ms-2">
                 A
                 <input
@@ -244,13 +275,13 @@
               In order to acquire a <span class="fw-bold"><span data-attackcost-target="targetHashRate">0</span> <span class="fs11">Ph/s</span></span>
               hashrate, it would take
               <span class="fw-bold" data-attackcost-target="countDevice">0</span>
-              <span class="fs11" data-attackcost-target="deviceName">&mdash;</span>
+              device<span data-attackcost-target="deviceSuffix">(s)</span>
               at a cost of <span class="fw-bold">$<span data-attackcost-target="totalDeviceCost">0</span>
               <span class="fs11">USD</span></span> to buy <span data-attackcost-target="devicePronoun">them</span>.
             </div>
             <div class="mt-1 ms-2">
               Electricity consumed by <span class="fw-bold" data-attackcost-target="countDevice">0</span>
-              <span class="fs11" data-attackcost-target="deviceName">&mdash;</span> in
+              device<span data-attackcost-target="deviceSuffix">(s)</span> in
               <span data-attackcost-target="durationLongDesc">0</span> is
               <span class="position-relative fw-bold">
               <span class="fw-bold" data-attackcost-target="totalKwh">0</span> <span class="fs11">kWh</span></span>.
@@ -259,7 +290,7 @@
               Cost of <span data-attackcost-target="durationLongDesc">0</span>
               electricity consumption for
               <span class="fw-bold" data-attackcost-target="countDevice">0</span>
-              <span class="fs11" data-attackcost-target="deviceName">&mdash;</span> is
+              device<span data-attackcost-target="deviceSuffix">(s)</span> is
               <span class="position-relative fw-bold">
                 $<span class="fw-bold" data-attackcost-target="totalElectricity">0</span>
                 <span class="fs11">USD</span></span>.
@@ -275,7 +306,7 @@
                 max="100"
                 value="5"
                 size="3"
-              >% of the cost of the miner<span data-attackcost-target="deviceSuffix">(s)</span>.
+              >% of the cost of the device<span data-attackcost-target="deviceSuffix">(s)</span>.
             </div>
             <div class="mt-1 ms-2">
               The additional facility cost is <span class="fw-bold">$<span data-attackcost-target="otherCostsValue">0</span>
@@ -297,7 +328,7 @@
           <div class="ms-4 d-none" data-attackcost-target="internalAttackPosText">
             <div class="mt-1 ms-2">
               Current total staked is
-              <span class="fw-bold"><span data-attackcost-target="ticketPoolValue">0</span> <span class="fs11">DCR</span></span>.
+              <span class="fw-bold"><span data-attackcost-target="ticketPoolValue">0</span> <span class="fs11">VAR</span></span>.
             </div>
             <div class="mt-1 ms-2">
               An internal <input
@@ -319,10 +350,10 @@
             <div class="mt-1 ms-2">
               <span class="position-relative fw-bold">
                 <span class="fw-bold" data-attackcost-target="ticketPoolAttack">0</span>
-                <span class="fs11">DCR</span>
+                <span class="fs11">VAR</span>
               </span>
               is needed for the attack
-              (<span class="position-relative fw-bold"><span data-attackcost-target="ticketPoolValue">0</span> <span class="fs11">DCR</span>
+              (<span class="position-relative fw-bold"><span data-attackcost-target="ticketPoolValue">0</span> <span class="fs11">VAR</span>
                 <span data-attackcost-target="operatorSign"> * </span>
                 <span data-attackcost-target="attackPosPercentAmountLabel">0</span>%</span>).
             </div>
@@ -332,15 +363,15 @@
                 <span>$</span><span class="fw-bold" data-attackcost-target="totalPos">0</span>
                 <span class="fs11">USD</span>
               </span>
-              (<span class="position-relative fw-bold"><span data-attackcost-target="totalDCRPosLabel">0</span> <span class="fs11">DCR</span>
+              (<span class="position-relative fw-bold"><span data-attackcost-target="totalVarPosLabel">0</span> <span class="fs11">VAR</span>
                 <span> * </span>
-                $<span data-attackcost-target="dcrPriceLabel">0</span> <span class="fs11">USD/DCR</span></span>).
+                $<span data-attackcost-target="varPriceLabel">0</span> <span class="fs11">USD/VAR</span></span>).
             </div>
           </div>
           <div class="ms-4 d-none" data-attackcost-target="externalAttackPosText">
             <div class="mt-1 ms-2">
               Current total staked is
-              <span class="fw-bold"><span data-attackcost-target="ticketPoolValue">0</span> <span class="fs11">DCR</span></span>.
+              <span class="fw-bold"><span data-attackcost-target="ticketPoolValue">0</span> <span class="fs11">VAR</span></span>.
             </div>
             <div class="mt-1 ms-2">
               An external <input
@@ -354,23 +385,23 @@
                       size="4"
                       autofocus
               >% PoS attack would add
-              <span class="fw-bold"><span data-attackcost-target="additionalDcr">0</span> <span class="fs11">DCR</span></span>
+              <span class="fw-bold"><span data-attackcost-target="additionalVar">0</span> <span class="fs11">VAR</span></span>
               to the total staked.
             </div>
             <div class="mt-1 ms-2">
               New total staked will be
-              <span class="fw-bold"><span data-attackcost-target="newTicketPoolValue">0</span> <span class="fs11">DCR</span></span>.
+              <span class="fw-bold"><span data-attackcost-target="newTicketPoolValue">0</span> <span class="fs11">VAR</span></span>.
             </div>
         {{- /* CALCULATED PoS WARNING DISPLAY */ -}}
         <div data-attackcost-target="attackNotPossibleWrapperDiv" class="mt-1 ms-2 blink-container d-none" style="color: #f12222; margin-left: 8px; ">
             Attack not possible. Total coin supply is
-            <span class="fw-bold"><span data-attackcost-target="coinSupply">0</span> <span class="fs11">DCR</span></span>.
+            <span class="fw-bold"><span data-attackcost-target="coinSupply">0</span> <span class="fs11">VAR</span></span>.
         </div>
         <div class="mt-1 ms-2" data-attackcost-target="projectedPriceDiv" style="{display: block}">
             The projected ticket price is
             <span class="position-relative fw-bold">
             <span class="fw-bold" data-attackcost-target="projectedTicketPrice">0</span>
-              <span class="fs11">DCR</span>
+              <span class="fs11">VAR</span>
             </span>
             (A <span class="fw-bold"><span data-attackcost-target="projectedTicketPriceIncrease">0</span>%</span>
             <span data-attackcost-target="projectedTicketPriceSign">change</span>).
@@ -381,9 +412,12 @@
               <span>$</span><span class="fw-bold" data-attackcost-target="totalPos">0</span>
               <span class="fs11">USD</span>
             </span>
-            (<span class="position-relative fw-bold"><span data-attackcost-target="totalDCRPosLabel">0</span> <span class="fs11">DCR</span>
+            (<span class="position-relative fw-bold"><span data-attackcost-target="totalVarPosLabel">0</span> <span class="fs11">VAR</span>
               <span> * </span>
-              $<span data-attackcost-target="dcrPriceLabel">0</span> <span class="fs11">USD/DCR</span></span>).
+              $<span data-attackcost-target="varPriceLabel">0</span> <span class="fs11">USD/VAR</span></span>).
+        </div>
+        <div class="mt-2 ms-2 text-secondary fs13">
+            Based on the hybrid PoW + PoS deterrence model with a fixed 50/50 reward split.
         </div>
       </div>
       </div>

--- a/wiki/code-analysis/attack-cost/flow.compact.md
+++ b/wiki/code-analysis/attack-cost/flow.compact.md
@@ -6,31 +6,34 @@
 (`parseInt`/`parseFloat`) → **all PoW/PoS math in the browser**.
 
 **Key architectural patterns:**
-- **No-compute handler:** `explorerroutes.go:2693-2742` only copies 6 fields from a
-  shared snapshot; no DB/RPC/XHR. Math lives entirely in JS.
+- **No-compute handler:** `explorerroutes.go` `AttackCost` only copies 5 fields from a
+  shared snapshot (height, hashrate, ticket price, ticket pool size/value, coin supply);
+  no DB/RPC/XHR. Math lives entirely in JS.
 - **VAR-only legacy snapshot:** consumes flat `HomeInfo.CoinSupply int64` /
   `TicketPoolInfo` (`explorertypes.go:811,1375`); never `VARCoinSupply`/`SKACoinSupply`.
-  Every "DCR" label = legacy VAR naming.
-- **Untyped Go→JS contract:** `data-attackcost-*` keys + `static targets` array
-  (`attackcost_controller.js:121-185`) are an exact string contract.
-- **Vendored-Dygraphs coupling:** monkey-patches private `doZoomY_`
-  (`attackcost_controller.js:252`).
+  All labels on the page are `VAR`.
+- **Manual-only exchange rate:** USD/VAR comes from the user-edited `Exchange Rate`
+  input only — no server-provided seed, no exchange-bot dependency. Default `1`.
+- **Manual-only device specs:** device hashrate, power, and price are user-edited
+  inputs (no hard-coded ASIC list, no external catalog). Defaults: 50 Th/s, 1500 W,
+  $1500.
+- **Untyped Go→JS contract:** `data-attackcost-*` keys + `static targets` array in
+  `attackcost_controller.js` are an exact string contract.
+- **Vendored-Dygraphs coupling:** monkey-patches private `doZoomY_` in
+  `attackcost_controller.js`.
 
 **Critical constraints:**
 - Precision: `parseInt`/`÷1e8` safe for 8-decimal VAR only; **breaks for 18-decimal SKA**
   (exceeds `float64`). Not portable to SKA without BigInt rewrite.
-- Price: `exchanges` `Conversion` returns `nil` only if bot nil; bot-but-no-state →
-  `Value:0`, so effective price is **0, not the `24.42` literal** (`bot.go:1056`).
 - Snapshot is process-global, possibly stale; pre-first-`Store()` → `tpSize=0` →
   `NaN`/`Infinity`.
 - `HomeInfo`/`TicketPoolInfo` are JSON-tagged, shared with HTTP API + home page.
 
 **Mutation checklist:**
-- Touch `HomeInfo.CoinSupply`/`TicketPoolInfo` types/units → handler `:2713-2731` + JS
-  `:203-209,602` + API JSON + home page.
+- Touch `HomeInfo.CoinSupply`/`TicketPoolInfo` types/units → handler template struct +
+  JS `parseInt`/÷1e8 sites + API JSON + home page.
 - Rename a `data-attackcost-*` **key** → silent `parseInt(null)=NaN` cascade.
 - Rename/remove a `data-attackcost-target` → JS throws in `connect()`, controller dead.
 - Add SKA → precision-corrupts via `parseInt`/`÷1e8`; needs BigInt path, not this one.
-- Remove/replace `xcBot` → price defaults; verify it's not silently `0`.
 - Upgrade Dygraphs → re-verify `doZoomY_` private override.
 - Loud failure only on template-exec error (`StatusPage`); JS-side failures are silent.

--- a/wiki/code-analysis/attack-cost/flow.full.md
+++ b/wiki/code-analysis/attack-cost/flow.full.md
@@ -4,13 +4,15 @@
 
 The `/attack-cost` page is a **51%-style majority-attack cost calculator** (PoW + PoS).
 It is unusual in this codebase: the Go side does **no computation** — the handler reads a
-process-global in-memory snapshot, renders six numbers into HTML `data-*` attributes, and
-**all attack math runs in the browser** (`attackcost_controller.js`). There is no DB query,
-no RPC call, and no XHR for this page.
+process-global in-memory snapshot, renders five chain scalars into HTML `data-*` attributes,
+and **all attack math runs in the browser** (`attackcost_controller.js`). There is no DB
+query, no RPC call, and no XHR for this page. The USD/VAR exchange rate and the mining
+device specs (hashrate, power, price) are entered by the user — there is no server-seeded
+rate and no hard-coded device list.
 
 Critical framing: the page is **single-coin / VAR-only by construction**. It consumes the
 legacy flat `HomeInfo.CoinSupply int64` and never touches `HomeInfo.VARCoinSupply` /
-`HomeInfo.SKACoinSupply`. Every "DCR" label in the template is legacy naming for VAR.
+`HomeInfo.SKACoinSupply`. All coin-amount labels on the rendered page are `VAR`.
 
 ## Section 2 — End-to-End Data Flow
 
@@ -26,7 +28,7 @@ monetarium-node RPC ──► blockdata collector ──► explorer.Store() ─
                                                                          │
                              attackcost_controller.connect(): parseInt / parseFloat
                                                                          │
-                             all PoW/PoS attack math in the browser (Dygraphs + Decred formula)
+                             all PoW/PoS attack math in the browser (Dygraphs + 50/50 hybrid formula)
 ```
 
 ## Section 3 — Per-Layer Breakdown
@@ -44,27 +46,26 @@ monetarium-node RPC ──► blockdata collector ──► explorer.Store() ─
 
 ### Layer B — HTTP handler
 
-- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go:2693-2742`
-  (`(*explorerUI).AttackCost`); route registered `cmd/dcrdata/main.go:817`.
+- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go` `(*explorerUI).AttackCost`;
+  route registered `cmd/dcrdata/main.go:817`.
 - **Data structures:** anonymous struct embedding `*CommonPageData` with
-  `HashRate float64`, `Height int64`, `DCRPrice float64`, `TicketPrice float64`,
-  `TicketPoolSize int64`, `TicketPoolValue float64`, `CoinSupply int64`.
+  `HashRate float64`, `Height int64`, `TicketPrice float64`, `TicketPoolSize int64`,
+  `TicketPoolValue float64`, `CoinSupply int64`. No `DCRPrice`/USD field — the rate is
+  user-entered in the browser.
 - **Transformations:**
-  - `price := 24.42`; overwritten whenever `exp.xcBot != nil` via
-    `exp.xcBot.Conversion(1.0)` (`exchanges/bot.go:1045`). `Conversion` returns `nil`
-    **only** when `bot == nil`; with the bot present but no exchange state yet it returns
-    `Value: 0` (`bot.go:1056-1057`) — so the effective price becomes **0, not 24.42**.
-  - Reads six fields from `exp.pageData` under `RLock`, no math performed.
+  - Reads five chain scalars (height, hashrate, ticket price, ticket pool size/value,
+    coin supply) from `exp.pageData` under `RLock`; no math, no exchange-bot call.
   - Renders via `execTemplateToString("attackcost", …)`; template error →
     `StatusPage(..., ExpStatusError)`.
 
 ### Layer C — Template (Go number → HTML string)
 
-- **Location:** `cmd/dcrdata/views/attackcost.tmpl:7-17` (the `data-attackcost-*` attribute
-  block); template registered in the set at `explorer.go:424`.
-- **Data structures:** `data-attackcost-height`, `-hashrate`, `-dcrprice`, `-ticket-price`,
+- **Location:** `cmd/dcrdata/views/attackcost.tmpl` (the `data-attackcost-*` attribute
+  block at the top of the controller container); template registered in the set at
+  `explorer.go:424`.
+- **Data structures:** `data-attackcost-height`, `-hashrate`, `-ticket-price`,
   `-ticket-pool-value`, `-ticket-pool-size`, `-coin-supply`. `CoinSupply int64` is emitted
-  as a raw VAR-atom integer string.
+  as a raw VAR-atom integer string. No `-dcrprice` attribute — the rate is user-entered.
 - **Transformations:** Go numeric → attribute string. ~90 `data-attackcost-target` hooks
   feed the controller; the attribute key set and the `targets` array are an **untyped
   contract**.
@@ -72,21 +73,26 @@ monetarium-node RPC ──► blockdata collector ──► explorer.Store() ─
 ### Layer D — Stimulus controller (string → Number → all math)
 
 - **Location:** `cmd/dcrdata/public/js/controllers/attackcost_controller.js`.
-- **Data structures / globals:** `height, dcrPrice, hashrate, tpSize, tpValue, tpPrice,
-  graphData, currentPoint, coinSupply` (module-level, line 47); `deviceList` (lines 63-80,
-  hardcoded `DCR5`/`D1` ASIC specs + a `medium.com/decred` citation).
+- **Data structures / globals:** `height, varPrice, hashrate, tpSize, tpValue, tpPrice,
+  graphData, currentPoint, coinSupply`, plus `deviceHashrate, devicePower, devicePrice`
+  (all module-level). Neutral defaults `defaultExchangeRate=1`, `defaultDeviceHashrate=50`,
+  `defaultDevicePower=1500`, `defaultDevicePrice=1500`.
 - **Transformations:**
-  - `connect()` lines 203-209: `parseInt(this.data.get('height'))`,
-    `parseFloat(this.data.get('ticketPrice'))`, `parseInt(this.data.get('coinSupply'))`, …
-  - `rateCalculation(y)` lines 49-61: Decred hybrid PoW/PoS deterrence formula
-    `(6x⁵−15x⁴+10x³)/(6y⁵−15y⁴+10y³)`.
-  - `calculate()` lines 503-579: device count, electricity, PoS DCR-need, projected ticket
-    price, totals.
-  - `showPosCostWarning()` lines 601-611: `coinSupply / 100000000` — hardcoded 1e8 divisor
-    (8-decimal assumption); if `DCRNeed > totalDCRInCirculation` it flags
+  - `connect()`: `parseInt(this.data.get('height'))`,
+    `parseFloat(this.data.get('ticketPrice'))`, `parseInt(this.data.get('coinSupply'))`,
+    etc. The USD/VAR rate is seeded from `defaultExchangeRate` and then overwritten by
+    either the `?price=` URL param or the manual input — never from a server attribute.
+    Device specs are seeded from the `default*` constants and overwritten by URL params
+    `device_hashrate`/`device_power`/`device_price` or the manual inputs.
+  - `rateCalculation(y)`: hybrid PoW/PoS deterrence formula
+    `(6x⁵−15x⁴+10x³)/(6y⁵−15y⁴+10y³)`, bit-exact across the Monetarium rework.
+  - `calculate()`: device count = `ceil(targetHashRate * 1000 / deviceHashrate)`,
+    electricity, PoS `varNeed`, projected ticket price, totals.
+  - `showPosCostWarning()`: `coinSupply / 100000000` — hardcoded 1e8 divisor
+    (8-decimal VAR assumption); if `varNeed > totalVarInCirculation` it flags
     "Attack not possible".
   - TurboQuery URL state: `attack_time, target_pow, kwh_rate, other_costs, target_pos,
-    price, device, attack_type` (lines 189-198, 324-331).
+    price, device_hashrate, device_power, device_price, attack_type`.
 
 ## Section 4 — Cross-Layer Dependencies
 
@@ -95,12 +101,13 @@ monetarium-node RPC ──► blockdata collector ──► explorer.Store() ─
   `explorertypes.go:812`) also serialized by the HTTP API and consumed by the home page —
   a field type/units change ripples far beyond this page.
 - **Template ↔ controller (brittle):** the `data-attackcost-*` attribute keys
-  (`this.data.get(...)`) and the `static targets` array (lines 121-185) form an exact,
-  untyped string contract. A renamed *data key* yields `parseInt(null) = NaN` silently; a
+  (`this.data.get(...)`) and the `static targets` array form an exact, untyped string
+  contract. A renamed *data key* yields `parseInt(null) = NaN` silently; a
   renamed/removed *target* throws in `connect()` and kills the controller.
-- **Price ↔ exchange bot:** `DCRPrice` depends on `exchanges` bot state at request time;
-  no state → `$0` everywhere, no error.
-- **Dygraphs:** `attackcost_controller.js:252` monkey-patches the private
+- **No exchange-bot coupling:** the handler does not call `exp.xcBot`; USD/VAR comes
+  from the manual input only. Past versions of this handler did seed the rate from
+  `xcBot.Conversion` — do not reintroduce that coupling.
+- **Dygraphs:** `attackcost_controller.js` monkey-patches the private
   `Dygraph.prototype.doZoomY_` — version-fragile coupling to the vendored Dygraphs build.
 
 ## Section 5 — Critical Constraints
@@ -114,67 +121,75 @@ monetarium-node RPC ──► blockdata collector ──► explorer.Store() ─
   client-side `Number` math model is not portable to SKA without a BigInt rewrite.
 - **Snapshot semantics:** process-global `pageData` guarded by an RWMutex; before the first
   `Store()` all fields are zero (`tpSize = 0` → divisions produce `NaN`/`Infinity`).
-- **Misleading price fallback:** the literal `24.42` is *not* the no-exchange value; with
-  the bot present and no state the effective price is `0`.
+- **No server-seeded exchange rate / device list:** USD/VAR and device specs are
+  scenario parameters the user enters. Monetarium has no listed market price; the
+  handler must not call `xcBot` or seed any rate from the server.
 
 ## Section 6 — Mutation Impact
 
 When modifying this page, check:
 
-- **Direct dependencies:** `explorerroutes.go:2713-2731` struct fields;
-  `attackcost.tmpl:7-17` attribute keys; `attackcost_controller.js:203-209` parse calls.
-- **Indirect dependencies:** `HomeInfo`/`TicketPoolInfo` shared with HTTP API + home page;
-  `explorer.go:574-649` `Store()` population; `exchanges` bot `Conversion`.
+- **Direct dependencies:** the `AttackCost` template-struct fields in
+  `explorerroutes.go`; the top-of-container `data-attackcost-*` block in
+  `attackcost.tmpl`; the `parseInt`/`parseFloat` reads in `attackcost_controller.js`
+  `connect()`.
+- **Indirect dependencies:** `HomeInfo`/`TicketPoolInfo` shared with HTTP API + home
+  page; `explorer.go:574-649` `Store()` population.
 - **Serialization boundary:** Go numeric → `data-*` string → JS `parseInt/parseFloat`
   (and the JSON-tagged shared struct used elsewhere).
 - **Rendering layers:** Dygraphs (`doZoomY_` patch), ~90 `data-attackcost-target` hooks.
 
 **Silent failures (no error, wrong output):**
-- Bot present, no exchange state → `price = 0` → all USD figures `$0`.
 - `pageData` not yet populated (startup) → `tpSize = 0` → `NaN`/`Infinity` outputs.
 - Routing SKA atoms through this path → `parseInt` precision loss, wrong `/1e8` divisor.
 - Mistyped/renamed `data-*` key → `NaN` propagation through every output.
 
 **Hard failures (visible):**
-- Template execution error → `StatusPage(..., ExpStatusError)`
-  (`explorerroutes.go:2733-2736`).
+- Template execution error → `StatusPage(..., ExpStatusError)` in the `AttackCost`
+  handler.
 - Renamed/removed Stimulus *target* → JS exception in `connect()`, controller dead, page
   shows static `0`s.
 
 ## Section 7 — Common Pitfalls
 
-1. Assuming "DCR"/`coin_supply` here means total network value — it is **VAR only**; SKA is
+1. Assuming `coin_supply` here means total network value — it is **VAR only**; SKA is
    silently excluded.
 2. Multi-coin-ifying the page by piping SKA atoms through the existing
    `data-*`/`parseInt`/`/1e8` path — violates the 18-decimal `big.Int` rule, corrupts
    values with no error.
-3. Treating `24.42` as the no-exchange fallback — the real no-data price is `0`.
-4. Assuming the handler fetches fresh chain data — it reads a possibly-stale shared
+3. Re-introducing a server-seeded exchange rate (e.g. via `xcBot.Conversion`) — the
+   page is a scenario calculator; Monetarium has no listed market price. Don't do it.
+4. Re-introducing a hard-coded device catalog — the user types the three numbers
+   (hashrate / power / price); past Decred-era model presets were removed by design.
+5. Assuming the handler fetches fresh chain data — it reads a possibly-stale shared
    snapshot under `RLock`.
-5. Refactoring `HomeInfo`/`TicketPoolInfo` field types "just for this page" — the structs
+6. Refactoring `HomeInfo`/`TicketPoolInfo` field types "just for this page" — the structs
    feed the API JSON and the home page.
-6. Renaming template attributes for cleanliness — the `data.get()` keys and `targets`
+7. Renaming template attributes for cleanliness — the `data.get()` keys and `targets`
    array are an exact, untyped contract; mismatches fail silently or kill the controller.
-7. Upgrading Dygraphs without re-checking the private `doZoomY_` override.
+8. Upgrading Dygraphs without re-checking the private `doZoomY_` override.
 
 ## Section 8 — Evidence
 
 - `cmd/dcrdata/main.go:817` — route registration.
-- `cmd/dcrdata/internal/explorer/explorerroutes.go:2693-2742` — `AttackCost` handler;
-  `:2696-2700` price logic; `:2733-2736` template-error path.
+- `cmd/dcrdata/internal/explorer/explorerroutes.go` `AttackCost` — handler; reads under
+  `RLock`, renders, no math.
 - `cmd/dcrdata/internal/explorer/explorer.go:562-564, 574-649` — `Store()` → `HomeInfo`.
 - `explorer/types/explorertypes.go:811-837` (`HomeInfo`), `:1375-1382` (`TicketPoolInfo`).
 - `blockdata/blockdata.go:207` — `GetCoinSupply`.
-- `exchanges/bot.go:1045-1058` — `Conversion` (nil only when bot nil; `Value:0` when no state).
-- `cmd/dcrdata/views/attackcost.tmpl:7-17` — `data-*` contract; `:2731`-equivalent int64 emit.
-- `cmd/dcrdata/public/js/controllers/attackcost_controller.js:47` (globals),
-  `:49-61` (formula), `:63-80` (devices), `:121-185` (targets), `:203-209` (data parse),
-  `:252` (Dygraph hack), `:503-579` (calculate), `:601-611` (supply gate).
+- `cmd/dcrdata/views/attackcost.tmpl` — `data-*` contract at the top of the controller
+  container; manual `Exchange Rate`, `Device Hashrate`, `Device Power`, `Device Price`
+  inputs in the "Adjustable Parameters" / "PoW Attack" blocks.
+- `cmd/dcrdata/public/js/controllers/attackcost_controller.js` — module globals
+  (`varPrice`, `deviceHashrate`, `devicePower`, `devicePrice`, `coinSupply`, …),
+  neutral `default*` constants, `rateCalculation` (formula), `static targets` (Stimulus
+  contract), `connect()` (data parse + URL state), `Dygraph.prototype.doZoomY_` override,
+  `calculate()` (PoW + PoS totals), `showPosCostWarning()` (supply gate).
 
 See also:
-- /wiki/code-analysis/attack-cost/patterns.md (shares-pattern-with: VAR-only legacy snapshot, untyped `data-*`↔Stimulus contract, client-side-only math)
-- /wiki/code-analysis/attack-cost/impact.md (depends-on: shared `HomeInfo` struct, exchange-bot price, snapshot staleness)
-- /wiki/code-analysis/address/impact.md (shares-pattern-with: legacy flat-field shim / `DCR` labelling — attack-cost still reads its `HomeInfo` flat fields; address keeps the analogous back-compat VAR fields, now template-unread)
+- /wiki/code-analysis/attack-cost/patterns.md (shares-pattern-with: VAR-only legacy snapshot, untyped `data-*`↔Stimulus contract, client-side-only math, manual-only scenario inputs)
+- /wiki/code-analysis/attack-cost/impact.md (depends-on: shared `HomeInfo` struct, snapshot staleness)
+- /wiki/code-analysis/address/impact.md (shares-pattern-with: legacy flat-field shim — attack-cost still reads its `HomeInfo` flat fields; address keeps the analogous back-compat VAR fields, now template-unread)
 - /wiki/code-analysis/visualblocks/patterns.md (shares-pattern-with: untyped Go→JS contract, vendored Dygraphs coupling)
 - /wiki/core/constraints.md (depends-on: C1 numeric precision — float64 VAR vs big.Int SKA)
 - /wiki/core/pages.md (depends-on: `/attack-cost` route registry entry)

--- a/wiki/code-analysis/attack-cost/impact.md
+++ b/wiki/code-analysis/attack-cost/impact.md
@@ -10,11 +10,12 @@ Explicitly identified risks for changing the `/attack-cost` page. Failure mode n
 
 **Failure mode:** silent.
 
-**Description:** `attackcost_controller.js:209` `parseInt(coinSupply)` and `:602`
-`coinSupply / 100000000` assume 8-decimal VAR fitting `float64`. SKA has 18 decimals,
-exceeding the `float64` significand — values are silently truncated/rounded, and the
-"Attack not possible" gate (`:601-611`) compares corrupted magnitudes. Requires a BigInt
-path, not this one. (See `wiki/core/constraints.md` C1.)
+**Description:** In `attackcost_controller.js`, `parseInt(this.data.get('coinSupply'))`
+in `connect()` and `coinSupply / 100000000` in `showPosCostWarning` assume 8-decimal
+VAR fitting `float64`. SKA has 18 decimals, exceeding the `float64` significand —
+values are silently truncated/rounded, and the "Attack not possible" gate compares
+corrupted magnitudes. Requires a BigInt path, not this one.
+(See `wiki/core/constraints.md` C1.)
 
 ## Risk: Shared `HomeInfo` / `TicketPoolInfo` type or units change
 
@@ -25,21 +26,9 @@ path, not this one. (See `wiki/core/constraints.md` C1.)
 
 **Description:** `explorertypes.go:811,1375` structs are JSON-tagged
 (`json:"coin_supply"`) and consumed by the HTTP API and home page in addition to
-`explorerroutes.go:2713-2731` and `attackcost_controller.js:203-209,602`. A units change
-breaks the JS `/1e8` divisor and `tpSize`/`tpValue` divisions with no error here and
-mis-serializes the API elsewhere.
-
-## Risk: Exchange-bot price is silently zero
-
-**Trigger:** Exchange bot present but no state yet (startup, upstream outage), or removing
-`xcBot`.
-
-**Failure mode:** silent.
-
-**Description:** `exchanges/bot.go:1045-1058` `Conversion` returns `nil` **only** when
-`bot == nil`; with the bot present and no state it returns `Value: 0`. The handler guard
-`if rate := exp.xcBot.Conversion(1.0); rate != nil` (`explorerroutes.go:2696-2700`) then
-sets `price = 0`, **not** the `24.42` literal — every USD figure renders `$0`.
+the `AttackCost` handler in `explorerroutes.go` and the `parseInt`/`÷1e8` reads in
+`attackcost_controller.js`. A units change breaks the JS `/1e8` divisor and
+`tpSize`/`tpValue` divisions with no error here and mis-serializes the API elsewhere.
 
 ## Risk: Stale / unpopulated snapshot
 
@@ -47,10 +36,9 @@ sets `price = 0`, **not** the `24.42` literal — every USD figure renders `$0`.
 
 **Failure mode:** silent.
 
-**Description:** Handler reads process-global `pageData` under `RLock`
-(`explorerroutes.go:2702-2711`). Zero-valued `tpSize` makes `val * tpSize`,
-`getRowForX`, and `DCRNeed / tpSize` produce `NaN`/`Infinity`; the page renders alive but
-with garbage numbers.
+**Description:** Handler reads process-global `pageData` under `RLock`. Zero-valued
+`tpSize` makes `val * tpSize`, `getRowForX`, and `varNeed / tpSize` produce
+`NaN`/`Infinity`; the page renders alive but with garbage numbers.
 
 ## Risk: Untyped Go→JS contract drift
 
@@ -68,18 +56,26 @@ killing the controller so the page shows static `0`s.
 
 **Failure mode:** loud (JS exception) or silent (Y-zoom re-enabled).
 
-**Description:** `attackcost_controller.js:252` overrides private
+**Description:** `attackcost_controller.js` overrides private
 `Dygraph.prototype.doZoomY_`; a renamed/removed private member silently restores Y-zoom or
 throws on assignment.
+
+## Resolved: Exchange-bot price silently zero (historical)
+
+Prior version of this handler seeded the USD/VAR rate from `exp.xcBot.Conversion(1.0)`
+with a `24.42` literal fallback; when the bot was present without state, every USD
+figure rendered `$0`. The current handler no longer touches `xcBot` and exposes no
+server-seeded rate — the page sources the rate exclusively from the user-edited
+"Exchange Rate" input (default `1`). Do not reintroduce a server-seeded rate.
 
 ## Loud-failure summary
 
 The only Go-side loud failure is a template execution error →
-`StatusPage(..., ExpStatusError)` (`explorerroutes.go:2733-2736`). Nearly every other
+`StatusPage(..., ExpStatusError)` in the `AttackCost` handler. Nearly every other
 failure on this page is **silent** — the calculator renders but produces wrong numbers.
 
 See also:
 - /wiki/code-analysis/attack-cost/flow.full.md (depends-on)
 - /wiki/code-analysis/attack-cost/patterns.md (depends-on)
-- /wiki/code-analysis/address/impact.md (shares-pattern-with: legacy flat-field shim / `DCR` labelling — same back-compat VAR fields; address's are now template-unread, attack-cost's `HomeInfo` ones still read)
+- /wiki/code-analysis/address/impact.md (shares-pattern-with: legacy flat-field shim — same back-compat VAR fields; address's are now template-unread, attack-cost's `HomeInfo` ones still read)
 - /wiki/core/constraints.md (depends-on: C1 numeric precision — float64 VAR vs big.Int SKA)

--- a/wiki/code-analysis/attack-cost/patterns.md
+++ b/wiki/code-analysis/attack-cost/patterns.md
@@ -6,33 +6,52 @@ normalization is left to a future `Consolidate:` pass.
 ## No-Compute Handler / Client-Side Math
 
 **Description:** The Go handler performs **zero domain computation** — it copies a fixed
-set of scalars from a shared snapshot into template `data-*` attributes; every attack
-calculation (PoW device cost, electricity, PoS DCR-need, Decred hybrid deterrence formula,
+set of scalars (height, hashrate, ticket price, ticket pool size/value, coin supply)
+from a shared snapshot into template `data-*` attributes; every attack calculation
+(PoW device cost, electricity, PoS VAR-need, hybrid 50/50 deterrence formula,
 projected ticket price) runs in `attackcost_controller.js`.
 
 **Constraints:**
 - All numeric correctness lives in JS `Number`; the Go side cannot enforce precision.
 - Any value that must stay exact (SKA atoms) cannot pass through this pattern unchanged.
-- Source: `explorerroutes.go:2693-2742`; `attackcost_controller.js:49-61, 503-611`.
+- Source: `explorerroutes.go` `AttackCost`; `attackcost_controller.js` `rateCalculation`,
+  `calculate`, `showPosCostWarning`.
 
 ## VAR-Only Legacy Snapshot
 
 **Description:** Reads the legacy flat `HomeInfo.CoinSupply int64` / `TicketPoolInfo`
 (`explorertypes.go:811,1375`) and never the multi-coin `VARCoinSupply`/`SKACoinSupply`.
-All "DCR" labels are legacy VAR naming. Shared with `address/patterns.md`
+All coin-amount labels on the page are `VAR`. Shared with `address/patterns.md`
 ("Legacy flat-field shim (residual)") — the address page retains the same
 back-compat legacy flat VAR fields, though its template no longer reads them
 (attack-cost still does, for `HomeInfo`).
 
 **Constraints:**
-- Treat "coin supply" / "DCR" on this page as VAR-only; SKA is out of scope by design.
+- Treat "coin supply" on this page as VAR-only; SKA is out of scope by design.
 - `HomeInfo`/`TicketPoolInfo` are JSON-tagged and shared with the HTTP API + home page —
   field changes are cross-page.
+
+## Manual-Only Scenario Inputs (No Server-Sourced Defaults)
+
+**Description:** Two classes of input are user-edited and **not** seeded from the
+server: the USD/VAR `Exchange Rate` (Monetarium has no listing, so no authoritative
+rate) and the mining-device specs (hashrate, power, price — no hard-coded ASIC list,
+no external catalog). Defaults are neutral round numbers in the controller
+(`defaultExchangeRate=1`, `defaultDeviceHashrate=50`, `defaultDevicePower=1500`,
+`defaultDevicePrice=1500`).
+
+**Constraints:**
+- Do not re-introduce an auto-fetched exchange rate (no `xcBot.Conversion` here) — the
+  page is explicitly a scenario calculator, not a market-data view.
+- Do not re-introduce a hard-coded device catalog — users supply the three numbers.
+- Source: `attackcost_controller.js` module-level `default*` constants and the
+  `updateDeviceHashrate` / `updateDevicePower` / `updateDevicePrice` / `updatePrice`
+  action handlers.
 
 ## Untyped Go → Stimulus String Contract
 
 **Description:** Two coupled string sets — `data-attackcost-*` attribute keys read via
-`this.data.get(...)` and the `static targets` array (`attackcost_controller.js:121-185`).
+`this.data.get(...)` and the `static targets` array in `attackcost_controller.js`.
 Same pattern as `visualblocks/patterns.md` (untyped Go→JS contract).
 
 **Constraints:**
@@ -42,7 +61,7 @@ Same pattern as `visualblocks/patterns.md` (untyped Go→JS contract).
 
 ## Vendored-Dygraphs Private Override
 
-**Description:** `attackcost_controller.js:252` monkey-patches the private
+**Description:** `attackcost_controller.js` monkey-patches the private
 `Dygraph.prototype.doZoomY_` to disable Y-axis zoom. Shares the vendored-Dygraphs coupling
 seen in the charts/visualblocks flows.
 
@@ -51,5 +70,5 @@ seen in the charts/visualblocks flows.
 See also:
 - /wiki/code-analysis/attack-cost/flow.full.md (shares-pattern-with)
 - /wiki/code-analysis/visualblocks/patterns.md (shares-pattern-with: untyped Go→JS contract, vendored Dygraphs)
-- /wiki/code-analysis/address/patterns.md (shares-pattern-with: legacy flat-field shim / `DCR` labelling — address keeps the same back-compat VAR fields, now template-unread)
+- /wiki/code-analysis/address/patterns.md (shares-pattern-with: legacy flat-field shim — address keeps the back-compat VAR fields, now template-unread)
 - /wiki/core/constraints.md (depends-on: C1 numeric precision)


### PR DESCRIPTION
## Summary
- Drop Decred surface from `/attack-cost`: `DCR` → `VAR` labels everywhere, `USD/DCR` → `USD/VAR`; remove the `24.42` literal + `xcBot.Conversion` (Monetarium has no listing — rate is manual-only, neutral default `1`); replace the Antminer DR5 / WhatsMiner D1 device dropdown with three manual number inputs (hashrate / power / price, neutral defaults 50 Th/s / 1500 W / 1500 USD); drop the `medium.com/decred` formula citation and replace with a neutral one-liner about the 50/50 hybrid model.
- Internal naming aligned in lockstep: `priceDCR` → `exchangeRate`, `dcrPrice` → `varPrice`, `additionalDcr` → `additionalVar`, `totalDCRPos`/`Label` → `totalVarPos`/`Label`; TurboQuery URL state gains `device_hashrate`/`_power`/`_price` and drops `device`.
- The hybrid `(6x⁵−15x⁴+10x³) / (6y⁵−15y⁴+10y³)` deterrence formula is unchanged. The "no-compute handler / browser-side math" pattern is preserved; the snapshot read shrinks from 6 fields to 5 (no `DCRPrice`). Page stays strictly VAR-domain.
- Wiki code-analysis refreshed (`flow.compact.md`, `flow.full.md`, `patterns.md`, `impact.md`) — drop references to `DCRPrice` / `xcBot` / `24.42` / `deviceList` / Antminer / D1 / medium.com/decred; resolve the exchange-bot-silently-zero risk; add a "Manual-Only Scenario Inputs" pattern.

Spec: [wiki/specs/attack-cost/spec.md](wiki/specs/attack-cost/spec.md).
Closes #285.

## Test plan
- [x] `cd cmd/dcrdata && npm run check` — clean for touched files.
- [x] `cd cmd/dcrdata && npm test` — 286/286 tests pass.
- [x] `cd cmd/dcrdata && go vet ./...` and `go test ./internal/explorer/...` — pass.
- [x] `cd cmd/dcrdata && npm run build && go build -o monetarium-explorer .` — both succeed.
- [x] Repo-wide grep — no residual `DCRPrice` / `24.42` / `Antminer` / `WhatsMiner` / `medium.com/decred` on this page's surface (template + controller + code-analysis docs).
- [x] Live testnet walkthrough via Playwright at `http://localhost:17778/attack-cost`:
  - [x] Zero console errors/warnings across the session.
  - [x] All coin labels render as `VAR`; exchange-rate unit is `USD/VAR`; default rate `1`.
  - [x] All three new manual device inputs render with neutral defaults and drive the PoW math (60 devices @ 50 Th/s, $90k cost, 90 kWh, $9 electricity → $94,509.45 PoW total).
  - [x] Changing Exchange Rate 1 → 5 scales PoS total 5× (URL gains `?price=5`).
  - [x] Changing Device Hashrate 50 → 100 halves device count + cost + kWh + electricity (URL gains `&device_hashrate=100`).
  - [x] Slider 0.5 → 0.3 → 0.02 round-trips correctly; target_pos input mirrors.
  - [x] "Attack not possible" warning fires when `varNeed > coinSupply` and the total-cost container goes red; clears (d-none + neutral color) at lower target_pos.
  - [x] Dark theme renders cleanly — text contrast OK, new inputs visible, red warning legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)