### PR TITLE
wiki/code-analysis: add /side, /disapproved, /decodetx, /ticketpool traces + refresh /ticketpricewindows

### DIFF
--- a/wiki/code-analysis/decodetx/flow.compact.md
+++ b/wiki/code-analysis/decodetx/flow.compact.md
@@ -1,0 +1,26 @@
+# Decode/Broadcast Tx (`/decodetx`) — Compact
+
+**Flow:** `GET /decodetx` → `DecodeTxPage` → `rawtx.tmpl` (form only, no data); interactive `<textarea>` + Decode/Broadcast buttons → `messagesocket_service.send({event,message})` → `/ws` → `RootWebsocket` `switch msg.EventId` → `dataSource.DecodeRawTransaction`/`SendRawTransaction` (`ChainDB` → node RPC `decoderawtransaction`/`sendrawtransaction`) → JSON pretty-print → `{EventId: <id>+"Resp", Message}` → `rawtx_controller` `<pre>.textContent = evt`. A parallel handler exists at `/ps` ([pubsub/pubsubhub.go:291-317](../../../pubsub/pubsubhub.go#L291-L317)); `sendtx` is also exposed as `POST /insight/api/tx/send`.
+
+**Key architectural patterns:**
+
+- **No-data HTML shell + WS-only data path.** The HTTP handler renders a static form (`*CommonPageData` only). Unlike block/tx/address pages, there is no `pageData` mutation, no template/WS parity contract, no `data-*` payload. All real I/O happens on `/ws`. This is the simplest server-rendered page in the codebase by data surface, and the **only user-driven write path to the node**.
+- **Three independent transports of the same RPC.** `decodetx`/`sendtx` are implemented in (1) explorer WS `/ws` (`{EventId, Message}` envelope), (2) pubsub WS `/ps` (`{ID, RequestID, Data, Success}` envelope), and (3) Insight REST `POST /insight/api/tx/send` (broadcast only). They share `ChainDB.{Decode,Send}RawTransaction` but have **separate envelopes, separate size limits (`1<<20` vs `psh.wsHub.requestLimit` vs `iapi.params.MaxTxSize`), and separate error-string conventions**.
+- **Same-event success/error multiplexing.** Server responds on `<event>+"Resp"` for both success and failure; the body is a free string. The JS controller treats the body as opaque text — no parsing, no `innerHTML`, no DOM template cloning (correctly, since C6 doesn't apply to raw text dumps).
+- **Multi-coin pass-through.** `chainjson.Vout` already has the dual shape (`Value` float64 VAR-only `omitempty` + `SKAValue` string SKA-only + `CoinType`). The explorer marshals `*TxRawResult` to JSON verbatim, so SKA precision is preserved by accident of the data path being read-only.
+
+**Critical constraints:**
+
+- **C1** is preserved by pass-through. Any future intermediate code that reads `Vout.Value` as the canonical amount for a SKA output silently zeros it.
+- **C2** dual-pipeline applies: `/ws` and `/ps` handler arms must change together; mocks live only in `explorer_test.go`.
+- The 1 MB oversize branch on `/ws` sets a message then `continue`s — **the error never reaches the client** (silent failure).
+- This is the **only write surface** in the page tier. No per-request auth/gate beyond size; `autofocus` + Enter on textarea sends `decodetx`, broadcast still requires explicit click.
+
+**Mutation checklist (touching `/decodetx`):**
+
+1. Rename `decodetx`/`sendtx` strings? Update 5 sites: `rawtx.tmpl` `data-event-id` (×3), `websockethandlers.go` case, `pubsubhub.go` case, `pstypes.eventIDs` (`SigDecodeTx`/`SigSendTx`), `rawtx_controller.js` `registerEvtHandler` (`decodetxResp`/`sendtxResp`).
+2. Change `DecodeRawTransaction`/`SendRawTransaction` interface? Update **two** interface decls (explorer.go:111, pubsubhub.go:51), `ChainDB` impl in `db/dcrpg/`, `mockDataSource` in `explorer_test.go`, and `iapi.BlockData.SendRawTransaction` caller in `insight/apiroutes.go`.
+3. Touch `*chainjson.TxRawResult.Vout`? Confirm `Value omitempty` + `SKAValue` + `CoinType` invariant still holds end-to-end; do NOT introduce float conversion on the SKA path.
+4. Adjust size limits? Three independent values (`1<<20` in explorer, `psh.wsHub.requestLimit` in pubsub, `iapi.params.MaxTxSize` in Insight). No shared constant.
+5. Add structured data to the response? You'll be the first to depend on the response *shape* (currently it's just text). Either keep `<pre>.textContent` (no XSS surface) or adopt C6 cloning + parsed payload — don't mix.
+6. Delete or rename the route? Also update the legacy `/explorer/decodetx → /decodetx` redirect in `explorer.go:980`.

--- a/wiki/code-analysis/decodetx/flow.full.md
+++ b/wiki/code-analysis/decodetx/flow.full.md
@@ -1,0 +1,256 @@
+# Decode/Broadcast Tx (`/decodetx`) — Full Flow
+
+## Section 1 — Overview
+
+`/decodetx` is the explorer's only **user-driven write path to the node**. The HTTP handler is a near-empty HTML form: all real work happens over the explorer WebSocket (`/ws`). The page lets a user
+
+- paste a raw transaction hex blob and either **decode** it (RPC `decoderawtransaction`, read-only) or
+- **broadcast** it (RPC `sendrawtransaction`, mutates node mempool).
+
+The same operations are exposed over a second WebSocket transport (`/ps`, pubsub) with a different envelope shape, and the broadcast operation is additionally exposed as `POST /insight/api/tx/send`. The page itself uses only `/ws`.
+
+The HTTP handler renders no transaction data — the page is a shell. Unlike block/tx/address pages, there is no template payload, no `commonData` mutation, and no shared `pageData` state. The flow is purely interactive client→server→node→client over a single WS channel.
+
+## Section 2 — End-to-End Data Flow
+
+```
+                   HTTP (one-shot, no payload)
+Browser ── GET /decodetx ──▶ DecodeTxPage ──▶ templates.exec("rawtx") ──▶ rawtx.tmpl (form only)
+
+                   Interactive: WebSocket /ws
+Browser textarea ──▶ rawtx_controller.send(e)
+   │   {event: "decodetx" | "sendtx", message: <hex>}
+   ▼
+messagesocket_service.send ─JSON over WS──▶ RootWebsocket recv goroutine (explorer/websockethandlers.go:80)
+                                                │
+                            switch msg.EventId  ▼
+                            ┌───────────────────────────────┐
+                            │ "decodetx" → dataSource       │
+                            │   .DecodeRawTransaction       │── ChainDB.DecodeRawTransaction
+                            │ "sendtx"   → dataSource       │   (db/dcrpg/pgblockchain.go:7367)
+                            │   .SendRawTransaction         │── ChainDB.SendRawTransaction
+                            └───────────────────────────────┘   (db/dcrpg/insightapi.go:49)
+                                                │                       │
+                                                ▼                       ▼
+                                  pgb.Client.DecodeRawTransaction   pgb.Client.SendRawTransaction
+                                  (RPC: decoderawtransaction)       (RPC: sendrawtransaction, 5s ctx timeout)
+                                                │                       │
+                                                ▼                       ▼
+                              *chainjson.TxRawResult            txhash string
+                              json.MarshalIndent → string       "Transaction sent: <hash>" string
+                                                │                       │
+                                                └───────┬───────────────┘
+                                                        ▼
+                              webData = {EventId: msg.EventId+"Resp", Message: <body>}
+                                                        │
+                                                        ▼
+                                       websocket.JSON.Send (ws)
+                                                        ▼
+Browser onmessage ──▶ forward(json.event, json.message) ──▶ rawtx_controller handler
+   • "decodetxResp" → header="Decoded tx",   <pre>.textContent = msg
+   • "sendtxResp"   → header="Sent tx",      <pre>.textContent = msg
+```
+
+The second transport (`/ps`) follows the same RPC path but wraps the response in a richer envelope (`{ID, RequestID, Data, Success}`); see Section 4.
+
+## Section 3 — Per-Layer Breakdown
+
+### 3.1 HTTP page render (server)
+
+**Location:**
+
+- Route: [cmd/dcrdata/main.go:783](../../../cmd/dcrdata/main.go#L783) — `r.Get("/decodetx", explore.DecodeTxPage)`.
+- Legacy redirect: [cmd/dcrdata/internal/explorer/explorer.go:980](../../../cmd/dcrdata/internal/explorer/explorer.go#L980) — `exp.Mux.Get("/decodetx", redirect("decodetx"))` (handles `/explorer/decodetx → /decodetx`).
+- Handler: [cmd/dcrdata/internal/explorer/explorerroutes.go:1897](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L1897) — `DecodeTxPage`.
+- Template: [cmd/dcrdata/views/rawtx.tmpl](../../../cmd/dcrdata/views/rawtx.tmpl).
+
+**Data structures:** none. The handler renders with only `*CommonPageData` (navbar/footer chrome, `Tip`, `NetName`, `Links`, etc.):
+
+```go
+str, err := exp.templates.exec("rawtx", struct {
+    *CommonPageData
+}{
+    CommonPageData: exp.commonData(r),
+})
+```
+
+**Transformations:** none specific to this page. The template body has no Go expressions that touch transaction data — the form (`<textarea>`, two buttons, output `<pre>`) is static.
+
+### 3.2 Frontend (Stimulus + WebSocket client)
+
+**Location:**
+
+- Stimulus controller: [cmd/dcrdata/public/js/controllers/rawtx_controller.js](../../../cmd/dcrdata/public/js/controllers/rawtx_controller.js).
+- WS client singleton: [cmd/dcrdata/public/js/services/messagesocket_service.js](../../../cmd/dcrdata/public/js/services/messagesocket_service.js).
+- WS bootstrap: [cmd/dcrdata/public/index.js:46-50](../../../cmd/dcrdata/public/index.js#L46-L50) — connects to `${proto}://${host}/ws` after a 300 ms delay.
+- Connection status UI: [cmd/dcrdata/public/js/controllers/connection_controller.js](../../../cmd/dcrdata/public/js/controllers/connection_controller.js) (page-wide footer indicator).
+
+**Targets** (declared on the form):
+
+| Target               | DOM            | Role                              |
+|----------------------|----------------|-----------------------------------|
+| `rawTransaction`     | `<textarea>`   | Hex input.                        |
+| `decode`             | `<button>`     | Submits `event: "decodetx"`.      |
+| `broadcast`          | `<button>`     | Submits `event: "sendtx"`.        |
+| `decodeHeader`       | `<h4>`         | Result section title.             |
+| `decodedTransaction` | `<pre>`        | Response body (raw text).         |
+
+**Transformations:**
+
+- `send(e)` (controller line 28) is bound to both `keypress` on the textarea (Enter only — `keyCode === 13`) and `click` on either button. It reads `data-event-id` from the source element (`"decodetx"` for textarea+Decode, `"sendtx"` for Broadcast), and calls `ws.send(eventID, this.rawTransactionTarget.value)`.
+- The controller wires two response handlers in `connect()`:
+
+  ```js
+  ws.registerEvtHandler('decodetxResp', (evt) => {
+    this.decodeHeaderTarget.textContent = 'Decoded tx'
+    fadeIn(this.decodedTransactionTarget)
+    this.decodedTransactionTarget.textContent = evt
+  })
+  ws.registerEvtHandler('sendtxResp', (evt) => {
+    this.decodeHeaderTarget.textContent = 'Sent tx'
+    ...
+  })
+  ```
+
+  Both handlers set `<pre>.textContent = evt` directly — no JSON parsing, no DOM templating, **no C6 cloning** (which is correct because the payload is intentionally a text blob, not structured data).
+
+- `ws.send` (service line 46) JSON-encodes `{event, message}` and pushes it onto a 5-deep pre-connect queue if the socket isn't open yet.
+- `ws.connection.onmessage` parses incoming JSON once per frame and dispatches to handlers by `event` string.
+
+### 3.3 WebSocket server — explorer (`/ws`)
+
+**Location:** [cmd/dcrdata/internal/explorer/websockethandlers.go:71-237](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L71-L237) — receive goroutine inside `RootWebsocket`.
+
+**Data structures:**
+
+- Request envelope: `WebSocketMessage{EventId string, Message string}` — `message` is hex on input.
+- Server-side budget: `requestLimit := 1 << 20` (1 MB) applied both to `ws.MaxPayloadBytes` and as a length check on `msg.Message`.
+
+**Transformations:**
+
+- `case "decodetx":` calls `exp.dataSource.DecodeRawTransaction(ctx, msg.Message)`. On success, `json.MarshalIndent(tx, "", "    ")` produces a pretty JSON string; that string becomes `webData.Message`. On error, `webData.Message = fmt.Sprintf("Error: %v", err)` (still success-framed — see Section 7).
+- `case "sendtx":` calls `exp.dataSource.SendRawTransaction(ctx, msg.Message)`. On success: `webData.Message = fmt.Sprintf("Transaction sent: %s", txid)`. On error: `"Error: %v"`.
+- Outbound envelope: `EventId = msg.EventId + "Resp"` (so the response event name is `decodetxResp` / `sendtxResp`); body is serialized via `websocket.JSON.Send`.
+
+### 3.4 Data source — ChainDB
+
+**Location:**
+
+- Interface (explorer-side): [cmd/dcrdata/internal/explorer/explorer.go:111-112](../../../cmd/dcrdata/internal/explorer/explorer.go#L111-L112).
+- Interface (pubsub-side): [pubsub/pubsubhub.go:51-52](../../../pubsub/pubsubhub.go#L51-L52).
+- Decode impl: [db/dcrpg/pgblockchain.go:7365-7379](../../../db/dcrpg/pgblockchain.go#L7365-L7379) — `ChainDB.DecodeRawTransaction`.
+- Send impl: [db/dcrpg/insightapi.go:47-63](../../../db/dcrpg/insightapi.go#L47-L63) — `ChainDB.SendRawTransaction`.
+
+**Transformations:**
+
+- `DecodeRawTransaction`: `hex.DecodeString(txhex)` → `pgb.Client.DecodeRawTransaction(ctx, bytes)` (node RPC). Returns `*chainjson.TxRawResult` (defined in [monetarium-node/rpc/jsonrpc/types/chainsvrresults.go:410](../../../../monetarium-node/rpc/jsonrpc/types/chainsvrresults.go#L410)).
+- `SendRawTransaction`: `txhelpers.MsgTxFromHex(txhex)` (parses and validates the wire format) → `context.WithTimeout(ctx, 5*time.Second)` → `pgb.Client.SendRawTransaction(ctx, msg, true)` (the `true` is `allowHighFees`). Returns the broadcast tx hash.
+
+**Multi-coin shape (important for C1):** `chainjson.Vout` already has the dual-precision shape required for SKA:
+
+```go
+type Vout struct {
+    Value        float64            `json:"value,omitempty"`    // VAR only (omitted for SKA)
+    SKAValue     string             `json:"skavalue,omitempty"` // SKA only (atoms as string)
+    N            uint32             `json:"n"`
+    Version      uint16             `json:"version"`
+    CoinType     uint8              `json:"cointype"`
+    ScriptPubKey ScriptPubKeyResult `json:"scriptPubKey"`
+}
+```
+
+Because the explorer passes this through verbatim as a JSON blob (it never reads `Value` itself), SKA precision is preserved end-to-end **as long as no future intermediate code calls `*TxRawResult` field accessors and converts SKA atoms via float**.
+
+### 3.5 Mocks
+
+`DecodeRawTransaction` / `SendRawTransaction` have one mock pair:
+
+- [cmd/dcrdata/internal/explorer/explorer_test.go:134-139](../../../cmd/dcrdata/internal/explorer/explorer_test.go#L134-L139) — `mockDataSource`.
+
+Pubsub has no separate mock for these two methods (its test suite does not exercise the decodetx/sendtx branch).
+
+### 3.6 Alternate transports (same RPC, different envelope)
+
+- **Pubsub `/ps`** ([pubsub/pubsubhub.go:291-317](../../../pubsub/pubsubhub.go#L291-L317)): same `case "decodetx" / "sendtx"`, same RPC calls, but the response is a `pstypes.ResponseMessage` (`{ID, RequestID, Data, Success}`) rather than the explorer's flat `{EventId, Message}`. The pubsub branch uses `"error: ..."` (lowercase, no `Error:` prefix) and sets `Success: true` explicitly on the success path.
+- **Insight REST `POST /insight/api/tx/send`** ([cmd/dcrdata/internal/api/insight/apiroutes.go:329-364](../../../cmd/dcrdata/internal/api/insight/apiroutes.go#L329-L364)): broadcasts only (no decode). Enforces `iapi.params.MaxTxSize` separately from the WS 1 MB limit, returns `{"txid": "<hash>"}` JSON.
+
+## Section 4 — Cross-Layer Dependencies
+
+| Coupling                          | Where                                                                                            | Notes                                                                                                                          |
+|-----------------------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `event` string contract           | Frontend `data-event-id` (rawtx.tmpl:15,22,29) ↔ server `switch msg.EventId` (websockethandlers.go:96) ↔ pubsub `case "decodetx"` (pubsubhub.go:291) ↔ `SigDecodeTx="decodetx"` (pubsub/types/pubsub_types.go:125-127) | Free string. A typo on either side silently routes to the `default` handler ("Unrecognized event ID"); no compile-time check. |
+| Response event suffix `"Resp"`     | Server appends in [websockethandlers.go:231](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L231); client registers `decodetxResp`/`sendtxResp` in [rawtx_controller.js:11,16](../../../cmd/dcrdata/public/js/controllers/rawtx_controller.js#L11-L16). | The suffix is the only mechanism distinguishing request from response on the same WS channel. |
+| `*chainjson.TxRawResult` shape    | Node ([monetarium-node/.../chainsvrresults.go:410](../../../../monetarium-node/rpc/jsonrpc/types/chainsvrresults.go#L410)) → `pgb.Client.DecodeRawTransaction` → marshaled verbatim to the browser. | Multi-coin shape (`Value` float64 VAR-only + `SKAValue` string SKA-only + `CoinType`) is owned by the node; the explorer doesn't normalize. |
+| Two parallel WS handlers          | `RootWebsocket` (explorer) and `pubsubhub.WebSocketHandler` (pubsub) implement `decodetx`/`sendtx` independently. | Duplicate switch arms must change together; the response envelopes (`{event,message}` vs `{ID,RequestID,Data,Success}`) are NOT interchangeable. |
+| 1 MB WS read limit                | [websockethandlers.go:65-67,90-94](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L65-L94) (hard-coded `1<<20`); pubsub uses `psh.wsHub.requestLimit`. | Insight REST uses a separate budget (`iapi.params.MaxTxSize`). Three independent size limits, no shared constant. |
+| Mock parity                       | `mockDataSource.{DecodeRawTransaction,SendRawTransaction}` (explorer_test.go).                   | If the interface signature changes, the mock must update or the test package fails to compile. |
+| WS bootstrap                      | [public/index.js:46-50](../../../cmd/dcrdata/public/index.js#L46-L50) connects to `/ws` and replays a 5-deep queue on `onopen`. | If the user clicks Decode before the socket opens, the message is queued; if more than 5 are queued, the oldest is shifted out silently. |
+
+## Section 5 — Critical Constraints
+
+| ID | Applies how |
+|----|-------------|
+| **[C1 — numeric precision](../../core/constraints.md#c1-numeric-precision--bifurcation-applies-to-block-tx-frontend)** | Node returns `Vout.Value float64` for VAR only and `Vout.SKAValue string` for SKA (atoms). The explorer passes the struct through `json.MarshalIndent` → string verbatim, so precision is preserved. Any future intermediate processing of `Value` for a SKA Vout (or float conversion of `SKAValue`) is silent corruption. |
+| **[C2 — dual pipeline mutation](../../core/constraints.md#c2-dual-pipeline-mutation-applies-to-block-tx)** | Two independent server-side handlers (`/ws` and `/ps`) implement decodetx/sendtx. They share the data-source method but have separate envelope formats, separate size limits, and separate error string conventions. Behavior changes must be applied to both. |
+| **[C3 — template/WS parity](../../core/constraints.md#c3-template--websocket-parity-applies-to-block-tx-frontend)** | Out of scope here: the template carries no data. All flow is WS-only, so there is no template/WS divergence risk on this page specifically. |
+| **C-implicit — write surface** | This is the **only user-facing write path** in the explorer to the node mempool (`sendrawtransaction`). Authentication/authorization is whatever the WS reverse proxy enforces — there is no per-request gate beyond the 1 MB size check. The textarea is `autofocus` and submits on Enter, so accidental broadcast is a UX consideration. |
+| **C-implicit — context lifetime** | `sendtx` uses `context.WithTimeout(ctx, 5*time.Second)` *inside* `ChainDB.SendRawTransaction`; `decodetx` uses the bare request context. A long-running node RPC for decode won't be timed out by the explorer (it relies on `wsReadTimeout`/`wsWriteTimeout` on the WS itself). |
+
+## Section 6 — Mutation Impact
+
+**When modifying anything related to `/decodetx`, check:**
+
+1. **Event-ID strings.** Renaming `"decodetx"` / `"sendtx"` requires changes in **all five** places: rawtx.tmpl `data-event-id` (3 occurrences: textarea, Decode button, Broadcast button — note Enter on textarea also fires `decodetx`), explorer `case` (websockethandlers.go), pubsub `case` (pubsubhub.go), `pstypes.eventIDs` map (`SigDecodeTx`/`SigSendTx`), and rawtx_controller.js `registerEvtHandler` calls (`decodetxResp`/`sendtxResp`). The response suffix `"Resp"` lives only on the server (`msg.EventId + "Resp"`); changing it requires a matching JS rename.
+2. **Interface signature.** `DecodeRawTransaction(ctx, txhex string) (*chainjson.TxRawResult, error)` is declared on **both** the explorer's `dataSource` interface (explorer.go:111) and the pubsub `sourceBase` interface (pubsubhub.go:51) — keep them in sync. The implementation is in `ChainDB` (db/dcrpg/pgblockchain.go:7367). Mocks live in explorer_test.go.
+3. **Response shape.** `*chainjson.TxRawResult` is the on-the-wire contract (as JSON text). Adding fields server-side is safe — the frontend just dumps the string. Removing or renaming fields breaks any external consumer that *does* parse, including future pages that might decode the same blob.
+4. **SKA precision.** The current code path is precision-safe by accident (pass-through string). The moment any intermediate code does `for _, vout := range tx.Vout { ... vout.Value ... }` and treats it as the canonical amount for SKA outputs, it silently corrupts atoms (`Value` is zero/omitted for SKA; `SKAValue` is the real atoms-as-string).
+5. **Size limit.** `requestLimit := 1 << 20` is local to `RootWebsocket`. The pubsub side uses `psh.wsHub.requestLimit` (separate value). The Insight REST side uses `iapi.params.MaxTxSize`. A consolidation effort that changes one limit should consider the other two.
+6. **Error semantics.** Both success and failure use the same `EventId+"Resp"` channel and the same header text ("Decoded tx" / "Sent tx") on the JS side. The frontend does not distinguish — see Section 7 pitfall 1.
+7. **Same-WS shared state.** The `RootWebsocket` connection that carries `decodetx`/`sendtx` *also* carries `newblock`, `mempool`, `newtxs`, etc. Changing the receive loop's request-size handling, error propagation, or `default` case affects every other client (homepage, mempool, visualblocks).
+
+### Silent failures
+
+- **Oversize request (>1 MB):** server sets `webData.Message = "Request too large"` then `continue` — the response is **never sent** because `webData.EventId` is set only in the trailing block. The client just sees nothing happen.
+- **`textContent = ''` on a `<textarea>`:** [rawtx_controller.js:34](../../../cmd/dcrdata/public/js/controllers/rawtx_controller.js#L34) clears `textContent` instead of `value`, so the textarea is **not actually cleared** after submit. Cosmetic but persistent.
+- **Pre-connect queue overflow:** `messagesocket_service.send` shifts the oldest queued message off when the buffer exceeds `maxQlength=5` ([messagesocket_service.js:48](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L48)). A rapid retry burst before WS open silently drops earlier attempts.
+- **SKA precision** if a future change parses `Value` for SKA Vouts (see C1 above).
+- **Pubsub vs explorer drift:** if a fix lands on `/ws` but not `/ps`, third-party tooling speaking the pubsub protocol gets stale behavior.
+
+### Hard failures
+
+- **Bad hex:** `hex.DecodeString` returns an error → `"Error: <message>"` flows back as `decodetxResp` (visible in the result `<pre>`, but heading still says "Decoded tx").
+- **Bad wire format on send:** `txhelpers.MsgTxFromHex` errors → `"Error: ..."` as `sendtxResp`.
+- **Node RPC timeout (sendtx, 5 s):** `pgb.Client.SendRawTransaction` returns timeout → `"Error: context deadline exceeded"`.
+- **Mock-signature mismatch:** changing the interface without updating `mockDataSource` fails `go test ./...` in `cmd/dcrdata/internal/explorer`.
+
+## Section 7 — Common Pitfalls
+
+1. **Assuming `decodetxResp` only fires on success.** The server uses the same event ID for both branches. A controller that styles or auto-parses the response on `decodetxResp` must inspect the message body for the `"Error: "` prefix. The current controller side-steps this by treating the body as opaque text and always showing the "Decoded tx" header — which is misleading on the error path but harmless.
+2. **Editing only the explorer's `case "decodetx"`.** The pubsub copy at [pubsub/pubsubhub.go:291](../../../pubsub/pubsubhub.go#L291) is structurally identical and has to track. There is no shared function between them; refactoring into a shared helper would reduce drift risk.
+3. **Treating the page like other explorer pages.** There is no `pageData`/`HomeInfo`/`commonData.X` to populate. Adding pre-decoded data to the server-rendered HTML would create the first template→WS parity dependency the page currently lacks (C3 trap).
+4. **Using `innerHTML` for the response (violating C6).** The current `<pre>.textContent = evt` is the right call — the response is intentionally raw text and contains potentially user-controlled hex/script content. Replacing it with `innerHTML` would open an XSS surface from a node-decoded `asm` or `addresses` string.
+5. **Coupling decode and send signatures.** They look alike but have different return types (`*TxRawResult` vs `string txid`) and different external surfaces (decode is internal-only, send is also exposed on `/insight/api/tx/send`). Don't refactor them behind a shared interface without updating the Insight REST caller.
+6. **Forgetting the legacy `/explorer/decodetx` route** ([explorer.go:980](../../../cmd/dcrdata/internal/explorer/explorer.go#L980)). It 308-redirects to `/decodetx`; if the canonical route is renamed, the redirect target must update too.
+7. **Cross-tx-coin assumption.** Per CLAUDE.md, a tx is always single-coin. If the decoded blob contains mixed `CoinType` Vouts, treat it as a node-side bug, not a feature; this page surfaces whatever the node returns without normalization.
+
+## Section 8 — Evidence
+
+- Route registration: [cmd/dcrdata/main.go:783](../../../cmd/dcrdata/main.go#L783); legacy redirect [cmd/dcrdata/internal/explorer/explorer.go:980](../../../cmd/dcrdata/internal/explorer/explorer.go#L980); WS routes [cmd/dcrdata/main.go:696-697](../../../cmd/dcrdata/main.go#L696-L697).
+- HTTP handler: [cmd/dcrdata/internal/explorer/explorerroutes.go:1895-1911](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L1895-L1911).
+- Template: [cmd/dcrdata/views/rawtx.tmpl](../../../cmd/dcrdata/views/rawtx.tmpl) (43 lines, no data bindings).
+- Explorer WS receive loop & cases: [cmd/dcrdata/internal/explorer/websockethandlers.go:71-237](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L71-L237), cases at lines 97 (`decodetx`) and 113 (`sendtx`).
+- Pubsub WS twin: [pubsub/pubsubhub.go:291-317](../../../pubsub/pubsubhub.go#L291-L317); signal constants [pubsub/types/pubsub_types.go:125-127](../../../pubsub/types/pubsub_types.go#L125-L127).
+- Data source interface: [cmd/dcrdata/internal/explorer/explorer.go:111-112](../../../cmd/dcrdata/internal/explorer/explorer.go#L111-L112); [pubsub/pubsubhub.go:51-52](../../../pubsub/pubsubhub.go#L51-L52).
+- Decode impl: [db/dcrpg/pgblockchain.go:7365-7379](../../../db/dcrpg/pgblockchain.go#L7365-L7379).
+- Send impl: [db/dcrpg/insightapi.go:47-63](../../../db/dcrpg/insightapi.go#L47-L63).
+- Insight REST send: [cmd/dcrdata/internal/api/insight/apiroutes.go:329-364](../../../cmd/dcrdata/internal/api/insight/apiroutes.go#L329-L364); route [cmd/dcrdata/internal/api/insight/apirouter.go:73](../../../cmd/dcrdata/internal/api/insight/apirouter.go#L73).
+- Node Vout/TxRawResult shape: [monetarium-node/rpc/jsonrpc/types/chainsvrresults.go:410-424](../../../../monetarium-node/rpc/jsonrpc/types/chainsvrresults.go#L410-L424) (TxRawResult) and lines 832-841 (Vout multi-coin fields).
+- Frontend controller: [cmd/dcrdata/public/js/controllers/rawtx_controller.js](../../../cmd/dcrdata/public/js/controllers/rawtx_controller.js).
+- WS client service: [cmd/dcrdata/public/js/services/messagesocket_service.js](../../../cmd/dcrdata/public/js/services/messagesocket_service.js).
+- WS bootstrap: [cmd/dcrdata/public/index.js:37-64](../../../cmd/dcrdata/public/index.js#L37-L64).
+- Mock data source: [cmd/dcrdata/internal/explorer/explorer_test.go:134-139](../../../cmd/dcrdata/internal/explorer/explorer_test.go#L134-L139).
+
+See also:
+- /wiki/code-analysis/transaction/flow.full.md (shares-pattern-with: `*chainjson.TxRawResult`/`Vout` shape consumed by the read-only `/tx` page; same multi-coin Vout contract)
+- /wiki/code-analysis/page-rendering/patterns.md (shares-pattern-with: WS event-string contract, but `/decodetx` is the inverse — the only page where shared `pageData` is NOT used)
+- /wiki/core/constraints.md (depends-on: C1 SKA atoms-as-string preserved via pass-through; depends-on: C2 dual `/ws` + `/ps` handler duplication)

--- a/wiki/code-analysis/decodetx/impact.md
+++ b/wiki/code-analysis/decodetx/impact.md
@@ -1,0 +1,140 @@
+# `/decodetx` — Mutation Impact
+
+Blast radius for changes to the `/decodetx` page, the `decodetx`/`sendtx` WS events, and the underlying `DecodeRawTransaction` / `SendRawTransaction` data-source methods.
+
+## R1 — Event-string drift across five sites
+
+**Trigger:** renaming `"decodetx"` or `"sendtx"` (or their `Resp` suffix).
+
+**Affected sites (all must change together):**
+
+- HTML form `data-event-id` attributes: textarea, Decode button, Broadcast button in [cmd/dcrdata/views/rawtx.tmpl:15,22,29](../../../cmd/dcrdata/views/rawtx.tmpl#L15).
+- Explorer WS `switch` arms: [cmd/dcrdata/internal/explorer/websockethandlers.go:97](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L97), [:113](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L113).
+- Pubsub WS `switch` arms: [pubsub/pubsubhub.go:291](../../../pubsub/pubsubhub.go#L291), [:309](../../../pubsub/pubsubhub.go#L309).
+- `pstypes.eventIDs` map: [pubsub/types/pubsub_types.go:125-127](../../../pubsub/types/pubsub_types.go#L125-L127) (`SigDecodeTx`, `SigSendTx`).
+- JS handler registration / deregistration: [cmd/dcrdata/public/js/controllers/rawtx_controller.js:11,16,24-25](../../../cmd/dcrdata/public/js/controllers/rawtx_controller.js#L11-L25).
+
+**Failure mode:** silent. A typo in any one site routes to the `default` case server-side (which logs `"Unrecognized event ID"` and skips response) or to no handler at all client-side (the `forward` helper short-circuits when `handlers[event] === undefined`). The Decode/Broadcast button just appears to do nothing.
+
+**Description:** the event string is an unstructured contract. There is no compile-time check between the template `data-event-id`, the Stimulus controller's `registerEvtHandler` argument, and the Go `switch` constant. The `+ "Resp"` suffix is purely server-appended ([websockethandlers.go:231](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L231)).
+
+## R2 — Oversize request silently dropped
+
+**Trigger:** any path that sends `> 1 MB` over `/ws` (including pasting a large blob into the decode textarea).
+
+**Affected flow:** [cmd/dcrdata/internal/explorer/websockethandlers.go:90-94](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L90-L94).
+
+**Failure mode:** silent. Code path:
+
+```go
+if len(msg.Message) > requestLimit {
+    log.Debug("Request size over limit")
+    webData.Message = "Request too large"
+    continue   // ← jumps back to ws.Receive; never reaches webData.EventId = msg.EventId + "Resp"
+}
+```
+
+Because `webData.EventId` is only set in the trailing block (after the `switch`), the response is never sent. The client sees no `decodetxResp`/`sendtxResp` and the result `<pre>` stays empty. The result UX is identical to "WebSocket disconnected" or "server hung", but logs only show a `Debug` line.
+
+**Description:** the early-exit kills the response framing along with the request handling. Fixing this in isolation (e.g. setting `webData.EventId = msg.EventId + "Resp"` before `continue`) is safe but small; the broader fix is moving the size check into the per-case block so it can produce a proper structured error.
+
+## R3 — Dual-pipeline drift between `/ws` and `/ps` handlers
+
+**Trigger:** changing the decode or send handler in one of the two WS servers (explorer or pubsub) without changing the other.
+
+**Affected flows:**
+
+- [/wiki/code-analysis/decodetx/flow.full.md](flow.full.md) §3.3 (explorer), §3.6 (pubsub).
+- Implementations: [cmd/dcrdata/internal/explorer/websockethandlers.go:97-120](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L97-L120) vs [pubsub/pubsubhub.go:291-317](../../../pubsub/pubsubhub.go#L291-L317).
+
+**Failure mode:** silent for third-party pubsub clients (the browser-facing flow is unaffected; the divergence shows up only against `/ps` consumers). C2-class.
+
+**Description:** the two handlers are structurally similar but not identical:
+
+| Aspect              | `/ws` (explorer)                                  | `/ps` (pubsub)                                                                       |
+|---------------------|---------------------------------------------------|--------------------------------------------------------------------------------------|
+| Envelope            | `{EventId, Message: <string>}`                    | `pstypes.ResponseMessage{ID, RequestID, Data: <string>, Success: bool}`              |
+| Success Data        | pretty-indented JSON string                       | pretty-indented JSON string                                                          |
+| Error string prefix | `"Error: %v"`                                     | `"error: %v"` (lowercase, with `Success: false`)                                     |
+| Size budget         | `requestLimit := 1 << 20` (hard-coded local)      | `psh.wsHub.requestLimit` (config-driven)                                             |
+| `Success` flag      | n/a (string-only)                                 | explicit boolean — set `true` only on success                                        |
+
+A refactor that only touches one side leaves the other speaking a stale dialect.
+
+## R4 — Interface signature fan-out
+
+**Trigger:** changing the signature of `DecodeRawTransaction` or `SendRawTransaction`.
+
+**Affected sites:**
+
+- Interface decl (explorer): [cmd/dcrdata/internal/explorer/explorer.go:111-112](../../../cmd/dcrdata/internal/explorer/explorer.go#L111-L112).
+- Interface decl (pubsub): [pubsub/pubsubhub.go:51-52](../../../pubsub/pubsubhub.go#L51-L52).
+- Interface decl (insight, send only): [cmd/dcrdata/internal/api/insight/apiroutes.go:51](../../../cmd/dcrdata/internal/api/insight/apiroutes.go#L51).
+- Implementation (decode): [db/dcrpg/pgblockchain.go:7367](../../../db/dcrpg/pgblockchain.go#L7367).
+- Implementation (send): [db/dcrpg/insightapi.go:49](../../../db/dcrpg/insightapi.go#L49).
+- Caller (insight REST send): [cmd/dcrdata/internal/api/insight/apiroutes.go:349](../../../cmd/dcrdata/internal/api/insight/apiroutes.go#L349).
+- Mock: [cmd/dcrdata/internal/explorer/explorer_test.go:134-139](../../../cmd/dcrdata/internal/explorer/explorer_test.go#L134-L139).
+
+**Failure mode:** loud (`go build` / `go test` failure). The two interface decls must be kept identical; the test package fails to compile if `mockDataSource` lags.
+
+**Description:** the only sites that consume these methods at runtime are the three transports (`/ws`, `/ps`, `/insight/api/tx/send`); there is no other caller. The mock fan-out is shallow (one type, two methods).
+
+## R5 — SKA precision loss on the response path (latent)
+
+**Trigger:** any code change that reads `*chainjson.TxRawResult.Vout[i].Value` or converts `Vout[i].SKAValue` via `strconv.ParseFloat` / `json.Number.Float64()` *between* the node RPC and the marshaled response.
+
+**Affected flow:** [/wiki/code-analysis/decodetx/flow.full.md](flow.full.md) §3.4, §5.
+
+**Failure mode:** silent. Atom precision drops at the float boundary; the visible JSON in the page `<pre>` shows truncated/zeroed amounts only on SKA Vouts (`CoinType != 0`).
+
+**Description:** the current flow is precision-safe by virtue of being pass-through — the explorer marshals the struct and forwards the string. The node already produces `Value float64 omitempty` (omitted for SKA) and `SKAValue string` (atoms, BigInt-safe). Any helper that hand-reads fields ("let me decorate the response with the address summary…", "let me compute the total…") becomes the first SKA-corruption site on this path. This is C1.
+
+## R6 — Same-event success/error multiplexing
+
+**Trigger:** a change that assumes `decodetxResp` (or `sendtxResp`) signals success.
+
+**Affected sites:** [rawtx_controller.js:11-20](../../../cmd/dcrdata/public/js/controllers/rawtx_controller.js#L11-L20) (current consumer treats body as opaque text — safe), plus any future controller or integration test.
+
+**Failure mode:** silent. Code that, say, parses the response body as JSON will throw on `"Error: <message>"` and report a generic JS error instead of the real backend message.
+
+**Description:** the server uses the same `EventId + "Resp"` for both branches and only signals failure via a `"Error: "` (explorer) or `"error: "` (pubsub) prefix in the body string. The frontend's current "always show 'Decoded tx' as the header" is misleading on the error path but harmless; any future logic that branches on success/failure must inspect the body, not the event name.
+
+## R7 — Receive-loop shared state
+
+**Trigger:** changes to the WS receive goroutine in `RootWebsocket` (the `for { ws.Receive → switch }` loop), `wsReadTimeout`/`wsWriteTimeout`, the `requestLimit` constant, or the `default` case.
+
+**Affected flows:** every page that uses `/ws` — `/`, `/visualblocks`, `/mempool`, `/ticketpool`, plus the connection indicator on every footer.
+
+**Failure mode:** mixed. A panic in any case kills the receive goroutine for that client only (and `closeWS` is `defer`-ed at the top), so the blast is "this tab loses WS until reload". A broader change (locking, signal channel, deadline) leaks into every page-level WS contract.
+
+**Description:** `/decodetx` shares the receive loop with the live-update fan-out (the `loop:` switch below the receive goroutine). The two halves run as separate goroutines per client but share the `ws *websocket.Conn`, `clientData`, and `closeWS` closure. Be careful when adding new cases that touch shared state (locks, the mempool inventory, `exp.pageData`).
+
+## R8 — Legacy `/explorer/decodetx` redirect
+
+**Trigger:** renaming or removing the `/decodetx` route.
+
+**Affected sites:** [cmd/dcrdata/main.go:783](../../../cmd/dcrdata/main.go#L783) (canonical) and [cmd/dcrdata/internal/explorer/explorer.go:980](../../../cmd/dcrdata/internal/explorer/explorer.go#L980) (`exp.Mux.Get("/decodetx", redirect("decodetx"))` — serves `/explorer/decodetx` → `/decodetx`).
+
+**Failure mode:** loud (the redirect 308s to a 404).
+
+**Description:** `exp.Mux` is the legacy `/explorer/*` sub-mux. The redirect's argument string `"decodetx"` is used to construct the new target URL inside `redirect(...)`. Don't change one without the other.
+
+## Safe-change checklist
+
+When modifying `/decodetx`:
+
+1. [ ] Did the change touch `data-event-id` strings? Update all five sites (rawtx.tmpl ×3, websockethandlers.go, pubsubhub.go, pstypes.eventIDs, rawtx_controller.js).
+2. [ ] Did the change touch the interface? Update both interface decls + `ChainDB` impl + `mockDataSource` + (for send only) the Insight REST caller.
+3. [ ] If the change adds an intermediate field read on `*chainjson.TxRawResult`, does it preserve SKA precision? (Use `SKAValue` string, not `Value`, for `CoinType != 0`.)
+4. [ ] If the change introduces structured frontend rendering of the response, did it switch from `<pre>.textContent = evt` to C6 template cloning + parsed JSON?
+5. [ ] If the change touches the receive loop in `RootWebsocket`, did you verify the live-update side (`loop:`) and every other page that uses `/ws` (homepage, mempool, visualblocks, ticketpool)?
+6. [ ] If the change touches the 1 MB limit, did you adjust the pubsub `psh.wsHub.requestLimit` and Insight `iapi.params.MaxTxSize` to match (or document the divergence)?
+7. [ ] If the route name or path changed, did you update the `/explorer/decodetx` redirect in `explorer.go:980`?
+8. [ ] If the change affects the pubsub or Insight twin, did you preserve their distinct envelopes (`{ID, RequestID, Data, Success}` vs JSON `{txid}`)?
+
+See also:
+- /wiki/code-analysis/decodetx/flow.full.md (derived-from)
+- /wiki/code-analysis/decodetx/patterns.md (shares-pattern-with: P1 form-shell, P2 three-transport, P3 multi-coin pass-through)
+- /wiki/code-analysis/page-rendering/patterns.md (shares-pattern-with: shared `RootWebsocket` receive loop)
+- /wiki/code-analysis/transaction/impact.md (shares-pattern-with: `*chainjson.TxRawResult.Vout` multi-coin contract)
+- /wiki/core/constraints.md (depends-on: C1 SKA precision, C2 dual-pipeline, C6 in-DOM cloning, C7 coin-type labels)

--- a/wiki/code-analysis/decodetx/patterns.md
+++ b/wiki/code-analysis/decodetx/patterns.md
@@ -1,0 +1,71 @@
+# `/decodetx` — Reusable Patterns
+
+The `/decodetx` flow is unusual in the codebase: a server-rendered page whose HTML handler carries **no data**, and whose entire interaction model lives on the WebSocket as request/response RPC-over-WS. The patterns below are the reusable shapes worth preserving when adding similar interactive pages (e.g. the existing `/verify-message` POST, or any future "submit-a-blob, get-a-result" tool).
+
+## P1 — HTML form as a pure shell over WS-RPC
+
+**Shape.** The HTTP handler returns a static form bound to a Stimulus controller; the controller serializes form input into `{event, message}` and sends it on the page-wide WS singleton. The server receives on `RootWebsocket`'s `switch msg.EventId`, runs the operation, and replies on `<event>+"Resp"`.
+
+**Why it recurs.** It sidesteps three things the standard page-render path imposes:
+
+- No `pageData` lock contention (the receive goroutine doesn't touch `exp.pageData`).
+- No template/WS parity (C3) because the template has no fields to mirror.
+- No per-action route (no second `webMux.Post(...)` + CSRF + 308 handling).
+
+**Constraints wherever this pattern is used:**
+
+- The WS connection is **shared with every other page** — `RootWebsocket` also carries `newblock`, `mempool`, `newtxs`, `getmempooltrimmed`, etc. A long-running synchronous case blocks the receive goroutine for that client only (each WS client has its own `go func()`), but a panic does not — it kills the connection for *that client* (defer `closeWS()`).
+- The response is delivered on `<event>+"Resp"` (server appends literally `+ "Resp"` to the inbound `EventId`). The frontend must register `<event>Resp` handlers, not `<event>` handlers.
+- The 1 MB request limit (`requestLimit := 1 << 20`) lives **inside `RootWebsocket`**; the pubsub twin (`/ps`) has its own `psh.wsHub.requestLimit`. There is no shared constant.
+- An oversize message is **silently dropped** (the server sets a message but the trailing send block only runs when `EventId` is set after the switch — see Impact). Operations that need user-visible failure on oversize must either lower their own threshold or wrap the size check before the switch.
+
+Sites: `/decodetx` (this flow), `getmempooltxs` / `getmempooltrimmed` (same receive loop, no HTML form, used by visualblocks & mempool), `getticketpooldata`.
+
+## P2 — Three-transport surface for the same node RPC
+
+**Shape.** A single `ChainDB` method (here: `DecodeRawTransaction`, `SendRawTransaction`) is wrapped by:
+
+- An explorer WS case in `RootWebsocket` (envelope: `{EventId, Message}`, body is a free string).
+- A pubsub WS case in `pubsubhub` (envelope: `pstypes.ResponseMessage{ID, RequestID, Data, Success}`, body is structured).
+- An Insight REST handler (envelope: JSON, with its own input-size budget).
+
+**Why it recurs.** Different consumer classes (browser, third-party WS subscriber, BTC-Pay-style Insight client) want different envelopes. The shared piece is the `ChainDB` method — the divergent pieces are framing, size limits, and error string conventions.
+
+**Constraints wherever this pattern is used:**
+
+- The interface signature must be declared **twice** (`dataSource` in `cmd/dcrdata/internal/explorer/explorer.go`, `sourceBase` in `pubsub/pubsubhub.go`). Adding a parameter requires updating both; the mocks in `explorer_test.go` must follow.
+- The three size budgets are independent. Don't assume changing the explorer WS limit covers the pubsub or Insight sides.
+- Error string formats differ: explorer uses `"Error: %v"` (capital E, colon, space); pubsub uses `"error: %v"` (lowercase). Don't normalize without checking external consumers.
+- The success-frame contract differs: explorer always responds (success → JSON body; failure → `"Error: ..."` body) on `<event>+"Resp"`; pubsub sets `respMsg.Success` as a boolean alongside `respMsg.Data`. A unified frontend would have to handle both shapes.
+
+Sites: `/decodetx` (decode + send), `getmempooltxs` (mempool read), `getversion`.
+
+## P3 — Multi-coin pass-through via opaque JSON
+
+**Shape.** When the upstream (node RPC) already produces correctly-shaped multi-coin data, the explorer can act as a relay: marshal the struct to JSON, send the string, let the consumer (or no one) parse. The `Vout` shape that travels through `/decodetx` is the canonical example:
+
+```go
+type Vout struct {
+    Value        float64            `json:"value,omitempty"`    // VAR only
+    SKAValue     string             `json:"skavalue,omitempty"` // SKA only (atoms string)
+    N            uint32             `json:"n"`
+    Version      uint16             `json:"version"`
+    CoinType     uint8              `json:"cointype"`
+    ScriptPubKey ScriptPubKeyResult `json:"scriptPubKey"`
+}
+```
+
+**Why it recurs.** Pass-through is the cheapest way to preserve C1 (SKA precision): the explorer never decodes the SKA string to a number, so it cannot lose precision. The same shape lands at `apitypes.Vout` for the read-only `/api/tx/*` and `/api/block/*` paths.
+
+**Constraints wherever this pattern is used:**
+
+- **Do not introduce intermediate field reads** in the Go layer on a `*chainjson.TxRawResult` returned by the node. Touching `Vout[i].Value` on a SKA output (`CoinType != 0`) reads zero (`omitempty` + missing JSON tag); converting `SKAValue` via `strconv.ParseFloat` truncates atoms.
+- The frontend must keep treating the response as opaque text (`<pre>.textContent = evt`) — switching to JSON parsing + DOM rendering re-introduces the precision risk *and* makes C6 (template cloning) load-bearing.
+- If a future change does need structured access (e.g. to highlight inputs/outputs), the JS side should parse with `JSON.parse` and route SKA fields through `splitSkaAtoms` / `formatAtomsAsCoinString` (the helpers listed in [/wiki/core/constraints.md](../../core/constraints.md#c7-centralized-coin-type-label-rendering-applies-to-block-tx-charts-mempool-address-frontend) C7), never via `Number(...)`.
+
+Sites: `/decodetx` (forward), `/api/tx/{txid}` and `/api/block/{hash}` REST (transaction trees expose `apitypes.Vout` with the same multi-coin shape).
+
+See also:
+- /wiki/code-analysis/transaction/patterns.md (shares-pattern-with: opaque pass-through of the same `Vout` multi-coin shape from node → REST)
+- /wiki/code-analysis/page-rendering/patterns.md (shares-pattern-with: WS event-string contract; `/decodetx` inverts the "shared `pageData`" assumption)
+- /wiki/core/constraints.md (depends-on: C1, C2, C4 — multi-coin atom strings preserved by being marshaled, not parsed)

--- a/wiki/code-analysis/disapproved-blocks/flow.compact.md
+++ b/wiki/code-analysis/disapproved-blocks/flow.compact.md
@@ -1,0 +1,27 @@
+# Disapproved Blocks Page (`/disapproved`) — Compact Knowledge
+
+**Flow:** new-block ingest → `StoreBlock.updateLastBlock` (flips `blocks.is_valid=false` on parent when vote-bit 0 is clear, cascades to vins/transactions/addresses/voutmarkers) → HTTP `GET /disapproved` (wrapped in `ETagAndLastModifiedIntercept`) → `explorerUI.DisapprovedBlocks` → `ChainDB.DisapprovedBlocks` → `retrieveDisapprovedBlocks` (`SELECT is_mainchain, height, previous_hash, hash, block_chain.next_hash FROM blocks JOIN block_chain ON this_hash=hash WHERE is_valid = FALSE ORDER BY height DESC`) → positional `rows.Scan` into `*dbtypes.BlockStatus` (skips `IsValid`) → `views/disapproved.tmpl` renders `Height / Main Chain / Parent / Child`.
+
+**Key Architectural Patterns:**
+
+- **`BlockStatus` shared struct, 4 readers, 4 column subsets.** `retrieveDisapprovedBlocks` (5 cols, skips `is_valid`), `retrieveSideChainBlocks` (5 cols, skips `is_mainchain`), `retrieveBlockStatus` (6 cols), `retrieveBlockStatuses` (3 cols + external `Height`). Each list endpoint pre-trims its filter column from the SELECT because the WHERE clause already pins it. Positional `rows.Scan` keeps the three files — `blockstmts.go`, `queries.go`, `db/dbtypes/types.go` — silently coupled.
+- **Single, always-on writer = `updateLastBlock`.** Unlike `/side` (two writers: reorg + opt-in startup import), `/disapproved` rows appear via the normal block-connect path: when `msgBlock.Header.VoteBits & 1 == 0`, the parent's `is_valid` is flipped to `false` and the change cascades to `vins`, `transactions`, `addresses`, and `vouts.spend_tx_row_id`. No flag, no opt-in.
+- **Block-scoped HTTP cache.** `/disapproved` is mounted under `withCache` (`ETagAndLastModifiedIntercept`); `/side` is **not**. Disapprovals only change on new-block notifications, which is the same trigger that invalidates the cache, so caching is coherent.
+- **No amounts, no JS, no WS.** C1, C2, C3, C6, C8 all out of scope. `data-controller="time"` is the only Stimulus binding (navbar/time helpers).
+
+**Critical Constraints:**
+
+- `bs.IsValid` is **never written by Scan** in this path — reading it downstream is reading a Go zero value, not a queried column. The WHERE clause is the only ground truth.
+- Positional `rows.Scan` invariant: column order in `SelectDisapprovedBlocks` ↔ Scan destination order ↔ `BlockStatus` field order. A one-line edit in any of the three can rewire data silently.
+- ETag cache invalidation is keyed on new-block notifications. A future field driven by any other trigger (mempool, exchange, governance) would serve stale.
+
+**Mutation Checklist:**
+
+1. Touching `BlockStatus` struct → re-check 4 `rows.Scan`s and 2 templates (`disapproved.tmpl`, `sidechains.tmpl`).
+2. Touching `SelectDisapprovedBlocks` columns → update Scan in `retrieveDisapprovedBlocks` in the same edit.
+3. Adding `{{.IsValid}}` to the template → must restore `is_valid` to the SELECT and Scan, else silently renders `false` everywhere.
+4. Touching `updateLastBlock` vote-bit logic → this is the only writer; a silent no-op empties the page on new blocks (no SQL error).
+5. Adding a field driven by anything other than new-block → break ETag invalidation or move off `withCache`.
+6. Adding real-time updates → imports C3/C6/C8; needs a dedicated WS message and a `data-controller` clone-template flow.
+7. Adding amounts → imports C1/C7; do not extend `BlockStatus`; build a new row type with SKA-string pipeline.
+8. Renaming the template or the dataSource method → update [explorer.go:401](../../../cmd/dcrdata/internal/explorer/explorer.go#L401) and [explorer_test.go:73](../../../cmd/dcrdata/internal/explorer/explorer_test.go#L73) mock.

--- a/wiki/code-analysis/disapproved-blocks/flow.full.md
+++ b/wiki/code-analysis/disapproved-blocks/flow.full.md
@@ -1,0 +1,266 @@
+# Disapproved Blocks Page (`/disapproved`) — Full Flow
+
+## Section 1 — Overview
+
+`/disapproved` lists every block whose **regular** transaction tree was invalidated by stakeholder votes on the *next* block — i.e. every row in the Postgres `blocks` table with `is_valid = FALSE`. It is a **read-only, single-query, server-rendered HTML page** with no WebSocket, no Stimulus controller, and no real-time update.
+
+The page is structurally a near-twin of [/side](../sidechain/flow.full.md): both endpoints return `[]*dbtypes.BlockStatus`, both run a single SQL JOIN of `blocks` and `block_chain`, both render four columns of block-status metadata. **No amounts, no per-coin maps, no fee data** — C1 (precision bifurcation), C3 (template/WS parity), and C8 (dual-transport shape) do not apply.
+
+Three load-bearing differences from `/side` shape the mutation surface:
+
+1. **Filter column.** `/side` filters on `is_mainchain = FALSE`; `/disapproved` filters on `is_valid = FALSE`. Each query's SELECT skips its own filter column (the WHERE makes it redundant), so the two queries leave **different** `BlockStatus` fields unwritten by Scan — `/side` leaves `IsMainchain` zero, `/disapproved` leaves `IsValid` zero.
+2. **Writer semantics.** `/side` rows are populated by reorg (`TipToSideChain`) or by opt-in startup import (`ImportSideChains`). `/disapproved` rows are populated by the normal **block-connect** path — `updateLastBlock` flips `is_valid=false` on the *previous* block when the current block's vote bits disapprove it. Disapprovals are produced by every running instance, no flag, on every block where stakeholders rejected the parent's regular tx tree.
+3. **HTTP cache.** `/disapproved` is mounted under `withCache` (`ETagAndLastModifiedIntercept`) at [cmd/dcrdata/main.go:801](../../../cmd/dcrdata/main.go#L801); `/side` is **not** ([cmd/dcrdata/main.go:768](../../../cmd/dcrdata/main.go#L768)). Disapprovals only change on new-block notifications, which is the same trigger that resets the cache's ETag, so caching is coherent. `/side` could in principle also be cached but currently is not.
+
+The page returns `[]*dbtypes.BlockStatus`. That struct is reused by **4 SQL functions** with different column subsets — this is the central mutation hazard, already documented in [sidechain/flow.full.md §3](../sidechain/flow.full.md). Treat this trace as the writer-specific complement to that one.
+
+## Section 2 — End-to-End Data Flow
+
+```text
+monetarium-node                                ┐
+   │ new-block notification                    │
+   ▼                                           │  writer path
+internal/notification.SignalNewBlock           │  (populate
+   │                                           │   is_valid=false
+   ▼                                           │   on parent)
+db/dcrpg.ChainDB.StoreBlock                    │
+   │ → updateLastBlock(msgBlock, isMainchain)  │
+   │                                           │
+   │  if (msgBlock.Header.VoteBits & 1) == 0:  │
+   │     updateLastBlockValid(parent, false)   │
+   │     + updateLastVins / updateTransactions │
+   │       Valid / updateLastAddressesValid    │
+   │     + clearVoutRegularSpendTxRowIDs       │
+   │     + AddressCache.Clear(addrs)           ┘
+
+────────── read path (every /disapproved request) ──────────
+
+HTTP GET /disapproved
+   │
+   ▼
+chi router (cmd/dcrdata/main.go)
+   │  withCache.ETagAndLastModifiedIntercept ← only on this endpoint
+   ▼
+explorerUI.DisapprovedBlocks
+   │
+   ▼
+explorerUI.dataSource.DisapprovedBlocks(ctx)
+   │  (interface in cmd/dcrdata/internal/explorer/explorer.go)
+   ▼
+db/dcrpg.ChainDB.DisapprovedBlocks   ── queryTimeout context
+   │
+   ▼
+retrieveDisapprovedBlocks
+   │
+   │  SELECT is_mainchain, height, previous_hash, hash, block_chain.next_hash
+   │  FROM blocks
+   │  JOIN block_chain ON this_hash=hash
+   │  WHERE is_valid = FALSE
+   │  ORDER BY height DESC;
+   ▼
+[]*dbtypes.BlockStatus  (5 of 6 fields populated; IsValid left zero)
+   │
+   ▼
+templates.exec("disapproved", { CommonPageData, Data })
+   │
+   ▼
+views/disapproved.tmpl  →  HTML response
+```
+
+The same data is also reachable indirectly:
+
+- `/rejects` → `http.Redirect(..., "/disapproved", 308)` ([cmd/dcrdata/main.go:769-771](../../../cmd/dcrdata/main.go#L769-L771)). Legacy alias; permanent redirect.
+- `/blocks` template links to `/disapproved` for users looking for PoS-invalidated blocks ([cmd/dcrdata/views/blocks.tmpl:179](../../../cmd/dcrdata/views/blocks.tmpl#L179)).
+
+## Section 3 — Per-Layer Breakdown
+
+### Router
+
+- **Location:** [cmd/dcrdata/main.go:799-801](../../../cmd/dcrdata/main.go#L799-L801)
+- **Code:**
+  ```go
+  withCache := r.With(explore.ETagAndLastModifiedIntercept)
+  withCache.Get("/", explore.Home)
+  withCache.Get("/disapproved", explore.DisapprovedBlocks)
+  ```
+- **Middleware:** `ETagAndLastModifiedIntercept` ([explorermiddleware.go:192](../../../cmd/dcrdata/internal/explorer/explorermiddleware.go#L192)) — block-scoped ETag/Last-Modified cache shared with `/`, `/mempool`, `/charts`, and other home-page-adjacent endpoints. See [page-rendering/patterns.md](../page-rendering/patterns.md) for the cache invariant.
+- **Legacy redirect:** [cmd/dcrdata/main.go:769-771](../../../cmd/dcrdata/main.go#L769-L771) — `/rejects` → `/disapproved` (308 Permanent).
+
+### Handler
+
+- **Location:** [cmd/dcrdata/internal/explorer/explorerroutes.go:288-318](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L288-L318)
+- **Logic:** call `dataSource.DisapprovedBlocks(ctx)`; on context-deadline error, render the timeout error page via `exp.timeoutErrorPage`; on any other error, render `StatusPage(defaultErrorCode, "failed to retrieve stakeholder disapproved blocks", ...)`; otherwise execute the `"disapproved"` template with `{ *CommonPageData, Data []*dbtypes.BlockStatus }`.
+- **No mutation, no derived fields, no per-coin handling.** Thin pass-through. Identical shape to `SideChains` handler ([explorerroutes.go:238-268](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L238-L268)).
+
+### DataSource interface
+
+- **Location:** [cmd/dcrdata/internal/explorer/explorer.go:91](../../../cmd/dcrdata/internal/explorer/explorer.go#L91) — `DisapprovedBlocks(context.Context) ([]*dbtypes.BlockStatus, error)`
+- **Test mock:** [cmd/dcrdata/internal/explorer/explorer_test.go:73](../../../cmd/dcrdata/internal/explorer/explorer_test.go#L73) — fan-out point if the signature changes.
+
+### ChainDB read method
+
+- **Location:** [db/dcrpg/pgblockchain.go:865-871](../../../db/dcrpg/pgblockchain.go#L865-L871)
+- **Behavior:** wraps `retrieveDisapprovedBlocks` in a `context.WithTimeout(ctx, pgb.queryTimeout)` and routes cancellation through `pgb.replaceCancelError`. Identical shape to `SideChainBlocks`.
+
+### SQL query + Scan
+
+- **SQL:** [db/dcrpg/internal/blockstmts.go:189-193](../../../db/dcrpg/internal/blockstmts.go#L189-L193)
+  ```sql
+  SelectDisapprovedBlocks = `SELECT is_mainchain, height, previous_hash, hash, block_chain.next_hash
+      FROM blocks
+      JOIN block_chain ON this_hash=hash
+      WHERE is_valid = FALSE
+      ORDER BY height DESC;`
+  ```
+- **Scan:** [db/dcrpg/queries.go:4020-4042](../../../db/dcrpg/queries.go#L4020-L4042)
+  ```go
+  err = rows.Scan(&bs.IsMainchain, &bs.Height, &bs.PrevHash, &bs.Hash, &bs.NextHash)
+  ```
+- **Critical:** five columns map to five of the six struct fields. **`bs.IsValid` is never written** — left at its Go zero value (`false`). The WHERE clause already filters `is_valid=false`, so the template treats all rows as disapproved, but anyone reading `bs.IsValid` from the returned slice elsewhere is reading a Scan-default, not a queried value. This is the **same hazard shape** as `/side` (which leaves `IsMainchain` unwritten) — but on a different field.
+
+### `BlockStatus` shared struct (4 readers, 4 column subsets)
+
+- **Location:** [db/dbtypes/types.go:2267-2275](../../../db/dbtypes/types.go#L2267-L2275)
+  ```go
+  type BlockStatus struct {
+      IsValid     bool
+      IsMainchain bool
+      Height      uint32
+      PrevHash    ChainHash
+      Hash        ChainHash
+      NextHash    ChainHash
+  }
+  ```
+- The four reader functions that share this struct each have a different positional Scan:
+
+  | Function | Cols | Order |
+  |---|---|---|
+  | `retrieveSideChainBlocks` | 5 | `is_valid, height, previous_hash, hash, next_hash` — skips `is_mainchain` (WHERE makes it false) |
+  | `retrieveDisapprovedBlocks` | 5 | `is_mainchain, height, previous_hash, hash, next_hash` — skips `is_valid` (WHERE makes it false) |
+  | `retrieveBlockStatus` | 6 | `is_valid, is_mainchain, height, previous_hash, hash, next_hash` — all fields |
+  | `retrieveBlockStatuses` | 3 | `is_valid, is_mainchain, hash` — `Height` set externally from query input |
+
+  See [db/dcrpg/internal/blockstmts.go:170-193](../../../db/dcrpg/internal/blockstmts.go#L170-L193) and [db/dcrpg/queries.go:3969-4074](../../../db/dcrpg/queries.go#L3969-L4074).
+- **Implication:** the two list endpoints (`/side`, `/disapproved`) each pre-trim one different filter column. Symmetric in shape; asymmetric in *which* field is unreliable.
+
+### Template
+
+- **Location:** [cmd/dcrdata/views/disapproved.tmpl](../../../cmd/dcrdata/views/disapproved.tmpl)
+- **Columns rendered:** `Height` (link to `/block/{hash}`), `Main Chain` (`.IsMainchain`, populated by Scan), `Parent` (`.PrevHash` → `/block/{prev}`), `Child` (`.NextHash` if set → `/block/{next}`; otherwise `none` with `title="This block is the tip of its chain."`).
+- **Does NOT render `IsValid`.** This is the field that Scan leaves zero, so omitting it from the template is what keeps the page coherent. Adding `{{.IsValid}}` to the template without first reading the column would silently render `false` for every row.
+- **External link:** `.Links.POSExplanation` points at `https://docs.decred.org/proof-of-stake/overview/` ([cmd/dcrdata/internal/explorer/explorer.go:169](../../../cmd/dcrdata/internal/explorer/explorer.go#L169)) — a residual Decred doc link (stale for Monetarium; the URL still resolves to upstream Decred). Cosmetic.
+- **No JS controller bound** beyond `data-controller="time"` (navbar helpers). Table id `disapprovedblockstable` is decorative — nothing selects on it.
+- **Template registration:** [cmd/dcrdata/internal/explorer/explorer.go:401](../../../cmd/dcrdata/internal/explorer/explorer.go#L401) — the literal string `"disapproved"` is in the `tmpls` slice; mismatched template name is a registration-time failure.
+
+### Writer path (how rows reach `is_valid=false`)
+
+There is **one and only one** writer path, embedded in the normal block-connect flow:
+
+- Entry: `ChainDB.StoreBlock` ([db/dcrpg/pgblockchain.go:3977-4040](../../../db/dcrpg/pgblockchain.go#L3977-L4040)) calls `pgb.updateLastBlock(msgBlock, isMainchain)` for every block.
+- `updateLastBlock` ([db/dcrpg/pgblockchain.go:4042-4155](../../../db/dcrpg/pgblockchain.go#L4042-L4155)) inspects `msgBlock.Header.VoteBits & 1`. Bit 0 == 0 means the **parent** block is disapproved by stakeholders. When this fires:
+  1. `updateLastBlockValid(db, parentDbID, false)` — flips `blocks.is_valid` for the parent row. SQL: `UpdateLastBlockValid` in [db/dcrpg/internal/blockstmts.go:203](../../../db/dcrpg/internal/blockstmts.go#L203).
+  2. `clearVoutRegularSpendTxRowIDs(db, parentHash)` — unsets `vouts.spend_tx_row_id` for any vouts the parent's regular txs had consumed (the spends are now invalid).
+  3. `updateLastVins(db, parentHash, false, isMainchain)` — propagates `is_valid=false` to the parent's vins rows.
+  4. `updateTransactionsValid(db, parentHash, false)` — propagates to the parent's regular transactions.
+  5. `updateLastAddressesValid(db, parentHash, false)` — propagates to the addresses table.
+  6. `pgb.AddressCache.Clear(addrs)` — evicts in-memory caches for the affected addresses.
+- **Side-chain guard:** if the current block being added is itself side-chain, `updateLastBlock` returns early when the parent is on the main chain ([db/dcrpg/pgblockchain.go:4058-4076](../../../db/dcrpg/pgblockchain.go#L4058-L4076)). Side-chain blocks **cannot** invalidate main-chain ancestors via this code path — exactly the symmetric constraint that keeps `/side` and `/disapproved` from cross-polluting.
+- **NOTE in code** ([pgblockchain.go:4149-4151](../../../db/dcrpg/pgblockchain.go#L4149-L4151)): tickets, votes, misses, treasury are *not* updated — the stake tree is not subject to stakeholder approval.
+
+**Observation:** unlike `/side` (two writers: startup import + reorg), `/disapproved` has a single, always-on writer. No flag, no opt-in. Any tip extension that disapproves its parent immediately mutates the parent's `is_valid=false` and adds it to the `/disapproved` set.
+
+### HTTP cache integration
+
+- `withCache.Get("/disapproved", ...)` wraps the handler in `ETagAndLastModifiedIntercept` ([explorermiddleware.go:193](../../../cmd/dcrdata/internal/explorer/explorermiddleware.go#L193)).
+- Disapprovals only change on block connect; the same event resets the ETag store. So clients with `If-None-Match` get a 304 between blocks. No staleness window beyond the normal new-block latency.
+- **Asymmetry with `/side`:** `/side` is **not** under `withCache`, even though its writer paths (reorg, startup import) also only fire on observable events. This is a discretionary choice, not a correctness issue — but anyone refactoring the route block should not "fix" the asymmetry without checking that `/side`'s writer events (`TipToSideChain`) reset the ETag store too.
+
+## Section 4 — Cross-Layer Dependencies
+
+- **Handler ↔ DataSource interface:** `DisapprovedBlocks(ctx)` is one of ~30 methods on `dataSource` ([explorer.go:80-110](../../../cmd/dcrdata/internal/explorer/explorer.go#L80-L110)). Mock must track signature.
+- **SQL ↔ Scan ↔ Struct:** three independent files must stay in lockstep — `blockstmts.go` (SELECT column list), `queries.go` (`rows.Scan` destinations), `db/dbtypes/types.go` (struct field order/types). Positional binding means a one-line edit in any of the three can silently rewire data into the wrong field.
+- **Struct ↔ Sibling readers:** because `BlockStatus` is the return type of four different SQL functions, a struct change ripples into `DisapprovedBlocks`, `SideChainBlocks`, `BlockStatus(hash)`, and `BlockStatuses(height)`. Two are list-page handlers (`/disapproved`, `/side`), one feeds `/block/{hash}` status rendering, one feeds height-keyed approval checks (see [explorerroutes.go:730](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L730)).
+- **Writer race:** between a `StoreBlock` mid-disapproval (flipping `is_valid=false`) and a concurrent `/disapproved` request, the page is best-effort consistent. The SELECT may pick up rows mid-cascade (e.g., `blocks.is_valid` flipped but `transactions.is_valid` not yet) — for this page it doesn't matter because only `blocks.is_valid` is queried. Other readers consuming the same parent block during the cascade window may see inconsistent state.
+- **Cache invalidation coupling:** the ETag intercept must be invalidated whenever any field this page renders could change. Today the trigger is new-block notification, which covers it. Adding a field to `disapproved.tmpl` driven by a *different* trigger (e.g. a mempool-derived field) would silently serve stale cached pages until the next block.
+
+## Section 5 — Critical Constraints
+
+This is one of the few pages where **most repository invariants do NOT apply**:
+
+- **C1 (precision bifurcation):** *Does not apply.* No amounts, no SKA, no per-coin maps. Don't add amount columns to this page without first reading C1 and adopting the SKA-string pipeline used elsewhere (`address`, `block`, `mempool`, `charts`).
+- **C2 (dual pipeline mutation):** *Does not apply.* No real-time pipeline. The page reads strictly from Postgres.
+- **C3 (template + WebSocket parity):** *Does not apply by absence* — no WebSocket transport for this page. Adding live updates would force C3/C8 reconciliation.
+- **C6 (in-DOM template cloning):** *Does not apply* — no JS-driven row creation. All rows are server-rendered.
+- **C8 (dual-transport shape asymmetry):** *Does not apply* — single HTTP transport.
+
+What **does** apply:
+
+- **Positional `rows.Scan` invariant** (recurs across the codebase; see [sidechain/flow.full.md §3](../sidechain/flow.full.md) and [time-based-blocks/impact.md](../time-based-blocks/impact.md)). Column order in `SelectDisapprovedBlocks` must match Scan destination order in `retrieveDisapprovedBlocks` must match the documented `BlockStatus` field ordering it relies on.
+- **`IsValid` field is Scan-default, not queried.** Read it nowhere downstream from a `DisapprovedBlocks` result; the WHERE clause is the only ground truth for "this block was disapproved."
+- **Single-coin / multi-coin invariants** are trivially satisfied — no transaction or amount data is rendered, so the multi-coin rules cannot be violated here. They re-emerge if a "tx count by coin" or "value invalidated" column is ever added.
+
+## Section 6 — Mutation Impact
+
+When modifying anything in this flow, check:
+
+1. **`BlockStatus` struct field order or type** — breaks 4 positional `Scan`s and 2 templates (`disapproved.tmpl`, `sidechains.tmpl`). Loud at Scan time if column count changes; **silent** if field types stay compatible (bool/bool, ChainHash/ChainHash). Always confirm by reading every `rows.Scan(&bs....)` in `db/dcrpg/queries.go` after a struct edit.
+2. **`SelectDisapprovedBlocks` column list** — must update `retrieveDisapprovedBlocks` `rows.Scan` in lockstep, otherwise loud Scan error or silent column shift.
+3. **`retrieveDisapprovedBlocks` Scan order** — same.
+4. **Template field references** — adding/removing struct fields breaks `{{.Field}}` references at template-execute time (loud at request time, not build time — Go templates have no compile-time type check).
+5. **Adding `{{.IsValid}}` to the template** — silently renders `false` for every row. Either drop the field from the SELECT-skip optimization (add it back to SELECT + Scan), or don't reference it.
+6. **`updateLastBlock` invalidation cascade** — the **only** code that flips `blocks.is_valid=false`. If the cascade ever stops calling `updateLastBlockValid`, this page silently empties on new blocks (no SQL error — just no rows added). If `clearVoutRegularSpendTxRowIDs` / `updateLastVins` / `updateTransactionsValid` ever stop firing in lockstep, downstream tx/address pages render stale "spent" markers that the block-level disapproval indicator on this page already shows.
+7. **`UpdateLastBlockValid` SQL** ([blockstmts.go:203](../../../db/dcrpg/internal/blockstmts.go#L203)) — the only writer to `blocks.is_valid`. Renaming the column requires synchronized edits in both list SELECTs and the cascade SQLs.
+8. **`ETagAndLastModifiedIntercept` invalidation trigger** — currently keyed on block notifications, which matches the writer trigger. If a future field on this page is driven by anything else (mempool, exchange feed, governance), the cache will serve stale pages.
+9. **Removing the `/rejects` redirect** — would break any external link or bookmark using the legacy alias. 308 Permanent says "always was, always will be"; flipping to 404 is a noticeable regression for long-tail traffic.
+10. **Adding a real-time element** (WebSocket push, Stimulus controller) — instantly imports C3/C8/C6 into this domain. Don't bolt on WS updates without a dedicated message shape and a `data-controller` clone-template flow.
+
+**Silent failures:**
+
+- Column-order swap (e.g., swapping `is_mainchain` and `next_hash` in either the SELECT or the Scan): the page renders nonsense in the "Main Chain" / "Child" columns without throwing. Caught only by visual inspection.
+- Adding `is_valid` back into the SELECT column list **without** also adding `&bs.IsValid` to Scan (or vice versa): loud Scan error.
+- `updateLastBlock` silently no-ops if the parent block lookup fails (logged at debug level, returns `nil`) — silent under-counting of disapprovals.
+- `ETagAndLastModifiedIntercept` over-coupling: an unrelated change that resets the ETag store on every request would make `/disapproved` re-render on every hit (no correctness issue, just throughput).
+
+**Hard failures:**
+
+- Removing `is_valid` from the `blocks` table, or the `block_chain.next_hash` column, or the JOIN: SQL error on every request to `/disapproved`, `/side`, and any `BlockStatus` lookup.
+- Renaming `BlockStatus` fields without updating `disapproved.tmpl` / `sidechains.tmpl`: template-execute error rendered as `StatusPage(defaultErrorCode, ...)`.
+- Misspelling `"disapproved"` in the template registration slice ([explorer.go:401](../../../cmd/dcrdata/internal/explorer/explorer.go#L401)): template lookup failure at request time.
+- `queryTimeout` set too low for an indexed scan over a large `blocks` table: `timeoutErrorPage` triggers.
+
+## Section 7 — Common Pitfalls
+
+- **Assuming `bs.IsValid` is populated by `DisapprovedBlocks`.** It isn't — the SQL omits the column because the WHERE filters `is_valid=false`. Reading the field downstream is reading the Scan default, not a queried value. Symmetric to the `/side` pitfall on `IsMainchain`.
+- **Treating `/disapproved` as a clone of `/side`.** Structurally they are; semantically they're not. `/side`'s rows are populated by chain reorganization; `/disapproved`'s rows are populated by stakeholder votes inside the normal block-connect path. A change to reorg handling does not affect `/disapproved`; a change to `updateLastBlock`'s vote-bit interpretation does.
+- **Bolt-on amount columns.** Tempting to add "value invalidated" / "tx count" columns. That immediately re-invites C1, C7, and the SKA-string pipeline. Don't add amounts to `BlockStatus`; build a separate row type if needed.
+- **Removing the SELECT-skip optimization.** Adding `is_valid` back into the SELECT just to "be explicit" is harmless if Scan is updated in lockstep, but if Scan isn't updated, you get a runtime Scan error. The optimization is load-bearing only by convention.
+- **Refactoring `updateLastBlock` "to clean it up".** It is the *only* writer that flips `blocks.is_valid` and it sequences five dependent table updates. Any reordering or short-circuit changes the per-table consistency window observable by the rest of the codebase.
+
+## Section 8 — Evidence
+
+- Route registration — [cmd/dcrdata/main.go:799-801](../../../cmd/dcrdata/main.go#L799-L801); `/rejects` redirect — [cmd/dcrdata/main.go:769-771](../../../cmd/dcrdata/main.go#L769-L771)
+- Handler — [cmd/dcrdata/internal/explorer/explorerroutes.go:288-318](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L288-L318)
+- Interface — [cmd/dcrdata/internal/explorer/explorer.go:91](../../../cmd/dcrdata/internal/explorer/explorer.go#L91)
+- Test mock — [cmd/dcrdata/internal/explorer/explorer_test.go:73](../../../cmd/dcrdata/internal/explorer/explorer_test.go#L73)
+- Template name registration — [cmd/dcrdata/internal/explorer/explorer.go:401](../../../cmd/dcrdata/internal/explorer/explorer.go#L401)
+- POSExplanation link — [cmd/dcrdata/internal/explorer/explorer.go:169](../../../cmd/dcrdata/internal/explorer/explorer.go#L169)
+- ChainDB read method — [db/dcrpg/pgblockchain.go:865-871](../../../db/dcrpg/pgblockchain.go#L865-L871)
+- SQL — [db/dcrpg/internal/blockstmts.go:189-193](../../../db/dcrpg/internal/blockstmts.go#L189-L193)
+- Scan — [db/dcrpg/queries.go:4020-4042](../../../db/dcrpg/queries.go#L4020-L4042)
+- Shared struct — [db/dbtypes/types.go:2267-2275](../../../db/dbtypes/types.go#L2267-L2275)
+- Template — [cmd/dcrdata/views/disapproved.tmpl](../../../cmd/dcrdata/views/disapproved.tmpl)
+- Entry link from `/blocks` — [cmd/dcrdata/views/blocks.tmpl:179](../../../cmd/dcrdata/views/blocks.tmpl#L179)
+- Writer cascade `updateLastBlock` — [db/dcrpg/pgblockchain.go:4042-4155](../../../db/dcrpg/pgblockchain.go#L4042-L4155)
+- Writer SQL `UpdateLastBlockValid` — [db/dcrpg/internal/blockstmts.go:203](../../../db/dcrpg/internal/blockstmts.go#L203)
+- ETag middleware — [cmd/dcrdata/internal/explorer/explorermiddleware.go:192-193](../../../cmd/dcrdata/internal/explorer/explorermiddleware.go#L192-L193)
+- Sibling `BlockStatus` SELECTs — [db/dcrpg/internal/blockstmts.go:170-193](../../../db/dcrpg/internal/blockstmts.go#L170-L193); sibling Scans — [db/dcrpg/queries.go:3969-4074](../../../db/dcrpg/queries.go#L3969-L4074)
+
+See also:
+
+- [/wiki/code-analysis/sidechain/flow.full.md](../sidechain/flow.full.md) (shares-pattern-with: same 4-reader `BlockStatus` Scan invariant, mirrored SELECT-skip-the-filter-column trick; differ on writer semantics and ETag wrap)
+- [/wiki/code-analysis/sidechain/impact.md](../sidechain/impact.md) (shares-pattern-with: positional Scan blast across 4 endpoints)
+- [/wiki/code-analysis/block/flow.full.md](../block/flow.full.md) (depends-on: `StoreBlock` is the writer entry point that calls `updateLastBlock`)
+- [/wiki/code-analysis/block/impact.md](../block/impact.md) (depends-on: block-ingestion mutations are the writers for `is_valid=false` rows)
+- [/wiki/code-analysis/time-based-blocks/impact.md](../time-based-blocks/impact.md) (shares-pattern-with: positional `rows.Scan` desync risk)
+- [/wiki/code-analysis/page-rendering/patterns.md](../page-rendering/patterns.md) (depends-on: `*CommonPageData` embedding + block-scoped ETag cache used here)
+- [/wiki/core/constraints.md](../../core/constraints.md) (depends-on: C1/C2/C3/C6/C8 explicitly out of scope — empty-amount page; re-imported if real-time or amount columns are ever added)

--- a/wiki/code-analysis/disapproved-blocks/impact.md
+++ b/wiki/code-analysis/disapproved-blocks/impact.md
@@ -1,0 +1,118 @@
+# Disapproved Blocks (`/disapproved`) — Mutation Impact
+
+Blast radius for changes touching the `/disapproved` page, its SQL, its shared struct, or its writer cascade. Read alongside [flow.full.md](flow.full.md) — this file is the change-checklist; the flow is the trace.
+
+## Quick-glance table
+
+| Change site | Direct break | Silent / Loud | Notes |
+|---|---|---|---|
+| `BlockStatus` struct field order/type | 4 `rows.Scan`s + 2 templates | Silent if types stay compatible, Loud if count changes | Shared with `/side`, `/block/{hash}`, height-keyed status |
+| `SelectDisapprovedBlocks` columns | `retrieveDisapprovedBlocks` Scan | Loud (count mismatch) or Silent (order swap) | One-line edit risk |
+| `retrieveDisapprovedBlocks` Scan order | Template column meanings | Silent | Render swaps without error |
+| Add `{{.IsValid}}` to template | Renders `false` everywhere | Silent | `IsValid` is Scan-default in this path |
+| `updateLastBlock` vote-bit logic | The whole page | Silent (no rows) | Sole writer of `blocks.is_valid=false` |
+| `UpdateLastBlockValid` SQL | Same | Loud (SQL error) | Renaming column breaks both SELECTs too |
+| `disapproved.tmpl` field references | Page render | Loud at request time | Templates have no compile-time type check |
+| `dataSource.DisapprovedBlocks` signature | `explorerUI` + mock | Loud at build | Update `explorer_test.go:73` mock |
+| `"disapproved"` in template-name slice | Template lookup | Loud at request time | [explorer.go:401](../../../cmd/dcrdata/internal/explorer/explorer.go#L401) |
+| Move `/disapproved` off `withCache` | ETag/Last-Modified disappear | Silent (correctness fine; throughput regresses) | OK to do; document why |
+| Remove `/rejects` redirect | External bookmarks | Loud for users (404) | Permanent redirect = stable contract |
+| Add WS push or Stimulus controller | Imports C3/C6/C8 | Silent without reconciliation | See [/wiki/core/constraints.md](../../core/constraints.md) |
+| Add amount columns | Imports C1/C7 | Silent (precision loss) without SKA pipeline | Don't extend `BlockStatus` |
+
+## Risk 1 — Positional `rows.Scan` desync across 4 readers (shared with `/side`)
+
+**Trigger:** any edit to `BlockStatus` field order/types, or to the column list in `SelectDisapprovedBlocks` / `SelectSideChainBlocks` / `SelectBlockStatus` / `SelectBlockStatuses`, or to the corresponding `rows.Scan` argument order.
+
+**Failure mode:**
+- **Loud:** column count mismatch → `sql: expected N destinations, got M` at request time.
+- **Silent:** column reorder with type-compatible columns (bool/bool, ChainHash/ChainHash) → wrong values land in wrong fields, no error.
+
+**Affected files (must be edited in lockstep):**
+- [db/dbtypes/types.go:2267-2275](../../../db/dbtypes/types.go#L2267-L2275) (struct)
+- [db/dcrpg/internal/blockstmts.go:170-193](../../../db/dcrpg/internal/blockstmts.go#L170-L193) (4 SELECTs)
+- [db/dcrpg/queries.go:3969-4074](../../../db/dcrpg/queries.go#L3969-L4074) (4 Scans)
+- [cmd/dcrdata/views/disapproved.tmpl](../../../cmd/dcrdata/views/disapproved.tmpl) + [cmd/dcrdata/views/sidechains.tmpl](../../../cmd/dcrdata/views/sidechains.tmpl) (field references)
+
+**See also:** [/wiki/code-analysis/sidechain/impact.md](../sidechain/impact.md) — same risk, mirrored on `IsMainchain`; [/wiki/code-analysis/time-based-blocks/impact.md](../time-based-blocks/impact.md) — same pattern in a different domain.
+
+## Risk 2 — `IsValid` field is Scan-default, not queried
+
+**Trigger:** any downstream consumer reading `bs.IsValid` from a slice returned by `ChainDB.DisapprovedBlocks`.
+
+**Failure mode:** Silent. The field is left at Go's zero value (`false`). Coincidentally correct *because* the WHERE clause filters `is_valid=false`, but it's not a contract — a future relaxation of the WHERE (e.g. adding `OR something_else`) would produce rows where `IsValid` is unreliably `false` regardless of the actual database value.
+
+**Why it exists:** the SELECT skips `is_valid` because the WHERE already pins it. Mirror of the `/side` shape, which skips `is_mainchain` for the same reason.
+
+**Mitigations:**
+- Don't read `bs.IsValid` from a `DisapprovedBlocks` result. If you need the flag, re-derive from "I got here because the row matched the WHERE."
+- If you ever loosen the WHERE clause, **add `is_valid` back to the SELECT and Scan** in the same change.
+
+## Risk 3 — `updateLastBlock` is the sole writer of `is_valid=false`
+
+**Trigger:** any refactor of [db/dcrpg/pgblockchain.go:4042-4155](../../../db/dcrpg/pgblockchain.go#L4042-L4155) — including reordering the cascade, short-circuiting on partial failure, or moving the vote-bit check.
+
+**Failure mode:**
+- **Silent (page side):** the page renders an empty table on new disapprovals while the chain continues. No SQL error, no log line beyond the existing `Infof("Previous block %s was DISAPPROVED ...")` failing to fire.
+- **Silent (downstream side):** `blocks.is_valid` and `transactions.is_valid` / `vins.is_valid` / `addresses.is_valid` / `vouts.spend_tx_row_id` drift out of agreement. The block-level marker on `/disapproved` may say "this block is disapproved" while the affected transactions on `/tx/{hash}` and addresses on `/address/{addr}` still appear as valid spends.
+
+**Atomicity note:** the cascade is **not** wrapped in a single Postgres transaction. Mid-cascade reads (e.g. a `/disapproved` request landing between `updateLastBlockValid` and `updateTransactionsValid`) may see partial state. For this page that's fine because only `blocks.is_valid` is queried; for `/tx/{hash}` and `/address/{addr}` it is observable inconsistency. See [block/impact.md](../block/impact.md) for the cross-table coherence concerns.
+
+## Risk 4 — ETag cache + non-block-driven field
+
+**Trigger:** adding a field to `disapproved.tmpl` whose underlying data changes outside the new-block notification (e.g. mempool stats, exchange rates, governance state).
+
+**Failure mode:** Silent. The cache invalidation key is set by block notifications inside `ETagAndLastModifiedIntercept`. A field driven by a different signal will appear correct on initial render and serve stale to clients with `If-None-Match` until the next block.
+
+**Mitigations:**
+- Move `/disapproved` off `withCache` if you need any non-block-driven content here.
+- Or arrange for the new signal to also invalidate the ETag store (read [page-rendering/patterns.md](../page-rendering/patterns.md) before doing this — the ETag store is shared across `/`, `/disapproved`, `/mempool`, `/charts`).
+
+## Risk 5 — Adding a real-time element
+
+**Trigger:** any addition of WebSocket push, a Stimulus controller, or live-DOM updates to `disapproved.tmpl`.
+
+**Failure mode:** Silent. The page currently satisfies C1/C2/C3/C6/C8 *by absence*. Adding a real-time element instantly imports those constraints, and the first new disapproval pushed via WS will reveal whichever one was overlooked:
+- C3: server-rendered row markup vs JS-cloned row markup must match.
+- C6: `document.importNode(tmpl.content, true)` against `<template id="...">`, never `innerHTML`.
+- C8: HTTP and WS shapes for the new field are two contracts, not one.
+
+**Mitigations:**
+- Use the [page-rendering/patterns.md](../page-rendering/patterns.md) `*CommonPageData` embedding + `<template id="...">` clone-flow.
+- Mirror the WS encoder in [block/flow.full.md](../block/flow.full.md) §4 if pushing per-block events.
+
+## Risk 6 — Adding amount columns
+
+**Trigger:** any column like "value invalidated", "tx count by coin", "fees invalidated".
+
+**Failure mode:** Silent. `BlockStatus` is amount-free by construction. Any new amount field grafted onto it will be at risk of:
+- C1 (precision bifurcation): SKA atoms exceed `float64` significand; `dcrutil.Amount.ToCoin()` corrupts SKA.
+- C7 (centralized coin-type label rendering): inline `"VAR"` / `` `SKA${n}` `` violates the canonical helper rule.
+
+**Mitigations:**
+- Don't extend `BlockStatus`. Build a sibling row type with `map[uint8]string` for per-coin amounts (atoms as base-10 strings).
+- Render labels via `coinSymbol` (Go) / `renderCoinType` (JS) only.
+- Read [address/patterns.md](../address/patterns.md) for the SKA-string pipeline shape before designing the column.
+
+## Risk 7 — `/rejects` redirect removal
+
+**Trigger:** deleting the `r.Get("/rejects", ...)` block at [cmd/dcrdata/main.go:769-771](../../../cmd/dcrdata/main.go#L769-L771).
+
+**Failure mode:** Loud for users — 404 on the legacy alias. The redirect is `308 StatusPermanentRedirect`, which says "always was, always will be"; downstream caches and external bookmarks may treat it as immutable. Removal is observably a regression.
+
+**Mitigation:** keep the redirect unless there is a deliberate decision to deprecate the alias (and document the version cutover).
+
+## Cross-domain notes
+
+- **`/side` vs `/disapproved` asymmetry on ETag caching** is discretionary, not a bug. Don't "normalize" the two routes without first verifying that `/side`'s writer events (`TipToSideChain`) also reset the shared ETag store.
+- **`BlockStatus`-as-external-contract.** Treat the struct as an external contract across 4 query functions, 2 list pages, and the `/block/{hash}` status display. Do not "clean up" field naming/ordering without coordinated edits.
+- **No upstream sync.** This codebase was squashed from `decred/dcrdata` with no git upstream. The `POSExplanation` link in [explorer.go:169](../../../cmd/dcrdata/internal/explorer/explorer.go#L169) still points at Decred docs — cosmetic, but worth flagging when refactoring the `Links` struct.
+
+See also:
+
+- [/wiki/code-analysis/sidechain/flow.full.md](../sidechain/flow.full.md) (shares-pattern-with: same shared struct + filter-skip-in-SELECT trick; differ on writer + ETag)
+- [/wiki/code-analysis/sidechain/impact.md](../sidechain/impact.md) (shares-pattern-with: `BlockStatus` 4-reader Scan blast)
+- [/wiki/code-analysis/block/impact.md](../block/impact.md) (depends-on: `StoreBlock`/`updateLastBlock` is the writer entry point; cross-table is_valid coherence)
+- [/wiki/code-analysis/time-based-blocks/impact.md](../time-based-blocks/impact.md) (shares-pattern-with: positional `rows.Scan` desync risk)
+- [/wiki/code-analysis/page-rendering/patterns.md](../page-rendering/patterns.md) (depends-on: block-scoped ETag cache shared across `/`, `/disapproved`, `/mempool`, `/charts`)
+- [/wiki/core/constraints.md](../../core/constraints.md) (depends-on: C1/C2/C3/C6/C8 out of scope today — re-imported by real-time or amount columns)

--- a/wiki/code-analysis/sidechain/flow.compact.md
+++ b/wiki/code-analysis/sidechain/flow.compact.md
@@ -1,0 +1,50 @@
+# Sidechain Page (`/side`) — Compact
+
+```text
+GET /side
+→ explorer.SideChains
+→ ChainDB.SideChainBlocks(ctx)               // queryTimeout-wrapped
+→ retrieveSideChainBlocks                    // SELECT … FROM blocks JOIN block_chain
+→ []*dbtypes.BlockStatus                     // 5 of 6 fields populated; IsMainchain unset
+→ views/sidechains.tmpl                      // static HTML; no WS, no Stimulus
+
+Writers that fill is_mainchain=false:
+  (A) startup batch (cfg.ImportSideChains, off by default)
+      → MissingSideChainBlocks → StoreBlock(isMainchain=false) → insertBlockPrevNext
+  (B) live reorg
+      → ChainMonitor.ReorgHandler → switchToSideChain → TipToSideChain
+      → setMainchainByBlockHash(hash, false)
+```
+
+## Key Architectural Patterns
+
+- **Read-only single-query page.** No real-time transport, no derived fields, no per-coin handling — the simplest page-rendering shape in the codebase.
+- **Shared `BlockStatus` struct, 4 different column subsets.** `BlockStatus` is the return of `SelectSideChainBlocks`, `SelectBlockStatus`, `SelectBlockStatuses`, and `SelectDisapprovedBlocks`. Each Scan is *positional and column-narrow* — fields not selected stay at Go-zero.
+- **Two independent writer paths.** Startup `ImportSideChains` (inserts new rows) vs live reorg `TipToSideChain` (mutates `is_mainchain` on existing rows). Reorg path skips `block_chain` row inserts.
+- **`ImportSideChains=false` by default.** Empty page is the expected state on a fresh sync with no in-flight reorg — not a bug.
+
+## Critical Constraints
+
+- **C1 (precision) does NOT apply** — no amounts. Don't add amount columns without also adopting the SKA-string pipeline used in `address`/`block`/`charts`.
+- **C8 (dual-transport) does NOT apply** — no WS path. Adding one re-imports C3/C8.
+- **Positional Scan invariant applies.** SQL column order ↔ `rows.Scan` destination order ↔ `BlockStatus` field semantics must stay in lockstep across all 4 sibling queries.
+
+## Mutation Checklist
+
+- Reorder/add `BlockStatus` fields → re-check **all 4** `rows.Scan(&bs.…)` sites in `db/dcrpg/queries.go` and both templates (`sidechains.tmpl`, `disapproved.tmpl`).
+- Change `SelectSideChainBlocks` column list → update `retrieveSideChainBlocks` Scan in lockstep.
+- Don't read `bs.IsMainchain` from a `SideChainBlocks` result — it is never populated by this query.
+- Adding a real-time element → design a WS payload + clone-template flow (C3/C6/C8) before writing JS.
+- New "tx count by coin" / "value" columns → build a separate row type; do not extend `BlockStatus`.
+
+## Silent Risks
+
+- Column-order swap (SELECT vs Scan) within compatible types (`bool` ↔ `bool`, hash ↔ hash) — page renders wrong values without error.
+- Reorg mid-request — row briefly appears with stale `is_mainchain` semantics; cosmetic.
+- `ImportSideChains=false` operator default — page silently empty even when node knows of side chains.
+
+## Loud Failures
+
+- Adding/removing a SELECT column without matching Scan → `sql.Rows.Scan: expected N destinations`.
+- Renaming a struct field referenced by the template → `template execute` error rendered as `StatusPage`.
+- DB query timeout → `timeoutErrorPage` path.

--- a/wiki/code-analysis/sidechain/flow.full.md
+++ b/wiki/code-analysis/sidechain/flow.full.md
@@ -1,0 +1,229 @@
+# Sidechain Page (`/side`) — Full Flow
+
+## Section 1 — Overview
+
+`/side` lists every block currently flagged `is_mainchain=false` in the Postgres `blocks` table. It is a **read-only, single-query, server-rendered HTML page**: no WebSocket, no Stimulus controller, no real-time update — the rendered table is a snapshot at request time.
+
+The page renders only **block-status metadata** (height, `is_valid`, hash, prev hash, next hash). It contains **no amounts, no per-coin maps, no fee data** — C1 (precision bifurcation) and the multi-coin / single-coin-tx invariants do **not** apply to this flow.
+
+The page shares its return type (`[]*dbtypes.BlockStatus`) and reading shape with **three sibling endpoints** that read from the same `block_chain JOIN blocks` join with different `WHERE` clauses (`/disapproved`, `/block/{hash}` status lookup, height-keyed status lookups). That shared struct is the main mutation hazard.
+
+## Section 2 — End-to-End Data Flow
+
+```text
+monetarium-node                                     ┐
+   │ getchaintips RPC (status: valid-headers /      │  writer paths
+   │  valid-fork)                                   │  (populate
+   ▼                                                │   is_mainchain=false)
+rpcutils.SideChains / SideChainFull                 │
+   │                                                │
+   ├── (A) startup, gated by cfg.ImportSideChains:  │
+   │     ChainDB.MissingSideChainBlocks             │
+   │     → CollectHash + StoreBlock(isMainchain=    │
+   │       false) → insertBlock + insertBlockPrev   │
+   │       Next                                     │
+   │                                                │
+   └── (B) live reorg:                              │
+         Notifier.ReorgHandler                      │
+         → db/dcrpg.ChainMonitor.ReorgHandler       │
+         → switchToSideChain                        │
+         → ChainDB.TipToSideChain                   │
+         → setMainchainByBlockHash(hash, false)     │
+           (+ updateTransactionsMainchain, votes,   │
+            tickets, addresses)                     ┘
+
+────────── read path (every /side request) ──────────
+
+HTTP GET /side
+   │
+   ▼
+chi router (cmd/dcrdata/main.go) → explorer.SideChains
+   │
+   ▼
+explorerUI.dataSource.SideChainBlocks(ctx)
+   │  (interface in cmd/dcrdata/internal/explorer/explorer.go)
+   ▼
+db/dcrpg.ChainDB.SideChainBlocks   ── queryTimeout context
+   │
+   ▼
+retrieveSideChainBlocks
+   │
+   │  SELECT is_valid, height, previous_hash, hash, block_chain.next_hash
+   │  FROM blocks
+   │  JOIN block_chain ON this_hash=hash
+   │  WHERE is_mainchain = FALSE
+   │  ORDER BY height DESC;
+   ▼
+[]*dbtypes.BlockStatus  (5 of 6 fields populated; IsMainchain left zero)
+   │
+   ▼
+templates.exec("sidechains", { CommonPageData, Data })
+   │
+   ▼
+views/sidechains.tmpl  →  HTML response
+```
+
+## Section 3 — Per-Layer Breakdown
+
+### Router
+
+- **Location:** [cmd/dcrdata/main.go:768](../../../cmd/dcrdata/main.go#L768)
+- **Code:** `r.Get("/side", explore.SideChains)` — no middleware, no `BlockHashPathOrIndexCtx`, no `CoinCtx`. The route is plain GET → handler.
+
+### Handler
+
+- **Location:** [cmd/dcrdata/internal/explorer/explorerroutes.go:238-268](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L238-L268)
+- **Logic:** call `dataSource.SideChainBlocks(ctx)`; on context-deadline error, render the timeout error page via `exp.timeoutErrorPage`; on any other error, render `StatusPage(defaultErrorCode, "failed to retrieve side chain blocks", ...)`; otherwise execute the `"sidechains"` template with `{ *CommonPageData, Data []*dbtypes.BlockStatus }`.
+- **No mutation, no derived fields, no per-coin handling.** The handler is a thin pass-through.
+
+### DataSource interface
+
+- **Location:** [cmd/dcrdata/internal/explorer/explorer.go:90](../../../cmd/dcrdata/internal/explorer/explorer.go#L90) — `SideChainBlocks(context.Context) ([]*dbtypes.BlockStatus, error)`
+- **Test mock:** [cmd/dcrdata/internal/explorer/explorer_test.go:70](../../../cmd/dcrdata/internal/explorer/explorer_test.go#L70) — fan-out point if the signature ever changes (see [address/impact.md](../address/impact.md) for the analogous coin-filter signature fan-out lesson).
+
+### ChainDB read method
+
+- **Location:** [db/dcrpg/pgblockchain.go:847-853](../../../db/dcrpg/pgblockchain.go#L847-L853)
+- **Behavior:** wraps `retrieveSideChainBlocks` in a `context.WithTimeout(ctx, pgb.queryTimeout)` and routes the cancellation error through `pgb.replaceCancelError` so the handler sees a recognizable timeout sentinel.
+
+### SQL query + Scan
+
+- **SQL:** [db/dcrpg/internal/blockstmts.go:170-174](../../../db/dcrpg/internal/blockstmts.go#L170-L174)
+  ```sql
+  SelectSideChainBlocks = `SELECT is_valid, height, previous_hash, hash, block_chain.next_hash
+      FROM blocks
+      JOIN block_chain ON this_hash=hash
+      WHERE is_mainchain = FALSE
+      ORDER BY height DESC;`
+  ```
+- **Scan:** [db/dcrpg/queries.go:3969-3991](../../../db/dcrpg/queries.go#L3969-L3991)
+  ```go
+  err = rows.Scan(&bs.IsValid, &bs.Height, &bs.PrevHash, &bs.Hash, &bs.NextHash)
+  ```
+- **Critical:** Scan is **positional and column-narrow**. Five columns map to five of the six struct fields. `bs.IsMainchain` is **never written** — left at its Go zero value (`false`). The WHERE clause already filters `is_mainchain=false`, so the template can treat all rows as side-chain, but anyone reading the returned slice elsewhere must remember `IsMainchain` is unreliable for this code path.
+
+### `BlockStatus` shared struct
+
+- **Location:** [db/dbtypes/types.go:2267-2275](../../../db/dbtypes/types.go#L2267-L2275)
+  ```go
+  type BlockStatus struct {
+      IsValid     bool
+      IsMainchain bool
+      Height      uint32
+      PrevHash    ChainHash
+      Hash        ChainHash
+      NextHash    ChainHash
+  }
+  ```
+- **Reused by 4 SQL queries with different column subsets:**
+  - `SelectSideChainBlocks` (this flow) — 5 cols, skips `is_mainchain`. See [db/dcrpg/internal/blockstmts.go:170-174](../../../db/dcrpg/internal/blockstmts.go#L170-L174).
+  - `SelectBlockStatus` — 6 cols, all fields. See [db/dcrpg/internal/blockstmts.go:176-179](../../../db/dcrpg/internal/blockstmts.go#L176-L179) and [db/dcrpg/queries.go:4040-4051](../../../db/dcrpg/queries.go#L4040-L4051).
+  - `SelectBlockStatuses` — 3 cols (height-keyed status lookup). See [db/dcrpg/internal/blockstmts.go:181-183](../../../db/dcrpg/internal/blockstmts.go#L181-L183) and the Scan around [db/dcrpg/queries.go:4060-4070](../../../db/dcrpg/queries.go#L4060-L4070).
+  - `SelectDisapprovedBlocks` (`/disapproved` page) — 5 cols, skips `is_valid` (the WHERE already filters `is_valid=false`). See [db/dcrpg/internal/blockstmts.go:189-193](../../../db/dcrpg/internal/blockstmts.go#L189-L193).
+- **Implication:** any reordering or addition of fields on `BlockStatus`, or any column reordering in any of these four queries, breaks at least one positional `Scan` silently (wrong field gets the value) or loudly (`sql.Scan: expected N destinations, got M`).
+
+### Template
+
+- **Location:** [cmd/dcrdata/views/sidechains.tmpl](../../../cmd/dcrdata/views/sidechains.tmpl)
+- **Columns rendered:** `Height` (link to `/block/{hash}`), `PoS Approved` (`.IsValid`), `Parent` (`.PrevHash` → `/block/{prev}`), `Child` (`.NextHash` if set → `/block/{next}`; otherwise "none" with a `title="This block is the tip of its chain."`).
+- **No JS controller is bound** beyond `data-controller="time"` (used by the navbar / time helpers, not by the side-chain table itself). The template has no `data-*` attributes for amounts and renders nothing that needs reconciling at the WebSocket layer.
+
+### Writer paths (how rows reach `is_mainchain=false`)
+
+There are **two and only two** writer paths that populate the rows /side reads:
+
+1. **Startup batch import** (gated by the `ImportSideChains` config flag).
+   - Flag definition: [cmd/dcrdata/config.go:151](../../../cmd/dcrdata/config.go#L151) — marked *experimental*, defaults to `false`. Env: `DCRDATA_IMPORT_SIDE_CHAINS`.
+   - Caller: [cmd/dcrdata/main.go:885-960](../../../cmd/dcrdata/main.go#L885-L960). Calls `chainDB.MissingSideChainBlocks(ctx)` then loops over each `SideChain.Hashes`, calls `collector.CollectHash(&blockHash)` + `chainDB.StoreBlock(msgBlock, /*isValid*/ true, /*isMainchain*/ false, ...)`.
+   - `MissingSideChainBlocks`: [db/dcrpg/pgblockchain.go:337-397](../../../db/dcrpg/pgblockchain.go#L337-L397) — drives off `rpcutils.SideChains(pgb.Client)` (filters `getchaintips` results by status `valid-headers` / `valid-fork`, see [rpcutils/rpcclient.go:320-332](../../../rpcutils/rpcclient.go#L320-L332)) and walks each tip backwards via `rpcutils.SideChainFull` ([rpcutils/rpcclient.go:334-371](../../../rpcutils/rpcclient.go#L334-L371)).
+   - `StoreBlock` writes a `block_chain` row for each side-chain block with `isMainchain=false`. The `block_chain` row is inserted via `insertBlockPrevNext` ([db/dcrpg/pgblockchain.go:3989-3994](../../../db/dcrpg/pgblockchain.go#L3989-L3994)). Side-chain blocks **skip** the `updateLastBlock` chain-linking when the previous block is mainchain ([db/dcrpg/pgblockchain.go:4058-4076](../../../db/dcrpg/pgblockchain.go#L4058-L4076)) — so /side rows whose `PrevHash` points at a mainchain block correctly leave the mainchain block's `next_hash` alone.
+
+2. **Live reorg** (every running instance, no flag).
+   - Notifier registers reorg handlers at [cmd/dcrdata/main.go:1066-1068](../../../cmd/dcrdata/main.go#L1066-L1068).
+   - `db/dcrpg.ChainMonitor.ReorgHandler` ([db/dcrpg/chainmonitor.go:139-175](../../../db/dcrpg/chainmonitor.go#L139-L175)) sets `InReorg=true`, calls `switchToSideChain(reorg)` ([db/dcrpg/chainmonitor.go:34-…](../../../db/dcrpg/chainmonitor.go#L34)).
+   - `switchToSideChain` → `ChainDB.TipToSideChain(mainRoot)` ([db/dcrpg/pgblockchain.go:3704-…](../../../db/dcrpg/pgblockchain.go#L3704)) walks from the current tip down to the common ancestor, calling `setMainchainByBlockHash(tipHash, false)` ([db/dcrpg/queries.go:4195-4200](../../../db/dcrpg/queries.go#L4195-L4200), backed by `UpdateBlockMainchain` in [db/dcrpg/internal/blockstmts.go:204](../../../db/dcrpg/internal/blockstmts.go#L204)) for each block. The same loop also flips `is_mainchain` on transactions, votes, tickets, addresses, and clears spent-vout markers via `clearVoutAllSpendTxRowIDs`.
+   - The new mainchain branch then comes in through the normal block-connect path.
+
+**Observation:** the reorg writer path mutates only the `blocks.is_mainchain` column on existing rows; it does **not** insert new `block_chain` rows for the demoted blocks (they already exist from when they were mainchain). The startup import path is the only one that *inserts* fresh `block_chain` rows for side blocks the explorer has never seen as mainchain.
+
+## Section 4 — Cross-Layer Dependencies
+
+- **Handler ↔ DataSource interface:** the `SideChainBlocks(ctx)` method is one of ~30 methods on the `dataSource` interface ([cmd/dcrdata/internal/explorer/explorer.go:80-110](../../../cmd/dcrdata/internal/explorer/explorer.go#L80-L110)). The test mock at [cmd/dcrdata/internal/explorer/explorer_test.go:70](../../../cmd/dcrdata/internal/explorer/explorer_test.go#L70) must track the signature.
+- **SQL ↔ Scan ↔ Struct:** **three independent files** must stay in lockstep — `blockstmts.go` (SELECT column list), `queries.go` (`rows.Scan` destinations), `db/dbtypes/types.go` (struct field order/types). Positional binding means a one-line edit in any of the three can silently rewire data into the wrong field.
+- **Struct ↔ Sibling readers:** because `BlockStatus` is the return type of four different SQL functions with four different column subsets, a struct change ripples into `SideChainBlocks`, `DisapprovedBlocks`, `BlockStatus(hash)`, and `BlockStatuses(height)`. Two of those are page handlers (`/side`, `/disapproved`), two feed the `/block/{hash}` rendering and stakeholder approval checks (see [cmd/dcrdata/internal/explorer/explorerroutes.go:730](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L730)).
+- **Writer races:** a reorg can flip `is_mainchain` on rows mid-request. The page is best-effort consistent (each row reflects its current `is_mainchain`/`next_hash` state). No locking ties the read against `TipToSideChain`. Because the query is short, the practical window is small, but `next_hash` may briefly point at a hash whose own `is_mainchain` has just been flipped.
+
+## Section 5 — Critical Constraints
+
+This is one of the few pages where **most repository invariants do NOT apply**:
+
+- **C1 (precision bifurcation):** *Does not apply.* No amounts, no SKA, no per-coin maps. Don't add amount columns to this page without first reading C1 and adopting the SKA-string pipeline used elsewhere (`address`, `block`, `mempool`, `charts`).
+- **C3 (template + WebSocket parity):** *Does not apply by absence* — there is no WebSocket transport for this page. Adding live updates would force C3/C8 reconciliation against a new push path.
+- **C8 (dual-transport shape asymmetry):** *Does not apply* — single HTTP transport.
+
+What **does** apply:
+
+- **Positional `rows.Scan` invariant** (recurs across the codebase; see [time-based-blocks/impact.md](../time-based-blocks/impact.md) for the analogous risk in time-grouped block flows). Column order in `SelectSideChainBlocks` must match Scan destination order in `retrieveSideChainBlocks` must match the documented struct field ordering it depends on.
+- **Single-coin invariant** is *trivially satisfied* — side-chain blocks contain whatever transactions they contain, but this page renders no transaction or amount data, so the invariant cannot be violated *here*. It re-emerges if you ever add a "Tx count by coin type" column.
+- **`ImportSideChains` is off by default.** The /side page is an empty table unless either (a) a reorg occurred since this instance started, or (b) the operator explicitly opted into startup import. This is a product-visible constraint, not a code one.
+
+## Section 6 — Mutation Impact
+
+When modifying anything in this flow, check:
+
+1. **`BlockStatus` struct field order or type** — breaks 4 positional `Scan`s and 2 templates (`sidechains.tmpl`, `disapproved.tmpl`). Loud at Scan time if column count changes; **silent** if field types stay compatible (bool/bool, ChainHash/ChainHash). Always confirm by reading every `rows.Scan(&bs....)` in `db/dcrpg/queries.go` after a struct edit.
+2. **`SelectSideChainBlocks` column list** — must update `retrieveSideChainBlocks` `rows.Scan` in lockstep, otherwise loud Scan error or silent column shift.
+3. **`retrieveSideChainBlocks` Scan order** — same.
+4. **Template field references** — adding/removing struct fields breaks `{{.Field}}` references at template-parse time (loud, but only at request time, not build time — there is no Go-level type check on Go templates).
+5. **`StoreBlock(isMainchain=false)` path** — the *only* code that inserts new side-chain rows via the startup import. If you refactor `insertBlockPrevNext`, the `block_chain.next_hash`-NULL invariant for side-chain tips (used by the template's `{{if .NextHash}}…{{else}}none{{end}}` branch) can drift.
+6. **`TipToSideChain` / `setMainchainByBlockHash`** — these are the *only* writers that move existing rows from main to side under live conditions. If their atomicity changes (e.g. a per-row transaction is removed), the /side page may render partially-demoted rows.
+7. **Adding a real-time element (WebSocket push, Stimulus controller)** — instantly imports C3/C8/C4 into this domain. Don't bolt on WS updates without designing a dedicated message shape and a `data-controller` clone-template flow ([core/constraints.md](../../core/constraints.md) C6).
+
+**Silent failures:**
+
+- Column-order swap (e.g. swapping `is_valid` and `height` in either the SELECT or the Scan): the page renders nonsense in the "PoS Approved" column without throwing. Caught only by visual inspection.
+- Adding `is_mainchain` back into the SELECT column list **without** also adding `&bs.IsMainchain` to Scan: loud Scan error. Adding to Scan **without** updating SELECT: same error in the other direction.
+- Reorg occurring mid-request: a row whose `is_mainchain` was just flipped to `true` may still appear in the result set if the WHERE was evaluated pre-flip. Cosmetic; resolves on next refresh.
+- `ImportSideChains=false` operator default: page silently empty even when the node knows of side chains. **Not a bug — by design.**
+
+**Hard failures:**
+
+- Removing `is_mainchain` from the `blocks` table or the JOIN column from `block_chain`: SQL error on every request to `/side`, `/disapproved`, and any `BlockStatus` lookup.
+- Renaming `BlockStatus` fields without updating `sidechains.tmpl` / `disapproved.tmpl`: template-execute error rendered as `StatusPage(defaultErrorCode, ...)`.
+- `queryTimeout` set too low for an indexed scan over a large `blocks` table: `timeoutErrorPage` triggers and the user sees a timeout page.
+
+## Section 7 — Common Pitfalls
+
+- **Assuming `bs.IsMainchain` is populated by `SideChainBlocks`.** It isn't — the SQL omits the column. Anyone consuming the returned slice downstream and reading `IsMainchain` will see `false` for every row, which is *coincidentally correct* for this query but is **not** a contract — a future query change that introduces non-side rows would silently mislabel them. If you need to be sure, re-derive from the WHERE clause, not from the field.
+- **Bolt-on amount columns.** Tempting to add "tx count" / "value transferred" columns to make the page richer. That immediately re-invites C1, C7, and the SKA-string pipeline. Don't add amounts to `BlockStatus`; build a separate row type if needed.
+- **Refactor `BlockStatus` "to clean it up".** It looks like a small inert DTO but is load-bearing across 4 SQL functions, 2 pages, and the `/block/{hash}` status display. Treat it as an *external* contract.
+- **Confusing the two writer paths.** Startup `ImportSideChains` and live reorg `TipToSideChain` are independent. Side-chain blocks discovered by the node *before* this instance started will not appear unless `ImportSideChains=true`. A reorg during runtime *will* populate side rows regardless of the flag.
+- **Trusting `block_chain.next_hash` for side blocks at all times.** It is populated only when a *later* block on the same side chain is inserted via `StoreBlock` → `updateLastBlock`. Side-chain tips have NULL `next_hash` by design, which the template handles with the `none` branch.
+
+## Section 8 — Evidence
+
+- Route registration — [cmd/dcrdata/main.go:768](../../../cmd/dcrdata/main.go#L768)
+- Handler — [cmd/dcrdata/internal/explorer/explorerroutes.go:238-268](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L238-L268)
+- Interface — [cmd/dcrdata/internal/explorer/explorer.go:90](../../../cmd/dcrdata/internal/explorer/explorer.go#L90)
+- Test mock — [cmd/dcrdata/internal/explorer/explorer_test.go:70](../../../cmd/dcrdata/internal/explorer/explorer_test.go#L70)
+- ChainDB read method — [db/dcrpg/pgblockchain.go:847-853](../../../db/dcrpg/pgblockchain.go#L847-L853)
+- SQL — [db/dcrpg/internal/blockstmts.go:170-193](../../../db/dcrpg/internal/blockstmts.go#L170-L193)
+- Scan — [db/dcrpg/queries.go:3969-3991](../../../db/dcrpg/queries.go#L3969-L3991)
+- Struct — [db/dbtypes/types.go:2267-2275](../../../db/dbtypes/types.go#L2267-L2275)
+- Template — [cmd/dcrdata/views/sidechains.tmpl](../../../cmd/dcrdata/views/sidechains.tmpl)
+- Startup import — [cmd/dcrdata/main.go:885-960](../../../cmd/dcrdata/main.go#L885-L960); [cmd/dcrdata/config.go:151](../../../cmd/dcrdata/config.go#L151)
+- `MissingSideChainBlocks` — [db/dcrpg/pgblockchain.go:337-397](../../../db/dcrpg/pgblockchain.go#L337-L397)
+- `rpcutils.SideChains` / `SideChainFull` — [rpcutils/rpcclient.go:320-371](../../../rpcutils/rpcclient.go#L320-L371)
+- `StoreBlock` writer — [db/dcrpg/pgblockchain.go:3977-4040](../../../db/dcrpg/pgblockchain.go#L3977-L4040)
+- `updateLastBlock` side-chain guard — [db/dcrpg/pgblockchain.go:4058-4076](../../../db/dcrpg/pgblockchain.go#L4058-L4076)
+- Reorg handler chain — [cmd/dcrdata/main.go:1066-1068](../../../cmd/dcrdata/main.go#L1066-L1068); [db/dcrpg/chainmonitor.go:139-175](../../../db/dcrpg/chainmonitor.go#L139-L175)
+- `TipToSideChain` — [db/dcrpg/pgblockchain.go:3704](../../../db/dcrpg/pgblockchain.go#L3704)
+- `setMainchainByBlockHash` — [db/dcrpg/queries.go:4195-4200](../../../db/dcrpg/queries.go#L4195-L4200); UpdateBlockMainchain SQL — [db/dcrpg/internal/blockstmts.go:204](../../../db/dcrpg/internal/blockstmts.go#L204)
+
+See also:
+
+- [/wiki/code-analysis/block/flow.full.md](../block/flow.full.md) (shares-pattern-with: `BlockStatus` is also consumed by block-detail status lookups)
+- [/wiki/code-analysis/block/impact.md](../block/impact.md) (depends-on: block-ingestion mutations are the writers for side-chain rows too)
+- [/wiki/code-analysis/time-based-blocks/impact.md](../time-based-blocks/impact.md) (shares-pattern-with: positional `rows.Scan` desync risk)
+- [/wiki/code-analysis/page-rendering/patterns.md](../page-rendering/patterns.md) (depends-on: `*CommonPageData` embedding used by the handler)
+- [/wiki/core/constraints.md](../../core/constraints.md) (depends-on: C1 does NOT apply here — explicitly out of scope; C6 applies *if* a real-time element is ever added)

--- a/wiki/code-analysis/sidechain/flow.full.md
+++ b/wiki/code-analysis/sidechain/flow.full.md
@@ -222,6 +222,8 @@ When modifying anything in this flow, check:
 
 See also:
 
+- [/wiki/code-analysis/disapproved-blocks/flow.full.md](../disapproved-blocks/flow.full.md) (shares-pattern-with: structural twin — same `BlockStatus` shared struct, same 4-reader Scan invariant, mirrored filter-skip-in-SELECT trick; differs on writer semantics (`updateLastBlock` vote-bit cascade vs reorg + startup import) and on `withCache` ETag wrap (which `/disapproved` has and `/side` does not))
+- [/wiki/code-analysis/disapproved-blocks/impact.md](../disapproved-blocks/impact.md) (shares-pattern-with: `BlockStatus` 4-reader Scan blast; mirrored `IsValid` Scan-default trap vs this trace's `IsMainchain` Scan-default trap)
 - [/wiki/code-analysis/block/flow.full.md](../block/flow.full.md) (shares-pattern-with: `BlockStatus` is also consumed by block-detail status lookups)
 - [/wiki/code-analysis/block/impact.md](../block/impact.md) (depends-on: block-ingestion mutations are the writers for side-chain rows too)
 - [/wiki/code-analysis/time-based-blocks/impact.md](../time-based-blocks/impact.md) (shares-pattern-with: positional `rows.Scan` desync risk)

--- a/wiki/code-analysis/sidechain/impact.md
+++ b/wiki/code-analysis/sidechain/impact.md
@@ -1,0 +1,106 @@
+# Sidechain — Mutation Impact
+
+Blast-radius reference for changes that touch the `/side` page, its DB writers, or the shared `BlockStatus` row type. Companion to [flow.full.md](flow.full.md).
+
+## 1. `BlockStatus` struct edits (4-endpoint blast)
+
+**Trigger:** any change to [db/dbtypes/types.go:2267-2275](../../../db/dbtypes/types.go#L2267-L2275) — field add, remove, reorder, or type change.
+
+**Affected positional `rows.Scan` sites in [db/dcrpg/queries.go](../../../db/dcrpg/queries.go):**
+
+| Function | SQL (in [internal/blockstmts.go](../../../db/dcrpg/internal/blockstmts.go)) | Cols scanned | Skipped |
+|---|---|---|---|
+| `retrieveSideChainBlocks` ([queries.go:3969-3991](../../../db/dcrpg/queries.go#L3969-L3991)) | `SelectSideChainBlocks` | `is_valid, height, previous_hash, hash, next_hash` | `is_mainchain` (filtered by WHERE) |
+| `retrieveDisapprovedBlocks` ([queries.go:4020-…](../../../db/dcrpg/queries.go#L4020)) | `SelectDisapprovedBlocks` | `is_mainchain, height, previous_hash, hash, next_hash` | `is_valid` (filtered by WHERE) |
+| Block-status (single hash) | `SelectBlockStatus` | all 6 columns | — |
+| Block-statuses (by height) | `SelectBlockStatuses` | `is_valid, is_mainchain, hash` | `height, previous_hash, next_hash` |
+
+**Failure modes:**
+
+- **Loud** — adding a field whose type breaks positional Scan binding (e.g. inserting a new `string` between two `bool`s shifts the Scan offsets) → `sql.Rows.Scan: ...` at request time.
+- **Silent** — same-type swap (e.g. accidentally reorder `IsValid` and `IsMainchain`): all 4 Scan sites compile, page renders, but the "PoS Approved" column on `/side` now displays the `is_mainchain` value, and the `/disapproved` page mislabels disapproval status. No build/test signal — only visible by inspecting the rendered table.
+
+**Mitigation:** treat `BlockStatus` as an external contract. If you must change it, edit all 4 Scan sites in the same commit and grep for `*dbtypes.BlockStatus` consumers (`BlockStatus(ctx, hash)`, `BlockStatuses(ctx, height)`, `TransactionBlocks(...)`, the two page handlers) before merging.
+
+## 2. SQL ↔ Scan desync (positional invariant)
+
+**Trigger:** edit either `SelectSideChainBlocks` ([blockstmts.go:170-174](../../../db/dcrpg/internal/blockstmts.go#L170-L174)) or the matching `rows.Scan` ([queries.go:3981](../../../db/dcrpg/queries.go#L3981)) without updating the other.
+
+**Failure modes:**
+
+- Adding a column to SELECT without adding a `&bs.Field` → `sql.Rows.Scan: expected 6 destinations, got 5 in Scan` (or vice versa). Loud.
+- Reordering existing columns in SELECT → Scan binds wrong source to wrong destination. Silent if types are compatible.
+
+**Mitigation:** the SQL string and the Scan expression must be edited as one unit. Same risk pattern documented in [time-based-blocks/impact.md](../time-based-blocks/impact.md) for `BlocksGroupedInfo` Scan.
+
+## 3. `IsMainchain` is never populated on `/side` results
+
+**Trigger:** downstream code reads `bs.IsMainchain` from a slice returned by `ChainDB.SideChainBlocks(ctx)`.
+
+**Why it's a trap:** `SelectSideChainBlocks` does *not* SELECT `is_mainchain`, so the Scan leaves the field at Go-zero (`false`). For this specific query the value is coincidentally correct (the WHERE filtered `is_mainchain=false`), but the *field is uninitialized*, not assigned. A future maintainer who reuses these `[]*dbtypes.BlockStatus` rows in another context — or relaxes the WHERE clause — will see uniformly-false `IsMainchain` and mistake it for real data.
+
+**Failure mode:** silent — passes Go type-check and integration tests that don't read the field. Only visible if someone later filters by `bs.IsMainchain` and is surprised that everything is "side".
+
+**Mitigation:** when reading a `BlockStatus`, know which SQL function produced it. If `IsMainchain` matters, use `SelectBlockStatus` / `SelectBlockStatuses`.
+
+## 4. `ImportSideChains` flag — empty page is *correct*
+
+**Trigger:** operator complains that `/side` is empty despite the node reporting side chains in `getchaintips`.
+
+**Why:** `cfg.ImportSideChains` defaults to `false` ([cmd/dcrdata/config.go:151](../../../cmd/dcrdata/config.go#L151), marked *experimental*). The startup batch import at [cmd/dcrdata/main.go:885-960](../../../cmd/dcrdata/main.go#L885-L960) only runs when the flag is on. Without the flag, side-chain rows enter the DB only via live reorgs that happen *after* this instance started.
+
+**Failure mode:** silent product behavior — not a bug. Document this in any spec that promises "side chains since genesis".
+
+**Mitigation:** if /side completeness becomes a product requirement, switch to enabling the flag by default *or* run a one-shot import on upgrade. Either change widens the startup window meaningfully — measure first.
+
+## 5. Reorg-during-request consistency
+
+**Trigger:** `TipToSideChain` runs while a `/side` request is mid-flight.
+
+**Why:** the read query (`retrieveSideChainBlocks`) and the writer (`setMainchainByBlockHash` per row, plus per-row updates to transactions / votes / tickets / addresses in [pgblockchain.go:3704-…](../../../db/dcrpg/pgblockchain.go#L3704)) share no application-level lock. Postgres MVCC isolates the SELECT, but the writer commits row-by-row, so the next request can see a different set.
+
+**Failure mode:** silent and benign — page shows the snapshot at that request's read timestamp. Resolves on refresh.
+
+**Mitigation:** none needed unless you start emitting `/side` as a side-effect of a write path. If you do, snapshot the height range explicitly.
+
+## 6. Adding a real-time element imports C3/C8/C4
+
+**Trigger:** "let's push new side-chain blocks via WebSocket as they're discovered."
+
+**Why:** the page currently has zero WS/Stimulus surface. Adding one immediately imports the dual-transport patterns documented for `block`, `visualblocks`, and `mempool`: server-side template render *and* WS message *and* JS reconciliation must all match field-by-field ([core/constraints.md](../../core/constraints.md) C3/C8, plus C6 for clone-template rendering).
+
+**Failure mode:** the classic C8 bug — server-rendered initial table shows correct data, WS-pushed updates silently miss new fields, and the page degrades on refresh.
+
+**Mitigation:** if you really want this, design the WS payload, the `<template>` clone target, and the JS controller as a single unit. Cross-reference [visualblocks/patterns.md](../visualblocks/patterns.md) for prior art on dual-pipeline tile rendering — `/side` would be the simplest possible instance of that pattern.
+
+## 7. Adding amount columns re-imports C1
+
+**Trigger:** product asks for "value transferred in side blocks" or "tx count by coin" on `/side`.
+
+**Why:** the current row type is precision-free. As soon as you carry amounts, SKA's 18-decimal precision must be preserved as `big.Int`-derived strings end-to-end ([core/constraints.md](../../core/constraints.md) C1). The naive path — extend `BlockStatus` with a `float64` total — silently corrupts SKA values.
+
+**Failure mode:** silent precision loss on SKA values; VAR rows look fine in tests that only exercise VAR.
+
+**Mitigation:** build a separate row type (`SideChainBlockRow` or similar) that carries `CoinStats map[uint8]CoinStat` or per-coin amount strings, exactly as `BlocksGroupedInfo`/`address.AddressInfo` do. Do not extend `BlockStatus`.
+
+## 8. Writer-path asymmetry: insert vs update
+
+**Trigger:** refactor of the side-chain writers.
+
+**Why:**
+
+- Startup import (`StoreBlock(isMainchain=false)`) **inserts** new `block_chain` rows.
+- Live reorg (`TipToSideChain`) **updates** existing `blocks.is_mainchain`; it does *not* touch `block_chain` (those rows already exist from when the block was mainchain).
+
+If the two paths are unified — for example by routing both through a single "make this block side-chain" helper — make sure the new helper still distinguishes "row does not exist yet" (insert + `insertBlockPrevNext`) from "row exists with `is_mainchain=true`" (UPDATE only). Conflating them risks duplicate `block_chain` rows.
+
+**Mitigation:** keep the `is_mainchain=false` insertion path (`StoreBlock`/`insertBlockPrevNext`) separate from the demotion path (`setMainchainByBlockHash`), or assert single-row presence before inserting.
+
+---
+
+## See also
+
+- [/wiki/code-analysis/sidechain/flow.full.md](flow.full.md) (companion full flow)
+- [/wiki/code-analysis/block/impact.md](../block/impact.md) (depends-on: block ingestion writes side rows too via `StoreBlock`)
+- [/wiki/code-analysis/time-based-blocks/impact.md](../time-based-blocks/impact.md) (shares-pattern-with: positional `rows.Scan` desync risk)
+- [/wiki/core/constraints.md](../../core/constraints.md) (C1 explicitly out of scope here; C3/C6/C8 become applicable the moment any real-time element is added)

--- a/wiki/code-analysis/sidechain/impact.md
+++ b/wiki/code-analysis/sidechain/impact.md
@@ -101,6 +101,8 @@ If the two paths are unified — for example by routing both through a single "m
 ## See also
 
 - [/wiki/code-analysis/sidechain/flow.full.md](flow.full.md) (companion full flow)
+- [/wiki/code-analysis/disapproved-blocks/impact.md](../disapproved-blocks/impact.md) (shares-pattern-with: `BlockStatus` 4-reader Scan blast; mirrored Scan-default trap on `IsValid` rather than `IsMainchain`; differs on writer — always-on `updateLastBlock` cascade vs `/side`'s opt-in startup import + reorg)
+- [/wiki/code-analysis/disapproved-blocks/flow.full.md](../disapproved-blocks/flow.full.md) (shares-pattern-with: structural twin read path; filter-skip-in-SELECT trick on a different column)
 - [/wiki/code-analysis/block/impact.md](../block/impact.md) (depends-on: block ingestion writes side rows too via `StoreBlock`)
 - [/wiki/code-analysis/time-based-blocks/impact.md](../time-based-blocks/impact.md) (shares-pattern-with: positional `rows.Scan` desync risk)
 - [/wiki/core/constraints.md](../../core/constraints.md) (C1 explicitly out of scope here; C3/C6/C8 become applicable the moment any real-time element is added)

--- a/wiki/code-analysis/ticketpool/flow.compact.md
+++ b/wiki/code-analysis/ticketpool/flow.compact.md
@@ -1,0 +1,30 @@
+# /ticketpool — Compact Knowledge
+
+## Flow
+
+`Postgres tickets/transactions → ChainDB.TicketPoolVisualization → ticketPoolGraphsCache (process-global, height-keyed, trylock-gated) → {HTTP /api/ticketpool/charts | HTTP /api/ticketpool/bydate/{tp} | WS getticketpooldata→Resp} → ticketpool_controller.js processData → Dygraphs purchases+price + DOM outputs table`. Server handler `explorerUI.Ticketpool` renders only the template shell with `commonData`; **zero chart data is SSR-injected**. JS re-requests over WS on every `newblock` signal (server `sigNewBlock` carries `WebsocketBlock`, not ticket data).
+
+## Key Architectural Patterns
+
+- **P1 Form-shell over WS-RPC.** Same shape as `/decodetx`: HTML carries no data; JS holds the `getticketpooldata`/`getticketpooldataResp` request/response loop. Refresh trigger = client-side `newblock` listener, not a server push of ticket data.
+- **P2 Tri-modal struct with positional Scan.** One `dbtypes.PoolTicketsData` (`Time/Price/Mempool/Immature/Live/Outputs/Count` parallel slices) is populated by three different SQL Scans, each filling a different field subset. Column reordering swaps fields silently.
+- **P3 Stale-while-revalidate cache.** Package-`var` `ticketPoolGraphsCache` keyed `(interval, height)`. `TryLock` on `tpUpdatePermission[interval]` picks the updater; stale data is served immediately to non-updaters. Inner refresh retries on `pgb.Height()` advance to keep the three sub-charts consistent at one block.
+- **P4 Dual-transport overlay with divergent semantics.** Same JSON field `mempool.price` (`apitypes.PriceCountTime.Price float64`), two formulas: REST = `stakeDiff.ToCoin() + feeAvg`; WS = `inv.Tickets[0].TotalOut`. C8-class asymmetry inside one logical field.
+
+## Critical Constraints
+
+- Tickets are **VAR-only** (C1, [/wiki/core/staking-rewards.md](../../core/staking-rewards.md) §2). Entire pipeline is float64; safe *only* because of VAR's 8-decimal precision. Adding SKA tickets requires a full `[]string`/`*big.Int` rewrite.
+- `Bars` button strings (`"all"/"day"/"wk"/"mo"`) must match `dbtypes.TimeGroupingFromStr`; mismatch silently falls into `UnknownGrouping` → 422.
+- WS event names `getticketpooldata` / `getticketpooldataResp` are hardcoded in both JS and the Go switch; `EventId + "Resp"` is appended server-side.
+- `populateOutputs` uses `innerHTML` (C6 exception); tolerated because all interpolated values pass through `parseInt()`. Do not add string interpolation.
+- JS purchases-chart y2 label says `(DCR)`; price-chart x-label says `(VAR)`. Legacy `DCR` leak.
+
+## Mutation Checklist
+
+When changing `/ticketpool`: (1) align all three `rows.Scan` calls with their SELECT column order; (2) mirror any new field across REST `getTicketPoolCharts` and WS `getticketpooldata` payloads; (3) update mempool overlay on **both** sides if semantics change; (4) extend `dbtypes.TimeBasedGroupings` map + `TimeGroupingFromStr` switch + JS button HTML together; (5) never widen `PoolTicketsData.Price` to carry SKA without converting to a string/BigInt pipeline; (6) preserve the height-retry loop in `ticketPoolVisualization` to keep the three sub-charts at one block.
+
+See also:
+- [/wiki/code-analysis/ticketpool/flow.full.md](flow.full.md)
+- [/wiki/code-analysis/ticketpool/patterns.md](patterns.md)
+- [/wiki/code-analysis/ticketpool/impact.md](impact.md)
+- [/wiki/core/constraints.md](../../core/constraints.md) (C1, C2, C3, C6, C7, C8)

--- a/wiki/code-analysis/ticketpool/flow.full.md
+++ b/wiki/code-analysis/ticketpool/flow.full.md
@@ -1,0 +1,256 @@
+# /ticketpool — Full Data-Flow Trace
+
+## Section 1 — Overview
+
+`/ticketpool` is a **no-data HTML shell + three live data channels**. The Go handler returns only the template + `commonData`; every data series rendered by Dygraphs (purchase-time histogram, price histogram, sstxcommitment-output donut) reaches the page via:
+
+1. HTTP `GET /api/ticketpool/charts` on first connect (full payload).
+2. HTTP `GET /api/ticketpool/bydate/{tp}` on **Bars** button change (time chart only, re-binned).
+3. WebSocket `getticketpooldata <bars>` request fired by the JS on every `newblock` signal → `getticketpooldataResp` (full payload).
+
+All three sources funnel through one DB helper: `ChainDB.TicketPoolVisualization(ctx, interval)`. Results are memoized in a **process-global, height-keyed, lazy-refresh cache** (`ticketPoolGraphsCache`) gated by per-interval `trylock.Mutex` (stale-while-revalidate).
+
+Ticket data is **VAR-only by chain design** (PoS staking instrument denominated in VAR; tickets pay out per [/wiki/core/staking-rewards.md](../../core/staking-rewards.md) §2–3). `PoolTicketsData.Price` is `[]float64`, safe under C1.
+
+## Section 2 — End-to-End Data Flow
+
+```
+Postgres `tickets` JOIN `transactions`
+   │  retrieveTicketsByDate / retrieveTicketByPrice / retrieveTicketsGroupedByType
+   ▼
+ChainDB.ticketPoolVisualization  →  ticketPoolGraphsCache (per-interval, height-keyed)
+   │
+   ├─ HTTP path:
+   │     appContext.getTicketPoolCharts   ← /api/ticketpool/charts
+   │     appContext.getTicketPoolByDate   ← /api/ticketpool/bydate/{tp}   (TicketPoolCtx middleware)
+   │        + DataSource.GetMempoolPriceCountTime()  →  apitypes.PriceCountTime
+   │     ▼
+   │     apitypes.TicketPoolChartsData (JSON)
+   │
+   └─ WS path:
+         explorerUI.RootWebsocket switch "getticketpooldata"
+            + inv.Tickets[0].TotalOut / len(inv.Tickets)   ← divergent mempool source
+         ▼
+         apitypes.TicketPoolChartsData (JSON, event "getticketpooldataResp")
+
+Browser:
+  views/ticketpool.tmpl  (static shell, data-controller="ticketpool")
+  public/js/controllers/ticketpool_controller.js
+     initialize() → lazy-import Dygraphs → makePurchasesGraph / makePriceGraph
+     connect()    → ws.registerEvtHandler('newblock')         → ws.send('getticketpooldata', this.bars)
+                  → ws.registerEvtHandler('getticketpooldataResp') → processData(JSON.parse(evt))
+                  → fetchAll() → GET /api/ticketpool/charts
+     onBarsChange → GET /api/ticketpool/bydate/{bars} → purchasesGraph.updateOptions
+     processData  → purchasesGraphData / priceGraphData / populateOutputs
+```
+
+## Section 3 — Per-Layer Breakdown
+
+### 3.1 Postgres / SQL
+
+**Location:** [db/dcrpg/internal/stakestmts.go:106-122](../../../db/dcrpg/internal/stakestmts.go#L106-L122), [db/dcrpg/internal/stakestmts.go:509-512](../../../db/dcrpg/internal/stakestmts.go#L509-L512), [db/dcrpg/internal/txstmts.go:165-170](../../../db/dcrpg/internal/txstmts.go#L165-L170).
+
+Three statements, all filtering `pool_status = 0 AND tickets.is_mainchain = TRUE`:
+
+- `SelectTicketsByPrice` — `SELECT price::NUMERIC, SUM(... block_height >= $1) immature, SUM(... < $1) live ... GROUP BY price::NUMERIC ORDER BY price::NUMERIC`.
+- `selectTicketsByPurchaseDate` (templated via `MakeSelectTicketsByPurchaseDate` → `formatGroupingQuery(... "transactions.block_time")`) — same shape, grouping is a Postgres `date_trunc` expression substituted via `%s`. The grouping string comes from `dbtypes.TimeBasedGrouping.String()` (`"all"|"year"|"month"|"week"|"day"`). `formatGroupingQuery` is the same family used by [/wiki/code-analysis/time-based-blocks/patterns.md](../time-based-blocks/patterns.md).
+- `SelectTicketsByType` — `SELECT DISTINCT num_vout, COUNT(*) ... GROUP BY num_vout`. Maps directly to the donut "Distribution of Tickets by Reward Outputs".
+
+Maturity boundary is computed in Go, not SQL: `bestBlock - chainParams.TicketMaturity` ([db/dcrpg/pgblockchain.go:1785-1790](../../../db/dcrpg/pgblockchain.go#L1785-L1790)). Postgres only knows the parameter `$1`.
+
+### 3.2 Scan / shaping into `dbtypes.PoolTicketsData`
+
+**Location:** [db/dcrpg/queries.go:1138-1236](../../../db/dcrpg/queries.go#L1138-L1236).
+
+`dbtypes.PoolTicketsData` ([db/dbtypes/types.go:2120-2128](../../../db/dbtypes/types.go#L2120-L2128)) is a flat-arrays-of-equal-length struct (`Time`, `Price`, `Mempool`, `Immature`, `Live`, `Outputs`, `Count`). One struct, three different population shapes:
+
+| Producer | Fields populated | Notes |
+|---|---|---|
+| `retrieveTicketsByDate` | `Time`, `Immature`, `Live`, `Price` | `Price[i] = toCoin(uint64(SUM(price)*1e8) / (live+immature))` — average per group as float64 VAR. |
+| `retrieveTicketByPrice` | `Immature`, `Live`, `Price` | `Price[i]` scanned directly from `price::NUMERIC` into Go `float64`. |
+| `retrieveTicketsGroupedByType` | `Outputs`, `Count` | `Outputs[i] = (num_vout - 1) / 2` (sstxcommitment count). |
+
+Critical detail: `retrieveTicketsByDate` does `uint64(price*1e8) / (live+immature)` — the `*1e8` round-trip via `float64` is a VAR-only path; safe per C1. **Do not extend this routine to SKA atoms** without rewriting to `*big.Int`.
+
+`toCoin(amt) = float64(amt)/1e8` ([db/dcrpg/queries.go:4297-4299](../../../db/dcrpg/queries.go#L4297-L4299)) — generic over `int64|uint64`, VAR-only.
+
+### 3.3 Cache layer
+
+**Location:** [db/dcrpg/pgblockchain.go:74-132](../../../db/dcrpg/pgblockchain.go#L74-L132), [db/dcrpg/pgblockchain.go:1830-1943](../../../db/dcrpg/pgblockchain.go#L1830-L1943).
+
+- `ticketPoolGraphsCache` is a **package-level `var`** — process-global, not per-`ChainDB`. Single-instance binary today; flag for future.
+- Per-interval maps: `Height[interval]`, `TimeGraphCache[interval]`, `PriceGraphCache[interval]`, `DonutGraphCache[interval]`.
+- Freshness: `isStale = (cache.Height[interval] != pgb.Height())`. No proactive invalidation; cache is refreshed lazily on first request after the block tip changes.
+- Concurrency: a `RWMutex` guards the cache maps; **`pgb.tpUpdatePermission[interval]` (`trylock.Mutex`)** gates which goroutine becomes the updater. A caller that finds stale data and *cannot* `TryLock` returns the stale copy immediately (does not block); a caller that finds *no* data blocks on the same lock until the in-flight updater finishes.
+- After refresh, the inner `ticketPoolVisualization` ([db/dcrpg/pgblockchain.go:1899-1943](../../../db/dcrpg/pgblockchain.go#L1899-L1943)) re-checks `pgb.Height()` after the three SQL queries and **retries from scratch if the height changed mid-query** to keep `(timeChart, priceChart, donutChart)` mutually consistent at a single height.
+
+### 3.4 HTTP API (REST)
+
+**Location:** [cmd/dcrdata/internal/api/apirouter.go:245-249](../../../cmd/dcrdata/internal/api/apirouter.go#L245-L249), [cmd/dcrdata/internal/api/apiroutes.go:1257-1325](../../../cmd/dcrdata/internal/api/apiroutes.go#L1257-L1325).
+
+Routes:
+
+- `GET /api/ticketpool/charts` → `getTicketPoolCharts` → `TicketPoolVisualization(ctx, AllGrouping)` **always**. Wraps in `apitypes.TicketPoolChartsData` and tacks on `Mempool: GetMempoolPriceCountTime()`.
+- `GET /api/ticketpool/bydate/{tp}` → `TicketPoolCtx` middleware ([cmd/dcrdata/internal/middleware/apimiddleware.go:691-699](../../../cmd/dcrdata/internal/middleware/apimiddleware.go#L691-L699)) stuffs `{tp}` into the request context → `getTicketPoolByDate` reads it via `m.GetTpCtx(r)`, defaults to `"day"` when empty, runs `TimeGroupingFromStr`, returns **only `TimeChart` + `height`** (price/donut discarded). `UnknownGrouping` → 422.
+- `GET /api/ticketpool/` → routed to `getTicketPoolByDate` with no `{tp}` → defaults to `"day"`.
+
+The wire shape for the full payload is `apitypes.TicketPoolChartsData`:
+
+```go
+// api/types/apitypes.go:933-939
+type TicketPoolChartsData struct {
+    ChartHeight  uint64                   `json:"height"`
+    TimeChart    *dbtypes.PoolTicketsData `json:"time_chart"`
+    PriceChart   *dbtypes.PoolTicketsData `json:"price_chart"`
+    OutputsChart *dbtypes.PoolTicketsData `json:"outputs_chart"`
+    Mempool      *PriceCountTime          `json:"mempool"`
+}
+```
+
+The `/bydate/{tp}` response uses an anonymous struct `{ Height int64; TimeChart *PoolTicketsData }` ([cmd/dcrdata/internal/api/apiroutes.go:1316-1322](../../../cmd/dcrdata/internal/api/apiroutes.go#L1316-L1322)). **The JS controller relies on `data.time_chart` and never reads `data.height` from this response** (note: capitalization mismatch — Go field `Height` serializes to `"height"`, but the JS controller only reads `data.height` from the *charts* / WS payloads, not from `bydate`). The `bydate` response carries no mempool.
+
+### 3.5 Mempool overlay (two divergent paths for the same logical field)
+
+REST `getTicketPoolCharts` ([cmd/dcrdata/internal/api/apiroutes.go:1274](../../../cmd/dcrdata/internal/api/apiroutes.go#L1274)):
+
+```go
+mp := c.DataSource.GetMempoolPriceCountTime()
+```
+
+→ [db/dcrpg/pgblockchain.go:6402-6406](../../../db/dcrpg/pgblockchain.go#L6402-L6406) → [mempool/mempoolcache.go:192-214](../../../mempool/mempoolcache.go#L192-L214):
+
+```go
+return &apitypes.PriceCountTime{
+    Price: dcrutil.Amount(c.stakeDiff).ToCoin() + feeAvg,  // stakeDiff + rolling avg of last N fees
+    Count: numFees,
+    Time:  dbtypes.NewTimeDef(c.timestamp),
+}
+```
+
+WS `getticketpooldata` ([cmd/dcrdata/internal/explorer/websockethandlers.go:194-205](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L194-L205)):
+
+```go
+mp := new(apitypes.PriceCountTime)
+inv := exp.MempoolInventory(); inv.RLock()
+if len(inv.Tickets) > 0 {
+    mp.Price = inv.Tickets[0].TotalOut       // first ticket's *raw* total out
+    mp.Count = len(inv.Tickets)              // count of *all* tickets in inv
+    mp.Time  = dbtypes.NewTimeDefFromUNIX(inv.Tickets[0].Time)
+}
+inv.RUnlock()
+```
+
+**Same field name, same JSON shape, different semantics**: REST → cached `stakeDiff + feeAvg`; WS → the head-of-list ticket's `TotalOut` (a `txhelpers.TotalOutFromMsgTx(msgTx).ToCoin()` VAR float). On a quiet mempool, `inv.Tickets[0].TotalOut` can be price+fee for *that single* ticket. On the REST path, `Price` is the predicted next-block ticket price. This is a real C8-class dual-transport asymmetry inside one logical field.
+
+### 3.6 WebSocket request/response path
+
+**Location:** [cmd/dcrdata/internal/explorer/websockethandlers.go:169-221](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L169-L221).
+
+The explorer `/ws` handler is a request/response RPC-over-WebSocket switch (same shape as `decodetx` / `getmempooltxs` — see [/wiki/code-analysis/decodetx/patterns.md](../decodetx/patterns.md) P1). The client sends `WebSocketMessage{EventId: "getticketpooldata", Message: "<interval-string>"}`; the server replies with `EventId: "getticketpooldataResp"` (suffix appended at line 231: `webData.EventId = msg.EventId + "Resp"`). The reply payload is the JSON-marshaled `TicketPoolChartsData` (same struct as REST `/api/ticketpool/charts`, including the divergent `Mempool`).
+
+The `newblock` push on the *server* (`sigNewBlock`) does **not** deliver ticketpool data — it delivers a `WebsocketBlock{Block, Extra}` ([cmd/dcrdata/internal/explorer/websockethandlers.go:271-282](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L271-L282)). The *client* JS listens for the `newblock` event and reactively re-requests ticketpool data via `ws.send('getticketpooldata', this.bars)`. So `newblock` is a refresh **trigger**, not a payload carrier — and the server has zero knowledge of which `bars` setting each client holds.
+
+### 3.7 Server-side page handler
+
+**Location:** [cmd/dcrdata/internal/explorer/explorerroutes.go:811-824](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L811-L824).
+
+```go
+func (exp *explorerUI) Ticketpool(w http.ResponseWriter, r *http.Request) {
+    str, err := exp.templates.exec("ticketpool", exp.commonData(r))
+    // ...
+}
+```
+
+A no-compute handler — same "form-shell" shape as `/decodetx` ([/wiki/code-analysis/decodetx/patterns.md](../decodetx/patterns.md) P1) and `/parameters` ([/wiki/code-analysis/parameters/patterns.md](../parameters/patterns.md)). The only data injected at render time is `*CommonPageData` (see [/wiki/code-analysis/page-rendering/patterns.md](../page-rendering/patterns.md)).
+
+### 3.8 Template
+
+**Location:** [cmd/dcrdata/views/ticketpool.tmpl](../../../cmd/dcrdata/views/ticketpool.tmpl).
+
+A static shell with `data-controller="ticketpool"`. Three Dygraph mount points (`#tickets-by-purchase-date`, `#tickets-by-purchase-price`) plus one table for the outputs donut (`data-ticketpool-target="outputs"`). Zoom and Bars button rows are mirror-symmetric (same four values: `all` / `day` / `wk` / `mo`). The template carries **no server-rendered data series whatsoever**.
+
+### 3.9 JS controller
+
+**Location:** [cmd/dcrdata/public/js/controllers/ticketpool_controller.js](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js).
+
+- `initialize()` — lazy-imports Dygraphs (`/* webpackChunkName: "dygraphs" */`), builds two empty graphs (`makePurchasesGraph` with seed `[[0,0,0,0,0]]`, `makePriceGraph` with seed `[[0,0,0,0]]`).
+- `connect()` — registers `newblock` (→ re-fire WS request) and `getticketpooldataResp` (→ `processData`) handlers, then runs `fetchAll()`.
+- `fetchAll()` — `requestJSON('/api/ticketpool/charts')` → `processData`.
+- `processData(data)` — branches on which keys are present (full payload sets all four; `bydate` only sets `time_chart`). Mempool overlay is merged into the time chart only if `tipHeight === data.height` (`processData` line 180).
+- `purchasesGraphData(items, memP)` — iterates `items.time[]` (parses ISO strings → `Date`), produces rows `[date, mempoolCount, immature, live, price]`. Sets module-globals `origDate` (epoch ms of first bucket) and `ms` (epoch ms of last bucket + 1000ms) used by `getWindow` for the Zoom buttons.
+- `priceGraphData(items, memP)` — special-cases when mempool price matches an existing bucket vs. a new bucket; resorts via `Comparator` if a new bucket was added.
+- `populateOutputs(data)` — builds the donut table via `innerHTML` from numeric values it pre-coerces with `parseInt()`; safe from XSS only because every interpolated value is numeric. **Violates C6** (no `<template>` clone) — accepted because inputs are integers, not free strings.
+- `onBarsChange(e)` — sets `this.bars`, GETs `/api/ticketpool/bydate/{bars}`, calls `purchasesGraphData(response.time_chart)` (no mempool merge in this branch) and updates the purchases graph only.
+- `disconnect()` — destroys both Dygraphs and deregisters WS handlers.
+
+Labels: `'A.v.g. Tickets Value (DCR)'` (purchases y2-axis) and `'Ticket Price (VAR)'` (price x-axis). The `DCR` string is a legacy label leak — see [/wiki/specs/parameters/spec.md](../../specs/parameters/spec.md) and [/wiki/specs/attack-cost/spec.md](../../specs/attack-cost/spec.md) for the `DCR`→`VAR` rename pattern. (C7 prefers the `coinSymbol` / `renderCoinType` helpers, but neither is the right tool for a column header — the constraint here is the spec, not C7 directly.)
+
+## Section 4 — Cross-Layer Dependencies
+
+| From | To | Coupling | Brittleness |
+|---|---|---|---|
+| JS `bars` button label | `dbtypes.TimeGroupingFromStr` | Strings `"all"/"day"/"wk"/"mo"` must match the switch in [db/dbtypes/types.go:842-857](../../../db/dbtypes/types.go#L842-L857). | Adding a new button on the JS side without extending the Go switch silently falls into `UnknownGrouping` → 422 (REST) / WS error. |
+| `dbtypes.PoolTicketsData` field order | three different SQL `rows.Scan` calls | Positional, not named — `Scan(&timestamp, &price, &immature, &live)` vs `Scan(&price, &immature, &live)` vs `Scan(&output, &count)`. | Reordering the columns in a `SELECT` silently swaps fields. Same class of risk as time-based-blocks ([/wiki/code-analysis/time-based-blocks/impact.md](../time-based-blocks/impact.md)). |
+| JS `processData` | `apitypes.TicketPoolChartsData` JSON tags | `data.time_chart`, `data.price_chart`, `data.outputs_chart`, `data.mempool`, `data.height` — read by name from the parsed JSON. | Renaming a JSON tag on the Go side without updating the JS reader silently drops a series. No type check. |
+| WS `getticketpooldata` `EventId` literal | `webData.EventId = msg.EventId + "Resp"` ([websockethandlers.go:231](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L231)) | JS hard-codes `'getticketpooldata'` and `'getticketpooldataResp'`. | Renaming the event on either side silently breaks live refresh — JS continues to render only the initial HTTP fetch. (Same R1-class drift as [/wiki/code-analysis/decodetx/impact.md](../decodetx/impact.md).) |
+| `ticketPoolGraphsCache` (package `var`) | `ChainDB` instance | Process-global, not per-instance. | A second `ChainDB` in the same binary (testing, multi-network) would silently share cache and serve cross-instance data. Single-instance today. |
+| Mempool `Price` semantics REST vs WS | `apitypes.PriceCountTime.Price float64` | One JSON field, two producer formulas (see §3.5). | The frontend cannot distinguish which value it received; chart legend can shift after a `newblock` refresh. C8-class. |
+| JS `processData` height gate | `this.tipHeight === data.height` | The "mempool overlay only when fresh" rule relies on the WS payload setting `data.height` and `data.mempool` together. | If WS ever returned `height` without `mempool` (or vice versa), the time chart could lock out future mempool merges (line 180). |
+
+## Section 5 — Critical Constraints
+
+- **C1 (precision):** Tickets are a VAR-only PoS instrument (see [/wiki/core/staking-rewards.md](../../core/staking-rewards.md) §2 — ticket price, returned cost, and 1/5-of-50% subsidy share are all VAR-denominated). `PoolTicketsData.Price []float64`, `MempoolTx.TotalOut float64`, `toCoin() float64`, Dygraphs `digitsAfterDecimal: 8` — the entire pipeline is float64 VAR end-to-end. **This is intentional; safe under C1 *only* because tickets are VAR.** Any attempt to introduce a SKA-denominated ticket variant must rewrite the struct away from `[]float64` to `[]string` and replace `toCoin`/`*1e8` with `*big.Int` arithmetic.
+- **C2 (dual pipeline mutation):** Two collection paths feed the page — DB (Postgres `tickets` JOIN) and live mempool (`DataCache` + `MempoolInventory`). The mempool overlay further splits into two sub-paths (REST = avg-fee + stakeDiff, WS = first-ticket TotalOut). Any change to the ticket-row population (e.g. adding a new column to the SELECT for filtering) must update three `Scan` sites *and* the cache invariant that all three sub-charts share one `(height, interval)` key.
+- **C3 + C8 (template+WS parity, dual-transport asymmetry):** The HTML template carries **no** chart data — there is no SSR variant to keep in parity. But the two non-static data paths (REST and WS) carry the **same struct** with **different `Mempool.Price` semantics** (§3.5). This is a C8 manifestation that isn't currently catalogued in [/wiki/core/constraints.md](../../core/constraints.md) C8's three concrete examples — flag for consolidation.
+- **C6 (template cloning):** `populateOutputs` builds the donut table via `innerHTML` concatenation, not `<template>` cloning. Tolerated because all interpolated values are pre-coerced with `parseInt()` to integers. **Do not extend the function with any user-derived string** without converting to a `<template>` clone.
+- **C7 (coin-symbol helper):** Legacy `DCR` label survives in the purchases y2-axis (`'A.v.g. Tickets Value (DCR)'`, [ticketpool_controller.js:242](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js#L242)). The x-axis on the price chart already says `(VAR)`. The two labels disagree on a single page.
+
+## Section 6 — Mutation Impact
+
+When modifying `/ticketpool`, check:
+
+| Mutation | Direct deps | Indirect deps | Failure mode |
+|---|---|---|---|
+| Add a column to `PoolTicketsData` | All three Scan sites; both Go consumers (REST + WS); JS `processData`; potentially Dygraphs labels/colors arrays | Cache struct (per-interval map values are the same struct → automatic) | **Loud** if Go consumer dereferences a nil slice; **silent** if JS just ignores the unknown key. |
+| Reorder columns in any of the three SQL statements | The matching `rows.Scan` call | Cache shape | **Silent** — values swap with no error (positional Scan). |
+| Add a new time-grouping (e.g. `"hr"`) | `dbtypes.TimeBasedGroupings` map, `TimeGroupingFromStr` switch, `NumIntervals` constant, `formatGroupingQuery` regex, JS bar button HTML, controller `bars` whitelist | Cache map size (`tpUpdatePermission` map is built from the same enum, so new entries get a lock automatically) | **Loud**: missing enum entry → `UnknownGrouping` → 422 on REST, "Error: unknown interval" on WS. **Silent**: missing JS button just means the user can't pick it. |
+| Add a new chart series (e.g. revoked-tickets buckets) | `PoolTicketsData` arrays, new SQL, new Scan, new cache field; **both** REST and WS payloads + JS `processData` branch | Bars-only `/bydate` response intentionally drops `price_chart` and `outputs_chart` — decide if the new field belongs there too | **Silent** drift between REST/WS if only one is updated (C3-shaped). |
+| Change `MempoolPriceCountTime.Price` semantics | `mempoolcache.GetTicketPriceCountTime` | Also need to update WS branch's manual computation in [websockethandlers.go:194-205](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L194-L205) or the WS overlay drifts further | **Silent** — the legend just shows a different number after a `newblock`. |
+| Tune the cache invalidation key (e.g. add a fee-mix sub-key) | `TicketPoolData` and `UpdateTicketPoolData` signatures; `tpUpdatePermission` map type | Any test that asserts old behavior | **Silent** stale data; possibly **loud** if existing callers don't supply the new key. |
+| Rename the WS event | Both string literals in JS (`'newblock'`, `'getticketpooldata'`, `'getticketpooldataResp'`) and the server switch case + suffix append | JS `disconnect()` deregister call uses the same string | **Silent** — `newblock` refresh loop silently breaks; initial HTTP load still works. |
+| Promote tickets to SKA | Every `float64` in this trace becomes `*big.Int` or `string`; `digitsAfterDecimal: 8` becomes invalid; `populateOutputs` table is fine (integer counts); the `*1e8` round-trip in `retrieveTicketsByDate` becomes a precision-loss site | This is effectively a full rewrite of the pipeline; not a minor change | **Silent corruption** — exceeds float64 significand; see [/wiki/code-analysis/charts/impact.md](../charts/impact.md) for the analogous SKA-through-float trap. |
+
+## Section 7 — Common Pitfalls
+
+- **Treating "mempool" identically across REST and WS.** Same struct, different formulas. A bug fix on the REST side does not reach the WS side unless explicitly mirrored (§3.5).
+- **Assuming `/ticketpool` is push-driven.** It is not. The server's `sigNewBlock` carries `WebsocketBlock`, not ticket data. The JS controller *re-requests* ticket data on every `newblock` — every connected client triggers a fresh `TicketPoolVisualization(ctx, <their-bars>)` per block. The cache absorbs the duplication (single updater wins via `TryLock`); without the cache, this would be N concurrent DB hits per block.
+- **Editing one of the three Scan calls and forgetting the others.** All three populate the same `PoolTicketsData` struct, but each fills a different field subset. A new SELECT column on one branch leaves zero values in the slices populated by the other two — and Dygraphs renders zero as a real value, not a gap.
+- **Adding SKA support in the wrong place.** Tickets are VAR by chain design. The temptation to "make this multi-coin" would corrupt SKA precision (C1) and produce nonsense data — tickets do not exist for SKA coins.
+- **Forgetting that `/api/ticketpool/bydate/{tp}` returns no `mempool` field.** A future refactor that unifies the two REST handlers via the same response struct must either backfill `Mempool` or leave it nil and document the asymmetry. The JS `onBarsChange` does *not* call `processData`; it goes straight to `purchasesGraph.updateOptions`, bypassing the mempool-overlay logic.
+- **Trusting `inv.Tickets[0].TotalOut` as "the mempool ticket price".** It is the *raw* total-out of whichever ticket happens to be first in the inventory slice. In a multi-ticket mempool it is not representative.
+- **Cache + height-changed-mid-query.** `ticketPoolVisualization` retries the three SQL queries if `pgb.Height()` advanced between first and last query; do not remove this retry loop ([db/dcrpg/pgblockchain.go:1909-1940](../../../db/dcrpg/pgblockchain.go#L1909-L1940)) — without it the three charts could disagree by one block on rapid reorgs / fast tip advance.
+
+## Section 8 — Evidence
+
+- Handler: [cmd/dcrdata/internal/explorer/explorerroutes.go:811-824](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L811-L824)
+- Template: [cmd/dcrdata/views/ticketpool.tmpl](../../../cmd/dcrdata/views/ticketpool.tmpl)
+- JS controller: [cmd/dcrdata/public/js/controllers/ticketpool_controller.js](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js)
+- API routes: [cmd/dcrdata/internal/api/apirouter.go:245-249](../../../cmd/dcrdata/internal/api/apirouter.go#L245-L249)
+- API handlers: [cmd/dcrdata/internal/api/apiroutes.go:1257-1325](../../../cmd/dcrdata/internal/api/apiroutes.go#L1257-L1325)
+- Middleware: [cmd/dcrdata/internal/middleware/apimiddleware.go:691-699](../../../cmd/dcrdata/internal/middleware/apimiddleware.go#L691-L699)
+- WS handler: [cmd/dcrdata/internal/explorer/websockethandlers.go:169-231](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L169-L231)
+- DB cache: [db/dcrpg/pgblockchain.go:74-132](../../../db/dcrpg/pgblockchain.go#L74-L132), [db/dcrpg/pgblockchain.go:1830-1943](../../../db/dcrpg/pgblockchain.go#L1830-L1943)
+- DB queries: [db/dcrpg/queries.go:1138-1236](../../../db/dcrpg/queries.go#L1138-L1236), [db/dcrpg/queries.go:4297-4299](../../../db/dcrpg/queries.go#L4297-L4299)
+- DB SQL: [db/dcrpg/internal/stakestmts.go:106-122](../../../db/dcrpg/internal/stakestmts.go#L106-L122), [db/dcrpg/internal/stakestmts.go:509-512](../../../db/dcrpg/internal/stakestmts.go#L509-L512), [db/dcrpg/internal/txstmts.go:165-170](../../../db/dcrpg/internal/txstmts.go#L165-L170)
+- Mempool overlay: [mempool/mempoolcache.go:192-214](../../../mempool/mempoolcache.go#L192-L214), [db/dcrpg/pgblockchain.go:6402-6406](../../../db/dcrpg/pgblockchain.go#L6402-L6406)
+- Types: [api/types/apitypes.go:931-960](../../../api/types/apitypes.go#L931-L960), [db/dbtypes/types.go:2118-2128](../../../db/dbtypes/types.go#L2118-L2128), [db/dbtypes/types.go:827-857](../../../db/dbtypes/types.go#L827-L857)
+
+See also:
+- /wiki/core/constraints.md (depends-on: C1 numeric precision — VAR-only float64 pipeline; C2 dual collection paths; C6 template-cloning exception in `populateOutputs`; C7 legacy `DCR` label leak; C8 mempool dual-transport semantic drift)
+- /wiki/core/staking-rewards.md (depends-on: tickets are VAR-only by chain design)
+- /wiki/code-analysis/decodetx/patterns.md (shares-pattern-with: P1 form-shell over WS-RPC; the `getticketpooldata` switch is the same shape as `decodetx`/`sendtx`)
+- /wiki/code-analysis/parameters/flow.full.md (shares-pattern-with: no-compute Go handler that renders only `commonData`)
+- /wiki/code-analysis/page-rendering/patterns.md (depends-on: `*CommonPageData` template injection)
+- /wiki/code-analysis/time-based-blocks/patterns.md (shares-pattern-with: `formatGroupingQuery` family + positional `rows.Scan` invariant)
+- /wiki/code-analysis/charts/impact.md (shares-pattern-with: SKA-through-float trap — relevant if tickets ever go multi-coin)
+- /wiki/code-analysis/mempool/flow.full.md (depends-on: `MempoolInventory` + `MempoolCache` upstream producers of the WS / REST mempool overlay)

--- a/wiki/code-analysis/ticketpool/impact.md
+++ b/wiki/code-analysis/ticketpool/impact.md
@@ -1,0 +1,100 @@
+# /ticketpool — Mutation Impact
+
+## Risk: PoolTicketsData column-Scan desync
+
+**Trigger:** any change to the column list in `SelectTicketsByPrice`, `selectTicketsByPurchaseDate`, or `SelectTicketsByType` — including reordering, adding, or dropping a SELECT expression.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.1, §3.2
+**Failure mode:** silent
+**Description:** [db/dcrpg/queries.go:1138-1236](../../../db/dcrpg/queries.go#L1138-L1236) uses positional `rows.Scan(&timestamp, &price, &immature, &live)` / `Scan(&price, &immature, &live)` / `Scan(&output, &count)`. Reordering swaps fields without error. The same struct (`dbtypes.PoolTicketsData`) is populated by all three; partial mismatches surface only as wrong values on the chart, not as runtime errors. Same class as [/wiki/code-analysis/time-based-blocks/impact.md](../time-based-blocks/impact.md) and [/wiki/code-analysis/windows/impact.md](../windows/impact.md).
+
+## Risk: REST/WS payload drift
+
+**Trigger:** adding a field to `apitypes.TicketPoolChartsData` on one of the two sites that produce it (REST `getTicketPoolCharts` or WS `getticketpooldata` switch case) without updating the other.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.4, §3.6
+**Failure mode:** silent
+**Description:** Initial page load uses HTTP `/api/ticketpool/charts` → new field renders. First `newblock` arrives, JS fires WS request, WS payload is missing the new field → JS reads `undefined` and either no-ops or zeroes out a series. The chart looks correct on first paint and silently degrades on update — the exact failure-mode signature flagged by C8 in [/wiki/core/constraints.md](../../core/constraints.md). A symmetric risk applies in reverse if the WS branch is updated first.
+
+## Risk: Mempool.Price semantic drift
+
+**Trigger:** modifying `DataCache.GetTicketPriceCountTime` (REST formula) or the WS branch's manual `mp.Price = inv.Tickets[0].TotalOut` ([websockethandlers.go:199](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L199)) — or simply not realizing they exist.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.5
+**Failure mode:** silent
+**Description:** Same JSON field (`mempool.price`), same Go type (`float64`), two producers, two formulas. REST → `stakeDiff.ToCoin() + feeAvg` (predicted next ticket price). WS → first-ticket `TotalOut` (one specific mempool ticket's value). The JS controller has no way to tell which value it received; the legend silently flips on every `newblock` re-fetch. Until consolidated, **never claim to "fix the mempool ticket price" without auditing both formulas**.
+
+## Risk: WS event-name drift
+
+**Trigger:** renaming `'getticketpooldata'`, `'getticketpooldataResp'`, or `'newblock'` on either the JS or Go side.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.6
+- /wiki/code-analysis/decodetx/impact.md R1
+**Failure mode:** silent
+**Description:** JS hardcodes the three strings in [ticketpool_controller.js:150-160](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js#L150-L160); the server side spells `"getticketpooldata"` in the switch case ([websockethandlers.go:169](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L169)) and appends `+ "Resp"` at line 231. The `disconnect()` deregister calls also depend on the same literals. Rename safety = grep across both `.js` and `.go`, plus the suffix-appending line. Same R1-class risk as [/wiki/code-analysis/decodetx/impact.md](../decodetx/impact.md).
+
+## Risk: TimeGrouping enum drift
+
+**Trigger:** adding a new bars/zoom interval in the JS controller without extending `dbtypes.TimeBasedGroupings` / `TimeGroupingFromStr` / `NumIntervals`.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.1, §3.4
+**Failure mode:** loud (REST 422 / WS "Error: unknown interval"), but silent on the UI side: the failing tile shows the previous chart with no visible error message.
+**Description:** JS sends `bars` as `"all"/"day"/"wk"/"mo"`. `TimeGroupingFromStr` rejects anything else as `UnknownGrouping`. The map `dbtypes.TimeBasedGroupings`, the switch in `TimeGroupingFromStr`, and the JS button HTML must move together. Note `tpUpdatePermission` is built off the same `NumIntervals` constant — new enum values automatically get a lock.
+
+## Risk: SKA-through-VAR pipeline corruption
+
+**Trigger:** any attempt to introduce SKA-denominated tickets into this trace without rewriting `PoolTicketsData.Price` from `[]float64` to a string/`*big.Int` shape.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.2, §3.9
+- /wiki/code-analysis/charts/impact.md (analogous SKA-through-float trap)
+**Failure mode:** silent corruption
+**Description:** Tickets are a VAR-only PoS instrument by chain design ([/wiki/core/staking-rewards.md](../../core/staking-rewards.md) §2). `retrieveTicketsByDate` does `uint64(price*1e8) / (live+immature)` then `toCoin(uint64)` — both rely on values fitting in `float64`'s significand. SKA atom counts (18 decimals) overflow this window; results would silently round/drift. C1 violation.
+
+## Risk: Cache-loop removal
+
+**Trigger:** simplifying `ticketPoolVisualization` ([db/dcrpg/pgblockchain.go:1899-1943](../../../db/dcrpg/pgblockchain.go#L1899-L1943)) by removing the `for { ... heightEnd != height ... }` retry.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.3
+**Failure mode:** silent
+**Description:** Without the loop, the three sub-charts (time / price / outputs) can be drawn at different block heights when the tip advances mid-query — the page would self-disagree by one block on a busy chain. The loop is the only thing that enforces the "one (height, interval) per cache entry" invariant.
+
+## Risk: Process-global cache cross-talk
+
+**Trigger:** instantiating a second `ChainDB` in the same process (multi-network test harness, dual-mode build).
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.3
+**Failure mode:** silent
+**Description:** `ticketPoolGraphsCache` is `var` at the package level ([db/dcrpg/pgblockchain.go:90](../../../db/dcrpg/pgblockchain.go#L90)). Two `ChainDB` instances would share it and serve each other's data. Not a risk today (single-instance binary) but is a footgun for any future multi-network refactor.
+
+## Risk: C6 violation surface (populateOutputs)
+
+**Trigger:** extending [ticketpool_controller.js:79-96](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js#L79-L96) (`populateOutputs`) to include user-derived strings or non-numeric data.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.9
+**Failure mode:** XSS if untrusted strings are interpolated; otherwise none.
+**Description:** Current code is safe because every interpolated value is forced through `parseInt()`. The function is the only `innerHTML`-based template on this page; widening it would re-introduce the C6 risk that the rest of the project's per-template `<template>` cloning specifically prevents.
+
+## Risk: Legacy `DCR` label leak
+
+**Trigger:** none — this is an existing inconsistency, not a mutation risk. Documenting for sweep work.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.9
+**Failure mode:** cosmetic
+**Description:** [ticketpool_controller.js:242](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js#L242) says `'A.v.g. Tickets Value (DCR)'`; the price chart at line 271 already says `'Ticket Price (VAR)'`. The same `DCR`→`VAR` rename pattern is being applied across [/wiki/specs/parameters/spec.md](../../specs/parameters/spec.md) and [/wiki/specs/attack-cost/spec.md](../../specs/attack-cost/spec.md); fold into that sweep.
+
+## Risk: `/bydate` response asymmetry
+
+**Trigger:** unifying `getTicketPoolByDate` to return a `TicketPoolChartsData` (instead of the anonymous `{Height, TimeChart}` struct) without updating the JS to expect `mempool`/`price_chart`/`outputs_chart` keys on this branch.
+**Affected flows:**
+- /wiki/code-analysis/ticketpool/flow.full.md §3.4, §3.9
+**Failure mode:** silent
+**Description:** `onBarsChange` calls `purchasesGraphData(response.time_chart)` directly with **no mempool merge** — it does not route through `processData`. If `/bydate` were widened to a full payload, the mempool tile and the outputs donut would *not* refresh on bars change unless the controller is also updated to dispatch through `processData`.
+
+See also:
+- /wiki/code-analysis/ticketpool/flow.full.md
+- /wiki/code-analysis/ticketpool/patterns.md
+- /wiki/core/constraints.md (depends-on: C1, C2, C3, C6, C7, C8)
+- /wiki/code-analysis/decodetx/impact.md (shares-pattern-with: R1 WS event-name drift)
+- /wiki/code-analysis/time-based-blocks/impact.md (shares-pattern-with: positional Scan desync)
+- /wiki/code-analysis/windows/impact.md (shares-pattern-with: positional Scan desync)
+- /wiki/code-analysis/charts/impact.md (shares-pattern-with: SKA-through-float silent corruption)

--- a/wiki/code-analysis/ticketpool/patterns.md
+++ b/wiki/code-analysis/ticketpool/patterns.md
@@ -1,0 +1,62 @@
+# /ticketpool — Architectural Patterns
+
+## P1: Form-shell + WS-RPC refresh loop
+
+**What:** The server handler is a one-line `templates.exec("ticketpool", commonData(r))`; no data is injected via SSR. All chart data arrives at the client through three independent channels (HTTP `/api/ticketpool/charts`, HTTP `/api/ticketpool/bydate/{tp}`, and WS request/response `getticketpooldata`→`getticketpooldataResp`). The `newblock` WS signal carries `WebsocketBlock` (not ticketpool data); the JS controller listens for it and **re-requests** ticketpool data on every block by calling `ws.send('getticketpooldata', this.bars)`.
+
+**Where:** [cmd/dcrdata/internal/explorer/explorerroutes.go:811-824](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L811-L824) (handler), [cmd/dcrdata/views/ticketpool.tmpl](../../../cmd/dcrdata/views/ticketpool.tmpl) (template), [cmd/dcrdata/public/js/controllers/ticketpool_controller.js:149-163](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js#L149-L163) (controller).
+
+**Constraints:**
+- Event names (`'newblock'`, `'getticketpooldata'`, `'getticketpooldataResp'`) are duplicated across JS and the server switch + `EventId + "Resp"` suffix. Renaming any one silently breaks live refresh.
+- Initial render of the page shows two empty Dygraphs (seed rows `[[0,0,0,0,0]]` / `[[0,0,0,0]]`) until `fetchAll()` returns. Acceptable latency for this page; do not paper over with synthetic data.
+- This shape is shared with `/decodetx` (see [/wiki/code-analysis/decodetx/patterns.md](../decodetx/patterns.md) P1). Both pages survive without server-rendered data because the wait for the first WS/HTTP fetch is short and the empty chart is visually obvious.
+
+## P2: Tri-modal struct with positional Scan
+
+**What:** `dbtypes.PoolTicketsData` is one struct of seven parallel `[]…` slices (`Time`, `Price`, `Mempool`, `Immature`, `Live`, `Outputs`, `Count`). Three SQL queries each populate a different subset using positional `rows.Scan`. The JS controller branches on which field-subset is non-empty.
+
+**Where:** [db/dbtypes/types.go:2118-2128](../../../db/dbtypes/types.go#L2118-L2128); producers in [db/dcrpg/queries.go:1138-1236](../../../db/dcrpg/queries.go#L1138-L1236); consumer dispatch in [ticketpool_controller.js:172-199](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js#L172-L199).
+
+**Constraints:**
+- The struct's seven slices must always be either fully populated *for the relevant chart* or all absent — partial population would render zeroes (Dygraphs treats zero as a real value).
+- Adding a column to any of the three `SELECT`s requires updating the matching `rows.Scan` call positionally **and** the consumer (`processData` branch). No name-based safety net.
+- Same positional-Scan risk as [/wiki/code-analysis/time-based-blocks/patterns.md](../time-based-blocks/patterns.md) and [/wiki/code-analysis/windows/patterns.md](../windows/patterns.md).
+
+## P3: Process-global stale-while-revalidate cache, height-keyed, trylock-gated
+
+**What:** `ticketPoolGraphsCache` is a **package-level `var`** (not `*ChainDB`-scoped) holding per-interval `{Height, TimeGraph, PriceGraph, DonutGraph}`. On read: a `RWMutex` protects the maps. On freshness check: stale ⇔ `cache.Height[interval] != pgb.Height()`. On miss/stale: a per-interval `trylock.Mutex` (`tpUpdatePermission[interval]`) picks the single goroutine that runs the SQL refresh — concurrent callers either return stale data (if it exists) or block on the same lock waiting for the in-flight update. The inner `ticketPoolVisualization` re-fetches `pgb.Height()` before and after the three sub-queries and **loops if the tip advanced mid-query** to keep all three charts at one height.
+
+**Where:** [db/dcrpg/pgblockchain.go:74-132](../../../db/dcrpg/pgblockchain.go#L74-L132) (cache types + helpers), [db/dcrpg/pgblockchain.go:1830-1943](../../../db/dcrpg/pgblockchain.go#L1830-L1943) (TicketPoolVisualization / inner ticketPoolVisualization with retry loop).
+
+**Constraints:**
+- No proactive invalidation — refresh only on next read after height change. Cold-cache + simultaneous WS `newblock` from many clients = one updater per interval; the rest get blocked or stale.
+- The cache is process-global, not per-`ChainDB`. Multi-instance binaries would silently share. Single-instance today.
+- All three sub-charts must share one `height` (the inner retry loop enforces this). Removing the loop introduces inter-chart inconsistency on rapid tip advance.
+
+## P4: Dual-transport overlay with divergent semantics inside one field
+
+**What:** `apitypes.PriceCountTime` is sent on both the REST path (`GET /api/ticketpool/charts`) and the WS path (`getticketpooldataResp`). Both expose `Price float64` / `Count int` / `Time TimeDef`. **The two computations are different**: REST uses `DataCache.GetTicketPriceCountTime` → `stakeDiff.ToCoin() + feeAvg`; WS uses the head-of-list `inv.Tickets[0].TotalOut` and `len(inv.Tickets)`. Same JSON shape, different semantics — a C8 manifestation inside a single field rather than across struct shapes.
+
+**Where:** [mempool/mempoolcache.go:192-214](../../../mempool/mempoolcache.go#L192-L214) (REST), [cmd/dcrdata/internal/explorer/websockethandlers.go:194-205](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L194-L205) (WS), `apitypes.PriceCountTime` at [api/types/apitypes.go:955-960](../../../api/types/apitypes.go#L955-L960).
+
+**Constraints:**
+- Treat REST and WS `Mempool.Price` as two *contracts* even though they share a struct. A fix to one path must consciously update the other.
+- The JS legend shows whatever value arrived last; values can shift after each `newblock` refresh as the client switches between the two formulas.
+
+## P5: VAR-only float64 staking pipeline
+
+**What:** Every monetary value in this trace is `float64` VAR — `PoolTicketsData.Price []float64`, `MempoolTx.TotalOut float64`, `toCoin(amt) float64`, Dygraphs `digitsAfterDecimal: 8`. There is no SKA branch and there cannot be one without restructuring the data shape, because **tickets are a PoS staking instrument denominated only in VAR** ([/wiki/core/staking-rewards.md](../../core/staking-rewards.md) §2).
+
+**Where:** [db/dbtypes/types.go:2118-2128](../../../db/dbtypes/types.go#L2118-L2128), [db/dcrpg/queries.go:1142-1204](../../../db/dcrpg/queries.go#L1142-L1204), [db/dcrpg/queries.go:4297-4299](../../../db/dcrpg/queries.go#L4297-L4299), [cmd/dcrdata/public/js/controllers/ticketpool_controller.js:111-122](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js#L111-L122).
+
+**Constraints:**
+- The `uint64(price*1e8)` round-trip in `retrieveTicketsByDate` is VAR-safe only. Extending this path to handle SKA atoms via `float64` would silently corrupt values >2^53 atoms.
+- "Make this multi-coin" is not a refactor — it is a redesign that requires upstream chain semantics for SKA tickets (which do not currently exist).
+
+See also:
+- /wiki/code-analysis/ticketpool/flow.full.md
+- /wiki/code-analysis/ticketpool/impact.md
+- /wiki/code-analysis/decodetx/patterns.md (shares-pattern-with: P1 form-shell over WS-RPC)
+- /wiki/code-analysis/time-based-blocks/patterns.md (shares-pattern-with: P2 positional-Scan + `formatGroupingQuery`)
+- /wiki/code-analysis/page-rendering/patterns.md (depends-on: commonData injection)
+- /wiki/core/constraints.md (depends-on: C1 VAR-only float64; C6 template-clone exception; C8 dual-transport semantic asymmetry)

--- a/wiki/code-analysis/windows/flow.compact.md
+++ b/wiki/code-analysis/windows/flow.compact.md
@@ -1,11 +1,54 @@
-- **One-line Flow:** RPC → `blocks` Table (PostgreSQL) → `SelectWindowsByLimit` Query → `dbtypes.BlocksGroupedInfo` → `StakeDiffWindows` Handler → `windows.tmpl` Template
-- **Key Architectural Patterns:**
-  - **DB-Side Aggregation:** Heavy lifting for interval groupings is performed in Postgres via integer division (`GROUP BY (height/size)*size`), not in memory.
-  - **Struct Pass-Through:** Handler provides direct array mapping of `dbtypes.BlocksGroupedInfo` directly to the template execution without intermediate transformation.
-- **Critical Constraints:**
-  - Relies on integer division truncation in SQL to establish window boundaries.
-  - Assumes `is_mainchain = true` blocks perfectly represent the voting interval state.
-- **Mutation Checklist:**
-  - [ ] Check `SelectWindowsByLimit` when changing `blocks` schema.
-  - [ ] Ensure `int64` atom values from DB remain compatible with `toFloat64Amount` rendering in `windows.tmpl`.
-  - [ ] Verify pagination math (`bestWindow`) matches any changed `StakeDiffWindowSize`.
+# Windows — Compact Knowledge
+
+**One-line flow:**
+`blocks` table → `SelectWindowsByLimit` SQL bucket → `retrieveWindowBlocks` Scan + `parseCoinTxStats` → `BlocksGroupedInfo` → `(*ChainDB).PosIntervals` → `dataSource.PosIntervals` → `StakeDiffWindows` handler → `views/windows.tmpl` → HTML. No REST, no WebSocket.
+
+**Key architectural patterns:**
+
+- **DB-side integer-division bucketing.** Windows are formed by SQL
+  `GROUP BY (height/$1)*$1` with `$1 = chainParams.StakeDiffWindowSize`
+  (default 144), filtered to `is_mainchain`. No Go-side re-aggregation.
+- **Multi-coin tx-count reconciliation.** `JSONB_AGG(coin_tx_stats)` carries
+  per-coin `tx_count`; `parseCoinTxStats` sums it and overrides flat
+  `SUM(num_rtx)` when larger. Lenient unmarshal — falls back to flat count on
+  empty/padded/error JSON (intentional for pre-multi-coin history).
+- **Shared `BlocksGroupedInfo` struct.** Same struct populated from a
+  different SQL by the time-based-blocks listing — a cross-domain contract,
+  not a per-flow type.
+- **Legacy VAR-only render path.** `TicketPrice int64` atoms →
+  `toFloat64Amount` (= `dcrutil.Amount.ToCoin() float64`) at the template
+  boundary. SKA-safe pipeline is **not** used here; routing SKA atoms through
+  this helper silently loses precision.
+- **Triple-bound pagination.** Handler computes `bestWindow` from
+  `StakeDiffWindowSize`; `retrieveWindowBlocks` independently re-derives
+  `startHeight/endHeight` from the same `windowSize`; `CalculateWindowIndex`
+  re-derives the displayed `IndexVal`. All three must use the same
+  `windowSize`.
+
+**Critical constraints:**
+
+- C1: `TicketPrice` is VAR int64 atoms; render via `toFloat64Amount` only.
+  Never reuse this path for SKA.
+- C7: `Transactions` is the post-reconciliation multi-coin total, not flat
+  `num_rtx`.
+- SQL `$1` denominator, `chainParams.StakeDiffWindowSize`, and the handler's
+  `bestWindow` math must all agree — no DB-level check.
+- 11-column positional `rows.Scan` in `retrieveWindowBlocks` mirrors
+  `SelectWindowsByLimit`'s SELECT list; reorder either side and values
+  silently swap into wrong columns.
+- Page is server-rendered HTML only; no WebSocket subscription updates it.
+
+**Mutation checklist:**
+
+- [ ] SQL `$1` denominator == `chainParams.StakeDiffWindowSize` (3 callsites).
+- [ ] `rows.Scan` arity/order matches `SelectWindowsByLimit` column list.
+- [ ] `windows.tmpl` field references match `BlocksGroupedInfo` exactly.
+- [ ] Time-based-blocks flow checked (shared struct).
+- [ ] `coin_tx_stats` JSON shape (`tx_count`/`size`) preserved; lenient
+      fallback in `parseCoinTxStats` preserved.
+- [ ] `TicketPrice` stays VAR-scale `int64` atoms (or `toFloat64Amount` is
+      changed everywhere together).
+- [ ] Handler pagination ↔ `retrieveWindowBlocks` range math ↔
+      `CalculateWindowIndex` all use the same `windowSize`.
+- [ ] `dataSource` interface (`explorer.go:100`) + mock (`explorer_test.go:100`)
+      moved with any `PosIntervals` signature change.

--- a/wiki/code-analysis/windows/flow.full.md
+++ b/wiki/code-analysis/windows/flow.full.md
@@ -1,55 +1,314 @@
 ### Section 1 — Overview
-Data flow trace for the Ticket Price Windows page (`/ticketpricewindows`), which aggregates block statistics over stake difficulty intervals.
+
+End-to-end trace for the **`/ticketpricewindows`** page (the Windows / Ticket Price
+Windows listing). The page is a paginated table whose rows are stake-difficulty
+windows — fixed-size groups of mainchain blocks (`chaincfg.Params.StakeDiffWindowSize`,
+default 144). For each window the table shows the index, end block, per-window
+sums of regular txs / votes / fresh tickets / revocations, total size, and the
+window's difficulty and `MAX(sbits)` ticket price. The page is fully
+server-rendered Go HTML (`windows.tmpl`); no REST or WebSocket consumes this
+flow. Refreshed at `HEAD=3cdba1e7`.
 
 ### Section 2 — End-to-End Data Flow
+
 ```text
-RPC (getblock) → blocks Table (PostgreSQL) → SelectWindowsByLimit Query → dbtypes.BlocksGroupedInfo → StakeDiffWindows Handler → windows.tmpl Template → Frontend
+monetarium-node JSON-RPC (block ingest, separate flow)
+    → PostgreSQL  blocks  table          (num_rtx, voters, fresh_stake, revocations, size, sbits, difficulty, coin_tx_stats, is_mainchain)
+        → SelectWindowsByLimit            (db/dcrpg/internal/blockstmts.go:131)
+        → retrieveWindowBlocks            (db/dcrpg/queries.go:905) — Scan → parseCoinTxStats → BlocksGroupedInfo build
+            → (*ChainDB).PosIntervals     (db/dcrpg/pgblockchain.go:1807) — adds queryTimeout + replaceCancelError
+                → dataSource interface    (cmd/dcrdata/internal/explorer/explorer.go:100)
+                    → (*explorerUI).StakeDiffWindows handler (cmd/dcrdata/internal/explorer/explorerroutes.go:386)
+                        → exp.templates.exec("windows", ...) (explorerroutes.go:433)
+                            → views/windows.tmpl rendering   → HTTP HTML response
 ```
 
+Inputs: `?offset=<windows>&rows=<page size>` query string. Output: HTML
+(`text/html`). There is no JSON API and no WebSocket update for this page; the
+only client-side behavior is the `data-controller="pagenavigation"` pager and a
+`data-controller="time"` age-relative widget.
+
 ### Section 3 — Per-Layer Breakdown
-- **Location:** Node RPC / Syncer
-- **Data Structures:** Raw Block
-- **Transformations:** The explorer node parses blocks and extracts block header and transaction data (e.g. `sbits`, `voters`, `fresh_stake`, `revocations`).
 
-- **Location:** `db/dcrpg/internal/blockstmts.go` & `db/dcrpg/queries.go`
-- **Data Structures:** `blocks` table, `dbtypes.BlocksGroupedInfo`
-- **Transformations:** `SelectWindowsByLimit` uses `GROUP BY (height/$1)*$1` to aggregate blocks into window sizes (default 144). It computes `SUM` for txs, tickets, votes, size, and extracts `MAX(sbits)` for the ticket price.
+**3.1 PostgreSQL `blocks` table (source of truth)**
 
-- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go` (`StakeDiffWindows`)
-- **Data Structures:** `[]*dbtypes.BlocksGroupedInfo`
-- **Transformations:** Wraps the queried data with pagination logic and UI states, passing it as `Data` to the template.
+- **Location:** `db/dcrpg/internal/blockstmts.go:131` (`SelectWindowsByLimit`).
+- **Data structures (DB columns read):** `height`, `num_rtx`, `fresh_stake`,
+  `voters`, `revocations`, `size`, `sbits` (ticket price atoms), `difficulty`,
+  `time`, `is_mainchain`, and the JSONB column `coin_tx_stats`
+  (`map[uint8]CoinTxStats`).
+- **Transformations (entirely in SQL):**
+  - Buckets via integer-division `GROUP BY (height/$1)*$1 AS window_start` —
+    every block in `[k*size, (k+1)*size−1]` collapses to one row.
+  - Per-window: `MAX(difficulty)`, `MAX(sbits)`, `MIN(time)`, `COUNT(*)`,
+    `SUM(num_rtx)`, `SUM(fresh_stake)`, `SUM(voters)`, `SUM(revocations)`,
+    `SUM(size)`, plus `JSONB_AGG(coin_tx_stats)`.
+  - `WHERE height BETWEEN $2 AND $3 AND is_mainchain` — sidechain/orphan rows
+    excluded from every aggregate.
+  - Ordered `BY window_start DESC` (newest first), expected to feed the table's
+    top row.
 
-- **Location:** `cmd/dcrdata/views/windows.tmpl`
-- **Data Structures:** HTML template context
-- **Transformations:** Iterates `.Data` and formats numerical representations via `intComma` and template functions like `float64AsDecimalParts` and `toFloat64Amount`.
+**3.2 Go aggregation / row assembly**
+
+- **Location:** `db/dcrpg/queries.go:905` (`retrieveWindowBlocks`),
+  `db/dcrpg/queries.go:877` (`parseCoinTxStats`),
+  `db/dcrpg/pgblockchain.go:1807` (`(*ChainDB).PosIntervals`).
+- **Data structures:** `dbtypes.BlocksGroupedInfo` (`db/dbtypes/types.go:806`),
+  `dbtypes.CoinTxStats` (`db/dbtypes/types.go:2215`).
+- **Transformations:**
+  - `retrieveWindowBlocks` first derives the height range from `(limit, offset)`:
+    `endWindow = currentHeight/windowSize − offset`,
+    `startWindow = endWindow − limit + 1`,
+    `startHeight = startWindow*windowSize`,
+    `endHeight = (endWindow+1)*windowSize − 1`,
+    and binds those as `$2`/`$3`. **The windowSize used here and in the SQL
+    `$1` must be the same value** (`pgb.chainParams.StakeDiffWindowSize`).
+  - 11-column positional `rows.Scan(&startBlock, &difficulty, &txs, &tickets,
+    &votes, &revocations, &blockSizes, &sbits, &timestamp, &count,
+    &coinTxStats)` (`queries.go:924`). Note column-order coupling — any SQL
+    SELECT reorder silently swaps values.
+  - `txs = parseCoinTxStats(coinTxStats, txs)` (`queries.go:930`):
+    unmarshals `[]map[string]CoinTxStats`, sums every per-coin `TxCount`, and
+    **overrides** the flat `SUM(num_rtx)` only when the per-coin total is
+    larger. Empty / `\x00`-padded / unmarshal-error JSON silently falls back to
+    flat `txs` (lenient by design for windows whose blocks predate
+    `coin_tx_stats` population).
+  - `endBlock = startBlock + windowSize − 1`;
+    `index = CalculateWindowIndex(endBlock, windowSize)`
+    (`db/dbtypes/conversion.go:144`) — adds 1 for heights not divisible by
+    `windowSize`, so window-1 covers blocks 1..144.
+  - `TxCount = txs + tickets + revocations + votes` (assembled in Go, **not** a
+    DB column).
+  - `FormattedSize = humanize.Bytes(blockSizes)`.
+  - `(*ChainDB).PosIntervals` wraps the call in `context.WithTimeout(ctx,
+    pgb.queryTimeout)` and runs the result through `pgb.replaceCancelError` —
+    timeouts surface as a typed error the handler maps to a friendly page via
+    `timeoutErrorPage`.
+
+**3.3 Explorer handler (HTTP boundary)**
+
+- **Location:** `cmd/dcrdata/internal/explorer/explorerroutes.go:386`
+  (`(*explorerUI).StakeDiffWindows`), interface at
+  `cmd/dcrdata/internal/explorer/explorer.go:100`
+  (`dataSource.PosIntervals`), mock at
+  `cmd/dcrdata/internal/explorer/explorer_test.go:100`.
+- **Route:** `r.Get("/ticketpricewindows", explore.StakeDiffWindows)`
+  (`cmd/dcrdata/main.go:767`).
+- **Transformations:**
+  - Parses `?offset=<uint>&rows=<uint>`, returns `400` on parse error.
+  - Computes `bestWindow = Height() / StakeDiffWindowSize`; clamps
+    `offsetWindow ≤ bestWindow`; clamps `rows` to
+    `[minExplorerRows, maxExplorerRows]` (default `minExplorerRows`).
+  - Calls `exp.dataSource.PosIntervals(ctx, rows, offsetWindow)` on the
+    `dataSource` interface (production: `*dcrpg.ChainDB`). Timeout errors are
+    handled separately from "not found" via `exp.timeoutErrorPage`; any other
+    error renders `ExpStatusNotFound` (the message literally references "ticket
+    price windows").
+  - Builds the template context (anonymous struct) with `Data`, `WindowSize`,
+    `BestWindow`, `OffsetWindow`, `Limit`, `TimeGrouping: "Windows"`, and
+    `Pages: calcPages(int(bestWindow), int(rows), int(offsetWindow),
+    linkTemplate)` where
+    `linkTemplate = "/ticketpricewindows?offset=%d&rows=" + rows`.
+  - Calls `exp.templates.exec("windows", ...)` and writes the rendered HTML.
+
+**3.4 Template (presentation)**
+
+- **Location:** `cmd/dcrdata/views/windows.tmpl` (165 lines).
+- **Data structures:** the anonymous struct from §3.3 + `CommonPageData`.
+- **Transformations / field reads (column ↔ struct mapping):**
+  - `({{.BlocksCount}}/{{$.WindowSize}})` partial-window indicator (line 119).
+  - `.IndexVal` (line 120), `.EndBlock` (line 123, also forms the `/blocks?height=` deep link).
+  - Regular: `{{intComma .Transactions}}` (line 125, post-`parseCoinTxStats`).
+  - `.Voters` (line 126), `.FreshStake` (line 127), `.Revocations` (line 128).
+  - Mobile-only combined cell: `{{intComma .TxCount}}` (line 129).
+  - `.FormattedSize` (line 130, pre-humanized in Go).
+  - Difficulty:
+    `{{template "decimalParts" (float64AsDecimalParts .Difficulty 0 true)}}`
+    (line 131). `float64AsDecimalParts` is registered in
+    `cmd/dcrdata/internal/explorer/templates.go:747`.
+  - Ticket price:
+    `{{printf "%.2f" (toFloat64Amount .TicketPrice)}}` (line 132).
+    `toFloat64Amount(int64) float64` is `dcrutil.Amount(intAmount).ToCoin()`
+    (`templates.go:752`) — the **legacy VAR-only** atom→coin conversion.
+  - `.StartTime.UNIX` for the JS time controller (line 133),
+    `.StartTime.DatetimeWithoutTZ` for the fallback static cell (line 134).
+  - Pager rendered from `.Pages` plus prev/next anchors driven by
+    `.OffsetWindow`, `.Limit`, `$oldest`, `$lastWindow`.
+
+**3.5 Frontend (client-side)**
+
+- **No bespoke Stimulus controller for this page.** Only generic
+  `pagenavigation` (page-size dropdown / offset query rewrite) and the
+  shared `time` controller (relative-age rendering off `data-age`).
+- No WebSocket subscription: the table does not live-update; refresh on tip
+  advance is via full page reload only.
 
 ### Section 4 — Cross-Layer Dependencies
-- The Postgres aggregation query strictly depends on the node's `chaincfg.Params.StakeDiffWindowSize` matching the denominator used in `(height/$1)*$1`.
-- The frontend template tightly couples to the struct fields of `dbtypes.BlocksGroupedInfo` (e.g., `FreshStake`, `Voters`, `TicketPrice`).
+
+- **SQL `$1` ↔ `pgb.chainParams.StakeDiffWindowSize` ↔ handler
+  `exp.ChainParams.StakeDiffWindowSize`** must all be the same value. There is
+  no DB-level check; they're wired by convention. Three callsites:
+  `SelectWindowsByLimit` (`blockstmts.go:131`), `PosIntervals`
+  (`pgblockchain.go:1810`), and handler (`explorerroutes.go:409` /
+  `:445`).
+- **Positional `rows.Scan` ↔ SQL SELECT list ordering.** 11 columns; reorder
+  on either side silently swaps values into the wrong destination — see
+  `queries.go:924` against `blockstmts.go:131`. A column count change is a
+  loud `sql: expected N destination arguments`.
+- **`BlocksGroupedInfo` is shared verbatim with the
+  [time-based-blocks](/wiki/code-analysis/time-based-blocks/flow.full.md)
+  domain.** `retrieveTimeBasedBlockListing` (`queries.go:961`) populates a
+  different subset of the same struct (e.g. it sets `EndTime`; the windows
+  path does not). A field rename for one flow breaks the other's template.
+- **`coin_tx_stats` JSON contract.** The column type is JSONB; the Go shape is
+  `map[uint8]dbtypes.CoinTxStats` with the `tx_count` tag
+  (`db/dbtypes/types.go:2215`). `parseCoinTxStats` unmarshals the
+  aggregate as `[]map[string]CoinTxStats` (the `[]` from `JSONB_AGG`, the
+  string key because JSON object keys are strings).
+- **Interface boundary at `dataSource.PosIntervals`** —
+  `cmd/dcrdata/internal/explorer/explorer.go:100` and mock at
+  `explorer_test.go:100` must move in lockstep with the prod
+  `*ChainDB.PosIntervals` signature.
 
 ### Section 5 — Critical Constraints
-- **Window Size Grouping:** The aggregation relies on integer division truncation in PostgreSQL `(height/windowSize)*windowSize` to form accurate window boundaries.
-- **Mainchain Only:** The aggregation explicitly filters `is_mainchain = true`, meaning orphaned/sidechain blocks do not affect ticket price or window counts.
-- **Pagination Rules:** The calculation of `bestWindow` and `offsetWindow` assumes continuous block heights.
+
+- **C1 — Precision (VAR-only path).** `TicketPrice` is `int64` atoms (`sbits`,
+  VAR scale 1e8). It is rendered by `toFloat64Amount` →
+  `dcrutil.Amount.ToCoin() float64`. This is the **legacy VAR-only**
+  numeric pipeline; do not route SKA-scale atoms through `toFloat64Amount`
+  (would silently truncate at ~15 digits and/or hit scientific notation).
+  See [/wiki/core/constraints.md](/wiki/core/constraints.md) §C1.
+- **C7 — Multi-coin reconciliation.** Per-coin tx activity is read from the
+  JSONB `coin_tx_stats` column and summed by `parseCoinTxStats`; the
+  per-coin sum overrides flat `num_rtx` when larger. The page's "Regular"
+  column therefore reflects multi-coin activity, not just VAR. See
+  [/wiki/core/constraints.md](/wiki/core/constraints.md) §C7.
+- **Mainchain-only.** Every aggregate filters `is_mainchain`. Sidechain rows
+  contribute nothing to ticket price, block count, or any sum.
+- **Pagination assumes continuous mainchain height.** A reorged gap is
+  invisible to the integer-division bucket; the bucket key uses `height` not
+  `block index in mainchain`.
+- **Partial tip window is normal.** The most-recent row legitimately reports
+  `BlocksCount < WindowSize` and the template flags it with
+  `({{.BlocksCount}}/{{$.WindowSize}})`.
 
 ### Section 6 — Mutation Impact
-When modifying **ticket price windows or block aggregation**, check:
-- **Direct dependencies:** `dbtypes.BlocksGroupedInfo`, `retrieveWindowBlocks`.
-- **Indirect dependencies:** Any changes to `blocks` table insertions for `fresh_stake`, `voters`, or `revocations` will immediately alter window aggregations.
-- **Serialization boundaries:** The Postgres `blocks` table is the sole source of truth for this page's data.
-- **Rendering layers:** `windows.tmpl` expects `TicketPrice` as `int64` representing atoms (converted via `toFloat64Amount`).
 
-Failures:
-- **Silent failure:** Changing `chaincfg.Params.StakeDiffWindowSize` without updating the database query variables could result in malformed or misaligned windows.
-- **Hard failure:** Removing or renaming fields in `dbtypes.BlocksGroupedInfo` will panic the Go HTML template parser during execution.
+For exhaustive risk descriptions see
+[/wiki/code-analysis/windows/impact.md](/wiki/code-analysis/windows/impact.md).
+Summary of what to check before editing this flow:
+
+- **Direct dependencies:** `SelectWindowsByLimit`, `retrieveWindowBlocks` Scan
+  list and `BlocksGroupedInfo` builder, `parseCoinTxStats`, `PosIntervals`
+  timeout/replaceCancelError wrapping, `dataSource` interface + mock,
+  `StakeDiffWindows` handler, `windows.tmpl` field reads,
+  `CalculateWindowIndex`.
+- **Indirect dependencies:** any code that writes
+  `blocks.num_rtx / fresh_stake / voters / revocations / size / sbits /
+  difficulty / coin_tx_stats / is_mainchain` (block ingest + reorg paths) —
+  this is the **only** thing that determines what the page shows.
+- **Cross-flow:** `BlocksGroupedInfo` is shared with the time-based-blocks
+  flow; any rename/removal must be checked against `retrieveTimeBasedBlockListing`
+  + its template too.
+- **Serialization boundaries:** DB schema (positional Scan), JSONB
+  `coin_tx_stats` tag/shape, Go template field-by-name reads.
+- **Rendering layer:** `toFloat64Amount(int64)` and `float64AsDecimalParts`
+  contracts in `templates.go`.
+
+**Silent failures (no error, wrong table):**
+
+- SQL `$1` denominator diverges from `StakeDiffWindowSize`: misaligned
+  buckets, wrong `MAX(sbits)` per window, off-by-N pagination, mismatched
+  `IndexVal`.
+- `JSONB_AGG(coin_tx_stats)` column dropped or `tx_count` JSON tag renamed
+  while `parseCoinTxStats` stays: every window silently regresses to flat
+  `SUM(num_rtx)` (multi-coin activity dropped, violates C7).
+- `TicketPrice` column or struct field changes scale (already-coin vs atoms)
+  without updating `toFloat64Amount`: wrong-by-1e8 ticket price, no error.
+- `rows.Scan` destination reordered against SQL SELECT: values silently
+  swapped between columns (e.g. votes into size).
+- Pagination math edited in handler without the matching
+  `startHeight/endHeight` math in `retrieveWindowBlocks`: page shifts a whole
+  window or returns near-tip duplicates.
+
+**Hard failures (loud):**
+
+- Removing/renaming a field referenced by `windows.tmpl`
+  (`.IndexVal`, `.BlocksCount`, `.EndBlock`, `.Transactions`, `.Voters`,
+  `.FreshStake`, `.Revocations`, `.TxCount`, `.FormattedSize`,
+  `.Difficulty`, `.TicketPrice`, `.StartTime`) → Go `html/template` error at
+  execute time, handler returns the `Template execute failure` branch.
+- Adding/removing a column without matching `rows.Scan` arity → runtime
+  `sql: expected N destination arguments`.
+- Changing `dataSource.PosIntervals` signature without updating the mock in
+  `explorer_test.go:100` → build break in the explorer test package.
+- Changing `TicketPrice` type to something `toFloat64Amount(int64) float64`
+  can't accept → template execute error.
 
 ### Section 7 — Common Pitfalls
-- Modifying the ticket price data type (e.g., from `int64` atoms to `float64`) in the aggregation struct without updating the `toFloat64Amount` wrapper in `windows.tmpl`.
-- Changing the `blocks` table schema without updating the complex `SelectWindowsByLimit` SQL query.
+
+- **Routing SKA atoms through `toFloat64Amount` "to reuse the existing
+  helper".** `toFloat64Amount` is `dcrutil.Amount.ToCoin() float64` — it
+  encodes the VAR 1e8 scale and the `float64` precision ceiling. SKA atoms
+  exceed `float64`'s significand; reusing this helper for SKA at this page or
+  any other silently truncates and/or hits scientific notation. SKA stays as
+  decimal strings.
+- **Editing `StakeDiffWindowSize` in chain params but not auditing all three
+  callsites** (SQL `$1`, `retrieveWindowBlocks` arg, handler `bestWindow` /
+  context `WindowSize`). The page renders a plausible-looking-but-wrong
+  table — exactly the kind of failure neither `go build` nor `go test`
+  catches.
+- **Renaming a `BlocksGroupedInfo` field "for windows".** It also breaks the
+  time-based-blocks listing — the struct has no per-flow boundary. Add new
+  fields rather than rename shared ones, or rename and update both flows
+  together.
+- **Tightening `parseCoinTxStats` to error instead of fall back.** Older
+  windows have empty/`\x00`-padded JSON; the lenient fallback is intentional.
+  A hard error would 500 the page for any user paginating into old history.
+- **Treating `.Transactions` as a pure DB sum.** It's the post-reconciliation
+  multi-coin total (per-coin sum may override flat `num_rtx`); don't add a
+  parallel "regular tx" widget elsewhere that pulls `SUM(num_rtx)` directly
+  and call it the same name.
+- **Assuming the page has WebSocket updates.** It does not; the only live
+  bit is the `time` controller updating the age strings client-side.
 
 ### Section 8 — Evidence
-- **Query:** `db/dcrpg/internal/blockstmts.go:125` (`SelectWindowsByLimit`)
-- **Entrypoint:** `db/dcrpg/pgblockchain.go:1806` (`(*ChainDB).PosIntervals`, the `dataSource` method the handler calls)
-- **Aggregation:** `db/dcrpg/queries.go:905` (`retrieveWindowBlocks`)
-- **Routing:** `cmd/dcrdata/internal/explorer/explorerroutes.go:386` (`StakeDiffWindows`)
-- **UI:** `cmd/dcrdata/views/windows.tmpl`
+
+Routing / handler:
+- `cmd/dcrdata/main.go:767` — `r.Get("/ticketpricewindows", explore.StakeDiffWindows)`.
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:386` — `StakeDiffWindows`.
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:409` — `bestWindow := uint64(exp.Height() / exp.ChainParams.StakeDiffWindowSize)`.
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:419` — `exp.dataSource.PosIntervals(ctx, rows, offsetWindow)`.
+- `cmd/dcrdata/internal/explorer/explorerroutes.go:433` — `exp.templates.exec("windows", ...)`.
+
+Interface / mock:
+- `cmd/dcrdata/internal/explorer/explorer.go:100` — `dataSource.PosIntervals` interface method.
+- `cmd/dcrdata/internal/explorer/explorer_test.go:100` — `mockDataSource.PosIntervals`.
+
+DB / queries:
+- `db/dcrpg/pgblockchain.go:1807` — `(*ChainDB).PosIntervals` (queryTimeout + replaceCancelError).
+- `db/dcrpg/queries.go:905` — `retrieveWindowBlocks` (height-range math + 11-col Scan + builder).
+- `db/dcrpg/queries.go:877` — `parseCoinTxStats` (JSONB aggregate, lenient fallback).
+- `db/dcrpg/internal/blockstmts.go:131` — `SelectWindowsByLimit` SQL.
+
+Types / helpers:
+- `db/dbtypes/types.go:806` — `BlocksGroupedInfo` struct.
+- `db/dbtypes/types.go:2215` — `CoinTxStats` struct (`tx_count`, `size` JSON tags).
+- `db/dbtypes/conversion.go:144` — `CalculateWindowIndex`.
+
+Template / template helpers:
+- `cmd/dcrdata/views/windows.tmpl:116–135` — `{{range .Data}}` row rendering.
+- `cmd/dcrdata/views/windows.tmpl:132` — `{{printf "%.2f" (toFloat64Amount .TicketPrice)}}`.
+- `cmd/dcrdata/views/windows.tmpl:131` — `float64AsDecimalParts .Difficulty 0 true`.
+- `cmd/dcrdata/internal/explorer/templates.go:747` — `float64AsDecimalParts` registration.
+- `cmd/dcrdata/internal/explorer/templates.go:752` — `toFloat64Amount` registration (`dcrutil.Amount.ToCoin()`).
+
+---
+
+See also:
+- /wiki/code-analysis/windows/flow.compact.md (derived-from: this trace)
+- /wiki/code-analysis/windows/patterns.md (depends-on: reusable patterns extracted from this flow)
+- /wiki/code-analysis/windows/impact.md (depends-on: mutation blast radius for this flow)
+- /wiki/code-analysis/time-based-blocks/flow.full.md (shares-pattern-with: `dbtypes.BlocksGroupedInfo` struct pass-through)
+- /wiki/core/constraints.md#C1 (depends-on: numeric precision — VAR int64 atoms via `toFloat64Amount`)
+- /wiki/core/constraints.md#C7 (depends-on: per-coin-type label/model — `coin_tx_stats` reconciliation)

--- a/wiki/code-analysis/windows/impact.md
+++ b/wiki/code-analysis/windows/impact.md
@@ -19,9 +19,9 @@ window size at any of the three sites that must agree.
 
 **Description:**
 Three places must carry the same window size: the SQL bucket key
-`(height/$1)*$1` (`db/dcrpg/internal/blockstmts.go:125`); the value
+`(height/$1)*$1` (`db/dcrpg/internal/blockstmts.go:131`); the value
 `pgb.chainParams.StakeDiffWindowSize` passed into `retrieveWindowBlocks`
-(`db/dcrpg/pgblockchain.go:1806`, `db/dcrpg/queries.go:905`), which *also*
+(`db/dcrpg/pgblockchain.go:1810`, `db/dcrpg/queries.go:905`), which *also*
 recomputes `startHeight/endHeight` window boundaries from it; and
 `bestWindow := uint64(exp.Height() / exp.ChainParams.StakeDiffWindowSize)`
 plus `WindowSize: exp.ChainParams.StakeDiffWindowSize` in the handler
@@ -38,7 +38,7 @@ with no error and a plausible-looking table.
 ## Risk: `BlocksGroupedInfo` Field Removal / Rename (cross-domain)
 
 **Trigger:** Removing or renaming a field on
-`dbtypes.BlocksGroupedInfo` (`db/dbtypes/types.go:805`), or reordering the
+`dbtypes.BlocksGroupedInfo` (`db/dbtypes/types.go:806`), or reordering the
 `rows.Scan(...)` destination list in `retrieveWindowBlocks`.
 
 **Failure mode:** loud (template) / silent (cross-flow).
@@ -83,7 +83,7 @@ tags, or altering `parseCoinTxStats`.
 add/remove without a matching `Scan` change is a **hard failure**
 (`sql: expected N destination arguments`). More dangerous is the silent path:
 `parseCoinTxStats` (`db/dcrpg/queries.go:877`) unmarshals
-`[]map[string]dbtypes.CoinTxStats` (`db/dbtypes/types.go:2214`) and only
+`[]map[string]dbtypes.CoinTxStats` (`db/dbtypes/types.go:2215`) and only
 overrides the flat `SUM(num_rtx)` when the summed per-coin `TxCount` is
 larger; on empty/`\x00`-padded/short/unmarshal-error JSON it silently returns
 the flat `txs`. Renaming the `tx_count` JSON tag or breaking the

--- a/wiki/code-analysis/windows/patterns.md
+++ b/wiki/code-analysis/windows/patterns.md
@@ -8,7 +8,7 @@
 **Description:**
 Stake-difficulty (ticket-price) windows are not computed in Go memory. The
 aggregation is pushed entirely into a single Postgres statement,
-`SelectWindowsByLimit` (`db/dcrpg/internal/blockstmts.go:125`), which buckets
+`SelectWindowsByLimit` (`db/dcrpg/internal/blockstmts.go:131`), which buckets
 blocks with `SELECT (height/$1)*$1 AS window_start ... GROUP BY window_start`.
 `$1` is the consensus window size (`chaincfg.Params.StakeDiffWindowSize`,
 default 144) supplied by the caller. The bucket key relies on Postgres integer
@@ -24,7 +24,7 @@ Go-side loop re-aggregates these.
   (`db/dcrpg/queries.go:905`, called from `ChainDB.PosIntervals`
   `db/dcrpg/pgblockchain.go:1806`) must both be the *same* consensus window
   size. There is no DB-level check that `$1` equals the chain's actual window
-  size — they are wired by convention only.
+  size — they are wired by convention only. (`pgblockchain.go:1810`.)
 - Window boundaries are constrained twice: the `GROUP BY` truncation forms the
   bucket, and `retrieveWindowBlocks` separately computes
   `startHeight = startWindow*windowSize` /
@@ -41,7 +41,7 @@ Go-side loop re-aggregates these.
 
 **Description:**
 `SelectWindowsByLimit` filters with a bare boolean predicate `AND is_mainchain`
-(`db/dcrpg/internal/blockstmts.go:138`) inside the same `WHERE` as the height
+(`db/dcrpg/internal/blockstmts.go:144`) inside the same `WHERE` as the height
 range. Orphaned / sidechain rows in the `blocks` table are excluded from every
 aggregate (`SUM`, `MAX(sbits)`, `COUNT(*)`), so a window's reported ticket
 price, block count, and tx totals reflect mainchain consensus state only. A
@@ -73,7 +73,7 @@ The handler does no transformation between DB and template. `StakeDiffWindows`
 ... })`. `windows.tmpl` ranges over `.Data` and reads struct fields directly
 (`.IndexVal`, `.EndBlock`, `.Transactions`, `.Voters`, `.FreshStake`,
 `.Revocations`, `.TxCount`, `.BlocksCount`, `.Difficulty`, `.TicketPrice`).
-`dbtypes.BlocksGroupedInfo` (`db/dbtypes/types.go:805`) is the **same struct**
+`dbtypes.BlocksGroupedInfo` (`db/dbtypes/types.go:806`) is the **same struct**
 used by the time-based-blocks listing (`retrieveTimeBasedBlockListing`,
 `db/dcrpg/queries.go:961`, via `ChainDB.TimeBasedIntervals`). The two flows
 populate disjoint subsets of its fields from different SQL: the windows path
@@ -98,10 +98,10 @@ path fills `IndexVal/EndBlock/StartTime/EndTime` from `DATE_TRUNC`.
 **Description:**
 `SUM(num_rtx)` alone is not trusted as the window transaction count. The query
 also emits `JSONB_AGG(coin_tx_stats) AS coin_tx_stats`
-(`db/dcrpg/internal/blockstmts.go:135`). `retrieveWindowBlocks` scans this raw
+(`db/dcrpg/internal/blockstmts.go:141`). `retrieveWindowBlocks` scans this raw
 JSON and passes it through `parseCoinTxStats(coinTxStats, txs)`
 (`db/dcrpg/queries.go:877`): it unmarshals `[]map[string]dbtypes.CoinTxStats`
-(`db/dbtypes/types.go:2214`), sums every per-coin `TxCount`, and **overrides**
+(`db/dbtypes/types.go:2215`), sums every per-coin `TxCount`, and **overrides**
 the `SUM(num_rtx)` value when the per-coin total is larger. The displayed
 `Transactions` / `TxCount` therefore folds in per-coin-type activity rather
 than a single flat count — the multi-coin analogue of the legacy single-value

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -148,6 +148,15 @@ _The `/decodetx` page: a static HTML form whose handler carries no data; all int
 - patterns: code-analysis/decodetx/patterns.md — P1 form-shell over WS-RPC, P2 three-transport surface for the same node RPC, P3 multi-coin pass-through via opaque JSON
 - impact: code-analysis/decodetx/impact.md — R1 event-string drift across 5 sites, R2 oversize-request silent drop, R3 `/ws`/`/ps` dual-pipeline drift, R4 interface fan-out (+ mock), R5 latent SKA precision loss, R6 same-event success/error multiplexing, R7 shared receive loop, R8 legacy `/explorer/decodetx` redirect
 
+### Ticketpool
+
+_The `/ticketpool` page: form-shell HTML + three live data channels (HTTP `/api/ticketpool/charts`, HTTP `/api/ticketpool/bydate/{tp}`, WS `getticketpooldata`→`Resp`). Server `Ticketpool` handler injects only `commonData`; `sigNewBlock` carries no ticket data, the JS controller re-requests on every `newblock`. One `PoolTicketsData` struct populated by three positional Scans; process-global stale-while-revalidate cache keyed `(interval, height)` with `trylock.Mutex` updater election and an inner retry loop to keep all three sub-charts at one block. VAR-only float64 pipeline (tickets are a VAR PoS instrument by chain design); same JSON field `mempool.price` carries two different semantics across REST vs WS — a C8 manifestation inside a single field._
+
+- flow (compact): code-analysis/ticketpool/flow.compact.md — high-level summary of the form-shell + three-channel data path, height-keyed cache, and dual-transport mempool divergence
+- flow (full): code-analysis/ticketpool/flow.full.md — detailed handler → API/WS → DB → cache → SQL → Scan → JS controller trace, with REST/WS semantic asymmetry
+- patterns: code-analysis/ticketpool/patterns.md — P1 form-shell over WS-RPC, P2 tri-modal struct with positional Scan, P3 process-global stale-while-revalidate cache, P4 dual-transport overlay with divergent semantics, P5 VAR-only float64 staking pipeline
+- impact: code-analysis/ticketpool/impact.md — column-Scan desync, REST/WS payload drift, `Mempool.Price` semantic drift, WS event-name drift, TimeGrouping enum drift, SKA-through-VAR pipeline corruption, cache-loop removal, process-global cache cross-talk, C6 violation surface, legacy `DCR` label leak, `/bydate` response asymmetry
+
 ### Page-Rendering (cross-domain consolidation)
 
 _Mode-4 consolidation of the shared mechanics behind every server-rendered HTML page (block, mempool, visualblocks, parameters, charts, address). Not a flow — read alongside the per-domain flows it links. Covers out-of-band shared `pageData`/`invs` state, the multi-lock discipline, `*CommonPageData` struct-embedding template injection, and block-scoped ETag caching._

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -123,6 +123,14 @@ _The `/parameters` page: active-network consensus config. ~95% static `chaincfg.
 - patterns: code-analysis/parameters/patterns.md — near-static chaincfg.Params page: dual-source commonData/ExtendedParams split, hardcoded network-name prefix table, VAR-only subsidy rows, unchecked MaximumBlockSizes[0] fallback
 - impact: code-analysis/parameters/impact.md — commonData nil → .ChainParams deref crash, silent blank/misaligned address-prefix table on unknown network, stale/empty-slice MaximumBlockSize, unlocked pageData.BlockchainInfo race
 
+### Sidechain
+
+_The `/side` page: read-only HTML table of every block with `is_mainchain=false`. Single SQL query (`blocks JOIN block_chain`), no WebSocket, no Stimulus, no amounts — the simplest page-rendering shape in the codebase. Writers are two independent paths: startup `ImportSideChains` (off by default, inserts rows) and live reorg `TipToSideChain` (flips existing rows). `BlockStatus` is shared with 3 sibling endpoints (`/disapproved`, `/block/{hash}` status, height-keyed status) each Scanning a different column subset — positional Scan invariant._
+
+- flow (compact): code-analysis/sidechain/flow.compact.md — high-level summary of the read path, both writer paths, and why C1/C3/C8 don't apply
+- flow (full): code-analysis/sidechain/flow.full.md — detailed handler → DataSource → SQL → Scan → template trace, plus `ImportSideChains` and reorg writers
+- impact: code-analysis/sidechain/impact.md — `BlockStatus` 4-endpoint blast, positional Scan desync, uninitialized `IsMainchain`, `ImportSideChains=false` empty-page-is-correct, real-time-element imports C3/C8
+
 ### Page-Rendering (cross-domain consolidation)
 
 _Mode-4 consolidation of the shared mechanics behind every server-rendered HTML page (block, mempool, visualblocks, parameters, charts, address). Not a flow — read alongside the per-domain flows it links. Covers out-of-band shared `pageData`/`invs` state, the multi-lock discipline, `*CommonPageData` struct-embedding template injection, and block-scoped ETag caching._

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -62,10 +62,10 @@ _Address page rendering: paginated transaction table, chart endpoints, CSV downl
 
 ### Windows
 
-_Ticket price window intervals, calculating and displaying current and upcoming ticket prices._
+_Ticket price window intervals: server-rendered `/ticketpricewindows` page; SQL-side integer-division bucketing of mainchain blocks into stake-difficulty windows; multi-coin `coin_tx_stats` JSONB reconciliation; shared `BlocksGroupedInfo` struct with time-based-blocks. Revised at `HEAD=3cdba1e7`._
 
-- flow (compact): code-analysis/windows/flow.compact.md — high-level summary of ticket window calculations and database queries
-- flow (full): code-analysis/windows/flow.full.md — detailed, step-by-step function trace for deep debugging of window intervals
+- flow (compact): code-analysis/windows/flow.compact.md — one-line flow, key patterns, constraints, and a copy-pasteable mutation checklist for `/ticketpricewindows`
+- flow (full): code-analysis/windows/flow.full.md — strict 1–10 trace from `blocks` table → SQL aggregation → `BlocksGroupedInfo` → `PosIntervals` → `StakeDiffWindows` handler → `windows.tmpl`, with all current file:line refs
 - patterns: code-analysis/windows/patterns.md — ticket-price-window reusable behavior: Postgres integer-division GROUP BY grouping, mainchain-only filter, shared dbtypes.BlocksGroupedInfo pass-through, multi-coin coin_tx_stats reconciliation
 - impact: code-analysis/windows/impact.md — windows mutation blast radius: StakeDiffWindowSize/SQL-denominator desync, cross-domain BlocksGroupedInfo field changes, coin_tx_stats Scan mismatch, TicketPrice template-boundary type, pagination drift
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -131,6 +131,14 @@ _The `/side` page: read-only HTML table of every block with `is_mainchain=false`
 - flow (full): code-analysis/sidechain/flow.full.md — detailed handler → DataSource → SQL → Scan → template trace, plus `ImportSideChains` and reorg writers
 - impact: code-analysis/sidechain/impact.md — `BlockStatus` 4-endpoint blast, positional Scan desync, uninitialized `IsMainchain`, `ImportSideChains=false` empty-page-is-correct, real-time-element imports C3/C8
 
+### Disapproved Blocks
+
+_The `/disapproved` page: read-only HTML table of every block with `is_valid=false` (regular tx tree invalidated by stakeholder votes on the next block). Structural twin of `/side` — same shared `BlockStatus` struct, same `blocks JOIN block_chain` query — but with a single, always-on writer (`updateLastBlock` inside the normal block-connect path, no flag, no reorg required) and ETag/Last-Modified caching (`withCache`) that `/side` lacks. Each list endpoint pre-trims its filter column from the SELECT, leaving a different `BlockStatus` field unwritten by Scan: `/disapproved` leaves `IsValid` zero; `/side` leaves `IsMainchain` zero._
+
+- flow (compact): code-analysis/disapproved-blocks/flow.compact.md — high-level summary of the writer cascade, ETag-wrapped read path, shared `BlockStatus` Scan invariant, and why C1/C2/C3/C6/C8 are out of scope today
+- flow (full): code-analysis/disapproved-blocks/flow.full.md — detailed handler → DataSource → SQL → Scan → template trace, `updateLastBlock` vote-bit invalidation cascade, `/rejects` 308 alias, and the `withCache` divergence vs `/side`
+- impact: code-analysis/disapproved-blocks/impact.md — `BlockStatus` 4-reader Scan blast, `IsValid` Scan-default trap, `updateLastBlock` as sole writer (cross-table is_valid coherence), ETag cache key coupling, real-time/amount-column re-import of C1/C3/C6/C7/C8
+
 ### Page-Rendering (cross-domain consolidation)
 
 _Mode-4 consolidation of the shared mechanics behind every server-rendered HTML page (block, mempool, visualblocks, parameters, charts, address). Not a flow — read alongside the per-domain flows it links. Covers out-of-band shared `pageData`/`invs` state, the multi-lock discipline, `*CommonPageData` struct-embedding template injection, and block-scoped ETag caching._

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -139,6 +139,15 @@ _The `/disapproved` page: read-only HTML table of every block with `is_valid=fal
 - flow (full): code-analysis/disapproved-blocks/flow.full.md — detailed handler → DataSource → SQL → Scan → template trace, `updateLastBlock` vote-bit invalidation cascade, `/rejects` 308 alias, and the `withCache` divergence vs `/side`
 - impact: code-analysis/disapproved-blocks/impact.md — `BlockStatus` 4-reader Scan blast, `IsValid` Scan-default trap, `updateLastBlock` as sole writer (cross-table is_valid coherence), ETag cache key coupling, real-time/amount-column re-import of C1/C3/C6/C7/C8
 
+### Decode/Broadcast Tx
+
+_The `/decodetx` page: a static HTML form whose handler carries no data; all interaction runs over `/ws` as request/response RPC-over-WebSocket (`decodetx` / `sendtx` → `decodetxResp` / `sendtxResp`). The only user-driven write path to the node in the page tier. The same RPCs are exposed on three transports — explorer `/ws`, pubsub `/ps`, and Insight `POST /insight/api/tx/send` — each with its own envelope, size limit, and error-string convention. SKA precision is preserved by accident of pass-through: `*chainjson.TxRawResult` is marshaled verbatim and dumped into `<pre>.textContent`, never parsed by the explorer._
+
+- flow (compact): code-analysis/decodetx/flow.compact.md — HTML-shell + WS-only data path, three-transport surface, pass-through multi-coin invariant, mutation checklist
+- flow (full): code-analysis/decodetx/flow.full.md — handler → template → Stimulus → `/ws` `switch` → `ChainDB.{Decode,Send}RawTransaction` → node RPC trace, with the pubsub `/ps` twin and Insight REST surface
+- patterns: code-analysis/decodetx/patterns.md — P1 form-shell over WS-RPC, P2 three-transport surface for the same node RPC, P3 multi-coin pass-through via opaque JSON
+- impact: code-analysis/decodetx/impact.md — R1 event-string drift across 5 sites, R2 oversize-request silent drop, R3 `/ws`/`/ps` dual-pipeline drift, R4 interface fan-out (+ mock), R5 latent SKA precision loss, R6 same-event success/error multiplexing, R7 shared receive loop, R8 legacy `/explorer/decodetx` redirect
+
 ### Page-Rendering (cross-domain consolidation)
 
 _Mode-4 consolidation of the shared mechanics behind every server-rendered HTML page (block, mempool, visualblocks, parameters, charts, address). Not a flow — read alongside the per-domain flows it links. Covers out-of-band shared `pageData`/`invs` state, the multi-lock discipline, `*CommonPageData` struct-embedding template injection, and block-scoped ETag caching._


### PR DESCRIPTION
Adds four new `wiki/code-analysis/` domains for read-only / data-light pages and refreshes the existing `windows` domain. Each new domain follows the standard layout (`flow.full.md`, `flow.compact.md`, `patterns.md` where applicable, `impact.md`) and is registered in `wiki/index.md`. All four new ones share a thematic concern: documenting **what the page does NOT do** (no SSR data, no WebSocket push, no amounts, no multi-coin) is as load-bearing as documenting what it does, so future edits don't bolt on out-of-pattern surface area.

## What's included

### `/side` — sidechain
Simplest server-rendered page in the codebase: single `blocks JOIN block_chain WHERE is_mainchain=FALSE` query, no WS, no Stimulus, no amounts. Captures the two independent writer paths (`ImportSideChains`, off by default; live `TipToSideChain` reorg flip) and explicitly notes why C1/C3/C8 do not apply, to prevent future edits from bolting on amount columns or WebSocket pushes without re-importing the invariants.

### `/disapproved` — disapproved blocks
Structural twin of `/side`: same shared `BlockStatus` row type, same `blocks JOIN block_chain` query shape, but with a single always-on writer (`updateLastBlock` vote-bit cascade in the normal block-connect path) and `withCache` ETag/Last-Modified caching that `/side` lacks. Documents the `IsValid`-vs-`IsMainchain` Scan-default asymmetry that distinguishes the two pages and adds bidirectional `shares-pattern-with` links from the sidechain trace.

### `/decodetx` — decode/broadcast tx
Static HTML form whose handler carries no data; all interaction runs over `/ws` as request/response RPC-over-WebSocket (`decodetx`/`sendtx` → `decodetxResp`/`sendtxResp`). The only user-driven write path to the node in the page tier. Captures the three-transport surface for the same RPC (explorer `/ws`, pubsub `/ps`, Insight `POST /insight/api/tx/send`), each with its own envelope/size limit/error convention, and notes how SKA precision is preserved by accident of pass-through (`*chainjson.TxRawResult` is marshaled verbatim into `<pre>.textContent`).

### `/ticketpool` — ticket pool visualization
No-data form shell + three live data channels (HTTP `/api/ticketpool/charts`, HTTP `/api/ticketpool/bydate/{tp}`, WS `getticketpooldata`→`Resp`). Server `sigNewBlock` carries no ticket data; the JS controller re-requests on every `newblock`, absorbed by a process-global, height-keyed stale-while-revalidate cache with per-interval `trylock.Mutex` updater election and an inner retry loop that keeps all three sub-charts at one block.

Captures two non-trivial hazards worth recording:
- The same JSON field `mempool.price` carries different semantics across REST (`stakeDiff.ToCoin() + feeAvg`) vs WS (`inv.Tickets[0].TotalOut`) — a C8 manifestation inside a single field, not in C8's existing catalogued examples.
- One `PoolTicketsData` struct is populated by three positional `rows.Scan` calls against three different SELECT shapes, so reordering a column silently rewires fields.

Records the entire pipeline as VAR-only float64 (tickets are PoS VAR by chain design per `staking-rewards.md` §2) to prevent future edits from extending it to SKA without rewriting away from `[]float64`/`*1e8`.

### `/ticketpricewindows` — windows (refresh, not new)
Rewrites `flow.full.md` to the strict 1–10 template against current code (HEAD=3cdba1e7) and refreshes `flow.compact.md`. Two structural gaps in the prior trace are filled:

- The `dataSource` interface boundary (`cmd/dcrdata/internal/explorer/explorer.go:100`) + its mock (`explorer_test.go:100`) — previously the trace jumped straight from `*ChainDB.PosIntervals` to the handler, hiding a signature contract that has to move in lockstep across three files.
- The `parseCoinTxStats` multi-coin reconciliation step as a *transformation* in the flow itself (not just in `patterns.md`) — `.Transactions` on the page is the post-reconciliation per-coin sum, not flat `SUM(num_rtx)`, and the lenient JSON fallback for pre-multi-coin history is intentional.

Line refs in `patterns.md` / `impact.md` updated where they had drifted (`blockstmts.go:131/141/144`, `pgblockchain.go:1810`, `types.go:806/2215`). Index entry stamped `Revised at HEAD=3cdba1e7` with sharpened flow descriptions.

No code changes were warranted by the exploration: the constraint that `SQL $1 == chainParams.StakeDiffWindowSize` is held by convention at three callsites with no DB-level check, but no callsite is currently violating it; the legacy VAR-only `toFloat64Amount` render path is correct because `TicketPrice` is VAR-scale by design; the lenient `parseCoinTxStats` fallback is intentional. The risks remain documented; the code is consistent with them.

## Scope

- No code changes.
- `wiki/index.md` extended with four new sections; the `Windows` entry refreshed in place.
- New cross-links use the `depends-on` / `shares-pattern-with` / `derived-from` typed-link convention from `wiki/core/maintenance.md`.