### PR TITLE
cmd/dcrdata: remove dead Decred-era links from global nav

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -168,7 +168,7 @@ type links struct {
 var explorerLinks = &links{
 	CoinbaseComment: "https://github.com/decred/dcrd/blob/2a18beb4d56fe59d614a7309308d84891a0cba96/chaincfg/genesis.go#L17-L53",
 	POSExplanation:  "https://docs.decred.org/proof-of-stake/overview/",
-	APIDocs:         "https://github.com/decred/dcrdata#apis",
+	APIDocs:         "https://github.com/monetarium/monetarium-explorer#apis",
 	InsightAPIDocs:  "https://github.com/decred/dcrdata/blob/master/docs/Insight_API_documentation.md",
 	Github:          "https://github.com/monetarium/monetarium-explorer",
 	License:         "https://github.com/monetarium/monetarium-explorer/blob/main/LICENSE",

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -81,12 +81,8 @@
 					<a class="menu-item" data-keynav-skip href="/mempool" title="Monetarium mempool">Mempool</a>
 					<a class="menu-item" data-keynav-skip href="/ticketpool" title="Monetarium ticket pool">Ticket Pool</a>
 					<a class="menu-item jsonly" data-keynav-skip href="/charts" title="Monetarium charts">Charts</a>
-					<a class="menu-item" data-keynav-skip href="/agendas" title="Agendas">Agendas</a>
-					<a class="menu-item" data-keynav-skip href="/proposals" title="Proposals">Proposals</a>
-					<a class="menu-item" data-keynav-skip href="/market" title="Market">Market</a>
 					<a class="menu-item" data-keynav-skip href="/attack-cost" title="Monetarium Attack Cost">Attack Cost</a>
 					<a class="menu-item" data-keynav-skip href="/parameters" title="Chain Parameters">Parameters</a>
-					<a class="menu-item" data-keynav-skip href="/treasury" title="Monetarium Supply">Supply</a>
 					<a class="menu-item" data-keynav-skip href="/decodetx" title="Decode or send a raw transaction">Decode/Broadcast Tx</a>
 					<a class="menu-item" data-keynav-skip href="/verify-message" title="Verify Message">Verify Message</a>
 				{{- if eq .NetName "Mainnet"}}


### PR DESCRIPTION
## Summary

Closes #293.

The global header nav rendered by [`views/extras.tmpl`](cmd/dcrdata/views/extras.tmpl) exposed four broken / misleading items on every reviewable page — every page looked broken on first nav click. This PR is **nav-only**: handlers in `main.go` and the `exchanges` pipeline behind `/market` are untouched.

### Nav entries removed (`extras.tmpl`)

| Label | Target | Status | Why removed |
|---|---|---|---|
| Agendas | `/agendas` | 410 Gone | Handler intentionally disabled in `main.go` |
| Proposals | `/proposals` | 410 Gone | Handler intentionally disabled in `main.go` |
| Market | `/market` | 200 | Renders empty/legacy Decred data; broader `/market` disabling tracked separately |
| Supply | `/treasury` | 410 Gone | Mislabelled — `/treasury` has nothing to do with coin supply |

### Supply link decision — option (a): remove entirely

Per the issue's checklist, **option (a)** (lower-risk default). The home page already renders a multi-coin Coin Supply card ([`home_supply.tmpl`](cmd/dcrdata/views/home_supply.tmpl)); the per-coin SKA chart route `/charts?chart=coin-supply/N` remains reachable from `/charts` and from the home Coin Supply card. No new label/route decision needed.

### JSON API Docs (`internal/explorer/explorer.go`)

`Links.APIDocs` repointed from `github.com/decred/dcrdata#apis` → `github.com/monetarium/monetarium-explorer#apis`. The `README.md` already has a matching `## APIs` section / `#apis` anchor — no README change required.

### Known follow-ups out of scope

- `Links.InsightAPIDocs` still points at `decred/dcrdata` and is used by [`views/insight_root.tmpl:14`](cmd/dcrdata/views/insight_root.tmpl#L14). Worth its own PR.
- The broader `/market` disabling (handler + `exchanges` polling pipeline) is tracked separately.

## Test plan

- [x] `go build ./...` in `cmd/dcrdata` — clean
- [x] `go vet ./internal/explorer/...` — clean
- [x] `go test ./internal/explorer/...` — pass
- [x] `golangci-lint run -c .golangci.yml ./internal/explorer/...` — 0 issues
- [x] `gofmt -l internal/explorer/explorer.go` — clean
- [x] Pre-commit hook (gofmt + full `cmd/dcrdata` test suite) — pass
- [x] Negative grep on rendered home HTML: 0 hits for `href="/(agendas|proposals|market|treasury)"`
- [x] Negative grep on rendered home HTML: 0 hits for `github.com/decred/dcrdata#apis`
- [x] Playwright DOM dump of `#menu` on `/` and `/parameters`: 12 nav items, zero dead links, `JSON API Docs` href = `https://github.com/monetarium/monetarium-explorer#apis`
- [x] `curl` of `/agendas`, `/proposals`, `/treasury` still returns `410`; `/market` still `200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)