### PR TITLE
Add market code analysis documentation

### DIFF
--- a/wiki/code-analysis/market/flow.compact.md
+++ b/wiki/code-analysis/market/flow.compact.md
@@ -1,0 +1,26 @@
+# `/market` — Compact
+
+**Flow.** `external HTTP/gRPC (Coinbase, Binance, Mexc, dex.decred.org, optional DCRRates gRPC) → exchanges.ExchangeBot goroutine → bot.currentState + stateCopy → 3 outputs: (a) MarketPage handler → market.tmpl initial render; (b) watchExchanges → WebsocketExchangeUpdate → wsHub.xcChan → per-client xc chan → WS event "exchange" → public/index.js bridge → globalEventBus 'EXCHANGE_UPDATE' → market_controller._processXcUpdate; (c) /api/chart/market/{token}/{candlestick|depth} → QuickSticks/QuickDepth → versionedChart cache → market_controller.fetchChart.` Same bot also serves `xcBot.Conversion(float64)` for fiat sidebars on `/`, `/tx`, `/address`, `/treasury` (latter is 410-gated).
+
+**Key architectural patterns.**
+- **P1 — Globally-shared optional collector.** One `*exchanges.ExchangeBot` constructed in `main.go`, nullable on every consumer; gate is `if xcBot != nil`. Disabling the page does NOT disable the bot.
+- **P2 — Dual collection source for one collector.** gRPC `SubscribeExchanges` from a DCRRates master OR direct per-exchange HTTP poll on `DataExpiry` ticks; both fan into the same `exchangeChan`/`indexChan`.
+- **P3 — Lock-free snapshot read.** `updateState()` writes `currentStateBytes` + `stateCopy` under bot write lock; `State()` returns the read-only `stateCopy` under RLock. Template renders never hold the bot mutex.
+- **P4 — Versioned lazy-encoded chart cache.** `versionedChart` keyed `(market, token, bin|orderbook)`; `incrementChart` bumps the version on every relevant `updateExchange`; `QuickSticks/QuickDepth` re-encode only on version miss.
+- **P5 — Untyped WS bridge via globalEventBus.** Go const `exchangeUpdateID = "exchange"` → `public/index.js` registers `ws.registerEvtHandler('exchange', ...)` and republishes as `globalEventBus.publish('EXCHANGE_UPDATE', JSON.parse(e))`. Four string contracts in two JS files — silent if any drift.
+
+**Critical constraints.**
+- **C1.** Entire `exchanges/` is `float64` (price, volume, conversion). VAR-safe; **SKA-incompatible** — no SKA path exists. Reusing `Conversion(float64)` for SKA silently truncates.
+- **C7.** `market.tmpl` hard-codes the literal `DCR` (axis labels, "1 DCR =", "Volume (DCR)"); not routed through `coinSymbol`. The label and the data agree only because the data is in fact Decred.
+- **C8.** REST `ExchangeBotState` (full snapshot) ≠ WS `WebsocketExchangeUpdate` (per-exchange delta + aggregate). Two independent contracts; market controller reads both.
+- **Network-name gate is a no-op on Monetarium mainnet.** `cfg.EnableExchangeBot && activeChain.Name != "mainnet"` blocks only Monetarium testnet/simnet — Monetarium mainnet chaincfg `Name` is also `"mainnet"`. Only `EnableExchangeBot=false` (default) keeps Decred prices off a Monetarium UI.
+
+**Mutation checklist.**
+1. Change `WebsocketExchangeUpdate` field? Update `market.tmpl` AND `_processXcUpdate` AND `watchExchanges`.
+2. Change `ExchangeBotState` field? Update `market.tmpl` AND `/api/exchanges` consumers; WS path unaffected.
+3. Rename `"exchange"` event-id? Update `cmd/dcrdata/internal/explorer/websocket.go:372` AND `cmd/dcrdata/public/index.js:61`. Silent break.
+4. Rename `EXCHANGE_UPDATE`? Update `public/index.js:62` AND `market_controller.js:569,581`. Silent break.
+5. Add a non-DCR market? Touch `exchanges.go` (CurrencyPair consts, IsValid*, URL maps), `apiroutes.go::retrieveCurrencyPair`, `market.tmpl` (DCR literals), `market_controller.js` (`exchangeLinks`, pair constants). Compile catches Go side; template/JS literals drift silently.
+6. Adding SKA-fiat conversion? Build a new big.Int/string API on the bot — do NOT reuse `Conversion(float64)`.
+7. Removing the bot? Drop `XcBot` field on `ExplorerConfig` + `appContext`, delete ~7 `xcBot.Conversion(...)` callsites (home, address, tx, treasury × 2), delete `watchExchanges`, drop the bridge in `public/index.js`. Per-route removal is not enough.
+8. Toggling `exchange-monitor=1` on a Monetarium mainnet deployment will render real Decred prices. Verify the gate before enabling.

--- a/wiki/code-analysis/market/flow.full.md
+++ b/wiki/code-analysis/market/flow.full.md
@@ -1,0 +1,616 @@
+# `/market` — Full Flow Trace
+
+> Trace anchor: `HEAD` of `feature/dcrdata-nav-remove-dead-links` at write time.
+> Domain scope: the `/market` HTML page and the shared `exchanges` collector that also
+> feeds fiat conversions for `/`, `/tx/{txid}`, `/address/{address}`, and the (410-gated)
+> `/treasury` handler. Per [/wiki/core/pages.md](../../core/pages.md), this page is flagged
+> "should be disabled" — none of the listed exchanges trade Monetarium tokens. Document its
+> current real wiring so the future removal/replacement work has an accurate map.
+
+---
+
+## Section 1 — Overview
+
+`MarketPage` is a server-rendered HTML shell + Stimulus controller. It is the only page in
+the repo whose data flow originates from **external HTTP/gRPC sources** (Coinbase, Binance,
+Mexc, dex.decred.org, optional DCRRates master) — not from `monetarium-node` RPC or the
+PostgreSQL backend. A single `*exchanges.ExchangeBot` runs as a background goroutine; its
+in-memory snapshot is read three ways:
+
+- **HTML render** (initial paint of `/market`) — `MarketPage` handler reads `xcBot.State()`
+  and dumps it into [market.tmpl](../../../cmd/dcrdata/views/market.tmpl).
+- **WebSocket push** (live updates on `/market`) — `watchExchanges` reads
+  `xcBot.UpdateChannels()` and emits `WebsocketExchangeUpdate` to every connected client.
+- **Versioned REST chart cache** (depth/candlestick chart loads) —
+  `/api/chart/market/{token}/{candlestick|depth}` calls `xcBot.QuickSticks` /
+  `xcBot.QuickDepth`, which lazy-encode and cache JSON bytes.
+
+The same bot is also queried by other handlers via `xcBot.Conversion(float64) *Conversion`
+for fiat sidebars on home/tx/address pages. **All seven callsites use the same nullable
+`xcBot` pointer; the entire surface is float64-only (VAR-safe, SKA-incompatible) and
+DCR-symbol-hard-coded.**
+
+---
+
+## Section 2 — End-to-End Data Flow
+
+```
+[external feeds]                        ┌───────────── REST: GET /api/exchanges
+   │                                    │              GET /api/exchangerate
+   ├── gRPC SubscribeExchanges (DCRRates ├───── HTML: GET /market
+   │   master, if `ratemaster` set)     │              ↓
+   │                                    │       MarketPage handler ── exp.getExchangeState()
+   └── HTTP poll: Coinbase, Binance,    │              ↓                      ↓
+       Mexc, dex.decred.org             │       xcBot.State() (read-only snapshot)
+   ↓                                    │              ↓
+exchanges.ExchangeBot (one goroutine)   │       market.tmpl render
+   ├── exchangeChan / indexChan         │
+   │     ↓                              ├───── REST charts:
+   │   updateExchange / updateIndices   │       GET /api/chart/market/{token}/candlestick/{bin}
+   │     ↓                              │       GET /api/chart/market/{token}/depth
+   │   currentState (mutex-protected)   │              ↓
+   │     ├── currentStateBytes (JSON)   │       xcBot.QuickSticks / QuickDepth
+   │     └── stateCopy (read-only ptr)  │              ↓
+   │                                    │       versionedChart cache (per-key bytes)
+   └── signalExchangeUpdate / Index ─→ updateChans / indexChans (per subscriber)
+                                            ↓
+                            (explorer subscriber)
+                            explorer.watchExchanges()  [explorer.go:984]
+                                            ↓
+                            WebsocketExchangeUpdate (per-update, not full state)
+                                            ↓
+                            wsHub.xcChan  →  hub.run() fan-out  →  per-client xc chan
+                                            ↓
+                            RootWebsocket: WebSocketMessage{EventId:"exchange",
+                                                            Message: JSON(update)}
+                                            ↓
+[browser]
+   public/index.js:61    ws.registerEvtHandler('exchange', e ⇒
+                            globalEventBus.publish('EXCHANGE_UPDATE', JSON.parse(e)))
+                                            ↓
+   market_controller.js:568  globalEventBus.on('EXCHANGE_UPDATE', this.processXcUpdate)
+                                            ↓
+                            DOM mutation: price/volume/arrow/aggregate, BTC indices,
+                                          refreshChart() if depth/candlestick visible
+```
+
+The depth/candlestick chart is **not** served by the WS push. The WS update triggers an
+in-controller `clearCache(this.lastUrl) + refreshChart()` if a chart is currently visible,
+which issues a fresh `GET /api/chart/market/...` call.
+
+---
+
+## Section 3 — Per-Layer Breakdown
+
+### 3.1 Backend collector — `exchanges/` (separate Go module)
+
+**Location.** [exchanges/bot.go](../../../exchanges/bot.go),
+[exchanges/exchanges.go](../../../exchanges/exchanges.go). Module
+[exchanges/go.mod](../../../exchanges/go.mod).
+
+**Construction.** [main.go:413–440](../../../cmd/dcrdata/main.go) (`_main`):
+
+```go
+var xcBot *exchanges.ExchangeBot
+if cfg.EnableExchangeBot && activeChain.Name != "mainnet" {
+    log.Warnf("disabling exchange monitoring. only available on mainnet")
+    cfg.EnableExchangeBot = false
+}
+if cfg.EnableExchangeBot {
+    botCfg := exchanges.ExchangeBotConfig{
+        Index:          cfg.ExchangeCurrency,    // default "USD"
+        MasterBot:      cfg.RateMaster,
+        MasterCertFile: cfg.RateCertificate,
+    }
+    if cfg.DisabledExchanges != "" {
+        botCfg.Disabled = strings.Split(cfg.DisabledExchanges, ",")
+    }
+    xcBot, err = exchanges.NewExchangeBot(&botCfg)
+    if err != nil { /* log + continue, xcBot stays nil */ } else {
+        wg.Add(1); go xcBot.Start(ctx, &wg)
+    }
+}
+```
+
+`xcBot` is then passed as `ExplorerConfig.XcBot` and `appContext.XcBot`. It is **nullable
+on every consumer**.
+
+**Configured exchanges.** `exchanges/exchanges.go:169–183`:
+
+- Indices (BTC/USDT-fiat sources): `Coinbase` (`NewCoinbase`).
+- DCR-{Asset} markets: `Binance`, `DexDotDecred` (host
+  `dex.decred.org:7232`), `Mexc`. All Decred. No Monetarium asset.
+
+**Polling URLs** (all hard-coded `DCR`-symbol strings — `exchanges/exchanges.go:121–166`):
+e.g. `https://api.binance.com/api/v3/ticker/24hr?symbol=DCRUSDT`.
+
+**Start loop.** `exchanges/bot.go:434–561`. Two modes:
+
+1. **DCRRates master mode** — if `MasterBot != ""`, opens a gRPC `SubscribeExchanges` stream
+   and drains updates as `exchangeStateFromProto`. The local poll timer is drained and
+   never fires (`bot.masterConnection != nil ⇒ skip nextTick`).
+2. **Direct poll mode** — fan out: `for _, xc := range bot.Exchanges { go xc.Refresh() }`,
+   then schedule the next tick via `nextTick()` (per `DataExpiry`, default 5m, min 5s).
+   Each exchange writes to `bot.exchangeChan` / `bot.indexChan`; the `Start` loop dispatches
+   `updateExchange` / `updateIndices` and re-broadcasts via `signalExchangeUpdate` /
+   `signalIndexUpdate` to all subscriber channels registered through `UpdateChannels()`.
+
+**State recomputation.** `bot.go:949–976` (`updateState`):
+
+- `dcrPriceAndVolume(code)` averages per-DCR-exchange processed price/volume.
+- `processState` (`bot.go:824–857`) converts each `(pair, price)` into the index currency
+  via `indexPrice(BTC|USDT-Index, code)`, applies volume weighting, rejects exchanges older
+  than `RequestExpiry` (default 60m).
+- Snapshot copy: `bot.stateCopy = bot.currentState.copy()` — `copy()` deep-copies the two
+  `map[string]map[CurrencyPair]*ExchangeState` maps (`bot.go:112–122, 125–129`), so readers
+  hold a stable pointer that the writer never mutates.
+- JSON-marshals into `bot.currentStateBytes` for `StateBytes()`.
+
+**State exposure.**
+
+- `bot.State() *ExchangeBotState` — returns `bot.stateCopy` under RLock (`bot.go:646–650`).
+- `bot.IsFailed() bool` — true when there are no fresh BTC or DCR sources
+  (`bot.go:983–987`); set inside `updateState`. **The "failed" path returns the cached
+  stale `stateCopy` from `State()` but causes `getExchangeState` to return `nil`.**
+- `bot.Conversion(dcrVal float64) *Conversion` — used by other handlers (home, address,
+  tx). Returns `&Conversion{Value: xcState.Price * dcrVal, Index: xcState.Index}` if state
+  exists, else `&Conversion{Value:0, Index:"USD"}` (`bot.go:1045–1058`). **Never returns
+  nil if `bot != nil`** — so `if xcBot != nil` is the only practical gate.
+
+### 3.2 HTML render path — `MarketPage`
+
+**Handler.** `cmd/dcrdata/internal/explorer/explorerroutes.go:2513–2531`:
+
+```go
+func (exp *explorerUI) MarketPage(w http.ResponseWriter, r *http.Request) {
+    str, err := exp.templates.exec("market", struct {
+        *CommonPageData
+        XcState *exchanges.ExchangeBotState
+    }{
+        CommonPageData: exp.commonData(r),
+        XcState:        exp.getExchangeState(),
+    })
+    ...
+}
+```
+
+`exp.getExchangeState()` (`explorer.go:1047–1052`) returns `nil` when `xcBot == nil` **or**
+`xcBot.IsFailed()`. The template treats `nil` as the "monitoring disabled" branch.
+
+**Route.** [cmd/dcrdata/main.go:786](../../../cmd/dcrdata/main.go):
+`r.Get("/market", explore.MarketPage)`. Not wrapped in `withCache` — every hit re-executes
+the template (no ETag for `/market`).
+
+**Template.** [cmd/dcrdata/views/market.tmpl](../../../cmd/dcrdata/views/market.tmpl):
+
+- Lines 10–11: `{{- if $botState -}}` — single top-level gate. `nil` ⇒ renders
+  `<h5>Exchange monitoring disabled</h5>` only.
+- Lines 20–29: hard-coded `1 DCR =` literal + `{{printf "%.2f" $botState.Price}}`.
+- Lines 32–86: `Monetarium Markets` table built from `$botState.VolumeOrderedExchanges`
+  (`bot.go:215–238`, sorts `tokenedExchange` by descending volume). Calls
+  `xcDisplayName` (`templates.go:861–867`, special-cases `dcrdex → dex.decred.org`, else
+  `titler.String(token)`), `threeSigFigs`, `$botState.PriceToFiat`, `$botState.FiatToBtc`.
+- Lines 89–103: `Bitcoin Indices` block from `$botState.BitcoinIndices()` (`bot.go:166–175`,
+  maps token → `BTCIndex` state).
+- Lines 107–229: Stimulus chart shell — wires `data-market-target=...` for chart, bin,
+  zoom, exchange, conversion buttons.
+- Lines 178–186: `data-indices="{{$botState.Indices}}"` is a JSON blob (string),
+  `data-code="{{$botState.Index}}"` is the default currency code — both consumed by the
+  Stimulus controller in `connect()` (`market_controller.js:522–523`).
+
+The page does **not** use template cloning (C6 N/A — no `<template id="...">` here).
+
+### 3.3 WebSocket push path — `watchExchanges`
+
+**Subscriber goroutine.** Started unconditionally in `explorer.New()` (`explorer.go:426`):
+`go exp.watchExchanges()`. Early-returns if `exp.xcBot == nil`
+(`explorer.go:985`).
+
+**Channel registration.** `xcChans := exp.xcBot.UpdateChannels()` (`bot.go:604–618`) —
+each call allocates **new buffered (cap 16) channels** and appends them to the bot's
+`updateChans`/`indexChans` slices. So if `watchExchanges` were ever restarted, channels
+would leak; in practice it runs once for the process lifetime.
+
+**Per-update payload assembly** (`explorer.go:990–1017`):
+
+```go
+sendXcUpdate := func(isFiat bool, token, pair string, updater *exchanges.ExchangeState) {
+    xcState := exp.xcBot.State()
+    update := &WebsocketExchangeUpdate{
+        Updater: WebsocketMiniExchange{Token, CurrencyPair: pair,
+                                       Price, Volume, Change},
+        IsFiatIndex: isFiat,
+        Index:       exp.xcBot.Index,
+        Price:       xcState.Price,
+        Volume:      xcState.Volume,
+        Indices:     map[string]float64{
+            "BTC-Index":  xcState.BtcPrice,
+            "USDT-Index": indexPrice(USDTIndex, xcState.FiatIndices),
+        },
+    }
+    select {
+    case exp.wsHub.xcChan <- update:
+    default:
+        log.Warnf("Failed to send WebsocketExchangeUpdate on WebsocketHub channel")
+    }
+}
+```
+
+`Price`/`Volume` in the envelope are the **aggregated, multi-exchange-averaged** values
+(snapshot at the moment of the push). The `Updater` block is the **single exchange that
+triggered the update**.
+
+**Hub fan-out.** `websocket.go:320–323`:
+
+```go
+case update := <-wsh.xcChan:
+    for _, client := range wsh.clients {
+        client.xc <- update
+    }
+```
+
+Drops happen at the **bot → hub** boundary (`select default` with `wsHub.xcChan` cap 16,
+`websocket.go:101`), not at the **hub → client** boundary (blocking send per client).
+
+**Per-client encode + send.** `websockethandlers.go:306–322`:
+
+```go
+case update := <-xcChan:
+    buff := new(bytes.Buffer)
+    enc := json.NewEncoder(buff)
+    webData := WebSocketMessage{EventId: exchangeUpdateID /* "exchange" */, Message: "error"}
+    err := enc.Encode(update)
+    if err == nil { webData.Message = buff.String() }
+    err = send(webData)
+```
+
+`exchangeUpdateID = "exchange"` is the event-string contract (`websocket.go:372`).
+
+### 3.4 JS bridge + Stimulus controller
+
+**WS handler bridge.** [public/index.js:60–63](../../../cmd/dcrdata/public/index.js):
+
+```js
+ws.registerEvtHandler('exchange', (e) => {
+    globalEventBus.publish('EXCHANGE_UPDATE', JSON.parse(e))
+})
+```
+
+Registered exactly once per page load. **Not** controller-scoped — it lives at the SPA
+entry point. The only subscriber to `EXCHANGE_UPDATE` is the market controller
+(`market_controller.js:569`).
+
+**Initial fetch.** Stimulus `connect()` (`market_controller.js:509–574`):
+
+- Parses `data-indices` JSON → module-level `indices`.
+- Parses `data-code` → module-level `fiatCode`.
+- Restores `chart/xc/bin/pair` from URL via TurboQuery; defaults
+  `xc="binance"`, `pair=CurrencyPairDCRUSDT`, `bin="1h"`, `chart="depth"`.
+- Subscribes `EXCHANGE_UPDATE` → `_processXcUpdate`.
+- Lazy-imports Dygraphs (`/* webpackChunkName: "dygraphs" */`) then issues the first
+  `fetchChart()`.
+
+**Chart fetch.** `fetchChart()` (`market_controller.js:652–716`):
+
+- Builds `/api/chart/market/{xc}/candlestick/{bin}?currencyPair=${pair}` or
+  `/api/chart/market/{xc}/depth?currencyPair=${pair}`.
+- Module-level `responseCache` is keyed by full URL — first request populates,
+  subsequent identical requests skip the network. `requestCounter` deduplicates
+  in-flight calls (a later request abandons earlier callbacks).
+
+**WS update handler.** `_processXcUpdate(update)` (`market_controller.js:1092–1140`):
+
+- Updates module-level `indices` from `update.indices`.
+- Fiat branch (`update.fiat`): updates the per-token BTC index span (only `BTCIndex` —
+  `USDTIndex` updates are received but ignored visually).
+- DCR-asset branch: writes price/volume/arrow/fiat into the matching `xcRow` row, plus
+  updates the aggregate row and the big `data-market-target="price"` value.
+- If depth chart visible: clear cache for `lastUrl` and `refreshChart()`. If candlestick
+  visible: refresh only when cache already expired.
+
+### 3.5 REST chart cache
+
+**Route.** [apirouter.go:232–243](../../../cmd/dcrdata/internal/api/apirouter.go):
+
+```go
+mux.Route("/chart", func(r chi.Router) {
+    r.Route("/market/{token}", func(rd chi.Router) {
+        rd.Use(m.ExchangeTokenContext)
+        rd.With(m.StickWidthContext).Get("/candlestick/{bin}", app.getCandlestickChart)
+        rd.Get("/depth", app.getDepthChart)
+    })
+    ...
+})
+```
+
+**Handlers.** [apiroutes.go:1987–2030](../../../cmd/dcrdata/internal/api/apiroutes.go).
+Both: gate on `c.xcBot == nil ⇒ 503`, extract token + currency pair via
+`retrieveCurrencyPair` (`apiroutes.go:2280–2291` — defaults to `DCR-BTC`, rejects anything
+that is not `DCR-BTC`/`DCR-USDT`), call `c.xcBot.QuickSticks` / `QuickDepth`
+(`bot.go:1077–1178`):
+
+- Cache lookup keyed `genCacheID(market, token, bin|orderbook)`.
+- On miss: take bot write lock, encode `candlestickResponse{Index, Price, Sticks,
+  Expiration}` or `depthResponse{BtcIndex, Price, Data, Expiration}`, store as a
+  `versionedChart{chartID, dataID, chart bytes}` keyed by the same chartID.
+- `dataID` is bumped by `incrementChart` inside `updateExchange` whenever new sticks or
+  depth arrive (`bot.go:880–887`); fetch races see a version mismatch and re-encode.
+
+**Other REST endpoints** that hit the same bot (not on `/market` UI but worth knowing):
+
+- `GET /api/exchanges` (`apiroutes.go:2138`) — returns `xcBot.State()` (or
+  `ConvertedState(code)` if `?code=` supplied).
+- `GET /api/exchangerate` (`apiroutes.go:2164`) — returns trimmed `ExchangeRates` view
+  (`bot.go:702–722`).
+- `GET /api/exchanges/codes` (`apiroutes.go:2191`) — returns `AvailableIndices()`.
+
+### 3.6 Cross-page consumers of the same bot
+
+`xcBot.Conversion(float64) *Conversion` is also called by:
+
+- Home page (`explorerroutes.go:199–207`) — `ExchangeRate`, `StakeDiff`, `CoinSupply`,
+  `PowSplit` as fiat sidebar.
+- Address page (`explorerroutes.go:768–769`) — `pageData.FiatConversion =
+  xcBot.Conversion(data.TotalSent)`, gated to addresses with last block time < 1h.
+- Tx page (`explorerroutes.go:1357–1359`) — `pageData.Conversions.{Total, Fees}`.
+- Treasury (`explorerroutes.go:1501–1517`) — `ConvertedBalance`, `FiatBalance`. The
+  `/treasury` route currently returns HTTP 410 (`main.go:804–809`), but **the handler code
+  still exists and is reachable through the explorerUI's struct**.
+
+All consumers pass **VAR coin values** (via `dcrutil.Amount(...).ToCoin() float64`); none
+of them pass SKA atoms (which would silently truncate — see §5).
+
+---
+
+## Section 4 — Cross-Layer Dependencies
+
+### 4.1 The bot is one nullable pointer shared across many layers
+
+`*exchanges.ExchangeBot` is constructed in `main.go` and passed by pointer into:
+
+- `ExplorerConfig.XcBot` → `explorerUI.xcBot` (`explorer.go:235, 324`).
+- `appContext.XcBot` (REST API) — see `cmd/dcrdata/main.go:482, 640`.
+
+Every consumer guards with `if xcBot != nil`. Disabling the bot is therefore not a route
+issue — the goroutines just never start and every guard fails. Removing the bot field is a
+**fan-out edit** across handler files.
+
+### 4.2 WS schema (`WebsocketExchangeUpdate`) ≠ REST schema (`ExchangeBotState`)
+
+The WS update is a **per-exchange delta** with an embedded aggregate snippet:
+
+```go
+type WebsocketExchangeUpdate struct {
+    Updater     WebsocketMiniExchange `json:"updater"`
+    IsFiatIndex bool                  `json:"fiat"`
+    Index       string                `json:"index"`
+    Price       float64               `json:"price"`   // aggregated
+    Volume      float64               `json:"volume"`  // aggregated
+    Indices     map[string]float64    `json:"indices"` // {BTC-Index, USDT-Index}
+}
+type WebsocketMiniExchange struct {
+    Token, CurrencyPair string
+    Price, Volume, Change float64
+}
+```
+
+The REST `ExchangeBotState` is the **full snapshot** with nested per-exchange/per-pair
+states + candlesticks + depth. **Renaming or restructuring `ExchangeBotState` does not
+auto-propagate to the WS shape, and vice versa.** This is a C8-class asymmetry (see
+[/wiki/core/constraints.md](../../core/constraints.md)).
+
+The market controller, on initial render, reads from `ExchangeBotState`-derived template
+fields. On live update, it reads from `WebsocketExchangeUpdate` fields. The two paths share
+no parsing code — any field added on one side must be replicated on the other (and in the
+template + JS reader).
+
+### 4.3 JS event-string + globalEventBus indirection
+
+The chain is:
+
+```
+Go const exchangeUpdateID = "exchange"
+   → JS ws.registerEvtHandler('exchange', ...)        [public/index.js]
+       → globalEventBus.publish('EXCHANGE_UPDATE', ...) [public/index.js]
+           → globalEventBus.on('EXCHANGE_UPDATE', ...)  [market_controller.js]
+```
+
+Four string contracts in two files. Renaming the Go constant breaks `index.js` silently
+(no error — handler just never fires); renaming the bus event breaks
+`market_controller.js` silently.
+
+### 4.4 Network-name gate is shared with the chain
+
+`if cfg.EnableExchangeBot && activeChain.Name != "mainnet"` in `main.go:414` reads the
+**chain config's `Name` string**. Monetarium's mainnet params file
+(`monetarium-node/chaincfg@v1.1.0/mainnetparams.go:84`) sets `Name: "mainnet"` — the
+same string as Decred. The check therefore does **not** veto exchange-monitor on a
+Monetarium mainnet deployment. The only practical brake is that `EnableExchangeBot`
+defaults to `false` and is commented out in
+[sample-dcrdata.conf:89](../../../cmd/dcrdata/sample-dcrdata.conf).
+
+### 4.5 Hard-coded "DCR" everywhere
+
+DCR symbol literals exist in five disconnected layers:
+
+| Layer | File | Form |
+|---|---|---|
+| Exchange URLs | `exchanges/exchanges.go:121–166` | `?symbol=DCRUSDT` query strings |
+| Currency-pair consts | `exchanges/exchanges.go:66–73` | `CurrencyPairDCRBTC`, `CurrencyPairDCRUSDT` |
+| Pair validator | `exchanges/exchanges.go:75–77` | `IsValidDCRPair` (closed set) |
+| Pair default + accept-list | `apiroutes.go:2280–2291` | `retrieveCurrencyPair` → `pair.IsValidDCRPair()` |
+| HTML/JS UI | `market.tmpl`, `market_controller.js` | `1 DCR =`, `Volume (DCR)`, `exchangeLinks.CurrencyPairDCRUSDT` |
+
+Changing any one of them in isolation breaks the rest. This is **not** routed through
+the canonical `coinSymbol`/`renderCoinType` helpers (C7).
+
+---
+
+## Section 5 — Critical Constraints
+
+### C1 — Numeric precision (`core/constraints.md` C1)
+
+**The entire `exchanges` package is float64-only.** Examples:
+
+- `BaseState.Price float64`, `BaseState.Volume float64`, `BaseState.Change float64`
+  (`exchanges.go:288–296`).
+- `xcBot.Conversion(dcrVal float64) *Conversion` (`bot.go:1045`).
+- `Conversion.Value float64`.
+- `Indices()` returns `map[string]float64`.
+- `processState`, `dcrPriceAndVolume`, `indexPrice` all `float64`.
+
+VAR has 8 decimals → safe in `float64`, and `dcrutil.Amount.ToCoin() float64` is the
+contract. **There is no SKA path.** Calling `xcBot.Conversion(skaAtomValueAsFloat)` would
+truncate to ~15 digits (silent C1 violation). Adding SKA-fiat conversion **requires a new
+`*big.Int`- or string-typed API** through the bot, not a reuse of `Conversion`.
+
+### C7 — Centralized coin-type labels
+
+The market page renders `DCR` as a literal string in `market.tmpl` (lines 22, 32, 39, 79
+through chart labels in JS). It does **not** call `coinSymbol`. Re-labeling these to
+`VAR`/`SKA{n}` would also change the meaning of what is being priced — these labels are
+load-bearing for the data, not just UX text.
+
+### C8 — Dual-transport shape asymmetry (`core/constraints.md` C8)
+
+REST `/api/exchanges` returns `ExchangeBotState` (full); WS `"exchange"` returns
+`WebsocketExchangeUpdate` (delta-plus-aggregate). Different schemas, different consumers,
+both reachable from the same controller. Aligns with the C8 manifestations already
+documented for block/transaction/visualblocks.
+
+### Hidden assumption — single-process bot
+
+There is exactly one `*ExchangeBot` per `monetarium-explorer` process. `UpdateChannels()`
+mutates the bot's subscriber slice under its own lock; the explorer only ever calls it
+once at startup. If a second goroutine called it (e.g. a hot-reload that re-ran
+`explorer.New`), every prior subscriber would leak a goroutine reading from a channel that
+never closes until process exit.
+
+### Hidden assumption — network-name gate is a Decred legacy
+
+The `activeChain.Name != "mainnet"` guard was meaningful in `dcrdata` (Decred testnet has
+`Name: "testnet3"`). On Monetarium it is a no-op — both Decred and Monetarium mainnet
+chaincfgs use the literal string `"mainnet"`. The check thus blocks exchange-monitor on
+Monetarium testnet/simnet only, not on mainnet.
+
+---
+
+## Section 6 — Mutation Impact
+
+> Detailed mutation analysis lives in [impact.md](impact.md). Headline items:
+
+- **Adding any SKA market** triggers a **silent precision loss** because every primitive
+  in `exchanges/` is `float64`. SKA fiat conversion requires a new big.Int API path —
+  cannot be done by reusing `Conversion(float64)`.
+- **Adding a real Monetarium market (VAR-USDT, SKA1-USDT, …)** requires symmetric edits in
+  five disconnected layers (URL strings, pair consts, validators, template literals, JS
+  links table). Compile catches the Go edges; the template/JS DCR literals drift silently.
+- **Network-name gate** is misleading on Monetarium mainnet — the `"mainnet"` check is a
+  no-op. Enabling `exchange-monitor=1` will start the bot and the page will render real
+  Decred prices in the Monetarium UI. **Silent content drift.**
+- **Disabling `/market` alone does not stop the bot.** The bot is constructed in `main.go`
+  independent of the route, and `xcBot.Conversion(...)` is called from ~7 other handlers.
+  Full removal is a fan-out edit.
+- **Renaming `exchangeUpdateID` ("exchange")** silently disconnects the WS bridge in
+  `public/index.js` (handler just never fires). Same for `EXCHANGE_UPDATE`.
+- **WS schema (`WebsocketExchangeUpdate`) and REST schema (`ExchangeBotState`) are
+  independent contracts** — fields added on one path do not auto-propagate; market controller
+  reads from both, so any new field needs three updates (Go REST, Go WS, JS reader).
+
+---
+
+## Section 7 — Common Pitfalls
+
+1. **"The /market page is disabled; we can remove `exchanges/`."**
+   No — `xcBot.Conversion(...)` is on the home, tx, and address pages. Drop without
+   accompanying handler edits and those pages crash on field-access of the conversions
+   struct (which is nil-safe only at the `Conversions == nil` gate, not at field level).
+
+2. **"Add a Monetarium SKA1-USDT entry to `exchanges.go`."**
+   Beyond the obvious URL/constant churn: the entire pipeline truncates SKA through
+   `float64`. Volumes, prices, depths, candlesticks — all `float64`. You will lose ≥3
+   decimal digits of precision per value and the displayed numbers will not match the
+   exchange's UI.
+
+3. **"Turn on exchange-monitor for a Monetarium deployment to test the page."**
+   The bot will start (the `!= "mainnet"` gate doesn't trigger) and connect to Coinbase,
+   Binance, Mexc, dex.decred.org. The page will render **real Decred markets** with
+   Monetarium branding. Easy to miss in QA because the numbers look plausible.
+
+4. **"The WS push includes the full state."**
+   It doesn't — it's a per-exchange delta with an aggregate price snippet. Filling the
+   initial state still requires a template render. If you remove the template render
+   path, the page will be blank until the first WS update arrives.
+
+5. **"Renaming `EXCHANGE_UPDATE` in `market_controller.js` is safe — it's the only
+   subscriber."**
+   It is — but the publisher in `public/index.js:62` uses the literal `'EXCHANGE_UPDATE'`
+   too. Two-file change, no compile-time link.
+
+6. **"`xcBot.IsFailed()` means the bot is broken."**
+   `IsFailed()` is true when there are zero up-to-date BTC sources **or** zero up-to-date
+   DCR sources — not when the bot itself errored. The `stateCopy` may still hold stale
+   data and `Conversion()` will still return it (with `Value:0` only if no state has ever
+   been populated). The HTML gate `getExchangeState() ⇒ nil` covers this case for
+   `/market`; the cross-page conversions do not.
+
+---
+
+## Section 8 — Evidence
+
+Code references supporting the trace above:
+
+- Bot construction + lifecycle:
+  [cmd/dcrdata/main.go:413–440](../../../cmd/dcrdata/main.go),
+  [exchanges/bot.go:54–96 (struct)](../../../exchanges/bot.go),
+  [exchanges/bot.go:295–430 (NewExchangeBot)](../../../exchanges/bot.go),
+  [exchanges/bot.go:434–561 (Start)](../../../exchanges/bot.go),
+  [exchanges/bot.go:949–976 (updateState)](../../../exchanges/bot.go).
+- Configured exchanges + URLs:
+  [exchanges/exchanges.go:121–183](../../../exchanges/exchanges.go).
+- State snapshot/copy:
+  [exchanges/bot.go:111–129](../../../exchanges/bot.go),
+  [exchanges/bot.go:646–650 (State)](../../../exchanges/bot.go),
+  [exchanges/bot.go:1045–1058 (Conversion)](../../../exchanges/bot.go),
+  [exchanges/bot.go:983–987 (IsFailed)](../../../exchanges/bot.go).
+- HTML handler + template:
+  [cmd/dcrdata/internal/explorer/explorerroutes.go:2513–2531 (MarketPage)](../../../cmd/dcrdata/internal/explorer/explorerroutes.go),
+  [cmd/dcrdata/internal/explorer/explorer.go:1047–1052 (getExchangeState)](../../../cmd/dcrdata/internal/explorer/explorer.go),
+  [cmd/dcrdata/views/market.tmpl](../../../cmd/dcrdata/views/market.tmpl),
+  [cmd/dcrdata/internal/explorer/templates.go:861–867 (xcDisplayName)](../../../cmd/dcrdata/internal/explorer/templates.go).
+- WS push:
+  [cmd/dcrdata/internal/explorer/explorer.go:984–1045 (watchExchanges)](../../../cmd/dcrdata/internal/explorer/explorer.go),
+  [cmd/dcrdata/internal/explorer/websocket.go:372–395 (types + const)](../../../cmd/dcrdata/internal/explorer/websocket.go),
+  [cmd/dcrdata/internal/explorer/websocket.go:320–323 (hub fan-out)](../../../cmd/dcrdata/internal/explorer/websocket.go),
+  [cmd/dcrdata/internal/explorer/websockethandlers.go:306–322 (encode + send)](../../../cmd/dcrdata/internal/explorer/websockethandlers.go).
+- JS bridge + controller:
+  [cmd/dcrdata/public/index.js:60–63 (bridge)](../../../cmd/dcrdata/public/index.js),
+  [cmd/dcrdata/public/js/services/messagesocket_service.js](../../../cmd/dcrdata/public/js/services/messagesocket_service.js),
+  [cmd/dcrdata/public/js/services/event_bus_service.js](../../../cmd/dcrdata/public/js/services/event_bus_service.js),
+  [cmd/dcrdata/public/js/controllers/market_controller.js:482–574 (connect)](../../../cmd/dcrdata/public/js/controllers/market_controller.js),
+  [cmd/dcrdata/public/js/controllers/market_controller.js:652–716 (fetchChart)](../../../cmd/dcrdata/public/js/controllers/market_controller.js),
+  [cmd/dcrdata/public/js/controllers/market_controller.js:1092–1140 (_processXcUpdate)](../../../cmd/dcrdata/public/js/controllers/market_controller.js).
+- REST chart cache:
+  [cmd/dcrdata/internal/api/apirouter.go:232–243](../../../cmd/dcrdata/internal/api/apirouter.go),
+  [cmd/dcrdata/internal/api/apiroutes.go:1987–2030 (chart handlers)](../../../cmd/dcrdata/internal/api/apiroutes.go),
+  [cmd/dcrdata/internal/api/apiroutes.go:2138–2203 (exchanges + rates + codes)](../../../cmd/dcrdata/internal/api/apiroutes.go),
+  [cmd/dcrdata/internal/api/apiroutes.go:2280–2291 (retrieveCurrencyPair)](../../../cmd/dcrdata/internal/api/apiroutes.go),
+  [exchanges/bot.go:1077–1178 (QuickSticks / QuickDepth)](../../../exchanges/bot.go).
+- Cross-page conversion callsites:
+  [cmd/dcrdata/internal/explorer/explorerroutes.go:199–207 (home)](../../../cmd/dcrdata/internal/explorer/explorerroutes.go),
+  [cmd/dcrdata/internal/explorer/explorerroutes.go:768–769 (address)](../../../cmd/dcrdata/internal/explorer/explorerroutes.go),
+  [cmd/dcrdata/internal/explorer/explorerroutes.go:1357–1359 (tx)](../../../cmd/dcrdata/internal/explorer/explorerroutes.go),
+  [cmd/dcrdata/internal/explorer/explorerroutes.go:1501–1517 (treasury — gated 410)](../../../cmd/dcrdata/internal/explorer/explorerroutes.go).
+- Config + nav:
+  [cmd/dcrdata/config.go:163–167](../../../cmd/dcrdata/config.go),
+  [cmd/dcrdata/sample-dcrdata.conf:88–99](../../../cmd/dcrdata/sample-dcrdata.conf),
+  [cmd/dcrdata/views/extras.tmpl:86](../../../cmd/dcrdata/views/extras.tmpl) (nav link to `/market`).
+- Monetarium chain Name == "mainnet": `monetarium-node/chaincfg@v1.1.0/mainnetparams.go:84`
+  (vendored module, not in repo tree).
+
+See also:
+- [/wiki/core/constraints.md](../../core/constraints.md) (depends-on: C1 numeric precision, C7 coin-label centralization, C8 dual-transport asymmetry)
+- [/wiki/core/pages.md](../../core/pages.md) (depends-on: `/market` is listed under "Should be disabled")
+- [/wiki/code-analysis/page-rendering/patterns.md](../page-rendering/patterns.md) (shares-pattern-with: out-of-band shared `pageData`/`invs` state — here the shared state is `xcBot`)
+- [/wiki/code-analysis/visualblocks/flow.full.md](../visualblocks/flow.full.md) (shares-pattern-with: C8 dual-transport schema divergence)
+- [/wiki/code-analysis/attack-cost/flow.full.md](../attack-cost/flow.full.md) (shares-pattern-with: another VAR-only, exchange-bot-coupled handler — `attack-cost` reads `HomeInfo.PriceConversion` written by `Store` from `xcBot`)

--- a/wiki/code-analysis/market/impact.md
+++ b/wiki/code-analysis/market/impact.md
@@ -1,0 +1,319 @@
+# Market — Mutation Impact
+
+Blast radius for changes to the `/market` page, the `exchanges` collector, and the WS
+exchange-update pipeline. Use this checklist when:
+
+- Removing `/market` (the documented near-term direction per
+  [/wiki/core/pages.md](../../core/pages.md)).
+- Adding a Monetarium-native market (VAR-USDT, SKA1-USDT, …) to replace the Decred markets.
+- Touching `xcBot.Conversion(...)` callsites or the `WebsocketExchangeUpdate` shape.
+- Renaming the WS event-id or the `EXCHANGE_UPDATE` bus event.
+
+Severity scale: **Critical** (data corruption / crash) · **High** (silent UX drift,
+hard-to-notice in QA) · **Medium** (loud break caught by smoke test) · **Low**
+(cosmetic / dev-time only).
+
+---
+
+## R1 — `float64` monoculture inside `exchanges/` (C1 silent violation surface)
+
+**Trigger.** Adding any SKA market to the `exchanges` package, or routing SKA values
+through `xcBot.Conversion(...)`.
+
+**Affected flow.** Backend collector (`exchanges/bot.go`, `exchanges/exchanges.go`) →
+every consumer.
+
+**Failure mode.** **Silent.** SKA has 18 decimals (>15-digit float64 significand);
+truncation happens inside `BaseState.Price float64`, `xcBot.Conversion(float64)`, the
+multi-source average in `processState`, and `JSON.parse(...).price` on the JS side
+(`Number` is also IEEE 754 double).
+
+**Description.** The entire `exchanges/` package — including all subscriber channels, the
+WS `WebsocketExchangeUpdate.Price/Volume/Indices`, the REST `BaseState` / `ExchangeBotState`
+/ `ExchangeRates`, and the `Conversion` struct — is `float64`. There is no `*big.Int` or
+atom-string code path. Adding a SKA market by reusing this surface silently truncates
+≥3 decimal digits per value; the page will render plausible numbers that don't match the
+underlying exchange feed.
+
+**Fix shape.** A SKA fiat conversion needs a new API: a `*big.Int`- or string-typed
+`ConversionAtoms(coinType uint8, atoms string) *Conversion`-equivalent, possibly with a
+separate `BaseState`-like struct that carries the price as a string. Don't squeeze SKA
+through the existing float64 plumbing.
+
+**See.** [/wiki/core/constraints.md](../../core/constraints.md) C1.
+
+---
+
+## R2 — DCR-symbol hard-coding (5-layer fan-out)
+
+**Trigger.** Adding or renaming a market in `exchanges.go`. Re-labelling any "DCR"
+string in the template or JS controller to "VAR" / "SKA{n}".
+
+**Affected layers.**
+
+| Layer | File | Symbol form |
+|---|---|---|
+| URL strings | [exchanges/exchanges.go:121–166](../../../exchanges/exchanges.go) | `?symbol=DCRUSDT` query params |
+| CurrencyPair consts | [exchanges/exchanges.go:66–73](../../../exchanges/exchanges.go) | `CurrencyPairDCRBTC`, `CurrencyPairDCRUSDT` |
+| Validators | [exchanges/exchanges.go:75–81](../../../exchanges/exchanges.go) | `IsValidDCRPair`, `IsValidIndex` |
+| REST handler | [apiroutes.go:2280–2291](../../../cmd/dcrdata/internal/api/apiroutes.go) | `retrieveCurrencyPair` |
+| HTML labels | [market.tmpl](../../../cmd/dcrdata/views/market.tmpl) lines 22, 39, 91 | `"1 DCR ="`, `"DCR Vol."`, `Bitcoin Indices` heading |
+| JS controller | [market_controller.js:1002–1003, 1110–1113](../../../cmd/dcrdata/public/js/controllers/market_controller.js) | `exchangeLinks.CurrencyPairDCRUSDT/BTC`, axis labels |
+
+**Failure mode.** Go side: **Loud** — renaming `CurrencyPairDCRBTC` breaks compile across
+the package. Template/JS literals: **Silent** — page renders "DCR" labels next to
+non-Decred prices, or "VAR" labels next to actually-Decred prices, depending on which
+direction the edit went.
+
+**Description.** None of the DCR literals are routed through `coinSymbol` /
+`renderCoinType` (C7). The label and the data are coupled only by convention — the
+labels are accurate today only because the data really is Decred.
+
+**Fix shape.** Treat the whole stack as one atomic change. If adding a Monetarium market,
+introduce a new `CurrencyPair` constant + URLs block + validator branch + handler accept
+case + template/JS variant in one commit.
+
+---
+
+## R3 — Network-name gate is a no-op on Monetarium mainnet
+
+**Trigger.** Setting `exchange-monitor=1` on a Monetarium mainnet deployment.
+
+**Affected flow.** Bot construction → all downstream consumers.
+
+**Failure mode.** **High — silent content drift.** The Monetarium UI will render real
+Decred exchange data (Coinbase, Binance, Mexc, dex.decred.org) as if it were the local
+asset's market.
+
+**Description.** [main.go:414](../../../cmd/dcrdata/main.go) guards exchange-monitor with:
+
+```go
+if cfg.EnableExchangeBot && activeChain.Name != "mainnet" {
+    log.Warnf("disabling exchange monitoring. only available on mainnet")
+    cfg.EnableExchangeBot = false
+}
+```
+
+In `dcrdata`, this kept ExchangeBot off Decred testnet. In Monetarium, the mainnet
+chaincfg's `Name` field is also literally `"mainnet"`
+(`monetarium-node/chaincfg@v1.1.0/mainnetparams.go:84`) — so the guard fires only on
+Monetarium testnet/simnet. The only practical brake on Monetarium mainnet is that
+`EnableExchangeBot` defaults to `false` and is commented out in
+[sample-dcrdata.conf:89](../../../cmd/dcrdata/sample-dcrdata.conf).
+
+**Fix shape.** When (not if) `/market` is disabled per the
+[pages.md](../../core/pages.md) plan, also rip out the `ExchangeBot` construction in
+`main.go` so a stray `exchange-monitor=1` cannot surface Decred markets. If keeping the
+construction code, change the gate to something Monetarium-meaningful (an explicit
+network ID + asset whitelist).
+
+---
+
+## R4 — Cross-page fan-out: disabling the page does not disable the bot
+
+**Trigger.** Removing the `/market` route without auditing the rest of the codebase.
+
+**Affected handlers.**
+
+- Home (`explorerroutes.go:199–207` — `homeConversions{ExchangeRate, StakeDiff, CoinSupply, PowSplit}`)
+- Address (`explorerroutes.go:768–769` — `pageData.FiatConversion`, gated to addresses with `BlockTime` within 1h)
+- Tx (`explorerroutes.go:1357–1359` — `pageData.Conversions.{Total, Fees}`)
+- Treasury (`explorerroutes.go:1501–1517` — `ConvertedBalance`, `FiatBalance`; route returns 410 but the handler code is still reachable through struct dispatch)
+- MarketPage (`explorerroutes.go:2520`)
+- REST: `/api/exchanges`, `/api/exchangerate`, `/api/exchanges/codes`,
+  `/api/chart/market/{token}/{candlestick|depth}`
+  ([apiroutes.go:1987–2030, 2138–2203](../../../cmd/dcrdata/internal/api/apiroutes.go))
+- `watchExchanges` goroutine fired unconditionally in `explorer.New()`
+  ([explorer.go:426](../../../cmd/dcrdata/internal/explorer/explorer.go)) — early-returns
+  if `xcBot == nil`.
+- WS `/ws` event bridge in
+  [public/index.js:60–63](../../../cmd/dcrdata/public/index.js).
+
+**Failure mode.** **Medium.** A partial removal leaves the bot polling exchange APIs
+(network egress, log spam) with no UI surface. No crash. If only the route is removed and
+the page is requested, chi returns 404 — but the bot still polls.
+
+**Description.** The bot is constructed in `main.go` independent of any route registration.
+Per-route gating is independent of bot lifecycle. Complete removal requires editing
+~7 handler files, the WS bridge, the explorer goroutine, and the `XcBot` fields in
+`ExplorerConfig` / `appContext`.
+
+**Fix shape.** When removing `/market`:
+
+1. Drop the `MarketPage` handler + route + `views/market.tmpl` +
+   `public/js/controllers/market_controller.js`.
+2. Drop the WS bridge in `public/index.js`.
+3. Drop `watchExchanges` + `WebsocketExchangeUpdate` + `WebsocketMiniExchange` +
+   `exchangeUpdateID` + `xcChan` from `websocket.go` / `websockethandlers.go`.
+4. Drop `xcBot.Conversion(...)` callsites in home / address / tx / treasury (and the
+   `Conversions` / `homeConversions` types if they become empty).
+5. Drop the four REST endpoints + `retrieveCurrencyPair` + middleware
+   (`ExchangeTokenContext`, `StickWidthContext`).
+6. Drop `XcBot` from `ExplorerConfig` + `appContext` and the `*exchanges.ExchangeBot`
+   import.
+7. Drop the bot construction block in `main.go`.
+8. Drop the `exchanges/` and `exchanges/rateserver/` modules (separate `go.mod` —
+   confirm no other module imports them with `grep -rn "monetarium-explorer/exchanges" .`).
+
+---
+
+## R5 — WS event-id + bus event string drift (silent break)
+
+**Trigger.** Renaming `exchangeUpdateID` ("exchange") or `'EXCHANGE_UPDATE'`.
+
+**Affected sites.**
+
+- `cmd/dcrdata/internal/explorer/websocket.go:372` (`const exchangeUpdateID = "exchange"`)
+- `cmd/dcrdata/internal/explorer/websockethandlers.go:309` (used)
+- `cmd/dcrdata/public/index.js:61` (`ws.registerEvtHandler('exchange', ...)`)
+- `cmd/dcrdata/public/index.js:62` (`globalEventBus.publish('EXCHANGE_UPDATE', ...)`)
+- `cmd/dcrdata/public/js/controllers/market_controller.js:569, 581`
+
+**Failure mode.** **High — silent.** WS messages flow but the handler never fires; the
+market page renders the initial template snapshot then stops updating. No JS error.
+
+**Description.** Four string literals, two files on the JS side, two on the Go side.
+No compile-time link.
+
+**Fix shape.** Co-edit all four sites in the same commit. Consider extracting a shared
+constant on the JS side at minimum.
+
+---
+
+## R6 — `WebsocketExchangeUpdate` vs `ExchangeBotState` schema asymmetry (C8)
+
+**Trigger.** Adding a field on either schema and reading it from the other side.
+
+**Affected files.**
+
+- WS schema: `cmd/dcrdata/internal/explorer/websocket.go:376–395`.
+- REST schema: `exchanges/bot.go:100–109` (`ExchangeBotState`).
+- WS emit: `explorer.go:990–1017` (`watchExchanges.sendXcUpdate`).
+- WS consume: `market_controller.js:1092–1140` (`_processXcUpdate`).
+- REST/template consume: `market.tmpl` (initial render).
+
+**Failure mode.** **High — silent.** Initial render shows the new field, live updates
+don't (or vice versa).
+
+**Description.** C8 manifestation: same logical concept (exchange state), two on-the-wire
+shapes. The market controller reads from both, never reconciling that fields on the WS
+delta are a strict subset of the REST snapshot.
+
+**Fix shape.** Treat the two schemas as independent contracts. Any added field needs
+co-edits in: Go REST struct, Go WS struct, `sendXcUpdate` builder, JS template reader, JS
+WS handler. Reference `core/constraints.md` C8 for the general rule.
+
+---
+
+## R7 — DCRRates remote master keeps polling even when page is dead
+
+**Trigger.** Leaving `ratemaster=<host>` configured after `/market` removal.
+
+**Affected sites.**
+
+- `bot.connectMasterBot` ([bot.go:564–591](../../../exchanges/bot.go)) — gRPC dial,
+  goroutine reading the stream forever, reconnect loop with backoff.
+- `exchanges/ratesproto` (generated protobuf), `exchanges/rateserver` (the master
+  server — separate Go module).
+
+**Failure mode.** **Low — resource leak.** A goroutine, an open TLS connection, plus
+periodic reconnect attempts on disconnect.
+
+**Description.** Even with no UI surface, if the bot is constructed and `MasterBot` is
+set, the stream is opened and drained. Indirectly, this also keeps the `dcrrates`
+generated code in the dependency graph.
+
+**Fix shape.** Covered by R4 (drop bot construction). If keeping the bot for cross-page
+conversions but removing rateserver support, also drop `MasterBot`/`MasterCertFile` from
+the config struct and the `connectMasterBot` path.
+
+---
+
+## R8 — Module-level JS state survives within an SPA session
+
+**Trigger.** Mounting two `data-controller="market"` blocks on the same page, or
+introducing a controller that imports `market_controller.js` indirectly.
+
+**Affected sites.**
+
+- `market_controller.js`: module-level `settings`, `responseCache`, `requestCounter`,
+  `Dygraph`, `indices`, `fiatCode`, `availableCandlesticks`, `availableDepths`,
+  `conversionFactor`, `chartStroke`, `focused`, `refreshAvailable`, `stickZoom` (lines
+  62–98 of the file).
+
+**Failure mode.** **Low — cross-controller cross-talk.** Two market controllers on one
+page would share request cache and settings.
+
+**Description.** Stimulus controllers are normally instance-scoped, but the file declares
+many `let`/`const` at module top-level — those persist across `connect()`/`disconnect()`
+within the same SPA session. `disconnect()` partially resets `responseCache = {}`
+([market_controller.js:577](../../../cmd/dcrdata/public/js/controllers/market_controller.js))
+but not the rest.
+
+**Fix shape.** Not a current bug — there is exactly one `/market` page in the app and one
+controller mount. Document the constraint so future refactors don't multi-mount the
+controller.
+
+---
+
+## R9 — Aggregated price hides per-exchange divergence (default 60m staleness window)
+
+**Trigger.** One subscribed exchange returns a stale or wildly-off price within
+`RequestExpiry` (default 60m).
+
+**Affected sites.**
+
+- `bot.dcrPriceAndVolume` ([bot.go:927–947](../../../exchanges/bot.go)) — average across
+  exchanges that pass `processState`.
+- `bot.processState` ([bot.go:824–857](../../../exchanges/bot.go)) — volume-weighted
+  per-pair sum.
+- `RequestExpiry` default `60m`
+  ([bot.go:30](../../../exchanges/bot.go), [main.go:418–423](../../../cmd/dcrdata/main.go)).
+
+**Failure mode.** **Medium — visible drift.** The big "1 DCR =" headline price is the
+aggregate; individual exchange rows still show their per-exchange figures, so the
+discrepancy is observable but not flagged.
+
+**Description.** `dcrPriceAndVolume` averages across DcrExchanges; one stuck exchange
+warps the aggregate until its `LastUpdate` falls outside `RequestExpiry`. Tunable via
+`DataExpiry` / `RequestExpiry`, both defaults pinned high.
+
+**Fix shape.** Not a defect — accepting noise is the design. Worth knowing when
+investigating "why does the home page price not match Binance".
+
+---
+
+## R10 — `IsFailed()` is partial, and `Conversion()` still returns stale on failure
+
+**Trigger.** All BTC indices OR all DCR exchanges go stale for longer than `RequestExpiry`.
+
+**Affected sites.**
+
+- `bot.updateState` ([bot.go:950–960](../../../exchanges/bot.go)) sets
+  `bot.failed = true` when `btcPrice == 0 || dcrPrice == 0` — leaves `stateCopy` pointing
+  at the last good values.
+- `bot.IsFailed()` ([bot.go:983–987](../../../exchanges/bot.go)).
+- `getExchangeState` ([explorer.go:1047–1052](../../../cmd/dcrdata/internal/explorer/explorer.go))
+  returns `nil` when `IsFailed()` — `/market` shows "monitoring disabled".
+- `xcBot.Conversion` ([bot.go:1045–1058](../../../exchanges/bot.go)) does **not** check
+  `IsFailed()` — keeps returning `Value: xcState.Price * dcrVal` from the stale snapshot.
+
+**Failure mode.** **Medium — silent.** `/market` correctly degrades to the "disabled"
+text. Home / tx / address pages keep showing stale fiat conversions.
+
+**Description.** The "fail-safe" wiring is implemented in `MarketPage` only.
+Cross-page conversion callsites never call `IsFailed`. As long as the bot has ever held a
+valid price, the home page will keep showing the last cached fiat value indefinitely.
+
+**Fix shape.** Either (a) make `xcBot.Conversion(...)` return `nil` when `IsFailed()`, or
+(b) add explicit `IsFailed()` checks at each consumer. Both are behavior changes; pick
+one and apply uniformly. Document on the `Conversion` struct.
+
+---
+
+See also:
+- [/wiki/core/constraints.md](../../core/constraints.md) (depends-on: C1, C7, C8)
+- [/wiki/code-analysis/market/flow.full.md](flow.full.md) (depends-on: trace this risk list against)
+- [/wiki/code-analysis/market/patterns.md](patterns.md) (depends-on: P1 — globally-shared optional collector)
+- [/wiki/code-analysis/page-rendering/impact.md](../page-rendering/impact.md) (shares-pattern-with: cross-page shared state risks — `xcBot` is the share here)
+- [/wiki/core/pages.md](../../core/pages.md) (depends-on: `/market` listed under "Should be disabled" — R3, R4 inform the disable plan)

--- a/wiki/code-analysis/market/patterns.md
+++ b/wiki/code-analysis/market/patterns.md
@@ -1,0 +1,168 @@
+# Market — Patterns
+
+Reusable architectural behavior observed in the `/market` flow. Each pattern names
+something already used elsewhere in the codebase (or worth comparing against) so future
+mutations can stay consistent.
+
+---
+
+## P1 — Globally-shared optional collector
+
+`*exchanges.ExchangeBot` is constructed in `main.go` once and threaded everywhere as a
+nullable pointer (`ExplorerConfig.XcBot`, `appContext.XcBot`). Every consumer applies the
+same guard:
+
+```go
+if exp.xcBot != nil {
+    conversions = &homeConversions{
+        ExchangeRate: exp.xcBot.Conversion(1.0),
+        ...
+    }
+}
+```
+
+**Where it appears.**
+- Home page conversions ([explorerroutes.go:199–207](../../../cmd/dcrdata/internal/explorer/explorerroutes.go))
+- Address fiat conversion (line 768)
+- Tx page conversions (line 1357)
+- Treasury (lines 1501, 1517 — gated by HTTP 410 on the route)
+- MarketPage (line 2520)
+- REST `/api/exchanges`, `/api/exchangerate`, `/api/exchanges/codes`,
+  `/api/chart/market/{token}/{candlestick|depth}`
+  ([apiroutes.go:1987–2030, 2138–2203](../../../cmd/dcrdata/internal/api/apiroutes.go))
+
+**Why it recurs.** Exchange data is "nice to have, often unavailable" — the bot may be
+disabled, may fail to construct, or may be in the `IsFailed()` state. Pushing the
+nullability into every consumer (rather than substituting a stub bot) keeps the failure
+mode explicit. Pattern mirrors how `agendaDB`, `proposalsDB`, and `voteTracker` are also
+constructed-then-passed-nullable in `main.go`.
+
+**Constraints.**
+- Always guard with `if xcBot != nil`. Do not call `xcBot.Method()` unguarded — even
+  though `Conversion` is nil-receiver-safe (`bot.go:1046`), most other methods are not
+  (`State`, `IsFailed`, `UpdateChannels`, …).
+- Disabling a UI route does not disable the bot. Removing the bot is a fan-out edit
+  across all consumer files.
+- Constructing two bots breaks the lock-free snapshot assumption — `State()` returns a
+  pointer that is mutated only by the writer, and there is exactly one writer per bot.
+
+---
+
+## P2 — Dual collection source for one collector
+
+`ExchangeBot.Start` decides at startup whether to consume updates from:
+
+- A **remote DCRRates gRPC master** (`bot.connectMasterBot` →
+  `dcrrates.SubscribeExchanges` stream). When connected, the local polling timer is drained
+  and never fires. Reconnect loop with backoff
+  ([bot.go:441–502](../../../exchanges/bot.go)).
+- **Direct per-exchange HTTP poll**, scheduled by `bot.nextTick()` based on `DataExpiry`
+  (default 5m, min 5s), with `bot.Cycle()` calling `xc.Refresh()` on stale exchanges
+  ([bot.go:503–517, 991–1016](../../../exchanges/bot.go)).
+
+Both sources fan into the **same** `bot.exchangeChan` / `bot.indexChan`; the dispatch loop
+(`bot.go:519–561`) doesn't know which produced a given update.
+
+**Where it appears.** Only here. Worth contrasting with `mempool/` where there is a
+single collection path with multiple savers (see
+[/wiki/code-analysis/mempool/patterns.md](../mempool/patterns.md)).
+
+**Constraints.**
+- gRPC mode replaces, not supplements, polling. Don't add per-exchange logic on the
+  assumption that `Refresh()` runs.
+- Both paths must produce identical `ExchangeUpdate` / `IndexUpdate` shapes — gRPC mode
+  goes through `exchangeStateFromProto` ([exchanges.go:325–378](../../../exchanges/exchanges.go))
+  which mirrors what each `Refresh()` produces. Adding a field on one path silently
+  diverges output.
+
+---
+
+## P3 — Lock-free snapshot read via stateCopy
+
+`updateState()` ([bot.go:949–976](../../../exchanges/bot.go)) does three things under the
+bot write lock:
+
+1. Recompute aggregated price + volume.
+2. JSON-marshal `currentState` into `currentStateBytes`.
+3. Deep-copy `currentState` (`copy()` walks both nested maps,
+   [bot.go:111–129](../../../exchanges/bot.go)) and assign to `stateCopy`.
+
+`State()` returns `bot.stateCopy` under an RLock. Because no writer ever mutates
+`stateCopy` post-publish, every reader has a stable view.
+
+**Where it appears.** Only here in this code-analysis domain. Compare with
+`db/cache`-fronted handlers that hold longer locks across DB reads — those are vulnerable
+to render-time lock contention; the market bot avoids it.
+
+**Constraints.**
+- Anyone who reads `xcBot.State()` and then mutates the returned struct corrupts the
+  shared snapshot for all other readers. Treat the returned pointer as read-only.
+- The deep-copy is shallow at the `ExchangeState` level — only the outer two maps are
+  duplicated; the inner `*ExchangeState` pointers are shared. Practically safe today
+  because writers always replace the entry rather than mutating it in place
+  (`bot.currentState.DCRExchanges[token][pair] = update.State`,
+  [bot.go:892](../../../exchanges/bot.go)).
+
+---
+
+## P4 — Versioned, lazy-encoded chart cache
+
+`versionedChart{chartID, dataID, chart bytes}` ([bot.go:282–288](../../../exchanges/bot.go))
++ `chartVersions map[string]int`. Cache hit when `cache.dataID == bot.cachedChartVersion(chartID)`
+([bot.go:1063–1073](../../../exchanges/bot.go)).
+
+- `incrementChart` ([bot.go:803–810](../../../exchanges/bot.go)) bumps the version
+  whenever `updateExchange` sees fresh candlesticks for a `(market, token, bin)` or fresh
+  depth for `(market, token, "depth")` ([bot.go:880–887](../../../exchanges/bot.go)).
+- `QuickSticks` / `QuickDepth` ([bot.go:1077–1178](../../../exchanges/bot.go)) re-encode
+  on miss and stash the new bytes.
+
+**Where it appears.** Only here. The general "lazy-encoded versioned bytes" pattern shows
+up in `charts/` for chart payloads but with different mechanics (see
+[/wiki/code-analysis/charts/patterns.md](../charts/patterns.md)).
+
+**Constraints.**
+- Cache key is built by `genCacheID` (string concat with `-`). Don't introduce tokens that
+  contain `-` or you'll alias keys.
+- Encoding happens under the bot write lock (`bot.mtx.Lock()` in `QuickSticks`). Heavy
+  encodes block writes; for large depth payloads this can starve the dispatch loop. Not
+  currently an issue because depth size is bounded by exchange API.
+
+---
+
+## P5 — Untyped WS bridge via globalEventBus
+
+Go const `exchangeUpdateID = "exchange"`
+([websocket.go:372](../../../cmd/dcrdata/internal/explorer/websocket.go)) → JS
+`ws.registerEvtHandler('exchange', ...)`
+([public/index.js:60–63](../../../cmd/dcrdata/public/index.js)) → republished onto
+`globalEventBus` as `'EXCHANGE_UPDATE'` → `market_controller.js:569` subscribes.
+
+The WS handler is **registered at SPA entry**, not inside the controller. Other WS events
+(`newblock`, `mempool`, `getmempooltrimmedResp`, `decodetxResp`, `getticketpooldataResp`)
+are registered **inside** their controllers. The choice here lets `index.js` always carry
+exchange updates onto the bus even when no `/market` page is mounted (other listeners
+could subscribe in future — currently none do).
+
+**Where it appears.** Similar bus-republish pattern for `'BLOCK_RECEIVED'`
+([public/index.js:58](../../../cmd/dcrdata/public/index.js)) — the `newblock` event has
+many subscribers (status, address, blocks, home_latest_blocks, newblock, time, tx,
+visualBlocks, homepage, mempool), justifying the bridge. For `EXCHANGE_UPDATE` the single
+subscriber means the bridge is currently overkill, but harmless.
+
+**Constraints.**
+- Four string contracts in two JS files (`'exchange'` event-id, `'EXCHANGE_UPDATE'` bus
+  event, the controller's `on(...)`/`off(...)` pair). Renaming requires multi-file edit
+  with no compile-time link.
+- If a new page wants live exchange updates, it should subscribe to `EXCHANGE_UPDATE`
+  rather than registering its own `'exchange'` WS handler (the handler list is
+  per-eventID, so multiple WS handlers would each run, but the bus is the established
+  contract).
+- C8 (dual-transport asymmetry) applies: the WS payload `WebsocketExchangeUpdate` has a
+  different shape than the REST `ExchangeBotState`. Any new subscriber that conflates the
+  two will break on partial updates.
+
+See also:
+- [/wiki/code-analysis/page-rendering/patterns.md](../page-rendering/patterns.md) (shares-pattern-with: out-of-band shared state — bot is the cross-page shared resource here)
+- [/wiki/code-analysis/charts/patterns.md](../charts/patterns.md) (shares-pattern-with: lazy-encoded versioned chart cache, different mechanics)
+- [/wiki/core/constraints.md](../../core/constraints.md) (depends-on: C7 centralized coin labels, C8 dual-transport asymmetry)

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -158,6 +158,15 @@ _The `/ticketpool` page: form-shell HTML + three live data channels (HTTP `/api/
 - patterns: code-analysis/ticketpool/patterns.md — P1 form-shell over WS-RPC, P2 tri-modal struct with positional Scan, P3 process-global stale-while-revalidate cache, P4 dual-transport overlay with divergent semantics, P5 VAR-only float64 staking pipeline
 - impact: code-analysis/ticketpool/impact.md — column-Scan desync, REST/WS payload drift, `Mempool.Price` semantic drift, WS event-name drift, TimeGrouping enum drift, SKA-through-VAR pipeline corruption, cache-loop removal, process-global cache cross-talk, C6 violation surface, legacy `DCR` label leak, `/bydate` response asymmetry
 
+### Market
+
+_The `/market` page: server-rendered shell + Stimulus chart controller fed by a single nullable `*exchanges.ExchangeBot` (Coinbase + Binance + Mexc + dex.decred.org polling, or optional DCRRates gRPC master). The bot snapshot is read three ways: HTML render via `MarketPage`/`getExchangeState`, WS pushes via `watchExchanges → "exchange" event → globalEventBus 'EXCHANGE_UPDATE'`, and lazily-encoded versioned chart bytes via `/api/chart/market/{token}/{candlestick|depth}`. The same bot also drives `xcBot.Conversion(float64)` fiat sidebars on home/tx/address (and the 410-gated treasury handler). Per [/wiki/core/pages.md](core/pages.md) this page is flagged "should be disabled" — no Monetarium asset trades anywhere; the entire surface is `float64` (VAR-safe, SKA-incompatible) and DCR-symbol-hard-coded across 5 layers. Network-name gate `Name != "mainnet"` is a no-op on Monetarium mainnet._
+
+- flow (compact): code-analysis/market/flow.compact.md — three-channel data path, dual collection mode (DCRRates gRPC vs HTTP poll), snapshot/stateCopy invariant, mutation checklist
+- flow (full): code-analysis/market/flow.full.md — detailed bot construction → updateState → MarketPage handler / watchExchanges / QuickSticks·QuickDepth → market.tmpl + market_controller.js trace, including cross-page `Conversion(...)` callsites
+- patterns: code-analysis/market/patterns.md — P1 globally-shared optional collector, P2 dual collection source (gRPC vs poll), P3 lock-free stateCopy read, P4 versioned lazy-encoded chart cache, P5 untyped WS bridge via globalEventBus
+- impact: code-analysis/market/impact.md — `float64`-only SKA precision trap, 5-layer DCR-symbol hard-coding, network-name gate no-op on Monetarium mainnet, cross-page conversion fan-out (~7 sites), WS event-id silent drift, C8 WS vs REST schema asymmetry, `IsFailed()` only honored by `/market` (cross-page conversions show stale fiat)
+
 ### Page-Rendering (cross-domain consolidation)
 
 _Mode-4 consolidation of the shared mechanics behind every server-rendered HTML page (block, mempool, visualblocks, parameters, charts, address). Not a flow — read alongside the per-domain flows it links. Covers out-of-band shared `pageData`/`invs` state, the multi-lock discipline, `*CommonPageData` struct-embedding template injection, and block-scoped ETag caching._


### PR DESCRIPTION
- Introduced `impact.md` detailing the mutation impact of changes to the `/market` page, including potential failure modes and severity levels.
- Added `patterns.md` outlining reusable architectural behaviors observed in the `/market` flow, including shared collectors and dual collection sources.
- Updated `index.md` to include a section on the `/market` page, summarizing its structure and the implications of its current design.