### PR TITLE
wiki: revise tech-stack — correct claims, tighten wording, add missing libs

### DIFF
--- a/wiki/core/tech-stack.md
+++ b/wiki/core/tech-stack.md
@@ -1,28 +1,40 @@
 # Technology Stack
 
-Monetarium Explorer bridges rigorous Go multi-module architectures with frontend Javascript SPA concepts over a dynamic Postgres database layer.
+Go backend split across 10 modules (see [structure.md](structure.md)). Hotwired Stimulus + Webpack frontend, rendered server-side from Go templates and progressively enhanced. PostgreSQL is the primary store; Badger is a side KV for the live ticket pool. Module paths and config keys retain `dcrdata` / `dcrd` naming from the upstream fork (`cmd/dcrdata/`, `dcrduser`, `dcrdserv`, `dcrdcert`, etc.) — load-bearing, do not rename.
 
-## Foundation & Backend
-* **Language:** Go 1.23
-* **Routing:** `go-chi/chi/v5`
-* **Datastore:** 
-  * PostgreSQL `lib/pq` (General Chain Storage)
-  * Badger (Embedded KV for fast stake analysis)
-* **High-Precision Logic:** Standard-library `math/big` (`big.Int`, `big.Float`). VAR has 8 decimals and fits `float64` (via `dcrutil.Amount.ToCoin()`); SKA has 18 decimals and stays as `big.Int`-derived strings end-to-end (no float conversion).
-* **RPC Layer:** JSON-RPC client `monetarium-node/rpcclient` against `monetarium-node`, with types in `monetarium-node/rpc/jsonrpc/types`. (gRPC + protobuf are only used by the separate exchange-rate service in `exchanges/rateserver/`.)
+## Backend
+
+* **Language:** Go 1.23 (per `go.mod`; local toolchain may be newer).
+* **HTTP routing:** `go-chi/chi/v5`.
+* **Datastore:**
+  * PostgreSQL via `lib/pq` — all indexed chain data, queries, charts.
+  * Badger (`dgraph-io/badger`) — embedded KV holding the live ticket pool ([stakedb/](../../stakedb/)).
+* **Chain RPC:** JSON-RPC client `monetarium-node/rpcclient`; types in `monetarium-node/rpc/jsonrpc/types`. Chain primitives — `chaincfg`, `dcrutil`, `wire`, `txscript/stdscript` — also from `monetarium-node`.
+* **HTTP APIs:** two surfaces co-served on the same port:
+  * `/api/...` — dcrdata-native ([cmd/dcrdata/internal/api/](../../cmd/dcrdata/internal/api/)).
+  * `/insight/api/...` and `/insight/socket.io/` — Insight-compatible ([cmd/dcrdata/internal/api/insight/](../../cmd/dcrdata/internal/api/insight/)).
 * **WebSockets:**
   * `github.com/coder/websocket` for the explorer (`/ws`) and pubsub (`/ps`) hubs, with RFC 6455 ping/pong keepalive.
-  * `googollee/go-socket.io` for the Insight compatibility bridge (`/insight/socket.io/`).
-  * `gorilla/websocket` only as the upstream exchange-rate client in `exchanges/`.
+  * `googollee/go-socket.io` for the Insight bridge (`/insight/socket.io/`).
+  * `gorilla/websocket` only as the upstream exchange-rate client in [exchanges/](../../exchanges/).
+* **High-precision arithmetic:** standard-library `math/big`. VAR has 8 decimals and fits `float64` (via `dcrutil.Amount.ToCoin()`); SKA has 18 decimals and stays as `big.Int`-derived strings end-to-end — no float conversion before the template boundary.
 
 ## Frontend
-* **Build Engine:** Webpack 5 (Configs handled by `.cjs` split environments)
-* **DOM Controllers:** Stimulus 3 (`@hotwired/stimulus`). Multiple controllers per page are common — e.g. the home template attaches six (`time`, `home-latest-blocks`, `homepage`, `mining`, `supply`, `voting`) to a single container.
-* **SPA Orchestrator:** Turbolinks 5.2.0 (Note: specifically skipped Hotwire Turbo upgrades in favor of vendored turbolinks)
-* **Templating:** Server-side executed Go `html/template` blocks inside `/cmd/dcrdata/views`.
-* **CSS Compilation:** SCSS `sass-loader` relying explicitly on overridden Bootstrap 5 utilities.
 
-## Quality Assurance Boundaries
-* **Go CI Limits:** `golangci-lint` utilizing deep `.golangci.yml` rulesets (e.g. `unparam`, `nilerr`, `bidichk`).
-* **JS Formatting:** Eslint standardized structures mapping to simple Vitest DOM suites.
-* **CSS Validation:** Stylelint strictly tracking standard-scss.
+* **Bundler:** Webpack 5 (`webpack@5.76.3`) with four `.cjs` configs (`common`, `dev`, `prod`, `analyze`).
+* **Controllers:** Stimulus 3 (`@hotwired/stimulus`). Multiple controllers per page is the norm — e.g. the home template attaches six (`time`, `home-latest-blocks`, `homepage`, `mining`, `supply`, `voting`) to a single container.
+* **Navigation enhancement:** Turbolinks 5.2.0, **vendored** at [cmd/dcrdata/public/js/vendor/turbolinks.min.js](../../cmd/dcrdata/public/js/vendor/turbolinks.min.js). Not the newer Hotwire Turbo.
+* **Templating:** server-side Go `html/template`, ~34 `.tmpl` files in [cmd/dcrdata/views/](../../cmd/dcrdata/views/), re-parsed on every request when started with `--reload-html`.
+* **CSS:** SCSS via `sass` + `sass-loader` layered on Bootstrap 5 (`bootstrap@5.3.8`).
+* **Charts:** Chart.js, vendored at [cmd/dcrdata/public/js/vendor/charts.min.js](../../cmd/dcrdata/public/js/vendor/charts.min.js).
+* **Other notable runtime libs:** DOMPurify (HTML sanitization), Lodash-es (utilities), Mousetrap (keyboard shortcuts), qrcode (QR generation).
+
+## Tooling
+
+* **Go lint:** `golangci-lint` per [.golangci.yml](../../.golangci.yml). Enabled linters: `asciicheck`, `bidichk`, `durationcheck`, `errchkjson`, `govet`, `grouper`, `ineffassign`, `makezero`, `misspell`, `nilerr`, `nosprintfhostport`, `reassign`, `rowserrcheck`, `tparallel`, `unconvert`, `unparam`. Multi-module iteration order is pinned in [lint.sh](../../lint.sh) and [run_tests.sh](../../run_tests.sh) so that `go mod tidy` cascades correctly.
+* **Go test build tags:** `pgonline`, `chartdata`, `fullpgdb` (see [run_tests.sh](../../run_tests.sh)). Without these, DB-backed paths are skipped; with them the script creates and drops a local `dcrdata_mainnet_test` Postgres database.
+* **Frontend lint / format:** ESLint 9, Stylelint 16 (`stylelint-config-standard-scss`), Prettier 3.
+* **Frontend test:** Vitest 4 with `environment: jsdom`; tests live next to source as `public/js/**/*.test.js`.
+* **Pre-commit hooks:** install once via `./dev/install-hooks.sh`. Staged `*.go` files trigger `gofmt` check + per-module `go test`; staged `*.js` / `*.scss` trigger Prettier / ESLint / Stylelint / Vitest.
+
+For CI/CD and container distribution, see [cicd.md](cicd.md). For repository layout and the 10-module workspace, see [structure.md](structure.md).

--- a/wiki/core/tech-stack.md
+++ b/wiki/core/tech-stack.md
@@ -8,13 +8,16 @@ Monetarium Explorer bridges rigorous Go multi-module architectures with frontend
 * **Datastore:** 
   * PostgreSQL `lib/pq` (General Chain Storage)
   * Badger (Embedded KV for fast stake analysis)
-* **High-Precision Logic:** Specialized big-number package routing 15+18 digit arithmetic.
-* **RPC Layer:** Protobuf bindings to `monetarium/monetarium-node/rpcclient`
-* **WebSockets:** `gorilla/websocket` with nested `googollee/go-socket.io` for generic Insight bridges.
+* **High-Precision Logic:** Standard-library `math/big` (`big.Int`, `big.Float`). VAR has 8 decimals and fits `float64` (via `dcrutil.Amount.ToCoin()`); SKA has 18 decimals and stays as `big.Int`-derived strings end-to-end (no float conversion).
+* **RPC Layer:** JSON-RPC client `monetarium-node/rpcclient` against `monetarium-node`, with types in `monetarium-node/rpc/jsonrpc/types`. (gRPC + protobuf are only used by the separate exchange-rate service in `exchanges/rateserver/`.)
+* **WebSockets:**
+  * `github.com/coder/websocket` for the explorer (`/ws`) and pubsub (`/ps`) hubs, with RFC 6455 ping/pong keepalive.
+  * `googollee/go-socket.io` for the Insight compatibility bridge (`/insight/socket.io/`).
+  * `gorilla/websocket` only as the upstream exchange-rate client in `exchanges/`.
 
 ## Frontend
 * **Build Engine:** Webpack 5 (Configs handled by `.cjs` split environments)
-* **DOM Controllers:** Stimulus 3 (`@hotwired/stimulus`) handling strict one-controller-per-page logic.
+* **DOM Controllers:** Stimulus 3 (`@hotwired/stimulus`). Multiple controllers per page are common — e.g. the home template attaches six (`time`, `home-latest-blocks`, `homepage`, `mining`, `supply`, `voting`) to a single container.
 * **SPA Orchestrator:** Turbolinks 5.2.0 (Note: specifically skipped Hotwire Turbo upgrades in favor of vendored turbolinks)
 * **Templating:** Server-side executed Go `html/template` blocks inside `/cmd/dcrdata/views`.
 * **CSS Compilation:** SCSS `sass-loader` relying explicitly on overridden Bootstrap 5 utilities.


### PR DESCRIPTION
## Summary

Revalidates and rewrites [wiki/core/tech-stack.md](wiki/core/tech-stack.md). Two commits:

1. **Correct the four wrong claims** (factual fixes).
2. **Sharpen wording, add real coverage, cross-link to sibling docs** (structural improvements).

## 1. Corrections (commit `022772b8`)

| Claim | Verdict |
|---|---|
| ~~Specialized big-number package routing **15+18 digit** arithmetic~~ | ✗ — standard-library `math/big`. The "15" digit figure does not exist anywhere in the code. VAR is 8 decimals (fits `float64` via `dcrutil.Amount.ToCoin`); SKA is 18 decimals (stays as `big.Int`-derived strings end-to-end). |
| ~~RPC Layer: **Protobuf** bindings to `monetarium-node/rpcclient`~~ | ✗ — it is a **JSON-RPC** client. Types live at `monetarium-node/rpc/jsonrpc/types`, used via [rpcutils/rpcclient.go:19](rpcutils/rpcclient.go#L19). Protobuf appears only in the separate exchange-rate gRPC service ([exchanges/rateserver/](exchanges/rateserver/)). |
| ~~WebSockets: `gorilla/websocket` with nested `googollee/go-socket.io`~~ | ✗ — `gorilla/websocket` was never used for the explorer/pubsub hubs. Those use `github.com/coder/websocket` (after #297; previously `golang.org/x/net/websocket`). `socket.io` stands alone at `/insight/socket.io/`, not nested. `gorilla/websocket` appears only as the upstream exchange-rate client. |
| ~~Stimulus 3 handling **strict one-controller-per-page** logic~~ | ✗ — multiple controllers per page is the norm. The home template alone attaches six controllers to one container: `data-controller="time home-latest-blocks homepage mining supply voting"`. |

## 2. Revision (commit `365751e2`)

- **Drop the content-free intro paragraph.** Replaced with one factual sentence: 10-module Go backend, Stimulus + Webpack frontend, Postgres + Badger storage. Plus an explicit note that `dcrd` / `dcrdata` legacy names (`cmd/dcrdata/`, `dcrduser`, `dcrdserv`, `dcrdcert`) are load-bearing — per [CLAUDE.md](CLAUDE.md#L31).
- **Drop branded labels.** "DOM Controllers" → "Controllers" (Stimulus's term). "SPA Orchestrator" → "Navigation enhancement" (Turbolinks is *because* we're not an SPA). "Build Engine" → "Bundler". "Quality Assurance Boundaries" → "Tooling".
- **Add items that were missing entirely:**
  - Chain primitive packages: `chaincfg`, `dcrutil`, `wire`, `txscript/stdscript`.
  - The dual HTTP API surface (`/api/...` dcrdata-native + `/insight/api/...` Insight-compatible).
  - Chart.js, vendored at [cmd/dcrdata/public/js/vendor/charts.min.js](cmd/dcrdata/public/js/vendor/charts.min.js).
  - Other runtime frontend libs: DOMPurify, Lodash-es, Mousetrap, qrcode.
  - Full enabled-linter list from [.golangci.yml](.golangci.yml).
  - Go test build tags: `pgonline`, `chartdata`, `fullpgdb` (per [run_tests.sh](run_tests.sh)).
  - Pre-commit hooks: `./dev/install-hooks.sh` and what it runs.
- **Cross-link to sibling wiki docs** so this page stays focused on "what libraries / versions / tools" and defers layout to [structure.md](wiki/core/structure.md) and CI to [cicd.md](wiki/core/cicd.md).
- **Inline file links** so readers can jump to the referenced configs and packages.

## What's still left unchanged

- The `Go 1.23` line (correct per `go.mod`).
- The `Webpack 5` / `Stimulus 3` / `Turbolinks 5.2.0` / `Bootstrap 5` / `Vitest 4` / `Stylelint 16` version references (all spot-checked against `package.json` and the vendored file header).
- Section ordering (Backend → Frontend → Tooling), which I think reads naturally.

## Test plan

- [x] Pre-commit hook green on both commits.
- [x] Every named library / package / file path verified by grep against the working tree at HEAD.
- [ ] Reviewer: skim the rendered markdown on GitHub. The WebSockets sub-list and the relative links to sibling wiki docs and source files are the most likely places for a rendering surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)