### PR TITLE
cmd/dcrdata: stack per-coin Total Sent and Regular as a mini-ledger on /mempool

### DIFF
--- a/cmd/dcrdata/public/js/controllers/mempool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.js
@@ -193,43 +193,24 @@ function activeSkaIds(coinStats) {
   return ids
 }
 
-function totalSentSkaCol(id, stats) {
-  const col = document.createElement('div')
-  col.className = 'col-12 col-md-6 col-lg-12 col-xl-6 text-center pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0'
-  col.setAttribute('data-coin-type', String(id))
-  const inner = document.createElement('div')
-  inner.className = 'd-inline-block text-center text-md-start text-lg-center text-xl-start'
-  const label = document.createElement('span')
-  label.className = 'text-secondary fs13'
-  label.textContent = 'Total Sent'
-  const amount = document.createElement('span')
-  amount.className = 'h4'
-  amount.textContent = humanize.formatCoinAtoms(stats.amount || '0', id)
-  const sym = document.createElement('span')
-  sym.className = 'text-secondary'
-  sym.textContent = renderCoinType(id)
-  inner.append(label, document.createElement('br'), amount, document.createTextNode(' '), sym)
-  col.appendChild(inner)
-  return col
+function cloneTotalSentSkaRow(template, id, stats) {
+  const row = template.content.firstElementChild.cloneNode(true)
+  row.setAttribute('data-coin-type', String(id))
+  row.querySelector('[data-slot="amount"]').textContent = humanize.formatCoinAtoms(
+    stats.amount || '0',
+    id
+  )
+  row.querySelector('[data-slot="symbol"]').textContent = renderCoinType(id)
+  return row
 }
 
-function regularSkaCol(id, stats) {
-  const col = document.createElement('div')
-  col.className = 'col-12 col-md-6 col-lg-12 col-xl-6 pb-3'
-  col.setAttribute('data-coin-type', String(id))
-  const head = document.createElement('div')
-  head.className = 'text-center text-secondary fs13'
-  head.textContent = 'Regular'
-  const count = document.createElement('div')
-  count.className = 'text-center h4 mb-0'
-  count.textContent = String(stats.regular_count || 0)
-  const totalLine = document.createElement('div')
-  totalLine.className = 'text-center fs13'
-  const amount = document.createElement('span')
-  amount.textContent = humanize.formatCoinAtoms(stats.regular_amount || '0', id)
-  totalLine.append(amount, document.createTextNode(` ${renderCoinType(id)}`))
-  col.append(head, count, totalLine)
-  return col
+function cloneRegularSkaRow(template, id, stats) {
+  const row = template.content.firstElementChild.cloneNode(true)
+  row.setAttribute('data-coin-type', String(id))
+  row.querySelector('[data-slot="count"]').textContent = String(stats.regular_count || 0)
+  row.querySelector('[data-slot="amountSymbol"]').textContent =
+    `${humanize.formatCoinAtoms(stats.regular_amount || '0', id)} ${renderCoinType(id)}`
+  return row
 }
 
 // syncSkaColsIn rebuilds the SKA (CoinType > 0) child cols of a row to match
@@ -274,7 +255,9 @@ export default class extends Controller {
       'txRowTemplate',
       'ticketRowTemplate',
       'revocationRowTemplate',
-      'voteRowTemplate'
+      'voteRowTemplate',
+      'totalSentSkaRowTemplate',
+      'regularSkaRowTemplate'
     ]
   }
 
@@ -372,11 +355,17 @@ export default class extends Controller {
     if (this.hasRevTotalTarget) {
       this.revTotalTarget.textContent = humanize.formatCoinAtoms(v.revoke_amount || '0', 0)
     }
-    if (this.hasTotalSentRowTarget) {
-      syncSkaColsIn(this.totalSentRowTarget, coinStats, totalSentSkaCol)
+    if (this.hasTotalSentRowTarget && this.hasTotalSentSkaRowTemplateTarget) {
+      const tpl = this.totalSentSkaRowTemplateTarget
+      syncSkaColsIn(this.totalSentRowTarget, coinStats, (id, stats) =>
+        cloneTotalSentSkaRow(tpl, id, stats)
+      )
     }
-    if (this.hasTransactionsRowTarget) {
-      syncSkaColsIn(this.transactionsRowTarget, coinStats, regularSkaCol)
+    if (this.hasTransactionsRowTarget && this.hasRegularSkaRowTemplateTarget) {
+      const tpl = this.regularSkaRowTemplateTarget
+      syncSkaColsIn(this.transactionsRowTarget, coinStats, (id, stats) =>
+        cloneRegularSkaRow(tpl, id, stats)
+      )
     }
   }
 

--- a/cmd/dcrdata/public/scss/cards.scss
+++ b/cmd/dcrdata/public/scss/cards.scss
@@ -27,6 +27,60 @@
   transform: translateX(-50%);
 }
 
+// Mempool mini-ledger: a 2-column grid (amount, symbol) stacking VAR on top of
+// active SKA-n rows inside a single Total Sent / Regular tile.
+.mempool-ledger {
+  display: inline-grid;
+  grid-template-columns: max-content max-content;
+  column-gap: 0.5rem;
+  row-gap: 0.15rem;
+  align-items: baseline;
+}
+
+.mempool-ledger-centered {
+  display: grid;
+  justify-content: center;
+}
+
+.mempool-ledger-row {
+  display: contents;
+}
+
+.mempool-ledger-row > .mempool-ledger-amount {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.mempool-ledger-row > .mempool-ledger-symbol {
+  white-space: nowrap;
+  text-align: left;
+}
+
+.mempool-ledger-secondary > .mempool-ledger-amount {
+  font-size: 1.0625rem; // ~17px
+  font-weight: 500;
+  line-height: 1.1;
+}
+
+.mempool-ledger-secondary > .mempool-ledger-symbol {
+  font-size: 0.75rem; // ~12px
+}
+
+// When no SKA coins are active, the centered ledger (Regular tile) falls back
+// to the vertically-stacked count-over-total presentation used by Tickets /
+// Votes / Revocations. Once any SKA row exists, the mini-ledger grid rules
+// above apply again.
+.mempool-ledger-centered:not(:has(.mempool-ledger-secondary)) {
+  display: block;
+  text-align: center;
+}
+
+.mempool-ledger-centered:not(:has(.mempool-ledger-secondary)) .mempool-ledger-amount,
+.mempool-ledger-centered:not(:has(.mempool-ledger-secondary)) .mempool-ledger-symbol {
+  display: block;
+  text-align: center;
+}
+
 body.darkBG {
   .secondary-card {
     background-color: $card-bg-secondary-dark;

--- a/cmd/dcrdata/views/mempool.tmpl
+++ b/cmd/dcrdata/views/mempool.tmpl
@@ -20,7 +20,33 @@
                         <span class="monicon-stack h5"></span>
                         <span class="h6 d-inline-block ps-2">Current Mempool</span>
                     </div>
-                    <div class="row" data-mempool-target="totalSentRow">
+                    <div class="row">
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 text-center pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
+                            <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
+                                <span class="text-secondary fs13">Total Sent</span>
+                                <br>
+                                <template data-mempool-target="totalSentSkaRowTemplate">
+                                    <div class="mempool-ledger-row mempool-ledger-secondary">
+                                        <span class="mempool-ledger-amount" data-slot="amount"></span>
+                                        <span class="mempool-ledger-symbol text-secondary" data-slot="symbol"></span>
+                                    </div>
+                                </template>
+                                <div class="mempool-ledger" data-mempool-target="totalSentRow">
+                                    <div class="mempool-ledger-row mempool-ledger-primary" data-coin-type="0">
+                                        <span class="mempool-ledger-amount h4 mb-0" data-mempool-target="totalSent">{{formatCoinAtoms $varStats.Amount 0}}</span>
+                                        <span class="mempool-ledger-symbol text-secondary">VAR</span>
+                                    </div>
+                                    {{- range orderedMempoolCoinStats .CoinStats}}
+                                    {{- if ne .CoinType 0}}
+                                    <div class="mempool-ledger-row mempool-ledger-secondary" data-coin-type="{{.CoinType}}">
+                                        <span class="mempool-ledger-amount">{{formatCoinAtoms .Stats.Amount .CoinType}}</span>
+                                        <span class="mempool-ledger-symbol text-secondary">{{.Symbol}}</span>
+                                    </div>
+                                    {{- end}}
+                                    {{- end}}
+                                </div>
+                            </div>
+                        </div>
                         <div class="col-12 col-md-6 col-lg-12 col-xl-6 text-center pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0">
                             <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
                                 <span class="text-secondary fs13">Last Block</span>
@@ -42,15 +68,6 @@
                                 <span class="h4" data-mempool-target="mempoolSize">{{.LikelyMineable.FormattedSize}}</span>
                             </div>
                         </div>
-                        {{range orderedMempoolCoinStats .CoinStats}}
-                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 text-center pb-3 pt-2 pt-md-0 pt-lg-2 pt-xl-0" data-coin-type="{{.CoinType}}">
-                            <div class="d-inline-block text-center text-md-start text-lg-center text-xl-start">
-                                <span class="text-secondary fs13">Total Sent</span>
-                                <br>
-                                <span class="h4"{{if eq .CoinType 0}} data-mempool-target="totalSent"{{end}}>{{formatCoinAtoms .Stats.Amount .CoinType}}</span> <span class="text-secondary">{{.Symbol}}</span>
-                            </div>
-                        </div>
-                        {{end}}
                     </div>
                 </div>
                 <div class="col-24 col-sm-12 col-md-24 col-lg-12 secondary-card pt-3 pb-3 px-3">
@@ -59,7 +76,32 @@
                       <span class="h6 d-inline-block ps-2">Transactions</span>
                     </div>
 
-                    <div class="row mt-1" data-mempool-target="transactionsRow">
+                    <div class="row mt-1">
+                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 pb-3">
+                            <div class="text-center text-secondary fs13">Regular</div>
+                            <template data-mempool-target="regularSkaRowTemplate">
+                                <div class="mempool-ledger-row mempool-ledger-secondary">
+                                    <span class="mempool-ledger-amount" data-slot="count"></span>
+                                    <span class="mempool-ledger-symbol" data-slot="amountSymbol"></span>
+                                </div>
+                            </template>
+                            <div class="mempool-ledger mempool-ledger-centered" data-mempool-target="transactionsRow">
+                                <div class="mempool-ledger-row mempool-ledger-primary" data-coin-type="0">
+                                    <span class="mempool-ledger-amount h4 mb-0" data-mempool-target="regCount">{{$varStats.RegularCount}}</span>
+                                    <span class="mempool-ledger-symbol fs13">
+                                        <span data-mempool-target="regTotal">{{formatCoinAtoms $varStats.RegularAmount 0}}</span> VAR
+                                    </span>
+                                </div>
+                                {{- range orderedMempoolCoinStats .CoinStats}}
+                                {{- if ne .CoinType 0}}
+                                <div class="mempool-ledger-row mempool-ledger-secondary" data-coin-type="{{.CoinType}}">
+                                    <span class="mempool-ledger-amount">{{.Stats.RegularCount}}</span>
+                                    <span class="mempool-ledger-symbol">{{formatCoinAtoms .Stats.RegularAmount .CoinType}} {{.Symbol}}</span>
+                                </div>
+                                {{- end}}
+                                {{- end}}
+                            </div>
+                        </div>
                         <div class="col-12 col-md-6 col-lg-12 col-xl-6 pb-3">
                             <div class="text-center text-secondary fs13">Tickets</div>
                             <div class="text-center h4 mb-0" data-mempool-target="ticketCount">{{$varStats.TicketCount}}</div>
@@ -94,15 +136,6 @@
                                 <span data-mempool-target="revTotal">{{formatCoinAtoms $varStats.RevokeAmount 0}}</span> VAR
                             </div>
                         </div>
-                        {{range orderedMempoolCoinStats .CoinStats}}
-                        <div class="col-12 col-md-6 col-lg-12 col-xl-6 pb-3" data-coin-type="{{.CoinType}}">
-                            <div class="text-center text-secondary fs13">Regular</div>
-                            <div class="text-center h4 mb-0"{{if eq .CoinType 0}} data-mempool-target="regCount"{{end}}>{{.Stats.RegularCount}}</div>
-                            <div class="text-center fs13">
-                                <span{{if eq .CoinType 0}} data-mempool-target="regTotal"{{end}}>{{formatCoinAtoms .Stats.RegularAmount .CoinType}}</span> {{.Symbol}}
-                            </div>
-                        </div>
-                        {{end}}
                     </div>
 
                 </div>


### PR DESCRIPTION
## Summary

- Groups the per-coin **Total Sent** and **Regular** metrics on `/mempool` into a single tile each: VAR primary on top, active SKAs listed below at a smaller size — Variant E of the design prototype.
- Falls back via CSS `:has()` to the original count-over-total stacking (matching Tickets / Votes / Revocations) when no SKA coins are active, so the VAR-only state is visually unchanged.
- SKA rows are now produced by cloning new `<template>` elements (`totalSentSkaRowTemplate`, `regularSkaRowTemplate`) and filling `data-slot` spans — matching the existing `voteRowTemplate` / `ticketRowTemplate` / etc. pattern, removing imperative DOM construction from the controller.

Closes #309.

## Test plan

- [x] `npm run check` clean (no new lint errors).
- [x] `npm test` — 286/286 passing, including `mempool_ska_sync.test.js`.
- [x] `npm run build` clean.
- [x] HTTP first paint at desktop and narrow viewports renders the Variant E layout when SKAs are active.
- [x] WebSocket-driven updates: when a SKA becomes active, a secondary row is cloned from the matching template and inserted; when it drops out, the row is removed and the tile falls back to the Tickets-style stacked layout for the Regular tile.