### PR TITLE
cmd/dcrdata,db/dcrpg: fix paginator page-size lockout and /days,/weeks overflow

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -100,6 +100,7 @@ type explorerDataSource interface {
 	VoutsForTx(context.Context, *dbtypes.Tx) ([]dbtypes.Vout, error)
 	PosIntervals(ctx context.Context, limit, offset uint64) ([]*dbtypes.BlocksGroupedInfo, error)
 	TimeBasedIntervals(ctx context.Context, timeGrouping dbtypes.TimeBasedGrouping, limit, offset uint64) ([]*dbtypes.BlocksGroupedInfo, error)
+	TimeBasedIntervalsCount(ctx context.Context, timeGrouping dbtypes.TimeBasedGrouping) (uint64, error)
 	AgendasVotesSummary(ctx context.Context, agendaID string) (summary *dbtypes.AgendaSummary, err error)
 	BlockTimeByHeight(ctx context.Context, height int64) (int64, error)
 	GetChainParams() *chaincfg.Params

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -112,6 +112,9 @@ func (m *mockDataSource) PosIntervals(ctx context.Context, limit, offset uint64)
 func (m *mockDataSource) TimeBasedIntervals(ctx context.Context, timeGrouping dbtypes.TimeBasedGrouping, limit, offset uint64) ([]*dbtypes.BlocksGroupedInfo, error) {
 	return nil, nil
 }
+func (m *mockDataSource) TimeBasedIntervalsCount(ctx context.Context, timeGrouping dbtypes.TimeBasedGrouping) (uint64, error) {
+	return 0, nil
+}
 func (m *mockDataSource) AgendasVotesSummary(ctx context.Context, agendaID string) (summary *dbtypes.AgendaSummary, err error) {
 	return nil, nil
 }

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -503,11 +503,12 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		rows = o
 	}
 	grouping := dbtypes.TimeGroupingFromStr(val)
-	i, err := dbtypes.TimeBasedGroupingToInterval(grouping)
-	if err != nil {
+	// TimeBasedGroupingToInterval is still called to validate the grouping
+	// (it errors on UnknownGrouping); the returned interval is unused now
+	// that pagination is row-count-driven rather than time-derived.
+	if _, err := dbtypes.TimeBasedGroupingToInterval(grouping); err != nil {
 		// default to year grouping if grouping is missing
-		i, err = dbtypes.TimeBasedGroupingToInterval(dbtypes.YearGrouping)
-		if err != nil {
+		if _, err = dbtypes.TimeBasedGroupingToInterval(dbtypes.YearGrouping); err != nil {
 			exp.StatusPage(w, defaultErrorCode, "Invalid year grouping found.", "",
 				ExpStatusError)
 			log.Errorf("Invalid year grouping found: error: %v ", err)
@@ -516,23 +517,26 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		grouping = dbtypes.YearGrouping
 	}
 
-	oldestBlockTime := exp.ChainParams.GenesisBlock.Header.Timestamp.Unix()
-	maxOffset := (time.Now().Unix() - oldestBlockTime) / int64(i)
-	m := uint64(maxOffset)
-	if offset > m {
-		offset = m
+	totalGroupings, err := exp.dataSource.TimeBasedIntervalsCount(ctx, grouping)
+	if exp.timeoutErrorPage(w, err, "TimeBasedIntervalsCount") {
+		return
+	}
+	if err != nil {
+		log.Errorf("TimeBasedIntervalsCount failed for /%s: %v", val, err)
+		exp.StatusPage(w, defaultErrorCode, defaultErrorMessage, "", ExpStatusError)
+		return
 	}
 
-	oldestBlockTimestamp := exp.ChainParams.GenesisBlock.Header.Timestamp
-	oldestBlockMonth := oldestBlockTimestamp.Month()
-	oldestBlockDay := oldestBlockTimestamp.Day()
-
-	now := time.Now()
-
-	if (grouping == dbtypes.YearGrouping && now.Month() < oldestBlockMonth) ||
-		grouping == dbtypes.MonthGrouping && now.Day() < oldestBlockDay ||
-		grouping == dbtypes.YearGrouping && now.Month() == oldestBlockMonth && now.Day() < oldestBlockDay {
-		maxOffset = maxOffset + 1
+	// maxOffset is the largest valid row offset (i.e. totalGroupings - 1),
+	// preserved as the semantic input to calcPages and to the template's
+	// "of (BestGrouping + 1) rows" display. When the chain has no blocks at
+	// all, leave it at 0 so the empty-data branch in the template renders.
+	var maxOffset int64
+	if totalGroupings > 0 {
+		maxOffset = int64(totalGroupings) - 1
+	}
+	if offset > uint64(maxOffset) {
+		offset = uint64(maxOffset)
 	}
 
 	if rows == 0 {

--- a/cmd/dcrdata/public/js/controllers/address_controller.js
+++ b/cmd/dcrdata/public/js/controllers/address_controller.js
@@ -13,7 +13,6 @@ import Zoom from '../helpers/zoom_helper'
 import globalEventBus from '../services/event_bus_service'
 
 const blockDuration = 5 * 60000
-const maxAddrRows = 160
 let Dygraph // lazy loaded on connect
 
 function txTypesFunc(d, binSize) {
@@ -353,10 +352,6 @@ export default class extends Controller {
 
   bindElements() {
     this.flowBoxes = this.flowTarget.querySelectorAll('input')
-    // pagesizeTarget is not available for dummy addresses
-    this.pageSizeOptions = this.hasPagesizeTarget
-      ? this.pagesizeTarget.querySelectorAll('option')
-      : []
     this.zoomButtons = this.zoomTarget.querySelectorAll('button')
     this.binputs = this.intervalTarget.querySelectorAll('button')
   }
@@ -549,20 +544,6 @@ export default class extends Controller {
     }
     setAbility(ctrl.pageplusTarget, params.offset + count < rowMax)
     setAbility(ctrl.pageminusTarget, params.offset - count >= 0)
-    ctrl.pageSizeOptions.forEach((option) => {
-      if (option.value > 100) {
-        if (rowMax > 100) {
-          option.disabled = false
-          option.text = option.value = Math.min(rowMax, maxAddrRows)
-        } else {
-          option.disabled = true
-          option.text = option.value = maxAddrRows
-        }
-      } else {
-        option.disabled = rowMax <= option.value
-      }
-    })
-    setAbility(ctrl.pagesizeTarget, rowMax > 20)
     const suffix = rowMax > 1 ? 's' : ''
     let rangeEnd = params.offset + count
     if (rangeEnd > rowMax) rangeEnd = rowMax

--- a/cmd/dcrdata/views/address.tmpl
+++ b/cmd/dcrdata/views/address.tmpl
@@ -390,18 +390,12 @@
                   id="pagesize"
                   data-address-target="pagesize"
                   data-action="change->address#changePageSize"
-                  class="form-control-sm mb-2 me-sm-2 mb-sm-0 {{if lt $TxnCount 20}}disabled{{end}} dropdown"
-                  {{- if lt $TxnCount 20}} disabled{{end}}
+                  class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropdown"
               >
-              {{- $Txlen := len .Transactions}}
-                <option {{if eq $Txlen 20}}selected {{end}}value="20"{{if lt $TxnCount 20}} disabled{{end}}>20</option>
-                <option {{if eq $Txlen 40}}selected {{end}}value="40"{{if lt $TxnCount 40}} disabled{{end}}>40</option>
-                <option {{if eq $Txlen 80}}selected {{end}}value="80"{{if lt $TxnCount 80}} disabled{{end}}>80</option>
-              {{- if lt $TxnCount 160}}
-                <option {{if eq $Txlen $TxnCount}}selected {{end}}value="{{$TxnCount}}"{{if le $TxnCount 160}} disabled{{end}}>{{$TxnCount}}</option>
-              {{- else}}
-                <option {{if ge $Txlen 160}}selected {{end}}value="160">160</option>
-              {{- end}}
+                <option {{if eq .Limit 20}}selected {{end}}value="20">20</option>
+                <option {{if eq .Limit 40}}selected {{end}}value="40">40</option>
+                <option {{if eq .Limit 80}}selected {{end}}value="80">80</option>
+                <option {{if eq .Limit 160}}selected {{end}}value="160">160</option>
               </select>
             </div>
           </div>

--- a/cmd/dcrdata/views/blocks.tmpl
+++ b/cmd/dcrdata/views/blocks.tmpl
@@ -27,18 +27,12 @@
         <span class="fs12 nowrap text-end">
           <select data-pagenavigation-target="pagesize" data-action="change->pagenavigation#setPageSize"
             data-offset="{{$pendingBlocks}}" data-offsetkey="height"
-            class="dropdown text-secondary my-2 {{if lt $blocksCount 10}}disabled{{end}}" {{if lt $blocksCount
-            10}}disabled="disabled" {{end}}>
-            {{if eq $blocksCount 20 30 50 100 .WindowSize}}{{else}}<option selected value="{{$blocksCount}}">
-              {{$blocksCount}} per page</option>{{end}}
-            {{if ge $pendingBlocks 20}}<option {{if eq $blocksCount 20}}selected{{end}} value="20">20 per page</option>
-            {{end}}
-            {{if ge $pendingBlocks 30}}<option {{if eq $blocksCount 30}}selected{{end}} value="30">30 per page</option>
-            {{end}}
-            {{if ge $pendingBlocks 50}}<option {{if eq $blocksCount 50}}selected{{end}} value="50">50 per page</option>
-            {{end}}
-            {{if ge $pendingBlocks 100}}<option {{if eq $blocksCount 100}}selected{{end}} value="100">100 per page
-            </option>{{end}}
+            class="dropdown text-secondary my-2">
+            <option {{if eq .Rows 10}}selected{{end}} value="10">10 per page</option>
+            <option {{if eq .Rows 20}}selected{{end}} value="20">20 per page</option>
+            <option {{if eq .Rows 30}}selected{{end}} value="30">30 per page</option>
+            <option {{if eq .Rows 50}}selected{{end}} value="50">50 per page</option>
+            <option {{if eq .Rows 100}}selected{{end}} value="100">100 per page</option>
           </select>
         </span>
         <nav aria-label="blocks navigation" data-limit="{{.Rows}}" class="ms-2 my-2 d-inline-block text-end">

--- a/cmd/dcrdata/views/proposals.tmpl
+++ b/cmd/dcrdata/views/proposals.tmpl
@@ -50,7 +50,6 @@
 
                         {{$count := (int64 (len .Proposals))}}
                         {{$oldest := (add .Offset $count)}}
-                        {{$pending := (subtract $.TotalCount .Offset)}}
 
                         <span class="fs12 nowrap text-end">
                             <label class="mb-0 me-1" for="tbPagesize">Page Size</label>
@@ -60,14 +59,13 @@
                                 data-action="change->pagenavigation#setPageSize"
                                 data-offset="{{$.Offset}}"
                                 data-offsetkey="offset"
-                                class="form-control-sm mb-2 me-sm-2 mb-sm-0 {{if lt $pending 20}}disabled{{end}} dropdown"
-                                {{if lt $pending 20}}disabled="disabled"{{end}}
+                                class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropdown"
                             >
-                            {{if ge $pending 20}}<option {{if eq $count 20}}selected{{end}} value="20">20</option>{{end}}
-                            {{if ge $pending 30}}<option {{if eq $count 30}}selected{{end}} value="30">30</option>{{end}}
-                            {{if ge $pending 50}}<option {{if eq $count 50}}selected{{end}} value="50">50</option>{{end}}
-                            {{if eq $.TotalCount $count 20 30 50}}{{else}}<option value="{{$.TotalCount}}">{{$.TotalCount}}</option>{{end}}
-                            {{if eq $count 20 30 50}}{{else}}<option selected value="{{$count}}">{{$count}}</option>{{end}}
+                                <option {{if eq .Limit 10}}selected{{end}} value="10">10</option>
+                                <option {{if eq .Limit 20}}selected{{end}} value="20">20</option>
+                                <option {{if eq .Limit 30}}selected{{end}} value="30">30</option>
+                                <option {{if eq .Limit 50}}selected{{end}} value="50">50</option>
+                                <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
                             </select>
                         </span>
                         <span class="fs12 nowrap text-end form-control-sm mb-2 me-sm-2 mb-sm-0">

--- a/cmd/dcrdata/views/timelisting.tmpl
+++ b/cmd/dcrdata/views/timelisting.tmpl
@@ -14,9 +14,6 @@
                 {{$oldest = (add .Offset $count)}}
                 {{$lastGrouping = (add .BestGrouping 1)}}
                 {{$lowerCaseVal := (toLowerCase .TimeGrouping)}}
-                {{$pending := (subtract $lastGrouping .Offset)}}
-                {{$dropVal := $lastGrouping}}
-                {{if gt $lastGrouping 200}}{{$dropVal = 200}}{{end}}
                 <span class="h2 d-flex pt-4 pb-1 pe-2">
                     {{.TimeGrouping}}
                     <span class="monicon-info fs14 ms-2 mt-2" title="Monetarium Blocks Grouped By {{.TimeGrouping}}"></span>
@@ -26,25 +23,21 @@
                   <span class="fs12 nowrap text-secondary px-2 my-2">
                     {{intComma (add .Offset 1)}} &ndash; {{intComma $oldest}} of {{ intComma $lastGrouping }} rows
                   </span>
-                  {{if ge $dropVal 10}}
-                    <span class="fs12 nowrap text-end">
-                        <select
-                            data-pagenavigation-target="pagesize"
-                            data-action="change->pagenavigation#setPageSize"
-                            data-offset="{{$.Offset}}"
-                            data-offsetkey="offset"
-                            class="dropdown text-secondary my-2 {{if lt $pending 10}}disabled{{end}}"
-                            {{if lt $pending 10}}disabled="disabled"{{end}}
-                        >
-                          {{if eq $count 20 30 50 100 200}}{{else}}<option selected value="{{$count}}">{{$count}} per page</option>{{end}}
-                          {{if ge $pending 20}}<option {{if eq $count 20}}selected{{end}} value="20">20 per page</option>{{end}}
-                          {{if ge $pending 30}}<option {{if eq $count 30}}selected{{end}} value="30">30 per page</option>{{end}}
-                          {{if ge $pending 50}}<option {{if eq $count 50}}selected{{end}} value="50">50 per page</option>{{end}}
-                          {{if ge $pending 100}}<option {{if eq $count 100}}selected{{end}} value="100">100 per page</option>{{end}}
-                          {{if eq $dropVal $count 20 30 50 100}}{{else}}<option value="{{$dropVal}}">{{$dropVal}} per page</option>{{end}}
-                        </select>
-                    </span>
-                  {{end}}
+                  <span class="fs12 nowrap text-end">
+                      <select
+                          data-pagenavigation-target="pagesize"
+                          data-action="change->pagenavigation#setPageSize"
+                          data-offset="{{$.Offset}}"
+                          data-offsetkey="offset"
+                          class="dropdown text-secondary my-2"
+                      >
+                        <option {{if eq .Limit 10}}selected{{end}} value="10">10 per page</option>
+                        <option {{if eq .Limit 20}}selected{{end}} value="20">20 per page</option>
+                        <option {{if eq .Limit 30}}selected{{end}} value="30">30 per page</option>
+                        <option {{if eq .Limit 50}}selected{{end}} value="50">50 per page</option>
+                        <option {{if eq .Limit 100}}selected{{end}} value="100">100 per page</option>
+                      </select>
+                  </span>
                   <nav aria-label="blocks navigation" data-limit="{{.Limit}}" class="ms-2 my-2 d-inline-block text-end">
                       <ul class="pages mb-0">
                           {{if ne .Offset 0}}

--- a/cmd/dcrdata/views/treasury.tmpl
+++ b/cmd/dcrdata/views/treasury.tmpl
@@ -298,18 +298,12 @@
               id="pagesize"
               data-address-target="pagesize"
               data-action="change->address#changePageSize"
-              class="form-control-sm mb-2 me-sm-2 mb-sm-0 {{if lt $TxnCount 20}}disabled{{end}} dropdown"
-              {{- if lt $TxnCount 20}} disabled{{end}}
+              class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropdown"
             >
-            {{- $Txlen := len .Transactions}}
-              <option {{if eq $Txlen 20}}selected {{end}}value="20"{{if lt $TxnCount 20}} disabled{{end}}>20</option>
-              <option {{if eq $Txlen 40}}selected {{end}}value="40"{{if lt $TxnCount 40}} disabled{{end}}>40</option>
-              <option {{if eq $Txlen 80}}selected {{end}}value="80"{{if lt $TxnCount 80}} disabled{{end}}>80</option>
-            {{- if lt $TxnCount 160}}
-              <option {{if eq $Txlen $TxnCount}}selected {{end}}value="{{$TxnCount}}"{{if le $TxnCount 160}} disabled{{end}}>{{$TxnCount}}</option>
-            {{- else}}
-              <option {{if ge $Txlen 160}}selected {{end}}value="160">160</option>
-            {{- end}}
+              <option {{if eq .Limit 20}}selected {{end}}value="20">20</option>
+              <option {{if eq .Limit 40}}selected {{end}}value="40">40</option>
+              <option {{if eq .Limit 80}}selected {{end}}value="80">80</option>
+              <option {{if eq .Limit 160}}selected {{end}}value="160">160</option>
             </select>
           </div>
         </div>

--- a/cmd/dcrdata/views/windows.tmpl
+++ b/cmd/dcrdata/views/windows.tmpl
@@ -11,11 +11,8 @@
         {{$windowsCount := (int64 (len .Data))}}
         <div class="px-1 mb-1">
             {{if gt $windowsCount 0}}
-            {{$pendingWindows := (int64 (index .Data 0).IndexVal)}}
             {{$oldest = (add .OffsetWindow $windowsCount)}}
             {{$lastWindow = (add .BestWindow 1)}}
-            {{$dropVal := $lastWindow}}
-            {{if gt $lastWindow 200}}{{$dropVal = 200}}{{end}}
             <div class="d-flex justify-content-between align-items-end">
               <span class="h2 d-flex pt-4 pb-1 pe-2">
                 Windows
@@ -32,15 +29,13 @@
                         data-action="change->pagenavigation#setPageSize"
                         data-offset="{{$.OffsetWindow}}"
                         data-offsetkey="offset"
-                        class="dropdown text-secondary my-2 {{if lt $pendingWindows 10}}disabled{{end}}"
-                        {{if lt $pendingWindows 10}}disabled="disabled"{{end}}
+                        class="dropdown text-secondary my-2"
                     >
-                      {{if eq $windowsCount 20 30 50 100 200}}{{else}}<option selected value="{{$windowsCount}}">{{$windowsCount}} per page</option>{{end}}
-                      {{if ge $pendingWindows 20}}<option {{if eq $windowsCount 20}}selected{{end}} value="20">20 per page</option>{{end}}
-                      {{if ge $pendingWindows 30}}<option {{if eq $windowsCount 30}}selected{{end}} value="30">30 per page</option>{{end}}
-                      {{if ge $pendingWindows 50}}<option {{if eq $windowsCount 50}}selected{{end}} value="50">50 per page</option>{{end}}
-                      {{if ge $pendingWindows 100}}<option {{if eq $windowsCount 100}}selected{{end}} value="100">100 per page</option>{{end}}
-                      {# {{if eq $dropVal $windowsCount 20 30 50 100}}{{else}}<option value="{{$dropVal}}">{{$dropVal}} per page</option>{{end}} #}
+                      <option {{if eq .Limit 10}}selected{{end}} value="10">10 per page</option>
+                      <option {{if eq .Limit 20}}selected{{end}} value="20">20 per page</option>
+                      <option {{if eq .Limit 30}}selected{{end}} value="30">30 per page</option>
+                      <option {{if eq .Limit 50}}selected{{end}} value="50">50 per page</option>
+                      <option {{if eq .Limit 100}}selected{{end}} value="100">100 per page</option>
                     </select>
                 </span>
                 <nav aria-label="blocks navigation" data-limit="{{.Limit}}" class="ms-2 my-2 d-inline-block text-end">

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -161,6 +161,13 @@ const (
 		ORDER BY index_value DESC
 		LIMIT $2 OFFSET $3;`
 
+	// SelectBlocksTimeListingCount returns the number of distinct
+	// time-truncated groupings that actually have at least one block. Its
+	// DATE_TRUNC expression MUST stay identical to the one in
+	// SelectBlocksTimeListingByLimit; the two values are paired by the
+	// time-based listing handler to drive pagination.
+	SelectBlocksTimeListingCount = `SELECT COUNT(DISTINCT DATE_TRUNC($1, time at time zone 'utc')) FROM blocks;`
+
 	// SelectBlocksPreviousHash = `SELECT previous_hash FROM blocks WHERE hash = $1;`
 
 	// SelectBlocksHashes = `SELECT hash FROM blocks ORDER BY id;`

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1831,6 +1831,19 @@ func (pgb *ChainDB) TimeBasedIntervals(ctx context.Context, timeGrouping dbtypes
 	return bgi, pgb.replaceCancelError(err)
 }
 
+// TimeBasedIntervalsCount returns the number of distinct time-truncated
+// groupings (days, weeks, months, or years) that actually contain at least
+// one block, used to drive pagination on the time-based listing views.
+func (pgb *ChainDB) TimeBasedIntervalsCount(ctx context.Context, timeGrouping dbtypes.TimeBasedGrouping) (uint64, error) {
+	if timeGrouping >= dbtypes.NumIntervals {
+		return 0, fmt.Errorf("invalid time grouping %d", timeGrouping)
+	}
+	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
+	defer cancel()
+	count, err := retrieveTimeBasedBlockListingCount(ctx, pgb.db, timeGrouping.String())
+	return count, pgb.replaceCancelError(err)
+}
+
 // TicketPoolVisualization helps block consecutive and duplicate DB queries for
 // the requested ticket pool chart data. If the data for the given interval is
 // cached and fresh, it is returned. If the cached data is stale and there are

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -955,6 +955,19 @@ func retrieveWindowBlocks(ctx context.Context, db *sql.DB, windowSize, currentHe
 	return data, nil
 }
 
+// retrieveTimeBasedBlockListingCount returns the number of distinct
+// time-truncated groupings (days, weeks, months, or years) that actually
+// contain at least one block. It is used to drive pagination on the
+// /days, /weeks, /months and /years views so page numbers never run past
+// the last grouping that has data.
+func retrieveTimeBasedBlockListingCount(ctx context.Context, db *sql.DB, timeInterval string) (uint64, error) {
+	var count uint64
+	if err := db.QueryRowContext(ctx, internal.SelectBlocksTimeListingCount, timeInterval).Scan(&count); err != nil {
+		return 0, fmt.Errorf("retrieveTimeBasedBlockListingCount failed: error: %w", err)
+	}
+	return count, nil
+}
+
 // retrieveTimeBasedBlockListing fetches blocks in chunks based on their block
 // time using the limit and offset provided. The time-based blocks groupings
 // include but are not limited to day, week, month and year.

--- a/wiki/code-analysis/time-based-blocks/patterns.md
+++ b/wiki/code-analysis/time-based-blocks/patterns.md
@@ -54,18 +54,21 @@ The DB layer formats `FormattedStartTime` uniformly as `startTime.Format("2006-0
 
 ---
 
-## Genesis-anchored pagination with partial-interval +1 buffer
+## Row-count-driven pagination via `COUNT(DISTINCT DATE_TRUNC(...))`
 
 **Appears in:**
 - [/wiki/code-analysis/time-based-blocks/flow.full.md](flow.full.md)
 
 **Description:**
-Pagination is not row-count driven; it is **time driven**. `maxOffset = (time.Now().Unix() - oldestBlockTime) / int64(i)` where `oldestBlockTime` is the genesis block header timestamp (`exp.ChainParams.GenesisBlock.Header.Timestamp`) and `i` is the interval length in seconds from `TimeBasedGroupingToInterval` ([cmd/dcrdata/internal/explorer/explorerroutes.go:521-523](../../../cmd/dcrdata/internal/explorer/explorerroutes.go); [db/dbtypes/conversion.go:110-133](../../../db/dbtypes/conversion.go)). A `+1` buffer is added to `maxOffset` for unaligned partial year/month intervals when "now" has not yet reached the genesis month/day boundary ([explorerroutes.go:534-538](../../../cmd/dcrdata/internal/explorer/explorerroutes.go)). The requested `offset` is clamped to `maxOffset` ([:524-526](../../../cmd/dcrdata/internal/explorer/explorerroutes.go)), and `lastOffset` (the final page's offset) is derived from `maxOffset % rows` ([:558-565](../../../cmd/dcrdata/internal/explorer/explorerroutes.go)). `maxOffset` is exported to the template as `BestGrouping` and consumed by `calcPages` and `timelisting.tmpl` ([:590-592](../../../cmd/dcrdata/internal/explorer/explorerroutes.go); [cmd/dcrdata/views/timelisting.tmpl:15,74](../../../cmd/dcrdata/views/timelisting.tmpl)).
+Pagination is **row-count driven**. `timeBasedBlocksListing` calls `dataSource.TimeBasedIntervalsCount(ctx, grouping)` which returns the exact number of distinct time-truncated groupings that contain at least one block: `SELECT COUNT(DISTINCT DATE_TRUNC($1, time at time zone 'utc')) FROM blocks` ([db/dcrpg/internal/blockstmts.go `SelectBlocksTimeListingCount`](../../../db/dcrpg/internal/blockstmts.go); [db/dcrpg/queries.go `retrieveTimeBasedBlockListingCount`](../../../db/dcrpg/queries.go); [db/dcrpg/pgblockchain.go `TimeBasedIntervalsCount`](../../../db/dcrpg/pgblockchain.go)). The handler then derives `maxOffset = totalGroupings - 1` (0 on an empty chain) and uses that as the semantic "largest valid offset" for the existing downstream math: the offset clamp, `lastOffset` derivation ([explorerroutes.go `lastOffsetRows := uint64(maxOffset) % rows`](../../../cmd/dcrdata/internal/explorer/explorerroutes.go)), `calcPages(int(maxOffset), …)`, and the template's `{{$lastGrouping = (add .BestGrouping 1)}}` ([cmd/dcrdata/views/timelisting.tmpl:15,74](../../../cmd/dcrdata/views/timelisting.tmpl)).
+
+This replaced an earlier genesis-anchored, time-driven formula (`maxOffset = (now - genesis) / interval_seconds` plus a partial-interval `+1` buffer for unaligned year/month boundaries). That earlier formula overestimated the page count whenever some intervals had no blocks (sparse chain, testnet, gaps), making the page-number switcher render pages past the last grouping that actually had data — see issue #302.
 
 **Constraints:**
-- `TimeBasedGroupingToInterval` returns `float64` seconds; `MonthGrouping`/`YearGrouping` use the approximation `daysPerMonth = 30.41666…` (365/12). The page-count math is intentionally approximate — do not "fix" it to exact calendar months without re-deriving the `+1` buffer logic, which compensates for the approximation against the genesis boundary.
-- `oldestBlockTime` is the chain genesis timestamp from `ChainParams`, not the oldest row in the DB. On a freshly-synced or pruned DB the two can differ; the math assumes genesis.
-- `BestGrouping` (the template name for `maxOffset`) drives both `calcPages` and the "last page" link (`{{add .BestGrouping 1}}`, `LastOffset`). Changing the offset formula requires re-checking both the clamp at `:524-526` and the `lastOffset` derivation at `:558-565`, and the template's `$lastGrouping` math.
+- The `DATE_TRUNC` expression in `SelectBlocksTimeListingCount` MUST be identical to the one in `SelectBlocksTimeListingByLimit` (same interval string, same `time at time zone 'utc'` cast). The two queries are paired: the count drives `calcPages`, the listing fills the page. A drift between them would make the displayed page-of-N header disagree with the actual rows returned.
+- The count query is unindexed against the truncated expression and runs once per request; consider a chain-tip-keyed cache in `db/cache` if profiling shows it as a hotspot. Currently the page itself runs a heavier aggregation, so the count is not the bottleneck.
+- `BestGrouping` (the template name for `maxOffset`) is exported to the template as `totalGroupings - 1`, so `{{add .BestGrouping 1}}` yields the actual row total for the "1 – N of M rows" header. Changing this derivation requires re-checking the template's arithmetic, `calcPages`'s expectation that its first argument is "last valid offset", and the `lastOffset` derivation.
+- `TimeBasedGroupingToInterval` is still invoked for validation only — its returned interval is no longer used for pagination. The function errors on `UnknownGrouping`, and the handler keeps the year-grouping fallback off that error path.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #302.

- **Bug 1 — page-size selector lockout.** On `/blocks`, `/days`, `/weeks`, `/months`, `/years`, `/ticketpricewindows`, `/proposals`, `/address`, `/treasury`, picking any value other than the default (10 or 20) made it impossible to switch back. Two layers were affected: the Go templates (server-rendered) and `address_controller.js`, which re-imposed the same disable client-side after each AJAX update.
- **Bug 2 — `/days`, `/weeks` page-number overflow.** Pagination used `maxOffset = (now − genesis) / interval` plus a partial-interval `+1` buffer — a calendar estimate that overshoots whenever some intervals have no blocks (sparse / test chains, gaps), so the switcher rendered page numbers past the last grouping with data.

## What changed

- New `SELECT COUNT(DISTINCT DATE_TRUNC(...))` query plumbed through `ChainDB.TimeBasedIntervalsCount` and the `explorerDataSource` interface; `timeBasedBlocksListing` now drives pagination from the exact grouping count. Partial-interval `+1` buffer removed.
- Page-size dropdowns standardised to stable, always-enabled fixed lists:
  - `/blocks`, `/days`, `/weeks`, `/months`, `/years`, `/ticketpricewindows`, `/proposals` → `10 / 20 / 30 / 50 / 100`
  - `/address`, `/treasury` → `20 / 40 / 80 / 160` (preserved — these pages can be transaction-heavy)
  - Selection driven by the requested rows count, not by `len(.Data)`. No conditional gating, no `disabled` guard, no fallback ad-hoc-value options.
- `address_controller.js`: removed the disable-after-AJAX + per-option-disable logic and the runtime mutation of "160" into `maxAddrRows`. Dropped the now-unused `maxAddrRows` constant and `pageSizeOptions` field.
- `wiki/code-analysis/time-based-blocks/patterns.md` §4 rewritten — was "Genesis-anchored pagination with partial-interval +1 buffer", now "Row-count-driven pagination via `COUNT(DISTINCT DATE_TRUNC(...))`".

## Test plan

- [x] `go test ./...` in `db/dcrpg` and `cmd/dcrdata` modules — green
- [x] `npm test` in `cmd/dcrdata` — vitest 286/286
- [x] `npm run check` — prettier / eslint / stylelint clean (only pre-existing warnings)
- [x] `/blocks?rows=50` → dropdown `10 / 20 / 30 / 50 [selected] / 100`
- [x] `/days?rows=10` → header reads "1 – 10 of 14 rows", switcher renders only pages `1 2` (down from a bogus "of 219 rows" with 22 pages)
- [x] `/days?rows=10&offset=10` (last partial page) → "11 – 14 of 14 rows", dropdown stays interactable
- [x] `/ticketpricewindows?rows=100` → dropdown clean
- [x] `/address/<addr>?n=20` and `?n=80` → dropdown `20 / 40 / 80 / 160`, round-trip across selections works (selector no longer disables itself after AJAX)
- [ ] `/proposals` and `/treasury` — template parses (Go test green) but runtime UX unverifiable on testnet (politeia / treasury services inactive). Will need manual confirmation on mainnet or a configured staging env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)