### PR TITLE
cmd/dcrdata: address page — align header cards; chart label on top

### DIFF
--- a/cmd/dcrdata/public/js/controllers/address_controller.js
+++ b/cmd/dcrdata/public/js/controllers/address_controller.js
@@ -155,6 +155,7 @@ let commonOptions, typesGraphOptions, amountFlowGraphOptions, balanceGraphOption
 // Cannot set these until DyGraph is fetched.
 function createOptions() {
   commonOptions = {
+    axes: { y: { axisLabelWidth: 70 } },
     digitsAfterDecimal: 8,
     showRangeSelector: true,
     rangeSelectorHeight: 20,
@@ -174,7 +175,6 @@ function createOptions() {
   typesGraphOptions = {
     labels: ['Date', 'Sending (regular)', 'Receiving (regular)', 'Tickets', 'Votes', 'Revocations'],
     colors: ['#69D3F5', '#2971FF', '#41BF53', 'darkorange', '#FF0090'],
-    ylabel: 'Tx Count',
     visibility: [true, true, true, true, true],
     legendFormatter: formatter,
     stackedGraph: true,
@@ -249,6 +249,7 @@ export default class extends Controller {
       'view',
       'mergedMsg',
       'chartLoader',
+      'chartTitle',
       'listLoader',
       'expando',
       'littlechart',
@@ -705,34 +706,36 @@ export default class extends Controller {
     const coinLabel = renderCoinType(coin)
     const amountFormatter = makeAmountFormatter(coin, ctrl.skaAtomsByTime)
     ctrl.flowTarget.classList.add('d-hide')
+    let title = ''
     switch (chart) {
       case 'types':
         options = {
           ...typesGraphOptions,
-          ylabel: 'Tx Count',
           legendFormatter: formatter,
           plotter: sizedBarPlotter(binSize)
         }
+        title = 'Tx Count'
         break
 
       case 'amountflow':
         options = {
           ...amountFlowGraphOptions,
-          ylabel: `Total (${coinLabel})`,
           legendFormatter: amountFormatter,
           plotter: sizedBarPlotter(binSize)
         }
+        title = `Total (${coinLabel})`
         ctrl.flowTarget.classList.remove('d-hide')
         break
 
       case 'balance':
         options = {
           ...balanceGraphOptions,
-          ylabel: `Balance (${coinLabel})`,
           legendFormatter: amountFormatter
         }
+        title = `Balance (${coinLabel})`
         break
     }
+    if (ctrl.hasChartTitleTarget) ctrl.chartTitleTarget.textContent = title
     options.zoomCallback = null
     options.drawCallback = null
     if (ctrl.graph === undefined) {

--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -137,7 +137,8 @@
   border: 1px solid #aaa;
 }
 
-.btn-set > label {
+.btn-set > label,
+.btn-set > span {
   position: absolute;
   top: -0.7em;
   line-height: 1em;

--- a/cmd/dcrdata/views/address.tmpl
+++ b/cmd/dcrdata/views/address.tmpl
@@ -42,7 +42,7 @@
           {{- $balance := .Balance -}}
           {{- $active := .ActiveCoins -}}
           {{- $varCB := index $balance.Coins 0 -}}
-          <div class="position-relative d-flex justify-content-between align-items-center flex-wrap">
+          <div class="position-relative d-flex justify-content-between align-items-start flex-wrap">
             <div class="d-inline-block text-start pe-2 pb-3">
               <span class="text-secondary fs13">Balance</span>
               <br>
@@ -155,8 +155,9 @@
             <div class="d-flex flex-wrap justify-content-around align-items-start">
               <div class="loader-v2 loading" data-address-target="chartLoader"></div>
               <div class="btn-set secondary-card d-inline-flex flex-nowrap mx-2">
-                <label>Chart</label>
+                <span>Chart</span>
                 <select
+                    id="address-chart-type"
                     class="chart-box d-inline-flex dropdown"
                     data-address-target="options"
                     data-action="change->address#changeGraph"
@@ -167,7 +168,7 @@
                 </select>
               </div>
               <div class="btn-set secondary-card d-inline-flex flex-nowrap mx-2">
-                <label>Coin</label>
+                <span>Coin</span>
                 {{- if gt (len .ActiveCoins) 1}}
                 <select
                     class="chart-box d-inline-flex dropdown"
@@ -210,7 +211,7 @@
                   data-address-target="zoom"
                   data-action="click->address#onZoom"
               >
-                <label>Zoom</label>
+                <span>Zoom</span>
                 <button class="btn-selected" name="all" data-fixed="1">All</button>
                 <button name="year">Year</button>
                 <button name="month">Month</button>
@@ -224,7 +225,7 @@
                   data-address-target="interval"
                   data-action="click->address#changeBin"
               >
-                  <label class="d-inline-flex pe-1">Group By </label>
+                  <span class="d-inline-flex pe-1">Group By </span>
                   <button name="year">Year</button>
                   <button class="btn-selected" name="month">Month</button>
                   <button name="week">Week</button>
@@ -250,6 +251,7 @@
             <div class="p-3 address_chart_wrap">
               <div class="expando monicon-expand" data-address-target="expando" data-action="click->address#toggleExpand"></div>
               <div class="py-5 fs16 d-none" data-address-target="noconfirms"></div>
+              <div class="text-start fs14 fw-bold text-secondary mb-1" data-address-target="chartTitle"></div>
               <div data-address-target="chart" class="address_chart"></div>
             </div>
           </div>
@@ -331,6 +333,7 @@
             <div class="d-inline-block text-end">
               <label class="mb-0 me-1" for="txntype">Type</label>
               <select
+                id="txntype"
                 name="txntype"
                 data-address-target="txntype"
                 data-action="change->address#changeTxType"
@@ -350,6 +353,7 @@
               <label class="mb-0 me-1" for="coin">Coin</label>
               {{- if gt (len .ActiveCoins) 1}}
               <select
+                id="coin"
                 name="coin"
                 data-address-target="coinFilter"
                 data-action="change->address#changeCoin"
@@ -364,6 +368,7 @@
               {{- $onlyCoin := index .ActiveCoins 0}}
               <span title="This address only has {{coinSymbol $onlyCoin}} transactions">
                 <select
+                  id="coin"
                   name="coin"
                   class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropdown"
                   disabled
@@ -374,6 +379,7 @@
               {{- else}}
               <span title="This address has no transactions">
                 <select
+                  id="coin"
                   name="coin"
                   class="form-control-sm mb-2 me-sm-2 mb-sm-0 dropdown"
                   disabled

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -71,7 +71,7 @@
 		</form>
 		<nav id="hamburger-menu" data-controller="menu" data-turbolinks-permanent>
 			<div id="menu-toggle">
-				<input type="checkbox" data-menu-target="toggle" data-action="change->menu#toggle"/>
+				<input type="checkbox" name="menu-toggle" aria-label="Toggle navigation menu" data-menu-target="toggle" data-action="change->menu#toggle"/>
 				<span class="patty"></span>
 				<span class="patty"></span>
 				<span class="patty short"></span>


### PR DESCRIPTION
## Summary

Fixes #308 (UI bugs on `/address/{address}`).

- **Header cards alignment.** Switch the Balance/Received/Spent flex container from `align-items-center` to `align-items-start`. The shorter Balance card no longer sinks toward the vertical centre when the taller Received/Spent cards add their "{N} outputs/inputs" subtext — all three section labels share the same horizontal baseline at every viewport, including the narrow widths where `flex-wrap` splits the row.
- **SKA1 chart label overlap.** Drop Dygraph's rotated `ylabel` and render the same text horizontally above the chart in a new `chartTitle` target sitting inside the chart paper. The rotated label sat to the left of the y-axis tick values; for SKA1 the atom magnitudes produced labels like `4000000Q` that bled into the ylabel area. Moving the label up removes the overlap entirely instead of fighting it with `axisLabelWidth` padding. A modest `axisLabelWidth: 70` is still set on `commonOptions` so long SKA tick labels render without truncation.
- **Adjacent a11y cleanups (surfaced by DevTools → Issues).** Bare `<label>` elements in the chart toolbar (`Chart`, `Coin`, `Zoom`, `Group By`) become `<span>` (they were decorative — no `for=` association). The `.btn-set > label` rule is widened to `.btn-set > label, .btn-set > span` so the floating-tab look is preserved. Added missing `id` to the chart-type select and to the Type/Coin filter selects (their existing `<label for="…">` was referencing a `name=`, not an `id`). Added `name="menu-toggle"` + `aria-label` to the shared hamburger checkbox.

Scope of the chart changes is the address controller only — `commonOptions`/`amountFlowGraphOptions`/`balanceGraphOptions`/`typesGraphOptions` are module-scoped, so no other Dygraph instances are affected. `.btn-set > span` was source- and runtime-audited across address, market, and treasury templates: no other page contains a `<span>` direct child of `.btn-set`, and no JS injects one.

## Test plan

- [x] Local testnet, address with both VAR and SKA1 activity (`TsZx9qK52WTmkJn1zHrFKNuTWkXJZrbxZjL`):
  - [x] At 1440px and 480px (post-`flex-wrap`), Balance / Received / Spent labels share a top baseline.
  - [x] Switch coin × chart through all 6 permutations (VAR × {types, amountflow, balance} and SKA1 × {types, amountflow, balance}); the horizontal title text updates, Dygraph's rotated `ylabel` is never rendered.
  - [x] SKA1 amountflow + balance charts: tick values render with comfortable clearance from the title.
  - [x] VAR charts: no regression in tick rendering.
- [x] DevTools → Issues panel: re-scanned after the change — 0 hits in the four categories that were flagged (`form-field-no-id-no-name`, `label-for-matches-name-not-id`, `label-for-matches-nothing`, `label-not-associated`).
- [x] `cd cmd/dcrdata && npm run check` clean; `npm run build` clean; pre-commit hook ran prettier + eslint + stylelint + vitest (286/286 ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)