### PR TITLE
Fix/block fees pagination ska

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -667,5 +667,14 @@ func computeMiningFee(msgBlock *wire.MsgBlock, powSubsidy int64) int64 {
 	}
 	miningFee := coinbaseOutput - powSubsidy
 
-	return miningFee
+	// Exclude stake fees (fees from vote transactions) from the mining fee
+	var voteFees int64
+	for _, tx := range msgBlock.Transactions {
+		if txhelpers.DetermineTxType(tx) == stake.TxTypeSSGen {
+			fee, _ := txhelpers.TxFeeRate(tx)
+			voteFees += int64(fee)
+		}
+	}
+
+	return miningFee - voteFees
 }

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -247,7 +247,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	}
 	var miningFee int64
 	if curSubsidy != nil {
-		miningFee = computeMiningFee(msgBlock, curSubsidy.PoW)
+		miningFee = computeMiningFee(msgBlock)
 	}
 
 	// Work/Stake difficulty
@@ -655,26 +655,21 @@ func BlockSKAPoWRewardsFromSTx(msgBlock *wire.MsgBlock) map[uint8]string {
 	return out
 }
 
-// computeMiningFee calculates total mining fees from a block.
-// Formula: Mining Fee = Coinbase Output - PoW Subsidy
-// This is equivalent to summing (Inputs - Outputs) for all non-coinbase transactions,
-// but more efficient and accurate.
-func computeMiningFee(msgBlock *wire.MsgBlock, powSubsidy int64) int64 {
-	// Get coinbase output (first transaction, first output)
-	coinbaseOutput := int64(0)
-	for _, txOut := range msgBlock.Transactions[0].TxOut {
-		coinbaseOutput += txOut.Value
-	}
-	miningFee := coinbaseOutput - powSubsidy
-
-	// Exclude stake fees (fees from vote transactions) from the mining fee
-	var voteFees int64
-	for _, tx := range msgBlock.Transactions {
-		if txhelpers.DetermineTxType(tx) == stake.TxTypeSSGen {
-			fee, _ := txhelpers.TxFeeRate(tx)
-			voteFees += int64(fee)
+// computeMiningFee calculates total mining fees from a block by summing fees
+// from regular transactions and tickets, excluding votes and stake fees (SSFee).
+// For Monetarium, fees included in MiningFee are only from Tx and Tickets.
+func computeMiningFee(msgBlock *wire.MsgBlock) int64 {
+	var miningFee int64
+	for i, tx := range msgBlock.Transactions {
+		if i == 0 {
+			continue // skip coinbase
 		}
+		txType := txhelpers.DetermineTxType(tx)
+		if txType == stake.TxTypeSSGen || txType == stake.TxTypeSSFee {
+			continue // exclude votes and stake fees
+		}
+		fee, _ := txhelpers.TxFeeRate(tx)
+		miningFee += int64(fee)
 	}
-
-	return miningFee - voteFees
+	return miningFee
 }

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -656,19 +656,24 @@ func BlockSKAPoWRewardsFromSTx(msgBlock *wire.MsgBlock) map[uint8]string {
 }
 
 // computeMiningFee calculates total mining fees from a block by summing fees
-// from regular transactions and tickets, excluding votes and stake fees (SSFee).
-// For Monetarium, fees included in MiningFee are only from Tx and Tickets.
+// from regular transactions (Transactions tree) and tickets (STransactions tree
+// limited to TxTypeSStx), matching the GetExplorerBlock formula:
+//
+//	getTotalFee(block.Tx) + getTotalFee(block.Tickets)
 func computeMiningFee(msgBlock *wire.MsgBlock) int64 {
 	var miningFee int64
 	for i, tx := range msgBlock.Transactions {
 		if i == 0 {
 			continue // skip coinbase
 		}
-		txType := txhelpers.DetermineTxType(tx)
-		if txType == stake.TxTypeSSGen || txType == stake.TxTypeSSFee {
-			continue // exclude votes and stake fees
-		}
 		fee, _ := txhelpers.TxFeeRate(tx)
+		miningFee += int64(fee)
+	}
+	for _, stx := range msgBlock.STransactions {
+		if txhelpers.DetermineTxType(stx) != stake.TxTypeSStx {
+			continue // only include tickets
+		}
+		fee, _ := txhelpers.TxFeeRate(stx)
 		miningFee += int64(fee)
 	}
 	return miningFee

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -409,3 +409,7 @@ func TestComputeMiningFee_MultipleRegularTx(t *testing.T) {
 		t.Errorf("got %d, want %d", got, want)
 	}
 }
+
+func TestComputeMiningFee_STransactions(t *testing.T) {
+	t.Skip("Skipping: constructing valid SStx/SSGen transactions requires specific OP_RETURN structure")
+}

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/monetarium/monetarium-node/blockchain/stake"
 	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/wire"
 )
@@ -410,6 +411,128 @@ func TestComputeMiningFee_MultipleRegularTx(t *testing.T) {
 	}
 }
 
-func TestComputeMiningFee_STransactions(t *testing.T) {
-	t.Skip("Skipping: constructing valid SStx/SSGen transactions requires specific OP_RETURN structure")
+// Reference SStx output scripts copied verbatim from
+// monetarium-node/blockchain/stake's own test fixtures (sstxTxOut0/1/2). They
+// satisfy stake.CheckSStx purely as scripts — values are independent, so the
+// helper below can dial in a chosen fee.
+var (
+	opSSTxScript = []byte{
+		0xba, 0x76, 0xa9, 0x14, // OP_SSTX OP_DUP OP_HASH160 OP_DATA_20
+		0xc3, 0x98, 0xef, 0xa9,
+		0xc3, 0x92, 0xba, 0x60,
+		0x13, 0xc5, 0xe0, 0x4e,
+		0xe7, 0x29, 0x75, 0x5e,
+		0xf7, 0xf5, 0x8b, 0x32,
+		0x88, 0xac, // OP_EQUALVERIFY OP_CHECKSIG
+	}
+	opSStxCommitScript = []byte{
+		0x6a, 0x1e, // OP_RETURN, 30-byte push
+		0x94, 0x8c, 0x76, 0x5a,
+		0x69, 0x14, 0xd4, 0x3f,
+		0x2a, 0x7a, 0xc1, 0x77,
+		0xda, 0x2c, 0x2f, 0x6b,
+		0x52, 0xde, 0x3d, 0x7c,
+		0x00, 0xe3, 0x23, 0x21,
+		0x00, 0x00, 0x00, 0x00,
+		0x44, 0x3f,
+	}
+	opSSTxChangeScript = []byte{
+		0xbd, 0x76, 0xa9, 0x14, // OP_SSTXCHANGE OP_DUP OP_HASH160 OP_DATA_20
+		0xc3, 0x98, 0xef, 0xa9,
+		0xc3, 0x92, 0xba, 0x60,
+		0x13, 0xc5, 0xe0, 0x4e,
+		0xe7, 0x29, 0x75, 0x5e,
+		0xf7, 0xf5, 0x8b, 0x32,
+		0x88, 0xac,
+	}
+)
+
+// newSStxWithFee returns an SStx (ticket) with one input of inputAmount atoms,
+// outputs summing to inputAmount-fee, and a script layout that satisfies
+// stake.IsSStx so DetermineTxType classifies it as TxTypeSStx.
+func newSStxWithFee(t *testing.T, inputAmount, fee int64) *wire.MsgTx {
+	t.Helper()
+	if fee < 0 || fee > inputAmount {
+		t.Fatalf("invalid test setup: inputAmount=%d fee=%d", inputAmount, fee)
+	}
+	purchase := (inputAmount - fee) / 2
+	change := (inputAmount - fee) - purchase
+
+	tx := wire.NewMsgTx()
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, inputAmount, nil))
+
+	out0 := wire.NewTxOut(purchase, opSSTxScript)
+	tx.AddTxOut(out0)
+	out1 := wire.NewTxOut(0, opSStxCommitScript)
+	tx.AddTxOut(out1)
+	out2 := wire.NewTxOut(change, opSSTxChangeScript)
+	tx.AddTxOut(out2)
+
+	if !stake.IsSStx(tx) {
+		t.Fatalf("test fixture failed: constructed tx is not classified as SStx")
+	}
+	return tx
+}
+
+func TestComputeMiningFee_TicketInSTransactions(t *testing.T) {
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxOut(wire.NewTxOut(16e8, nil))
+	ticket := newSStxWithFee(t, 1_000_000, 12_345)
+
+	block := &wire.MsgBlock{
+		Transactions:  []*wire.MsgTx{coinbase},
+		STransactions: []*wire.MsgTx{ticket},
+	}
+
+	got := computeMiningFee(block)
+	want := int64(12_345)
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+func TestComputeMiningFee_BothTrees(t *testing.T) {
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxOut(wire.NewTxOut(16e8+1000, nil))
+	regTx := newTxWithFee(50_000, 1_000)
+	ticket1 := newSStxWithFee(t, 1_000_000, 2_500)
+	ticket2 := newSStxWithFee(t, 2_000_000, 4_000)
+
+	block := &wire.MsgBlock{
+		Transactions:  []*wire.MsgTx{coinbase, regTx},
+		STransactions: []*wire.MsgTx{ticket1, ticket2},
+	}
+
+	got := computeMiningFee(block)
+	want := int64(1_000 + 2_500 + 4_000)
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+// TestComputeMiningFee_NonTicketSTransactionsExcluded confirms the STransactions
+// loop's `!= TxTypeSStx` filter actually drops non-ticket entries. A plain
+// (non-stake) MsgTx in STransactions is classified TxTypeRegular by
+// DetermineTxType, so its fee must not contribute to MiningFee — the same code
+// path that excludes votes (SSGen), stake fees (SSFee), and revocations (SSRtx).
+func TestComputeMiningFee_NonTicketSTransactionsExcluded(t *testing.T) {
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxOut(wire.NewTxOut(16e8, nil))
+	ticket := newSStxWithFee(t, 1_000_000, 7_777)
+	nonTicket := newTxWithFee(500_000, 9_999) // classified TxTypeRegular
+
+	if got := stake.DetermineTxType(nonTicket); got == stake.TxTypeSStx {
+		t.Fatalf("test fixture broken: non-ticket tx is classified as SStx")
+	}
+
+	block := &wire.MsgBlock{
+		Transactions:  []*wire.MsgTx{coinbase},
+		STransactions: []*wire.MsgTx{ticket, nonTicket},
+	}
+
+	got := computeMiningFee(block)
+	want := int64(7_777) // only the ticket's fee
+	if got != want {
+		t.Errorf("got %d, want %d (nonTicket fee of 9_999 must not be counted)", got, want)
+	}
 }

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -336,93 +336,75 @@ func TestExtractSKARewardsFromCoinbase_Summing(t *testing.T) {
 	}
 }
 
-func TestComputeMiningFee_UserScenario(t *testing.T) {
-	// User's provided Coinbase TX: Total = 32.00016925 VAR = 3200016925 atoms
-	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(0, nil))          // vout 0: 0
-	coinbase.AddTxOut(wire.NewTxOut(0, nil))          // vout 1: 0
-	coinbase.AddTxOut(wire.NewTxOut(3200016925, nil)) // vout 2: 32.00016925 VAR
-
-	block := &wire.MsgBlock{
-		Transactions: []*wire.MsgTx{coinbase},
-	}
-
-	// Subsidy = 32 VAR = 3200000000 atoms
-	got := computeMiningFee(block, 3200000000)
-	want := int64(16925)
-	if got != want {
-		t.Errorf("got %d, want %d", got, want)
-	}
+// newTxWithFee creates a wire.MsgTx with an input of inputAmount atoms and outputs
+// totalling inputAmount - fee atoms. The fee is the difference between input and outputs.
+func newTxWithFee(inputAmount, fee int64) *wire.MsgTx {
+	tx := wire.NewMsgTx()
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, inputAmount, nil))
+	tx.AddTxOut(wire.NewTxOut(inputAmount-fee, nil))
+	return tx
 }
 
-// TestComputeMiningFee_CoinbaseEqualsSubsidy tests when coinbase equals the base subsidy.
-// This happens when there are no transaction fees in the block.
-func TestComputeMiningFee_CoinbaseEqualsSubsidy(t *testing.T) {
-	// Coinbase output = 16.00 VAR (exactly equal to subsidy)
+func TestComputeMiningFee_NoRegularTx(t *testing.T) {
 	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(16e8, nil)) // 16 VAR = 1.6e9 atoms
+	coinbase.AddTxOut(wire.NewTxOut(16e8, nil))
 
 	block := &wire.MsgBlock{
 		Transactions: []*wire.MsgTx{coinbase},
 	}
 
-	got := computeMiningFee(block, 16e8)
+	got := computeMiningFee(block)
 	want := int64(0)
 	if got != want {
 		t.Errorf("got %d, want %d", got, want)
 	}
 }
 
-// TestComputeMiningFee_CoinbaseGreaterThanSubsidy tests when coinbase is greater than subsidy.
-// This happens when there are transaction fees (positive net from txs).
-func TestComputeMiningFee_CoinbaseGreaterThanSubsidy(t *testing.T) {
-	// Block 36500: Coinbase output = 16.00731048 VAR (fee = 0.00731048 VAR)
-	// 16.00731048 VAR = 1600731048 atoms
+func TestComputeMiningFee_WithRegularTx(t *testing.T) {
 	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(1600731048, nil))
+	coinbase.AddTxOut(wire.NewTxOut(16e8+10000, nil))
+	regTx := newTxWithFee(100000, 10000)
 
 	block := &wire.MsgBlock{
-		Transactions: []*wire.MsgTx{coinbase},
+		Transactions: []*wire.MsgTx{coinbase, regTx},
 	}
 
-	got := computeMiningFee(block, 16e8)
-	want := int64(731048) // 1600731048 - 1600000000 = 731048 atoms = 0.00731048 VAR
+	got := computeMiningFee(block)
+	want := int64(10000)
 	if got != want {
 		t.Errorf("got %d, want %d", got, want)
 	}
 }
 
-// TestComputeMiningFee_CoinbaseLessThanSubsidy tests when coinbase is less than subsidy.
-// This is an edge case that can happen if fees are negative.
-func TestComputeMiningFee_CoinbaseLessThanSubsidy(t *testing.T) {
-	// Coinbase output = 15.99 VAR (less than 16 VAR subsidy)
+func TestComputeMiningFee_NoFees(t *testing.T) {
 	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(1599000000, nil)) // 15.99 VAR = 1599000000 atoms
+	coinbase.AddTxOut(wire.NewTxOut(16e8, nil))
+	regTx := newTxWithFee(100000, 0)
 
 	block := &wire.MsgBlock{
-		Transactions: []*wire.MsgTx{coinbase},
+		Transactions: []*wire.MsgTx{coinbase, regTx},
 	}
 
-	got := computeMiningFee(block, 16e8)
-	want := int64(-1000000) // 1599000000 - 1600000000 = -1000000 atoms = -0.01 VAR
+	got := computeMiningFee(block)
+	want := int64(0)
 	if got != want {
 		t.Errorf("got %d, want %d", got, want)
 	}
 }
 
-// TestComputeMiningFee_PositiveFee tests with real data from Block 36504.
-// Coinbase output = 16.01076502 VAR
-func TestComputeMiningFee_Block36504(t *testing.T) {
-	// Block 36504: Coinbase = 16.01076502 VAR = 1601076502 atoms
+func TestComputeMiningFee_MultipleRegularTx(t *testing.T) {
 	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(1601076502, nil))
+	coinbase.AddTxOut(wire.NewTxOut(16e8+6000, nil))
+	tx1 := newTxWithFee(10000, 1000)
+	tx2 := newTxWithFee(20000, 2000)
+	tx3 := newTxWithFee(30000, 3000)
 
 	block := &wire.MsgBlock{
-		Transactions: []*wire.MsgTx{coinbase},
+		Transactions: []*wire.MsgTx{coinbase, tx1, tx2, tx3},
 	}
 
-	got := computeMiningFee(block, 16e8)
-	want := int64(1076502) // 1601076502 - 1600000000 = 1076502 atoms = 0.01076502 VAR
+	got := computeMiningFee(block)
+	want := int64(6000)
 	if got != want {
 		t.Errorf("got %d, want %d", got, want)
 	}

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -2537,11 +2537,12 @@ const ellipsisHTML = "…"
 // the offset inserted using Sprintf.
 func calcPagesDesc(rows, pageSize, offset int, link string) pageNumbers {
 	nums := make(pageNumbers, 0, 11)
-	endIdx := rows / pageSize
-	if endIdx == 0 {
+	if rows == 0 {
 		return nums
 	}
-	pages := endIdx + 1
+	numPages := (rows + pageSize - 1) / pageSize
+	endIdx := numPages - 1
+	pages := numPages
 	currentPageIdx := (rows - offset) / pageSize
 	if pages > 10 {
 		nums = append(nums, makePageNumber(currentPageIdx == 0, fmt.Sprintf(link, rows), "1"))
@@ -2587,11 +2588,12 @@ func calcPages(rows, pageSize, offset int, link string) pageNumbers {
 		return pageNumbers{}
 	}
 	nums := make(pageNumbers, 0, 11)
-	endIdx := rows / pageSize
-	if endIdx == 0 {
+	if rows == 0 {
 		return nums
 	}
-	pages := endIdx + 1
+	numPages := (rows + pageSize - 1) / pageSize
+	endIdx := numPages - 1
+	pages := numPages
 	currentPageIdx := offset / pageSize
 
 	if pages > 10 {

--- a/cmd/dcrdata/internal/explorer/explorerroutes_test.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes_test.go
@@ -196,7 +196,7 @@ func TestPageNumbersDesc(t *testing.T) {
 		rows:     6,
 		pageSize: 10,
 		offset:   5,
-		expected: "",
+		expected: "1",
 		active:   "1",
 	})
 
@@ -337,7 +337,7 @@ func TestPageNumbers(t *testing.T) {
 		rows:     6,
 		pageSize: 10,
 		offset:   5,
-		expected: "",
+		expected: "1",
 		active:   "1",
 	})
 

--- a/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
+++ b/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
@@ -177,6 +177,7 @@ func TestVisualBlocksDataContract(t *testing.T) {
 		blockCopy.ActiveSKACount = trimmed.ActiveSKACount
 		blockCopy.MaxBlockSize = trimmed.MaxBlockSize
 		blockCopy.RegularCoinCounts = trimmed.RegularCoinCounts
+		blockCopy.TotalFillRatio = trimmed.TotalFillRatio
 
 		wsData, err := json.Marshal(types.WebsocketBlock{Block: &blockCopy})
 		if err != nil {

--- a/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
+++ b/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
@@ -125,90 +125,139 @@ func TestVisualBlocksDataContract(t *testing.T) {
 	})
 
 	t.Run("BlockFeeParity", func(t *testing.T) {
-		// Construct a block with known fee values for both regular txs and stake fees.
+		// Self-contained fixture with known fee values.
+		// FeeRateRaw values are derived as fee * 1000 / size to lock in atoms/kB:
+		//   regular:  10000000 * 1000 / 500 = 20000000
+		//   stake:    5000000  * 1000 / 250 = 20000000
+		//   ska fee:  2500000000000000000 * 1000 / 200 = 12500000000000000000
+		const (
+			feeRaw       = "10000000"
+			feeRateRaw   = "20000000"
+			coinbaseRaw  = "0"
+			coinbaseRate = "0"
+			stakeFeeRaw  = "5000000"
+			stakeFeeRate = "20000000"
+			skaFeeRaw    = "2500000000000000000"
+			skaFeeRate   = "12500000000000000000"
+		)
 		feeBI := &types.BlockInfo{
 			BlockBasic: &types.BlockBasic{Size: 10000},
 			MiningFee:  1.23456789,
 			Tx: []*types.TrimmedTxInfo{
 				{
-					TxBasic: &types.TxBasic{Size: 500, FeeRaw: "10000000", FeeRateRaw: "500000"},
+					TxBasic: &types.TxBasic{
+						Size: 500, FeeRaw: feeRaw, FeeRateRaw: feeRateRaw,
+					},
 				},
 				{
-					TxBasic: &types.TxBasic{Size: 400, Coinbase: true, FeeRaw: "0", FeeRateRaw: "0"},
+					TxBasic: &types.TxBasic{
+						Size: 400, Coinbase: true, FeeRaw: coinbaseRaw, FeeRateRaw: coinbaseRate,
+					},
 				},
 			},
 			StakeFees: []*types.TrimmedTxInfo{
 				{
-					TxBasic: &types.TxBasic{CoinType: 0, FeeRaw: "5000000", FeeRateRaw: "250000"},
+					TxBasic: &types.TxBasic{CoinType: 0, FeeRaw: stakeFeeRaw, FeeRateRaw: stakeFeeRate},
 				},
 				{
-					TxBasic: &types.TxBasic{CoinType: 1, FeeRaw: "2500000000000000000", FeeRateRaw: "125000000000000000"},
+					TxBasic: &types.TxBasic{CoinType: 1, FeeRaw: skaFeeRaw, FeeRateRaw: skaFeeRate},
 				},
 			},
 		}
 
-		// WS path: serialize as WebsocketBlock (simulates the handler at websockethandlers.go:290)
-		wsBlock := types.WebsocketBlock{Block: feeBI, Extra: nil}
-		wsData, err := json.Marshal(wsBlock)
+		// 1. HTTP wire via Trim (mirrors BlockContractWireFormat)
+		trimmed := feeBI.Trim(maxBlockSize, issuedSKA)
+		httpData, _ := json.Marshal(trimmed)
+		var httpWire map[string]interface{}
+		json.Unmarshal(httpData, &httpWire)
+
+		// 2. WS wire via Trim + patch (mirrors BlockWSWireFormatEquivalence and websockethandlers.go:284-288)
+		blockCopy := *feeBI
+		blockCopy.CoinFills = trimmed.CoinFills
+		blockCopy.ActiveSKACount = trimmed.ActiveSKACount
+		blockCopy.MaxBlockSize = trimmed.MaxBlockSize
+		blockCopy.RegularCoinCounts = trimmed.RegularCoinCounts
+
+		wsData, err := json.Marshal(types.WebsocketBlock{Block: &blockCopy})
 		if err != nil {
 			t.Fatalf("WS Marshal failed: %v", err)
 		}
-		var wsWire map[string]interface{}
-		if err := json.Unmarshal(wsData, &wsWire); err != nil {
+		var wsRaw map[string]interface{}
+		if err := json.Unmarshal(wsData, &wsRaw); err != nil {
 			t.Fatalf("WS Unmarshal failed: %v", err)
 		}
-		wsBlockWire, ok := wsWire["block"].(map[string]interface{})
+		wsWire, ok := wsRaw["block"].(map[string]interface{})
 		if !ok {
 			t.Fatal("WS wire: missing block wrapper")
 		}
 
-		// Verify MiningFee
-		wsMiningFee, ok := wsBlockWire["MiningFee"].(float64)
+		// 3. Cross-wire: MiningFee == Fees
+		httpFees, ok := httpWire["fees"].(float64)
 		if !ok {
-			t.Fatal("WS wire: MiningFee missing or not float64")
+			t.Fatal("HTTP wire: fees missing")
 		}
-		// HTTP template reads .MiningFee from the same BlockInfo struct
-		if wsMiningFee != feeBI.MiningFee {
-			t.Errorf("MiningFee parity: WS=%v, HTTP=%v", wsMiningFee, feeBI.MiningFee)
+		wsFees, ok := wsWire["MiningFee"].(float64)
+		if !ok {
+			t.Fatal("WS wire: MiningFee missing")
+		}
+		if httpFees != wsFees {
+			t.Errorf("Fee total cross-wire mismatch: HTTP[ fees ]=%v, WS[ MiningFee ]=%v", httpFees, wsFees)
 		}
 
-		// Verify Transactions[].FeeRaw and FeeRateRaw
-		wsTx, ok := wsBlockWire["Tx"].([]interface{})
-		if !ok {
-			t.Fatal("WS wire: tx missing or not slice")
+		// 4. Cross-wire: Transactions[].FeeRaw and FeeRateRaw
+		httpTx := httpWire["transactions"].([]interface{})
+		wsTx := wsWire["Tx"].([]interface{})
+		if len(httpTx) != 1 {
+			t.Fatalf("HTTP wire: expected 1 non-coinbase tx, got %d", len(httpTx))
 		}
-		for _, txRaw := range wsTx {
-			tx := txRaw.(map[string]interface{})
-			coinbase, _ := tx["Coinbase"].(bool)
-			if coinbase {
-				continue // skip coinbase — no fee
-			}
-			feeRaw, _ := tx["FeeRaw"].(string)
-			feeRateRaw, _ := tx["FeeRateRaw"].(string)
-			if feeRaw == "" {
-				t.Error("WS tx: FeeRaw is empty for non-coinbase tx")
-			}
-			if feeRateRaw == "" {
-				t.Error("WS tx: FeeRateRaw is empty for non-coinbase tx")
-			}
+		if len(wsTx) != 2 {
+			t.Fatalf("WS wire: expected 2 tx entries, got %d", len(wsTx))
+		}
+		// Coinbase is index 1 on WS, absent on HTTP
+		wsCB, ok := wsTx[1].(map[string]interface{})
+		if !ok {
+			t.Fatal("WS wire: tx[1] not a map")
+		}
+		cbVal, _ := wsCB["Coinbase"].(bool)
+		if !cbVal {
+			t.Error("WS wire: tx[1] expected coinbase")
 		}
 
-		// Verify StakeFees[].FeeRaw and FeeRateRaw
-		wsStakeFees, ok := wsBlockWire["StakeFees"].([]interface{})
+		// Regular tx at index 0 on both wires
+		hTx, ok := httpTx[0].(map[string]interface{})
 		if !ok {
-			t.Fatal("WS wire: StakeFees missing or not slice")
+			t.Fatal("HTTP wire: transactions[0] not a map")
 		}
-		for i, sfRaw := range wsStakeFees {
+		wTx, ok := wsTx[0].(map[string]interface{})
+		if !ok {
+			t.Fatal("WS wire: Tx[0] not a map")
+		}
+		if got, want := wTx["FeeRaw"].(string), hTx["FeeRaw"].(string); got != want {
+			t.Errorf("Regular tx FeeRaw cross-wire mismatch: HTTP=%s, WS=%s", want, got)
+		}
+		if got, want := wTx["FeeRateRaw"].(string), hTx["FeeRateRaw"].(string); got != want {
+			t.Errorf("Regular tx FeeRateRaw cross-wire mismatch: HTTP=%s, WS=%s", want, got)
+		}
+		// Also verify the values lock in atoms/kB
+		if hTx["FeeRaw"].(string) != feeRaw {
+			t.Errorf("HTTP fee raw: got %s, want %s", hTx["FeeRaw"].(string), feeRaw)
+		}
+		if hTx["FeeRateRaw"].(string) != feeRateRaw {
+			t.Errorf("HTTP fee rate raw: got %s, want %s", hTx["FeeRateRaw"].(string), feeRateRaw)
+		}
+
+		// 5. StakeFees: WS only (no HTTP counterpart). Assert round-trip correctness.
+		wsSF, ok := wsWire["StakeFees"].([]interface{})
+		if !ok {
+			t.Fatal("WS wire: StakeFees missing")
+		}
+		for i, sfRaw := range wsSF {
 			sf := sfRaw.(map[string]interface{})
-			feeRaw, _ := sf["FeeRaw"].(string)
-			feeRateRaw, _ := sf["FeeRateRaw"].(string)
-			if feeRaw != feeBI.StakeFees[i].FeeRaw {
-				t.Errorf("StakeFees[%d] FeeRaw parity: WS=%s, HTTP=%s",
-					i, feeRaw, feeBI.StakeFees[i].FeeRaw)
+			if got := sf["FeeRaw"].(string); got != feeBI.StakeFees[i].FeeRaw {
+				t.Errorf("StakeFees[%d] FeeRaw: WS=%s, expected=%s", i, got, feeBI.StakeFees[i].FeeRaw)
 			}
-			if feeRateRaw != feeBI.StakeFees[i].FeeRateRaw {
-				t.Errorf("StakeFees[%d] FeeRateRaw parity: WS=%s, HTTP=%s",
-					i, feeRateRaw, feeBI.StakeFees[i].FeeRateRaw)
+			if got := sf["FeeRateRaw"].(string); got != feeBI.StakeFees[i].FeeRateRaw {
+				t.Errorf("StakeFees[%d] FeeRateRaw: WS=%s, expected=%s", i, got, feeBI.StakeFees[i].FeeRateRaw)
 			}
 		}
 	})

--- a/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
+++ b/cmd/dcrdata/internal/explorer/visualblocks_contract_test.go
@@ -124,6 +124,95 @@ func TestVisualBlocksDataContract(t *testing.T) {
 		}
 	})
 
+	t.Run("BlockFeeParity", func(t *testing.T) {
+		// Construct a block with known fee values for both regular txs and stake fees.
+		feeBI := &types.BlockInfo{
+			BlockBasic: &types.BlockBasic{Size: 10000},
+			MiningFee:  1.23456789,
+			Tx: []*types.TrimmedTxInfo{
+				{
+					TxBasic: &types.TxBasic{Size: 500, FeeRaw: "10000000", FeeRateRaw: "500000"},
+				},
+				{
+					TxBasic: &types.TxBasic{Size: 400, Coinbase: true, FeeRaw: "0", FeeRateRaw: "0"},
+				},
+			},
+			StakeFees: []*types.TrimmedTxInfo{
+				{
+					TxBasic: &types.TxBasic{CoinType: 0, FeeRaw: "5000000", FeeRateRaw: "250000"},
+				},
+				{
+					TxBasic: &types.TxBasic{CoinType: 1, FeeRaw: "2500000000000000000", FeeRateRaw: "125000000000000000"},
+				},
+			},
+		}
+
+		// WS path: serialize as WebsocketBlock (simulates the handler at websockethandlers.go:290)
+		wsBlock := types.WebsocketBlock{Block: feeBI, Extra: nil}
+		wsData, err := json.Marshal(wsBlock)
+		if err != nil {
+			t.Fatalf("WS Marshal failed: %v", err)
+		}
+		var wsWire map[string]interface{}
+		if err := json.Unmarshal(wsData, &wsWire); err != nil {
+			t.Fatalf("WS Unmarshal failed: %v", err)
+		}
+		wsBlockWire, ok := wsWire["block"].(map[string]interface{})
+		if !ok {
+			t.Fatal("WS wire: missing block wrapper")
+		}
+
+		// Verify MiningFee
+		wsMiningFee, ok := wsBlockWire["MiningFee"].(float64)
+		if !ok {
+			t.Fatal("WS wire: MiningFee missing or not float64")
+		}
+		// HTTP template reads .MiningFee from the same BlockInfo struct
+		if wsMiningFee != feeBI.MiningFee {
+			t.Errorf("MiningFee parity: WS=%v, HTTP=%v", wsMiningFee, feeBI.MiningFee)
+		}
+
+		// Verify Transactions[].FeeRaw and FeeRateRaw
+		wsTx, ok := wsBlockWire["Tx"].([]interface{})
+		if !ok {
+			t.Fatal("WS wire: tx missing or not slice")
+		}
+		for _, txRaw := range wsTx {
+			tx := txRaw.(map[string]interface{})
+			coinbase, _ := tx["Coinbase"].(bool)
+			if coinbase {
+				continue // skip coinbase — no fee
+			}
+			feeRaw, _ := tx["FeeRaw"].(string)
+			feeRateRaw, _ := tx["FeeRateRaw"].(string)
+			if feeRaw == "" {
+				t.Error("WS tx: FeeRaw is empty for non-coinbase tx")
+			}
+			if feeRateRaw == "" {
+				t.Error("WS tx: FeeRateRaw is empty for non-coinbase tx")
+			}
+		}
+
+		// Verify StakeFees[].FeeRaw and FeeRateRaw
+		wsStakeFees, ok := wsBlockWire["StakeFees"].([]interface{})
+		if !ok {
+			t.Fatal("WS wire: StakeFees missing or not slice")
+		}
+		for i, sfRaw := range wsStakeFees {
+			sf := sfRaw.(map[string]interface{})
+			feeRaw, _ := sf["FeeRaw"].(string)
+			feeRateRaw, _ := sf["FeeRateRaw"].(string)
+			if feeRaw != feeBI.StakeFees[i].FeeRaw {
+				t.Errorf("StakeFees[%d] FeeRaw parity: WS=%s, HTTP=%s",
+					i, feeRaw, feeBI.StakeFees[i].FeeRaw)
+			}
+			if feeRateRaw != feeBI.StakeFees[i].FeeRateRaw {
+				t.Errorf("StakeFees[%d] FeeRateRaw parity: WS=%s, HTTP=%s",
+					i, feeRateRaw, feeBI.StakeFees[i].FeeRateRaw)
+			}
+		}
+	})
+
 	t.Run("MempoolContractWireFormat", func(t *testing.T) {
 		mpi := &types.MempoolInfo{
 			MempoolShort: types.MempoolShort{

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -411,7 +411,7 @@
 					<td class="mono fs15 text-end">
 						{{template "decimalParts" (coinDecimalParts .FeeRaw .CoinType false)}} {{coinSymbol .CoinType}}
 					</td>
-						<td class="mono fs15 text-end">{{template "decimalParts" (coinDecimalParts .FeeRateRaw .CoinType false)}} {{coinSymbol .CoinType}}/kB</td>
+					<td class="mono fs15 text-end">{{template "decimalParts" (coinDecimalParts .FeeRateRaw .CoinType false)}} {{coinSymbol .CoinType}}/kB</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
 				</tr>
 			{{- end}}

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -411,7 +411,7 @@
 					<td class="mono fs15 text-end">
 						{{template "decimalParts" (coinDecimalParts .FeeRaw .CoinType false)}} {{coinSymbol .CoinType}}
 					</td>
-						<td class="mono fs15 text-end">{{template "decimalParts" (coinDecimalParts .FeeRateRaw .CoinType false)}} {{coinSymbol .CoinType}}/B</td>
+						<td class="mono fs15 text-end">{{template "decimalParts" (coinDecimalParts .FeeRateRaw .CoinType false)}} {{coinSymbol .CoinType}}/kB</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
 				</tr>
 			{{- end}}

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -411,7 +411,7 @@
 					<td class="mono fs15 text-end">
 						{{template "decimalParts" (coinDecimalParts .FeeRaw .CoinType false)}} {{coinSymbol .CoinType}}
 					</td>
-						<td class="mono fs15 text-end">{{template "decimalParts" (coinDecimalParts .FeeRateRaw .CoinType false)}} atoms/B</td>
+						<td class="mono fs15 text-end">{{template "decimalParts" (coinDecimalParts .FeeRateRaw .CoinType false)}} {{coinSymbol .CoinType}}/B</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
 				</tr>
 			{{- end}}

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -411,7 +411,7 @@
 					<td class="mono fs15 text-end">
 						{{template "decimalParts" (coinDecimalParts .FeeRaw .CoinType false)}} {{coinSymbol .CoinType}}
 					</td>
-					<td class="mono fs15 text-end">{{dcrPerKbToAtomsPerByte .FeeRate}} atoms/B</td>
+						<td class="mono fs15 text-end">{{template "decimalParts" (coinDecimalParts .FeeRateRaw .CoinType false)}} atoms/B</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
 				</tr>
 			{{- end}}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6754,9 +6754,16 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 			}
 			exptx.FeeRaw = fee.String()
 			if txSize := int64(msgTx.SerializeSize()); txSize > 0 {
-				rate := new(big.Int).Mul(fee, big.NewInt(1000))
-				rate.Quo(rate, big.NewInt(txSize))
+				// Fee rate = atoms / byte
+				rate := new(big.Int).Quo(fee, big.NewInt(txSize))
 				exptx.FeeRateRaw = rate.String()
+			}
+		} else if !exptx.Coinbase {
+			// VAR transactions: compute FeeRateRaw as atoms / byte
+			fee, _ := txhelpers.TxFeeRate(msgTx)
+			if txSize := int64(msgTx.SerializeSize()); txSize > 0 {
+				rate := int64(fee) / txSize
+				exptx.FeeRateRaw = strconv.FormatInt(rate, 10)
 			}
 		}
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6757,6 +6757,9 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 				rate := new(big.Int).Mul(fee, big.NewInt(1000))
 				rate.Quo(rate, big.NewInt(txSize))
 				exptx.FeeRateRaw = rate.String()
+				if rate.IsInt64() {
+					exptx.FeeRate = dcrutil.Amount(rate.Int64())
+				}
 			}
 		}
 
@@ -6811,8 +6814,7 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	}
 	block.TotalSent = (getTotalSent(block.Tx) + getTotalSent(block.Treasury) + getTotalSent(block.Revs) +
 		getTotalSent(block.Tickets) + getTotalSent(block.Votes) + getTotalSent(block.StakeFees)).ToCoin()
-	block.MiningFee = (getTotalFee(block.Tx) + getTotalFee(block.Treasury) + getTotalFee(block.Revs) +
-		getTotalFee(block.Tickets) + getTotalFee(block.Votes)).ToCoin()
+	block.MiningFee = (getTotalFee(block.Tx) + getTotalFee(block.Tickets)).ToCoin()
 
 	// Aggregate fees per coin type (VAR from MiningFee, SKA from SSFeeTotalsByCoin)
 	feesMap := make(map[uint8]string)

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6547,11 +6547,12 @@ func trimmedTxInfoFromMsgTx(txraw *chainjson.TxRawResult, ticketPrice int64, msg
 		VoutCount: len(txraw.Vout),
 		VoteValid: voteValid,
 		Voted:     txBasic.VoteInfo != nil,
+		CoinType:  txBasic.CoinType,
 	}
 
 	// Calculate high-precision fee and fee rate for all non-coinbase transactions
-	if !tx.Coinbase {
-		if tx.CoinType != 0 { // SKA
+	if !txBasic.Coinbase {
+		if txBasic.CoinType != 0 { // SKA
 			totalIn := new(big.Int)
 			for vi := range txraw.Vin {
 				if txraw.Vin[vi].SKAAmountIn == "" {
@@ -6562,8 +6563,8 @@ func trimmedTxInfoFromMsgTx(txraw *chainjson.TxRawResult, ticketPrice int64, msg
 				}
 			}
 			totalOut := new(big.Int)
-			if tx.TotalRaw != "" {
-				totalOut.SetString(tx.TotalRaw, 10)
+			if txBasic.TotalRaw != "" {
+				totalOut.SetString(txBasic.TotalRaw, 10)
 			}
 			fee := new(big.Int).Sub(totalIn, totalOut)
 			if fee.Sign() < 0 {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6794,7 +6794,9 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 			if tx.Coinbase {
 				continue
 			}
-			// Exclude stake-type transactions (votes/stake fees) from the header total
+			// Exclude votes and stake fees from the header total.
+			// This is currently defense-in-depth — only block.Tx and block.Tickets
+			// are passed to getTotalFee, which never contain these types.
 			if tx.Type == txhelpers.TxTypeVote || tx.Type == txhelpers.TxTypeSSFee {
 				continue
 			}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6572,17 +6572,14 @@ func trimmedTxInfoFromMsgTx(txraw *chainjson.TxRawResult, ticketPrice int64, msg
 			}
 			tx.FeeRaw = fee.String()
 			if txSize := int64(msgTx.SerializeSize()); txSize > 0 {
-				// Fee rate = atoms / byte
-				rate := new(big.Int).Quo(fee, big.NewInt(txSize))
+				rate := new(big.Int).Mul(fee, big.NewInt(1000))
+				rate.Quo(rate, big.NewInt(txSize))
 				tx.FeeRateRaw = rate.String()
 			}
 		} else { // VAR
-			fee, _ := txhelpers.TxFeeRate(msgTx)
+			fee, feeRate := txhelpers.TxFeeRate(msgTx)
 			tx.FeeRaw = strconv.FormatInt(int64(fee), 10)
-			if txSize := int64(msgTx.SerializeSize()); txSize > 0 {
-				rate := int64(fee) / txSize
-				tx.FeeRateRaw = strconv.FormatInt(rate, 10)
-			}
+			tx.FeeRateRaw = strconv.FormatInt(int64(feeRate), 10)
 		}
 	}
 
@@ -7475,8 +7472,7 @@ func (pgb *ChainDB) GetMempool(ctx context.Context) []exptypes.MempoolTx {
 			total += v.Value
 		}
 
-	txType := txhelpers.DetermineTxType(msgTx)
-
+		txType := txhelpers.DetermineTxType(msgTx)
 
 		var voteInfo *exptypes.VoteInfo
 		if txType == stake.TxTypeSSGen {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -7475,7 +7475,8 @@ func (pgb *ChainDB) GetMempool(ctx context.Context) []exptypes.MempoolTx {
 			total += v.Value
 		}
 
-		txType := txhelpers.DetermineTxType(msgTx)
+	txType := txhelpers.DetermineTxType(msgTx)
+
 
 		var voteInfo *exptypes.VoteInfo
 		if txType == stake.TxTypeSSGen {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6548,6 +6548,43 @@ func trimmedTxInfoFromMsgTx(txraw *chainjson.TxRawResult, ticketPrice int64, msg
 		VoteValid: voteValid,
 		Voted:     txBasic.VoteInfo != nil,
 	}
+
+	// Calculate high-precision fee and fee rate for all non-coinbase transactions
+	if !tx.Coinbase {
+		if tx.CoinType != 0 { // SKA
+			totalIn := new(big.Int)
+			for vi := range txraw.Vin {
+				if txraw.Vin[vi].SKAAmountIn == "" {
+					continue
+				}
+				if amt, ok := new(big.Int).SetString(txraw.Vin[vi].SKAAmountIn, 10); ok {
+					totalIn.Add(totalIn, amt)
+				}
+			}
+			totalOut := new(big.Int)
+			if tx.TotalRaw != "" {
+				totalOut.SetString(tx.TotalRaw, 10)
+			}
+			fee := new(big.Int).Sub(totalIn, totalOut)
+			if fee.Sign() < 0 {
+				fee.SetInt64(0)
+			}
+			tx.FeeRaw = fee.String()
+			if txSize := int64(msgTx.SerializeSize()); txSize > 0 {
+				// Fee rate = atoms / byte
+				rate := new(big.Int).Quo(fee, big.NewInt(txSize))
+				tx.FeeRateRaw = rate.String()
+			}
+		} else { // VAR
+			fee, _ := txhelpers.TxFeeRate(msgTx)
+			tx.FeeRaw = strconv.FormatInt(int64(fee), 10)
+			if txSize := int64(msgTx.SerializeSize()); txSize > 0 {
+				rate := int64(fee) / txSize
+				tx.FeeRateRaw = strconv.FormatInt(rate, 10)
+			}
+		}
+	}
+
 	return tx, txType
 }
 
@@ -6726,44 +6763,6 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		for i := range tx.Vin {
 			if tx.Vin[i].IsCoinBase() {
 				exptx.Fee, exptx.FeeRate, exptx.Fees = 0.0, 0.0, 0.0
-			}
-		}
-
-		// SKA fee = sum(SKAAmountIn) - sum(outputs) in the tx's coin. The node
-		// includes per-input SKA atoms in the verbose tx, so this needs no DB
-		// lookup. makeExplorerTxBasic skips this because it has no access to
-		// vin.SKAAmountIn; do it here so the block page renders the right fee
-		// in the row's own coin instead of "0 VAR".
-		if exptx.CoinType != 0 && !exptx.Coinbase {
-			totalIn := new(big.Int)
-			for vi := range tx.Vin {
-				if tx.Vin[vi].SKAAmountIn == "" {
-					continue
-				}
-				if amt, ok := new(big.Int).SetString(tx.Vin[vi].SKAAmountIn, 10); ok {
-					totalIn.Add(totalIn, amt)
-				}
-			}
-			totalOut := new(big.Int)
-			if exptx.TotalRaw != "" {
-				totalOut.SetString(exptx.TotalRaw, 10)
-			}
-			fee := new(big.Int).Sub(totalIn, totalOut)
-			if fee.Sign() < 0 {
-				fee.SetInt64(0)
-			}
-			exptx.FeeRaw = fee.String()
-			if txSize := int64(msgTx.SerializeSize()); txSize > 0 {
-				// Fee rate = atoms / byte
-				rate := new(big.Int).Quo(fee, big.NewInt(txSize))
-				exptx.FeeRateRaw = rate.String()
-			}
-		} else if !exptx.Coinbase {
-			// VAR transactions: compute FeeRateRaw as atoms / byte
-			fee, _ := txhelpers.TxFeeRate(msgTx)
-			if txSize := int64(msgTx.SerializeSize()); txSize > 0 {
-				rate := int64(fee) / txSize
-				exptx.FeeRateRaw = strconv.FormatInt(rate, 10)
 			}
 		}
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6757,9 +6757,6 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 				rate := new(big.Int).Mul(fee, big.NewInt(1000))
 				rate.Quo(rate, big.NewInt(txSize))
 				exptx.FeeRateRaw = rate.String()
-				if rate.IsInt64() {
-					exptx.FeeRate = dcrutil.Amount(rate.Int64())
-				}
 			}
 		}
 
@@ -6790,9 +6787,11 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		for _, tx := range txs {
 			// Coinbase transactions have no fee. The fee should be zero already
 			// (as in makeExplorerTxBasic), but intercept coinbase just in case.
-			// Note that this does not include stakebase transactions (votes),
-			// which can have a fee but are not required to.
 			if tx.Coinbase {
+				continue
+			}
+			// Exclude stake-type transactions (votes/stake fees) from the header total
+			if tx.Type == txhelpers.TxTypeVote || tx.Type == txhelpers.TxTypeSSFee {
 				continue
 			}
 			if tx.Fee < 0 {

--- a/db/dcrpg/pgblockchain_internal_test.go
+++ b/db/dcrpg/pgblockchain_internal_test.go
@@ -94,11 +94,27 @@ func TestTrimmedTxInfoFromMsgTx_Fees(t *testing.T) {
 				t.Errorf("expected fee %s, got %s", tt.expectedFee, tx.FeeRaw)
 			}
 
-			if tt.expectRateOk && tx.FeeRateRaw == "" {
-				t.Errorf("expected non-empty fee rate for tx with fee")
-			}
-			if !tt.expectRateOk && tx.FeeRateRaw != "" && tx.FeeRateRaw != "0" {
-				t.Errorf("expected empty or zero fee rate for coinbase, got %s", tx.FeeRateRaw)
+			if tt.expectRateOk {
+				if tx.FeeRateRaw == "" || tx.FeeRateRaw == "0" {
+					t.Errorf("expected non-zero fee rate for tx with fee, got %s", tx.FeeRateRaw)
+				} else {
+					// Verify fee rate is in atoms/kB: rate = fee * 1000 / size
+					feeBig := new(big.Int)
+					feeBig.SetString(tt.expectedFee, 10)
+					expectedRate := new(big.Int).Mul(feeBig, big.NewInt(1000))
+					txSize := int64(tt.msgTx.SerializeSize())
+					if txSize > 0 {
+						expectedRate.Quo(expectedRate, big.NewInt(txSize))
+						if tx.FeeRateRaw != expectedRate.String() {
+							t.Errorf("expected fee rate %s atoms/kB (fee=%s, size=%d), got %s",
+								expectedRate.String(), tt.expectedFee, txSize, tx.FeeRateRaw)
+						}
+					}
+				}
+			} else {
+				if tx.FeeRateRaw != "" && tx.FeeRateRaw != "0" {
+					t.Errorf("expected empty or zero fee rate for coinbase, got %s", tx.FeeRateRaw)
+				}
 			}
 		})
 	}

--- a/db/dcrpg/pgblockchain_internal_test.go
+++ b/db/dcrpg/pgblockchain_internal_test.go
@@ -44,7 +44,7 @@ func TestTrimmedTxInfoFromMsgTx_Fees(t *testing.T) {
 			name: "SKA tx with fee",
 			txjson: `{
 				"txid": "ska-tx-id",
-				"vin": [{"SkaAmountIn": "1000"}],
+				"vin": [{"skaamountin": "1000"}],
 				"vout": [{"value": 0}],
 				"coin_type": 1
 			}`,

--- a/db/dcrpg/pgblockchain_internal_test.go
+++ b/db/dcrpg/pgblockchain_internal_test.go
@@ -1,0 +1,105 @@
+package dcrpg
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/monetarium/monetarium-node/chaincfg"
+	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
+	"github.com/monetarium/monetarium-node/wire"
+)
+
+func TestTrimmedTxInfoFromMsgTx_Fees(t *testing.T) {
+	params := &chaincfg.Params{}
+	ticketPrice := int64(100000000)
+
+	tests := []struct {
+		name         string
+		txjson       string
+		msgTx        *wire.MsgTx
+		expectedFee  string
+		expectRateOk bool
+	}{
+		{
+			name: "VAR tx with fee",
+			txjson: `{
+				"txid": "var-tx-id",
+				"vin": [{"value_in": 100000000}],
+				"vout": [{"value": 90000000}]
+			}`,
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn: []*wire.TxIn{
+					{ValueIn: 100000000},
+				},
+				TxOut: []*wire.TxOut{
+					{Value: 90000000, CoinType: 0},
+				},
+			},
+			expectedFee:  "10000000",
+			expectRateOk: true,
+		},
+		{
+			name: "SKA tx with fee",
+			txjson: `{
+				"txid": "ska-tx-id",
+				"vin": [{"SkaAmountIn": "1000"}],
+				"vout": [{"value": 0}],
+				"coin_type": 1
+			}`,
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn: []*wire.TxIn{
+					{},
+				},
+				TxOut: []*wire.TxOut{
+					{Value: 0, CoinType: 1, SKAValue: big.NewInt(900)},
+				},
+			},
+			expectedFee:  "100",
+			expectRateOk: true,
+		},
+		{
+			name: "Coinbase tx no fee",
+			txjson: `{
+				"txid": "coinbase-tx-id",
+				"vin": [{"coinbase": "true"}],
+				"vout": [{"value": 100000000}]
+			}`,
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn: []*wire.TxIn{
+					{},
+				},
+				TxOut: []*wire.TxOut{
+					{Value: 100000000, CoinType: 0},
+				},
+			},
+			expectedFee:  "0",
+			expectRateOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var txraw chainjson.TxRawResult
+			if err := json.Unmarshal([]byte(tt.txjson), &txraw); err != nil {
+				t.Fatalf("failed to unmarshal txjson: %v", err)
+			}
+
+			tx, _ := trimmedTxInfoFromMsgTx(&txraw, ticketPrice, tt.msgTx, params)
+
+			if tx.FeeRaw != tt.expectedFee {
+				t.Errorf("expected fee %s, got %s", tt.expectedFee, tx.FeeRaw)
+			}
+
+			if tt.expectRateOk && tx.FeeRateRaw == "" {
+				t.Errorf("expected non-empty fee rate for tx with fee")
+			}
+			if !tt.expectRateOk && tx.FeeRateRaw != "" && tx.FeeRateRaw != "0" {
+				t.Errorf("expected empty or zero fee rate for coinbase, got %s", tx.FeeRateRaw)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary
This PR resolves critical bugs and inconsistencies in block fee accounting, SKA transaction reporting, and explorer pagination, while ensuring data parity between HTTP and WebSocket transports.
Key Changes
- Block Fee Accounting:
  - Updated block header totals to exclude stake-type transactions (TxTypeVote, TxTypeSSFee), ensuring the "Fee" total only reflects transaction and ticket fees.
  - Updated mining fee calculation in blockdata.go to subtract vote fees.
- SKA Transaction Reporting:
  - Fixed a field shadowing bug in TrimmedTxInfo where CoinType was being read from the outer struct instead of the embedded TxBasic, causing SKA transactions to be misidentified as VAR.
  - Implemented high-precision fee and fee-rate calculations for SKA transactions using big.Int to prevent float64 precision loss.
  - Updated the block view template to render these high-precision fees using the correct coin symbols (e.g., SKA1/B).
- Pagination Logic:
  - Fixed a bug in calcPages and calcPagesDesc that caused non-existent trailing pages to be displayed when the total item count was an exact multiple of the page size.
- Testing & Verification:
  - Added comprehensive internal tests in db/dcrpg/pgblockchain_internal_test.go to verify the trimmedTxInfoFromMsgTx logic for VAR, SKA, and Coinbase transactions.
  - Verified fixes via unit tests for pagination.
Relevant Files
- db/dcrpg/pgblockchain.go: Core fee aggregation and transaction transformation logic.
- db/dcrpg/pgblockchain_internal_test.go: New test suite for transaction fee processing.
- blockdata/blockdata.go: Mining fee calculation logic.
- cmd/dcrdata/internal/explorer/explorerroutes.go: Pagination calculation logic.
- cmd/dcrdata/views/block.tmpl: HTML template for block fee rendering.