### PR TITLE
cmd/dcrdata: clear address chart title from y-axis labels

### DIFF
--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -315,7 +315,7 @@ body.darkBG .chartview .dygraph-y2label {
   position: absolute;
   left: 1em;
   right: 2em;
-  top: 1em;
+  top: 2.5em;
   bottom: 1em;
 }
 

--- a/cmd/dcrdata/views/address.tmpl
+++ b/cmd/dcrdata/views/address.tmpl
@@ -251,7 +251,7 @@
             <div class="p-3 address_chart_wrap">
               <div class="expando monicon-expand" data-address-target="expando" data-action="click->address#toggleExpand"></div>
               <div class="py-5 fs16 d-none" data-address-target="noconfirms"></div>
-              <div class="text-start fs14 fw-bold text-secondary mb-1" data-address-target="chartTitle"></div>
+              <div class="text-start fs14 fw-bold text-secondary mt-n1 mb-1" data-address-target="chartTitle"></div>
               <div data-address-target="chart" class="address_chart"></div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Follow-up to #313. The address chart canvas was anchored at `top: 1em` inside `.address_chart_wrap`, so the in-flow `chartTitle` div and the first y-axis tick label sat at roughly the same vertical position — the rotated ylabel had previously hidden this, but once it was replaced by a horizontal title the collision became visible on VAR (`Balance (VAR)` overlapped the topmost tick label like `0.4`).

- [cmd/dcrdata/public/scss/charts.scss](cmd/dcrdata/public/scss/charts.scss#L318) — `.address_chart` `top: 1em` → `2.5em` (reserve ~1.5em empty space at top of the canvas area)
- [cmd/dcrdata/views/address.tmpl](cmd/dcrdata/views/address.tmpl#L254) — `chartTitle` gets `mt-n1` so the title nudges up into the newly available space

## Test plan

Verified live on the testnet explorer at `:17778` for an address with both VAR and SKA1 activity. Across all chart × coin combinations the title now sits clear of the y-axis labels (~23px gap measured on `Balance (VAR)`):

- [x] VAR / balance — `Balance (VAR)` clears `0 / 0.2 / 0.4`
- [x] VAR / amountflow — `Total (VAR)` clears `0 / 50 / 100`
- [x] VAR / types — `Tx Count` clears `0 / 10`
- [x] SKA1 / balance — `Balance (SKA1)` clears `0 / 2000000Q / 4000000Q` long tick strings
- [x] SKA1 / amountflow — `Total (SKA1)` clears long tick strings
- [x] No regression on the other charts page (uses a different controller)

Pre-commit hooks pass (prettier / eslint / stylelint / vitest 299 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)