### PR TITLE
.github/workflows: grant id-token write and bump checkout to v6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   review:
@@ -16,7 +17,7 @@ jobs:
       github.event.pull_request.base.ref == 'develop'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission so the Claude Code Review job can mint an OIDC token.
- Bump `actions/checkout` from v4 to v6.

## Test plan
- [ ] Trigger the Claude Code Review workflow on a PR targeting `develop` and confirm the job runs to completion without auth or checkout errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)