### PR TITLE
fix: compute SSFee reward from net output, rename Fee column to Rewards

### DIFF
--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -357,7 +357,7 @@
 				<tr>
 					<th>Transaction ID</th>
 					<th class="text-end">Total</th>
-					<th class="text-end">Fee</th>
+					<th class="text-end">Rewards</th>
 					<th class="text-end">Size</th>
 				</tr>
 			</thead>

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6734,9 +6734,26 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 		case stake.TxTypeTAdd, stake.TxTypeTSpend, stake.TxTypeTreasuryBase:
 			treasury = append(treasury, stx)
 		case stake.TxTypeSSFee:
-			// Set CoinType from first output
 			if len(msgTx.TxOut) > 0 {
-				stx.CoinType = uint8(msgTx.TxOut[0].CoinType)
+				// Determine coin type from the first SKA payout output.
+				// TxOut[0] may be a zero-value OP_RETURN marker (CoinType 0).
+				for _, out := range msgTx.TxOut {
+					if out.CoinType.IsSKA() && out.SKAValue != nil {
+						stx.CoinType = uint8(out.CoinType)
+						break
+					}
+				}
+				// SSFee is a distribution tx — the "fee" is the total
+				// reward amount (sum of all outputs with value).
+				totalReward := new(big.Int)
+				for _, out := range msgTx.TxOut {
+					if out.CoinType.IsSKA() && out.SKAValue != nil {
+						totalReward.Add(totalReward, out.SKAValue)
+					} else {
+						totalReward.Add(totalReward, big.NewInt(out.Value))
+					}
+				}
+				stx.FeeRaw = totalReward.String()
 			}
 			stakeFees = append(stakeFees, stx)
 		}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6743,24 +6743,7 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 						break
 					}
 				}
-				// SSFee is a distribution tx — the "reward" is the net
-				// value (totalOutput − totalInput), matching BlockSSFeeTotals.
-				net := new(big.Int)
-				for _, vin := range msgTx.TxIn {
-					if vin.SKAValueIn != nil {
-						net.Sub(net, vin.SKAValueIn)
-					} else {
-						net.Sub(net, big.NewInt(vin.ValueIn))
-					}
-				}
-				for _, out := range msgTx.TxOut {
-					if out.CoinType.IsSKA() && out.SKAValue != nil {
-						net.Add(net, out.SKAValue)
-					} else {
-						net.Add(net, big.NewInt(out.Value))
-					}
-				}
-				stx.FeeRaw = net.String()
+				stx.FeeRaw = ssFeeNetReward(msgTx).String()
 			}
 			stakeFees = append(stakeFees, stx)
 		}
@@ -6877,6 +6860,29 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	pgb.lastExplorerBlock.Unlock()
 
 	return block
+}
+
+// ssFeeNetReward computes the net reward for an SSFee transaction as
+// Σoutputs − Σinputs.  This matches blockSSFeeTotalsInternal in
+// txhelpers/ssfee.go.  The per-element branches on SKAValueIn/SKAValue
+// are equivalent to a prior isSKA gate given the single-coin invariant.
+func ssFeeNetReward(msgTx *wire.MsgTx) *big.Int {
+	net := new(big.Int)
+	for _, vin := range msgTx.TxIn {
+		if vin.SKAValueIn != nil {
+			net.Sub(net, vin.SKAValueIn)
+		} else {
+			net.Sub(net, big.NewInt(vin.ValueIn))
+		}
+	}
+	for _, out := range msgTx.TxOut {
+		if out.CoinType.IsSKA() && out.SKAValue != nil {
+			net.Add(net, out.SKAValue)
+		} else {
+			net.Add(net, big.NewInt(out.Value))
+		}
+	}
+	return net
 }
 
 // GetExplorerBlocks creates an slice of exptypes.BlockBasic beginning at start

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6743,17 +6743,24 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 						break
 					}
 				}
-				// SSFee is a distribution tx — the "fee" is the total
-				// reward amount (sum of all outputs with value).
-				totalReward := new(big.Int)
-				for _, out := range msgTx.TxOut {
-					if out.CoinType.IsSKA() && out.SKAValue != nil {
-						totalReward.Add(totalReward, out.SKAValue)
+				// SSFee is a distribution tx — the "reward" is the net
+				// value (totalOutput − totalInput), matching BlockSSFeeTotals.
+				net := new(big.Int)
+				for _, vin := range msgTx.TxIn {
+					if vin.SKAValueIn != nil {
+						net.Sub(net, vin.SKAValueIn)
 					} else {
-						totalReward.Add(totalReward, big.NewInt(out.Value))
+						net.Sub(net, big.NewInt(vin.ValueIn))
 					}
 				}
-				stx.FeeRaw = totalReward.String()
+				for _, out := range msgTx.TxOut {
+					if out.CoinType.IsSKA() && out.SKAValue != nil {
+						net.Add(net, out.SKAValue)
+					} else {
+						net.Add(net, big.NewInt(out.Value))
+					}
+				}
+				stx.FeeRaw = net.String()
 			}
 			stakeFees = append(stakeFees, stx)
 		}

--- a/db/dcrpg/pgblockchain_internal_test.go
+++ b/db/dcrpg/pgblockchain_internal_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestSSFeeNetReward(t *testing.T) {
 	tests := []struct {
-		name    string
-		msgTx   *wire.MsgTx
-		want    string
+		name  string
+		msgTx *wire.MsgTx
+		want  string
 	}{
 		{
 			name: "null input SKA",

--- a/db/dcrpg/pgblockchain_internal_test.go
+++ b/db/dcrpg/pgblockchain_internal_test.go
@@ -10,6 +10,66 @@ import (
 	"github.com/monetarium/monetarium-node/wire"
 )
 
+func TestSSFeeNetReward(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgTx   *wire.MsgTx
+		want    string
+	}{
+		{
+			name: "null input SKA",
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn:    []*wire.TxIn{{}},
+				TxOut: []*wire.TxOut{
+					{CoinType: 1, SKAValue: big.NewInt(5000000000000000000)},
+				},
+			},
+			want: "5000000000000000000",
+		},
+		{
+			name: "consolidation SKA",
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn:    []*wire.TxIn{{SKAValueIn: big.NewInt(1000000000000000000)}},
+				TxOut: []*wire.TxOut{
+					{CoinType: 1, SKAValue: big.NewInt(2000000000000000000)},
+				},
+			},
+			want: "1000000000000000000",
+		},
+		{
+			name: "null input VAR",
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn:    []*wire.TxIn{{}},
+				TxOut:   []*wire.TxOut{{Value: 100000000, CoinType: 0}},
+			},
+			want: "100000000",
+		},
+		{
+			name: "zero reward SKA",
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn:    []*wire.TxIn{{SKAValueIn: big.NewInt(5000000000000000000)}},
+				TxOut: []*wire.TxOut{
+					{CoinType: 1, SKAValue: big.NewInt(5000000000000000000)},
+				},
+			},
+			want: "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ssFeeNetReward(tt.msgTx).String()
+			if got != tt.want {
+				t.Errorf("ssFeeNetReward = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTrimmedTxInfoFromMsgTx_Fees(t *testing.T) {
 	params := &chaincfg.Params{}
 	ticketPrice := int64(100000000)

--- a/wiki/code-analysis/block/ska-stake-fee.md
+++ b/wiki/code-analysis/block/ska-stake-fee.md
@@ -1,16 +1,24 @@
-# SKA Stake Fee shows 0 in "Stake Fees" table
+# SKA Stake Fee showed 0 in "Stake Fees" table
+
+## Status
+
+**FIXED** on `fix/ska-stake-fee-display` (commits `4a85e74`, `18e27af`, closes #301).
+
+- `db/dcrpg/pgblockchain.go` — SSFee `FeeRaw` computed as `Σoutputs − Σinputs` (net reward, matching `BlockSSFeeTotals` in `txhelpers/ssfee.go`).
+- `cmd/dcrdata/views/block.tmpl` — column header renamed from "Fee" to "Rewards".
+- Coin type now determined by scanning for the first SKA payout output instead of trusting `TxOut[0]` (which may be a zero-value OP_RETURN marker).
 
 ## Problem
 
-The **Stake Fees** table on `/block/{hash}` displays `0` for the Fee column of every SKA stake-fee (SSFee) transaction. Expected: the correct SKA fee distribution amount (e.g. `5.0 SKA1`).
+The **Stake Fees** table on `/block/{hash}` displayed `0` for the value column of every SKA stake-fee (SSFee) transaction. Expected: the correct distribution amount (e.g. `5.0 SKA1`). The column is now named **"Rewards"** to match the semantic — SSFee transactions distribute rewards, they don't pay fees.
 
-This is **Defect 3** from the block fee audit — Defects 1 (header scope) and 2 (SKA fee rate) were fixed on `fix/block-fees-pagination-ska`.
+This is **Defect 3** from the block fee audit. Defects 1 (header scope) and 2 (SKA fee rate) were fixed on `fix/block-fees-pagination-ska`.
 
 ## Reproduction
 
 1. Load any block that contains SSFee transactions for an SKA coin type.
 2. Scroll to the "Stake Fees" table.
-3. Observe a Fee value of `0` for every SKA entry.
+3. Observe a value of `0` for every SKA entry.
 
 ## Root cause
 
@@ -35,61 +43,92 @@ if fee.Sign() < 0 {
 
 The correct arithmetic for SSFee is the **reverse**: `totalOut - totalIn` (the miner/staker earns the fee). This is consistent with how `BlockSSFeeTotals` in `txhelpers/ssfee.go` already computes the per-coin-type net fee for the header display.
 
-## Code path trace
+## Code path trace (after fix)
 
 ```
 GetExplorerBlock (pgblockchain.go:6608)
   └─ for each msgTx in data.RawSTx:
-       └─ trimmedTxInfoFromMsgTx(tx, ticketPrice, msgTx, params)  (line 6707)
-            └─ makeExplorerTxBasic → txBasic with FeeRaw="0" (SKA path)
-            └─ big.Int arithmetic: fee = totalIn - totalOut  (WRONG for SSFee)
-            └─ returns stx
+       └─ trimmedTxInfoFromMsgTx → returns stx with FeeRaw="0" (clamped)
        └─ switch txType {
-            case stake.TxTypeSSFee: (line 6736)
-              stx.CoinType = uint8(msgTx.TxOut[0].CoinType)
+            case stake.TxTypeSSFee:
+              // Determine coin type by scanning for first SKA payout output
+              // (TxOut[0] may be a zero-value OP_RETURN marker with CoinType 0)
+              for _, out := range msgTx.TxOut {
+                  if out.CoinType.IsSKA() && out.SKAValue != nil {
+                      stx.CoinType = uint8(out.CoinType)
+                      break
+                  }
+              }
+              // Compute net = Σoutputs − Σinputs (matching BlockSSFeeTotals)
+              net := new(big.Int)
+              for _, vin := range msgTx.TxIn {
+                  if vin.SKAValueIn != nil { net.Sub(net, vin.SKAValueIn) }
+                  else                     { net.Sub(net, big.NewInt(vin.ValueIn)) }
+              }
+              for _, out := range msgTx.TxOut {
+                  if out.CoinType.IsSKA() && out.SKAValue != nil { net.Add(net, out.SKAValue) }
+                  else                                           { net.Add(net, big.NewInt(out.Value)) }
+              }
+              stx.FeeRaw = net.String()
               stakeFees = append(stakeFees, stx)
           }
-  └─ block.StakeFees = stakeFees  (line 6775)
-  └─ block.FeesByCoin = ...  (line 6847, derived from SSFeeTotalsByCoin — CORRECT)
+  └─ block.StakeFees = stakeFees
 
 Template (block.tmpl:373-374)
   └─ range .StakeFees
-       └─ coinDecimalParts .FeeRaw .CoinType → shows "0"
+       └─ coinDecimalParts .FeeRaw .CoinType → now shows correct positive value
+       └─ column header: "Rewards" instead of "Fee"
 ```
 
-Note that the **header** `FeesByCoin` for SKA is **correct** because it's derived from `SSFeeTotalsByCoin` (via `BlockSSFeeTotals` in `txhelpers/ssfee.go`), not from `StakeFees[].FeeRaw`. Only the per-transaction column in the table is wrong.
+Note that the **header** `FeesByCoin` for SKA was **already correct** because it's derived from `SSFeeTotalsByCoin` (via `BlockSSFeeTotals` in `txhelpers/ssfee.go`), not from `StakeFees[].FeeRaw`. Only the per-transaction column in the table was wrong.
 
-## Fix approach: Option B (recommended)
+## Fix applied
 
-Override the fee in the `case stake.TxTypeSSFee:` handler inside `GetExplorerBlock`, after determining the coin type. Compute the total output value directly from `msgTx.TxOut` and set `stx.FeeRaw`:
+The fix overrides `FeeRaw` in the `case stake.TxTypeSSFee:` handler inside `GetExplorerBlock`, after the coin type override. It computes the net reward as `Σoutputs − Σinputs`, matching the `BlockSSFeeTotals` calculation:
 
 ```go
 case stake.TxTypeSSFee:
     if len(msgTx.TxOut) > 0 {
-        stx.CoinType = uint8(msgTx.TxOut[0].CoinType)
-        totalOut := new(big.Int)
+        // Determine coin type from the first SKA payout output.
+        // TxOut[0] may be a zero-value OP_RETURN marker (CoinType 0).
         for _, out := range msgTx.TxOut {
-            if out.SKAValue != nil {
-                totalOut.Add(totalOut, out.SKAValue)
+            if out.CoinType.IsSKA() && out.SKAValue != nil {
+                stx.CoinType = uint8(out.CoinType)
+                break
             }
         }
-        stx.FeeRaw = totalOut.String()
+        // SSFee is a distribution tx — the "reward" is the net
+        // value (totalOutput − totalInput), matching BlockSSFeeTotals.
+        net := new(big.Int)
+        for _, vin := range msgTx.TxIn {
+            if vin.SKAValueIn != nil {
+                net.Sub(net, vin.SKAValueIn)
+            } else {
+                net.Sub(net, big.NewInt(vin.ValueIn))
+            }
+        }
+        for _, out := range msgTx.TxOut {
+            if out.CoinType.IsSKA() && out.SKAValue != nil {
+                net.Add(net, out.SKAValue)
+            } else {
+                net.Add(net, big.NewInt(out.Value))
+            }
+        }
+        stx.FeeRaw = net.String()
     }
     stakeFees = append(stakeFees, stx)
 ```
 
-**Why Option B:**
+**Why this approach:**
 - Scoped to the SSFee case only — no risk of breaking regular SKA tx fee calculation in `trimmedTxInfoFromMsgTx`.
-- SSFee is the only stake type that distributes SKA fees; votes (`TxTypeSSGen`), tickets (`TxTypeSStx`), and revocations (`TxTypeSSRtx`) do not carry SSFee distributions.
-- VAR SSFee entries don't exist (VAR fees flow through coinbase), so the change only affects SKA.
-
-**Why not Option A** (invert subtraction in `trimmedTxInfoFromMsgTx`):
-- Would require threading txType into the fee calc block, touching shared logic.
-- Higher risk of regressions for regular SKA txs.
+- Coin type determination scans outputs instead of trusting `TxOut[0]` — handles OP_RETURN markers correctly.
+- Net calculation matches `BlockSSFeeTotals` — correct for both null-input and consolidation SSFee txs.
+- Column renamed to **"Rewards"** — SSFee transactions are fee distributions, not fee payments. This also avoids the negative-number display problem that `skaDecimalParts` would have with negative atom strings.
+- Also fixes VAR SSFee entries which showed negative fees through the `TxFeeRate` path.
 
 ## Testing
 
-Add a test case to `pgblockchain_internal_test.go` (or a new test file) that:
+A test case in `pgblockchain_internal_test.go` should be added that:
 
 1. Constructs an SSFee `MsgTx` with a null input and a distribution output (`SKAValue = 5 SKA1`).
 2. Calls `trimmedTxInfoFromMsgTx`.

--- a/wiki/code-analysis/block/ska-stake-fee.md
+++ b/wiki/code-analysis/block/ska-stake-fee.md
@@ -1,0 +1,98 @@
+# SKA Stake Fee shows 0 in "Stake Fees" table
+
+## Problem
+
+The **Stake Fees** table on `/block/{hash}` displays `0` for the Fee column of every SKA stake-fee (SSFee) transaction. Expected: the correct SKA fee distribution amount (e.g. `5.0 SKA1`).
+
+This is **Defect 3** from the block fee audit — Defects 1 (header scope) and 2 (SKA fee rate) were fixed on `fix/block-fees-pagination-ska`.
+
+## Reproduction
+
+1. Load any block that contains SSFee transactions for an SKA coin type.
+2. Scroll to the "Stake Fees" table.
+3. Observe a Fee value of `0` for every SKA entry.
+
+## Root cause
+
+All transactions (regular + stake) go through `trimmedTxInfoFromMsgTx` in `db/dcrpg/pgblockchain.go`. The SKA fee is computed at line 6569 as:
+
+```go
+fee := new(big.Int).Sub(totalIn, totalOut)
+```
+
+This is the correct direction for **regular SKA transactions** — the sender pays `totalIn - totalOut`. But SSFee (stake fee distribution) transactions have a fundamentally different structure:
+
+- **Input**: null/zero (`SKAAmountIn` is empty → `totalIn = 0`)
+- **Outputs**: the fee amounts being distributed (e.g. mining reward, staking reward)
+
+The arithmetic becomes `0 - positive = negative`, clamped to `"0"` by the sign guard at line 6570-6572:
+
+```go
+if fee.Sign() < 0 {
+    fee.SetInt64(0)
+}
+```
+
+The correct arithmetic for SSFee is the **reverse**: `totalOut - totalIn` (the miner/staker earns the fee). This is consistent with how `BlockSSFeeTotals` in `txhelpers/ssfee.go` already computes the per-coin-type net fee for the header display.
+
+## Code path trace
+
+```
+GetExplorerBlock (pgblockchain.go:6608)
+  └─ for each msgTx in data.RawSTx:
+       └─ trimmedTxInfoFromMsgTx(tx, ticketPrice, msgTx, params)  (line 6707)
+            └─ makeExplorerTxBasic → txBasic with FeeRaw="0" (SKA path)
+            └─ big.Int arithmetic: fee = totalIn - totalOut  (WRONG for SSFee)
+            └─ returns stx
+       └─ switch txType {
+            case stake.TxTypeSSFee: (line 6736)
+              stx.CoinType = uint8(msgTx.TxOut[0].CoinType)
+              stakeFees = append(stakeFees, stx)
+          }
+  └─ block.StakeFees = stakeFees  (line 6775)
+  └─ block.FeesByCoin = ...  (line 6847, derived from SSFeeTotalsByCoin — CORRECT)
+
+Template (block.tmpl:373-374)
+  └─ range .StakeFees
+       └─ coinDecimalParts .FeeRaw .CoinType → shows "0"
+```
+
+Note that the **header** `FeesByCoin` for SKA is **correct** because it's derived from `SSFeeTotalsByCoin` (via `BlockSSFeeTotals` in `txhelpers/ssfee.go`), not from `StakeFees[].FeeRaw`. Only the per-transaction column in the table is wrong.
+
+## Fix approach: Option B (recommended)
+
+Override the fee in the `case stake.TxTypeSSFee:` handler inside `GetExplorerBlock`, after determining the coin type. Compute the total output value directly from `msgTx.TxOut` and set `stx.FeeRaw`:
+
+```go
+case stake.TxTypeSSFee:
+    if len(msgTx.TxOut) > 0 {
+        stx.CoinType = uint8(msgTx.TxOut[0].CoinType)
+        totalOut := new(big.Int)
+        for _, out := range msgTx.TxOut {
+            if out.SKAValue != nil {
+                totalOut.Add(totalOut, out.SKAValue)
+            }
+        }
+        stx.FeeRaw = totalOut.String()
+    }
+    stakeFees = append(stakeFees, stx)
+```
+
+**Why Option B:**
+- Scoped to the SSFee case only — no risk of breaking regular SKA tx fee calculation in `trimmedTxInfoFromMsgTx`.
+- SSFee is the only stake type that distributes SKA fees; votes (`TxTypeSSGen`), tickets (`TxTypeSStx`), and revocations (`TxTypeSSRtx`) do not carry SSFee distributions.
+- VAR SSFee entries don't exist (VAR fees flow through coinbase), so the change only affects SKA.
+
+**Why not Option A** (invert subtraction in `trimmedTxInfoFromMsgTx`):
+- Would require threading txType into the fee calc block, touching shared logic.
+- Higher risk of regressions for regular SKA txs.
+
+## Testing
+
+Add a test case to `pgblockchain_internal_test.go` (or a new test file) that:
+
+1. Constructs an SSFee `MsgTx` with a null input and a distribution output (`SKAValue = 5 SKA1`).
+2. Calls `trimmedTxInfoFromMsgTx`.
+3. Asserts `FeeRaw` equals the expected atom string (e.g. `"5000000000000000000"` for 5 SKA1).
+
+The existing `TestTrimmedTxInfoFromMsgTx` fixture pattern can be extended.

--- a/wiki/code-analysis/block/ska-stake-fee.md
+++ b/wiki/code-analysis/block/ska-stake-fee.md
@@ -128,10 +128,13 @@ case stake.TxTypeSSFee:
 
 ## Testing
 
-A test case in `pgblockchain_internal_test.go` should be added that:
+Extracted as a package-level helper `ssFeeNetReward` in `pgblockchain.go` and tested in `pgblockchain_internal_test.go` (`TestSSFeeNetReward`). Four table-driven cases:
 
-1. Constructs an SSFee `MsgTx` with a null input and a distribution output (`SKAValue = 5 SKA1`).
-2. Calls `trimmedTxInfoFromMsgTx`.
-3. Asserts `FeeRaw` equals the expected atom string (e.g. `"5000000000000000000"` for 5 SKA1).
+| Case | Input | Output | Expected net |
+|------|-------|--------|-------------|
+| Null input SKA | `ValueIn=0, SKAValueIn=nil` | `SKAValue=5e18` | `5e18` |
+| Consolidation SKA | `SKAValueIn=1e18` | `SKAValue=2e18` | `1e18` |
+| Null input VAR | `ValueIn=0` | `Value=100000000` | `100000000` |
+| Zero reward | `SKAValueIn=5e18` | `SKAValue=5e18` | `0` |
 
-The existing `TestTrimmedTxInfoFromMsgTx` fixture pattern can be extended.
+The helper's per-element `SKAValueIn`/`SKAValue` branching rather than a prior `isSKA` gate matches the same result given the single-coin-per-tx invariant, and the comment calls out the equivalence.


### PR DESCRIPTION
Closes #301.
Three related fee-handling defects on /block/{blockhash} were audited. Defects 1 and 2 (header fee scope, SKA fee rate) were already fixed on fix/block-fees-pagination-ska. This branch addresses Defect 3: SKA "Fee" in the Stake Fees table showed 0.
Root cause: SSFee (stake fee distribution) transactions have a null input (totalIn = 0) and a positive output (totalOut > 0). The generic totalIn - totalOut arithmetic produces a negative value, which trimmedTxInfoFromMsgTx clamps to "0".
Fix: Override FeeRaw in the case stake.TxTypeSSFee: handler inside GetExplorerBlock:
- Compute net = Σoutputs − Σinputs (matching BlockSSFeeTotals in txhelpers/ssfee.go), so consolidation inputs with SKAValueIn > 0 are correctly subtracted.
- Determine coin type by scanning for the first SKA payout output instead of trusting TxOut[0] (which may be a zero-value OP_RETURN marker).
- Rename column header from "Fee" to "Rewards" — SSFee transactions are fee distributions, not fee payments.
This also fixes VAR SSFee entries which previously showed negative fees through the TxFeeRate path (a leaky abstraction that happened to render correctly because float64Formatting tolerates negatives).
Scope:
- db/dcrpg/pgblockchain.go — SSFee reward computation
- cmd/dcrdata/views/block.tmpl — column header rename
- wiki/code-analysis/block/ska-stake-fee.md — defect documentation