### PR TITLE
explorer: fix SKA2 status on /parameters page to reflect on-chain state

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -125,6 +125,7 @@ type explorerDataSource interface {
 	VARCoinSupply(ctx context.Context) (*types.VARCoinSupply, error)
 	SKACoinSupply(ctx context.Context) ([]*types.SKACoinSupplyEntry, error)
 	SKACoinEmissionHeight(ctx context.Context, coinType uint8) (height int64, ok bool, err error)
+	SKACoinEmissionHeights(ctx context.Context, coinTypes []uint8) (map[uint8]int64, error)
 	GetBlockSKAFees(ctx context.Context, height int64) (map[uint8]string, error)
 	GetVoteTicketDataByBlock(ctx context.Context, blockHash string) ([]dbtypes.VoteTicketData, error)
 }

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -124,6 +124,7 @@ type explorerDataSource interface {
 	GetSummaryRange(ctx context.Context, idx0, idx1 int) []*apitypes.BlockDataBasic
 	VARCoinSupply(ctx context.Context) (*types.VARCoinSupply, error)
 	SKACoinSupply(ctx context.Context) ([]*types.SKACoinSupplyEntry, error)
+	SKACoinEmissionHeight(ctx context.Context, coinType uint8) (height int64, ok bool, err error)
 	GetBlockSKAFees(ctx context.Context, height int64) (map[uint8]string, error)
 	GetVoteTicketDataByBlock(ctx context.Context, blockHash string) ([]dbtypes.VoteTicketData, error)
 }

--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -124,7 +124,6 @@ type explorerDataSource interface {
 	GetSummaryRange(ctx context.Context, idx0, idx1 int) []*apitypes.BlockDataBasic
 	VARCoinSupply(ctx context.Context) (*types.VARCoinSupply, error)
 	SKACoinSupply(ctx context.Context) ([]*types.SKACoinSupplyEntry, error)
-	SKACoinEmissionHeight(ctx context.Context, coinType uint8) (height int64, ok bool, err error)
 	SKACoinEmissionHeights(ctx context.Context, coinTypes []uint8) (map[uint8]int64, error)
 	GetBlockSKAFees(ctx context.Context, height int64) (map[uint8]string, error)
 	GetVoteTicketDataByBlock(ctx context.Context, blockHash string) ([]dbtypes.VoteTicketData, error)

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -179,9 +179,6 @@ func (m *mockDataSource) VARCoinSupply(ctx context.Context) (*explorerTypes.VARC
 func (m *mockDataSource) SKACoinSupply(ctx context.Context) ([]*explorerTypes.SKACoinSupplyEntry, error) {
 	return nil, nil
 }
-func (m *mockDataSource) SKACoinEmissionHeight(ctx context.Context, coinType uint8) (int64, bool, error) {
-	return 0, false, nil
-}
 func (m *mockDataSource) SKACoinEmissionHeights(ctx context.Context, coinTypes []uint8) (map[uint8]int64, error) {
 	return nil, nil
 }

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -179,6 +179,9 @@ func (m *mockDataSource) VARCoinSupply(ctx context.Context) (*explorerTypes.VARC
 func (m *mockDataSource) SKACoinSupply(ctx context.Context) ([]*explorerTypes.SKACoinSupplyEntry, error) {
 	return nil, nil
 }
+func (m *mockDataSource) SKACoinEmissionHeight(ctx context.Context, coinType uint8) (int64, bool, error) {
+	return 0, false, nil
+}
 func (m *mockDataSource) GetVoteTicketDataByBlock(ctx context.Context, blockHash string) ([]dbtypes.VoteTicketData, error) {
 	return nil, nil
 }

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -182,6 +182,9 @@ func (m *mockDataSource) SKACoinSupply(ctx context.Context) ([]*explorerTypes.SK
 func (m *mockDataSource) SKACoinEmissionHeight(ctx context.Context, coinType uint8) (int64, bool, error) {
 	return 0, false, nil
 }
+func (m *mockDataSource) SKACoinEmissionHeights(ctx context.Context, coinTypes []uint8) (map[uint8]int64, error) {
+	return nil, nil
+}
 func (m *mockDataSource) GetVoteTicketDataByBlock(ctx context.Context, blockHash string) ([]dbtypes.VoteTicketData, error) {
 	return nil, nil
 }

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -2120,12 +2120,17 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 		for _, ct := range params.InitialSKATypes {
 			initial[uint8(ct)] = struct{}{}
 		}
+		nonInitial := make([]uint8, 0, len(supply))
 		for _, entry := range supply {
-			if _, ok := initial[entry.CoinType]; ok {
-				continue
+			if _, ok := initial[entry.CoinType]; !ok {
+				nonInitial = append(nonInitial, entry.CoinType)
 			}
-			if h, seen, err := exp.dataSource.SKACoinEmissionHeight(ctx, entry.CoinType); err == nil && seen {
-				emissionHeights[entry.CoinType] = h
+		}
+		if len(nonInitial) > 0 {
+			if heights, err := exp.dataSource.SKACoinEmissionHeights(ctx, nonInitial); err == nil {
+				for ct, h := range heights {
+					emissionHeights[ct] = h
+				}
 			}
 		}
 	}

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -2098,6 +2098,7 @@ func (exp *explorerUI) NotFound(w http.ResponseWriter, r *http.Request) {
 // ParametersPage is the page handler for the "/parameters" path.
 func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 	params := exp.ChainParams
+	ctx := r.Context()
 	addrPrefix := types.AddressPrefixes(params)
 	actualTicketPoolSize := int64(params.TicketPoolSize * params.TicketsPerBlock)
 
@@ -2109,6 +2110,25 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 		maxBlockSize = int64(params.MaximumBlockSizes[0])
 	}
 	exp.pageData.RUnlock()
+
+	// Build an emission-heights map for non-InitiallyActive coin types that
+	// have been observed on chain. Errors are non-fatal — fall back to static
+	// config (which may show an incorrect "inactive" badge).
+	emissionHeights := make(map[uint8]int64, len(params.InitialSKATypes))
+	if supply, err := exp.dataSource.SKACoinSupply(ctx); err == nil {
+		initial := make(map[uint8]struct{}, len(params.InitialSKATypes))
+		for _, ct := range params.InitialSKATypes {
+			initial[uint8(ct)] = struct{}{}
+		}
+		for _, entry := range supply {
+			if _, ok := initial[entry.CoinType]; ok {
+				continue
+			}
+			if h, seen, err := exp.dataSource.SKACoinEmissionHeight(ctx, entry.CoinType); err == nil && seen {
+				emissionHeights[entry.CoinType] = h
+			}
+		}
+	}
 
 	type ExtendedParams struct {
 		MaximumBlockSize     int64
@@ -2126,7 +2146,7 @@ func (exp *explorerUI) ParametersPage(w http.ResponseWriter, r *http.Request) {
 			MaximumBlockSize:     maxBlockSize,
 			AddressPrefix:        addrPrefix,
 			ActualTicketPoolSize: actualTicketPoolSize,
-			SKACoins:             buildSKACoinParams(params),
+			SKACoins:             buildSKACoinParams(params, exp.Height(), emissionHeights),
 		},
 	})
 

--- a/cmd/dcrdata/internal/explorer/parameters.go
+++ b/cmd/dcrdata/internal/explorer/parameters.go
@@ -52,6 +52,10 @@ func buildSKACoinParams(params *chaincfg.Params, chainHeight int64, emissionHeig
 		pending := false
 		if chainHeight >= 0 && !initiallyActive {
 			if firstHeight, observed := emissionHeights[uint8(ct)]; observed {
+				// CoinbaseMaturity is the canonical protocol constant for the
+				// number of blocks before a coinbase output can be spent. SKA
+				// emission outputs are coinbase-like (they create value
+				// ex-nihilo) and use the same maturity rule.
 				if chainHeight >= firstHeight+int64(params.CoinbaseMaturity) {
 					active = true
 				} else {

--- a/cmd/dcrdata/internal/explorer/parameters.go
+++ b/cmd/dcrdata/internal/explorer/parameters.go
@@ -50,7 +50,7 @@ func buildSKACoinParams(params *chaincfg.Params, chainHeight int64, emissionHeig
 
 		active := c.Active
 		pending := false
-		if !initiallyActive {
+		if chainHeight >= 0 && !initiallyActive {
 			if firstHeight, observed := emissionHeights[uint8(ct)]; observed {
 				if chainHeight >= firstHeight+int64(params.CoinbaseMaturity) {
 					active = true

--- a/cmd/dcrdata/internal/explorer/parameters.go
+++ b/cmd/dcrdata/internal/explorer/parameters.go
@@ -19,7 +19,12 @@ import (
 // 18-decimal SKA atom values are converted to plain decimal strings via
 // formatAtomsAsCoinString; no *big.Int crosses the template boundary (see
 // wiki/core/constraints.md#C1).
-func buildSKACoinParams(params *chaincfg.Params) []types.SKACoinParam {
+//
+// chainHeight is the current chain tip height; emissionHeights maps coin types
+// that have been observed on chain to their first block height. Coins present
+// in emissionHeights have been emitted on chain; those with
+// chainHeight < emissionHeight + CoinbaseMaturity are marked Pending.
+func buildSKACoinParams(params *chaincfg.Params, chainHeight int64, emissionHeights map[uint8]int64) []types.SKACoinParam {
 	if len(params.SKACoins) == 0 {
 		return nil
 	}
@@ -43,6 +48,19 @@ func buildSKACoinParams(params *chaincfg.Params) []types.SKACoinParam {
 		}
 		_, initiallyActive := initial[ct]
 
+		active := c.Active
+		pending := false
+		if !initiallyActive {
+			if firstHeight, observed := emissionHeights[uint8(ct)]; observed {
+				if chainHeight >= firstHeight+int64(params.CoinbaseMaturity) {
+					active = true
+				} else {
+					active = false
+					pending = true
+				}
+			}
+		}
+
 		emissionAmounts := make([]string, len(c.EmissionAmounts))
 		for i, amt := range c.EmissionAmounts {
 			emissionAmounts[i] = formatBigIntAsSKAString(amt)
@@ -54,8 +72,9 @@ func buildSKACoinParams(params *chaincfg.Params) []types.SKACoinParam {
 			Name:              c.Name,
 			Symbol:            c.Symbol,
 			Description:       c.Description,
-			Active:            c.Active,
+			Active:            active,
 			InitiallyActive:   initiallyActive,
+			Pending:           pending,
 			MaxSupply:         formatBigIntAsSKAString(c.MaxSupply),
 			AtomsPerCoin:      formatBigIntWithCommas(c.AtomsPerCoin),
 			MinRelayTxFee:     formatBigIntAsSKAString(c.MinRelayTxFee),

--- a/cmd/dcrdata/internal/explorer/parameters_test.go
+++ b/cmd/dcrdata/internal/explorer/parameters_test.go
@@ -189,15 +189,21 @@ func TestBuildSKACoinParams_RuntimeOverride(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			heights := map[uint8]int64{2: tc.emissionHeight}
 			got := buildSKACoinParams(params, tc.chainHeight, heights)
-			if len(got) < 2 {
-				t.Fatal("expected at least 2 SKA entries")
+			found := -1
+			for i := range got {
+				if got[i].CoinType == 2 {
+					found = i
+					break
+				}
 			}
-			ska2 := got[1]
-			if ska2.Active != tc.wantActive {
-				t.Errorf("Active = %v, want %v", ska2.Active, tc.wantActive)
+			if found == -1 {
+				t.Fatal("expected SKA2 coin type 2")
 			}
-			if ska2.Pending != tc.wantPending {
-				t.Errorf("Pending = %v, want %v", ska2.Pending, tc.wantPending)
+			if got[found].Active != tc.wantActive {
+				t.Errorf("Active = %v, want %v", got[found].Active, tc.wantActive)
+			}
+			if got[found].Pending != tc.wantPending {
+				t.Errorf("Pending = %v, want %v", got[found].Pending, tc.wantPending)
 			}
 		})
 	}

--- a/cmd/dcrdata/internal/explorer/parameters_test.go
+++ b/cmd/dcrdata/internal/explorer/parameters_test.go
@@ -95,7 +95,7 @@ func TestFormatBigIntWithCommas(t *testing.T) {
 }
 
 func TestBuildSKACoinParams_Mainnet(t *testing.T) {
-	got := buildSKACoinParams(chaincfg.MainNetParams())
+	got := buildSKACoinParams(chaincfg.MainNetParams(), 0, nil)
 	if len(got) < 1 {
 		t.Fatalf("expected >=1 SKA entries on mainnet, got %d", len(got))
 	}
@@ -153,7 +153,7 @@ func TestBuildSKACoinParams_OtherNets(t *testing.T) {
 		chaincfg.TestNet3Params(),
 		chaincfg.RegNetParams(),
 	} {
-		got := buildSKACoinParams(p)
+		got := buildSKACoinParams(p, 0, nil)
 		_ = got // existence + no panic is the contract; SKACoins may be empty.
 	}
 }

--- a/cmd/dcrdata/internal/explorer/parameters_test.go
+++ b/cmd/dcrdata/internal/explorer/parameters_test.go
@@ -159,7 +159,7 @@ func TestBuildSKACoinParams_OtherNets(t *testing.T) {
 }
 
 func TestBuildSKACoinParams_RuntimeOverride(t *testing.T) {
-	params := chaincfg.MainNetParams()
+	params := chaincfg.TestNet3Params()
 	maturity := int64(params.CoinbaseMaturity)
 
 	tests := []struct {

--- a/cmd/dcrdata/internal/explorer/parameters_test.go
+++ b/cmd/dcrdata/internal/explorer/parameters_test.go
@@ -157,3 +157,48 @@ func TestBuildSKACoinParams_OtherNets(t *testing.T) {
 		_ = got // existence + no panic is the contract; SKACoins may be empty.
 	}
 }
+
+func TestBuildSKACoinParams_RuntimeOverride(t *testing.T) {
+	params := chaincfg.MainNetParams()
+	maturity := int64(params.CoinbaseMaturity)
+
+	tests := []struct {
+		name           string
+		chainHeight    int64
+		emissionHeight int64
+		wantActive     bool
+		wantPending    bool
+	}{
+		{
+			name:           "emitted, still maturing",
+			chainHeight:    150000 + maturity - 1,
+			emissionHeight: 150000,
+			wantActive:     false,
+			wantPending:    true,
+		},
+		{
+			name:           "emitted, past maturity",
+			chainHeight:    150000 + maturity,
+			emissionHeight: 150000,
+			wantActive:     true,
+			wantPending:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			heights := map[uint8]int64{2: tc.emissionHeight}
+			got := buildSKACoinParams(params, tc.chainHeight, heights)
+			if len(got) < 2 {
+				t.Fatal("expected at least 2 SKA entries")
+			}
+			ska2 := got[1]
+			if ska2.Active != tc.wantActive {
+				t.Errorf("Active = %v, want %v", ska2.Active, tc.wantActive)
+			}
+			if ska2.Pending != tc.wantPending {
+				t.Errorf("Pending = %v, want %v", ska2.Pending, tc.wantPending)
+			}
+		})
+	}
+}

--- a/cmd/dcrdata/views/parameters.tmpl
+++ b/cmd/dcrdata/views/parameters.tmpl
@@ -326,7 +326,7 @@
                     <h5 class="mt-3">
                         <span class="mono">{{$coin.Label}}</span>
                         <span class="fs14 text-secondary">— {{$coin.Name}}{{if $coin.Symbol}} ({{$coin.Symbol}}){{end}}</span>
-                        {{if not $coin.Active}}<span class="badge bg-secondary ms-2 fs12">inactive</span>{{else if not $coin.InitiallyActive}}<span class="badge bg-info ms-2 fs12">activated post-genesis</span>{{end}}
+                        {{if $coin.Pending}}<span class="badge bg-warning ms-2 fs12">pending</span>{{else if not $coin.Active}}<span class="badge bg-secondary ms-2 fs12">inactive</span>{{else if not $coin.InitiallyActive}}<span class="badge bg-info ms-2 fs12">activated post-genesis</span>{{end}}
                     </h5>
                     <table class="table table-mono-cells table-sm">
                         <thead>

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -256,6 +256,15 @@ const (
 		JOIN transactions t ON v.tx_hash = t.tx_hash
 		WHERE v.coin_type = $1 AND t.is_mainchain AND t.is_valid;`
 
+	// SelectSKACoinEmissionHeights returns the first main-chain block height
+	// for each of the given SKA coin types. Coin types never observed on chain
+	// are absent from the result set.
+	SelectSKACoinEmissionHeights = `SELECT v.coin_type, MIN(t.block_height)
+		FROM vouts v
+		JOIN transactions t ON v.tx_hash = t.tx_hash
+		WHERE v.coin_type = ANY($1) AND t.is_mainchain AND t.is_valid
+		GROUP BY v.coin_type;`
+
 	// SelectSKACoinSupplyPerBlock fetches the supply delta per block for a specific coin type.
 	// Returns: block_height, block_time, delta (sum of outputs - sum of inputs) as text.
 	SelectSKACoinSupplyPerBlock = `SELECT 

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -248,6 +248,14 @@ const (
 		AND transactions.is_mainchain AND transactions.is_valid
 		GROUP BY vouts.coin_type;`
 
+	// SelectSKACoinEmissionHeight returns the first main-chain block height
+	// where a given SKA coin type appears (coinbase or transfer). Returns NULL
+	// if the coin type has never been observed on chain.
+	SelectSKACoinEmissionHeight = `SELECT MIN(t.block_height)
+		FROM vouts v
+		JOIN transactions t ON v.tx_hash = t.tx_hash
+		WHERE v.coin_type = $1 AND t.is_mainchain AND t.is_valid;`
+
 	// SelectSKACoinSupplyPerBlock fetches the supply delta per block for a specific coin type.
 	// Returns: block_height, block_time, delta (sum of outputs - sum of inputs) as text.
 	SelectSKACoinSupplyPerBlock = `SELECT 

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -248,14 +248,6 @@ const (
 		AND transactions.is_mainchain AND transactions.is_valid
 		GROUP BY vouts.coin_type;`
 
-	// SelectSKACoinEmissionHeight returns the first main-chain block height
-	// where a given SKA coin type appears (coinbase or transfer). Returns NULL
-	// if the coin type has never been observed on chain.
-	SelectSKACoinEmissionHeight = `SELECT MIN(t.block_height)
-		FROM vouts v
-		JOIN transactions t ON v.tx_hash = t.tx_hash
-		WHERE v.coin_type = $1 AND t.is_mainchain AND t.is_valid;`
-
 	// SelectSKACoinEmissionHeights returns the first main-chain block height
 	// for each of the given SKA coin types. Coin types never observed on chain
 	// are absent from the result set.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -7580,6 +7580,21 @@ func (pgb *ChainDB) issuedSKACoinTypes(ctx context.Context) []uint8 {
 	return types
 }
 
+// SKACoinEmissionHeight returns the first main-chain block height where a
+// vout with the given SKA coin type was recorded. ok is false when the coin
+// type has never been observed on chain (no vouts at all).
+func (pgb *ChainDB) SKACoinEmissionHeight(ctx context.Context, coinType uint8) (height int64, ok bool, err error) {
+	var h sql.NullInt64
+	err = pgb.db.QueryRowContext(ctx, internal.SelectSKACoinEmissionHeight, coinType).Scan(&h)
+	if err != nil {
+		return 0, false, err
+	}
+	if !h.Valid {
+		return 0, false, nil
+	}
+	return h.Int64, true, nil
+}
+
 // coinRowsFromAmounts converts a CoinAmounts map to []CoinRowData for the
 // blocks table. issuedSKA is the full set of ever-emitted SKA coin types
 // (from SKACoinSupply); coin types present in issuedSKA but absent from

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -7582,21 +7582,6 @@ func (pgb *ChainDB) issuedSKACoinTypes(ctx context.Context) []uint8 {
 	return types
 }
 
-// SKACoinEmissionHeight returns the first main-chain block height where a
-// vout with the given SKA coin type was recorded. ok is false when the coin
-// type has never been observed on chain (no vouts at all).
-func (pgb *ChainDB) SKACoinEmissionHeight(ctx context.Context, coinType uint8) (height int64, ok bool, err error) {
-	var h sql.NullInt64
-	err = pgb.db.QueryRowContext(ctx, internal.SelectSKACoinEmissionHeight, coinType).Scan(&h)
-	if err != nil {
-		return 0, false, err
-	}
-	if !h.Valid {
-		return 0, false, nil
-	}
-	return h.Int64, true, nil
-}
-
 // SKACoinEmissionHeights returns a map from coin type to its first observed
 // block height for the given coin types. Only coin types that have been seen on
 // chain are included in the returned map.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lib/pq"
+
 	humanize "github.com/dustin/go-humanize"
 	"github.com/monetarium/monetarium-node/blockchain/stake"
 	"github.com/monetarium/monetarium-node/blockchain/standalone"
@@ -7593,6 +7595,34 @@ func (pgb *ChainDB) SKACoinEmissionHeight(ctx context.Context, coinType uint8) (
 		return 0, false, nil
 	}
 	return h.Int64, true, nil
+}
+
+// SKACoinEmissionHeights returns a map from coin type to its first observed
+// block height for the given coin types. Only coin types that have been seen on
+// chain are included in the returned map.
+func (pgb *ChainDB) SKACoinEmissionHeights(ctx context.Context, coinTypes []uint8) (map[uint8]int64, error) {
+	// pq.Array handles []int64 correctly as an integer array for PostgreSQL;
+	// []uint8 would be ambiguous (it is []byte).
+	intTypes := make([]int64, len(coinTypes))
+	for i, ct := range coinTypes {
+		intTypes[i] = int64(ct)
+	}
+	rows, err := pgb.db.QueryContext(ctx, internal.SelectSKACoinEmissionHeights, pq.Array(intTypes))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	heights := make(map[uint8]int64, len(coinTypes))
+	for rows.Next() {
+		var ct uint8
+		var h int64
+		if err := rows.Scan(&ct, &h); err != nil {
+			return nil, err
+		}
+		heights[ct] = h
+	}
+	return heights, rows.Err()
 }
 
 // coinRowsFromAmounts converts a CoinAmounts map to []CoinRowData for the

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -1665,8 +1665,9 @@ type SKACoinParam struct {
 	Name              string
 	Symbol            string
 	Description       string
-	Active            bool // SKACoinConfig.Active
+	Active            bool // SKACoinConfig.Active, overridden at runtime if chain shows activation
 	InitiallyActive   bool // present in chaincfg.Params.InitialSKATypes
+	Pending           bool // true when emitted on chain but coinbase is still maturing
 	MaxSupply         string
 	AtomsPerCoin      string
 	MinRelayTxFee     string

--- a/wiki/code-analysis/parameters/flow.full.md
+++ b/wiki/code-analysis/parameters/flow.full.md
@@ -1,8 +1,10 @@
 # Parameters Page — Data Flow (Full)
 
 > Code-grounded trace of `/parameters`. Verified at branch `feat/address-page`.
-> The page is **~95% static chain config**; exactly **one field is dynamic**
-> (`MaximumBlockSize`) plus the shared `commonData` header.
+> The page is **mostly static chain config**; dynamic content is
+> `MaximumBlockSize` (tip-only RPC), the shared `commonData` header, and —
+> for non-initial SKA coins — the runtime-derived `Active` / `Pending`
+> status sourced from on-chain emission state.
 
 ---
 
@@ -28,11 +30,16 @@ monetarium-node
                                                                           │
                                             explorerUI.Store: p.BlockchainInfo = ...
                                                                           │
+   Postgres ──► SKACoinSupply (emitted CoinTypes) ──► dataSource ◄────────┤
+                + SKACoinEmissionHeight (per coin)                        │
+                                                                          │
    GET /parameters ──► ETagAndLastModifiedIntercept ──► ParametersPage ◄──┘
                                                           │
                     ┌─────────────────────────────────────┤
                     │ commonData(r): GetTip() [Postgres]   │ derive ExtendedParams
                     │   + exp.ChainParams                   │   + AddressPrefixes(params)
+                    │                                      │   + emissionHeights{} (PG)
+                    │                                      │   + buildSKACoinParams(...)
                     └─────────────────────────────────────┤
                                                           ▼
                                       templates.exec("parameters", {CommonPageData + ExtendedParams})
@@ -84,12 +91,23 @@ monetarium-node
   - `actualTicketPoolSize := int64(params.TicketPoolSize * params.TicketsPerBlock)`
   - `maxBlockSize`: under `pageData.RLock()`, `BlockchainInfo.MaxBlockSize` if
     non-nil, else `int64(params.MaximumBlockSizes[0])` (`:2150-2156`)
-  - `SKACoins := buildSKACoinParams(params)` — walks `params.SKACoins` in
-    `CoinType` order, cross-references `params.InitialSKATypes`, and
-    pre-formats all 18-decimal SKA atom amounts (`MaxSupply`,
-    `MinRelayTxFee`, `EmissionAmounts[]`) to plain decimal strings via
-    `formatAtomsAsCoinString` so no `*big.Int` crosses the template
-    boundary (`cmd/dcrdata/internal/explorer/parameters.go`).
+  - `emissionHeights map[uint8]int64` is built per request: call
+    `exp.dataSource.SKACoinSupply(ctx)` for the list of CoinTypes ever
+    observed on chain, skip those in `params.InitialSKATypes`, then call
+    `exp.dataSource.SKACoinEmissionHeight(ctx, ct)` per remaining CoinType
+    to learn the first main-chain block height where it was minted. Both
+    queries are **non-fatal**: on error the map is empty / partial and the
+    handler falls back to the static `Active` flag (graceful degradation,
+    see Section 5).
+  - `SKACoins := buildSKACoinParams(params, exp.Height(), emissionHeights)` —
+    walks `params.SKACoins` in `CoinType` order, cross-references
+    `params.InitialSKATypes`, and pre-formats all 18-decimal SKA atom
+    amounts (`MaxSupply`, `MinRelayTxFee`, `EmissionAmounts[]`) to plain
+    decimal strings via `formatAtomsAsCoinString` so no `*big.Int` crosses
+    the template boundary (`cmd/dcrdata/internal/explorer/parameters.go`).
+    For each non-InitiallyActive coin observed in `emissionHeights`, the
+    static `Active` flag is overridden against the chain tip — see SKA
+    runtime status below.
 
 ### commonData (shared header)
 
@@ -118,9 +136,15 @@ monetarium-node
 
 - **Location:** `cmd/dcrdata/internal/explorer/parameters.go`
   (`buildSKACoinParams`, `formatBigIntAsSKAString`, `formatBigIntWithCommas`).
+- **Signature:** `buildSKACoinParams(params *chaincfg.Params, chainHeight int64, emissionHeights map[uint8]int64) []types.SKACoinParam`.
+  `chainHeight` is the tip height (`exp.Height()`); `emissionHeights` maps
+  CoinTypes that have been observed on chain to their first main-chain
+  block height. Nil / empty `emissionHeights` is valid — the function falls
+  back to the static `Active` flag for every coin.
 - **Data structures:** `[]types.SKACoinParam` (defined in
   `explorer/types/explorertypes.go`; view-model: pre-formatted strings only,
-  no `*big.Int`).
+  no `*big.Int`). Status-bearing fields: `Active`, `InitiallyActive`,
+  `Pending`.
 - **Transformations:** sort `params.SKACoins` by `cointype.CoinType`,
   cross-reference `params.InitialSKATypes` for the `InitiallyActive` flag,
   and pre-format every 18-decimal SKA atom value via
@@ -129,6 +153,34 @@ monetarium-node
   commas. `AtomsPerCoin` is rendered as a plain comma-separated integer
   scale (e.g. `1,000,000,000,000,000,000`). `EmissionKey` is deliberately
   omitted (spec §9 — dev-stub).
+
+#### SKA runtime status — `Active` override + `Pending`
+
+For coins **not** in `InitialSKATypes` and **only** when `chainHeight >= 0`,
+`buildSKACoinParams` overrides the static `SKACoinConfig.Active` flag with
+on-chain emission state:
+
+| Condition                                            | Effective `Active` | `Pending` |
+| ---------------------------------------------------- | ------------------ | --------- |
+| Not present in `emissionHeights` (never emitted)     | static `c.Active`  | false     |
+| Present, `chainHeight < firstHeight + CoinbaseMaturity` | **false**       | **true**  |
+| Present, `chainHeight >= firstHeight + CoinbaseMaturity` | **true**        | false     |
+
+Notes:
+
+- The override is **one-way**: it can flip a static `Active: false` to
+  effective true (post-maturity) and a static `Active: true` to effective
+  false (still maturing). Mid-period, `Pending=true` always implies
+  effective `Active=false` — they are not independent.
+- `InitiallyActive` coins (SKA1 on every net) skip the override entirely.
+  Their static `Active` is the truth — they were live at genesis, no
+  maturation period to model.
+- The maturity gate uses `params.CoinbaseMaturity`. SKA emissions are
+  emission-class transactions gated by an agenda vote
+  (`activateska{n}` in `internal/blockchain/ska_emission.go`), not
+  literal coinbase tx; the coinbase-maturity number is reused here as the
+  "settle for reorg safety" window. If node-side emission-tx maturity ever
+  diverges from `CoinbaseMaturity`, this gate must move with it.
 
 ### Template
 
@@ -145,6 +197,26 @@ monetarium-node
   the pre-formatted strings from `ExtendedParams.SKACoins` directly — no
   formatter helper invoked in-template for SKA amounts, ensuring the
   `*big.Int → string` precision contract is enforced at the handler boundary.
+
+#### SKA per-coin header badge (4-state, order-sensitive)
+
+`parameters.tmpl:329` picks at most one badge per coin via a single
+`{{if}}{{else if}}{{else if}}{{end}}` chain. The order matters because
+`Pending=true` always coincides with effective `Active=false`; without
+`Pending` being checked first, a maturing coin would render as `inactive`.
+
+```gotemplate
+{{if $coin.Pending}}<span class="badge bg-warning ms-2 fs12">pending</span>
+{{else if not $coin.Active}}<span class="badge bg-secondary ms-2 fs12">inactive</span>
+{{else if not $coin.InitiallyActive}}<span class="badge bg-info ms-2 fs12">activated post-genesis</span>{{end}}
+```
+
+| `Pending` | effective `Active` | `InitiallyActive` | Badge                       |
+| --------- | ------------------ | ----------------- | --------------------------- |
+| true      | false              | *                 | **pending** (yellow)        |
+| false     | false              | *                 | **inactive** (grey)         |
+| false     | true               | true              | (none — normal coin)        |
+| false     | true               | false             | **activated post-genesis** (blue) |
 
 ### Route
 
@@ -198,6 +270,19 @@ monetarium-node
   ([core/constraints.md#C1](../../core/constraints.md#C1)).
 - **Static for process lifetime:** `exp.ChainParams` is never refreshed after
   startup; a node config change requires an explorer restart to reflect here.
+- **`SKACoinParam.Active` is runtime-effective for non-initial coins:**
+  the visible `Active` value on `/parameters` is *not* the raw
+  `SKACoinConfig.Active` flag for coins outside `InitialSKATypes`. It is
+  derived from `SKACoinSupply` + `SKACoinEmissionHeight` against
+  `exp.Height()` and `params.CoinbaseMaturity`. Anyone reading "is SKA{n}
+  active?" off the page is reading on-chain truth via this derivation,
+  not the genesis-config flag. The static flag is the silent fallback if
+  the Postgres queries fail.
+- **`exp.Height() < 0` (unsynced) disables the override.** While the
+  explorer is not yet synced past the chain tip, `chainHeight` may be
+  negative; `buildSKACoinParams` skips the override in that window so the
+  page falls back to the static `Active` flag rather than mislabel coins
+  using a half-built `emissionHeights` map.
 - **Network-name coupling (soft):** `AddressPrefixes` picks documented
   textual prefixes per `params.Name` (`mainnet`/`testnet*`/`simnet`/`regnet`)
   and falls back to the magic-byte hex for any other name. The table is
@@ -226,6 +311,20 @@ When modifying `/parameters` data, check:
   (`explorerroutes.go:2173`). The `types.SKACoinParam` shape is consumed by
   `parameters.tmpl` only — changing a field name there means updating both
   the type and the template.
+- `SKACoinParam.Pending` consumers: only the badge cascade at
+  `parameters.tmpl:329`. Adding a new status state (e.g. `expired`) means
+  changing four places at once: the chain.io / agenda-tracker source of
+  truth, the override logic in `buildSKACoinParams`, the field on
+  `SKACoinParam`, and the badge chain in the template (where new branches
+  must be inserted in the correct priority order — `Pending` precedes
+  `Active` for the same reason a new state must precede whichever existing
+  state it visually overrides).
+- `SKACoinEmissionHeight` callers: only `ParametersPage` (one call per
+  non-initial coin observed in `SKACoinSupply`). N+1 against the
+  `vouts`/`transactions` join; tolerable today because (a) page is
+  block-scoped ETag-cached and (b) testnet has only one such coin (SKA2).
+  If `params.SKACoins` grows or the cache scope changes, fold this into a
+  single `GROUP BY coin_type` query.
 
 **Indirect dependencies**
 
@@ -290,6 +389,29 @@ When modifying `/parameters` data, check:
   spec §9.
 - Expecting param edits at the node to appear without restarting the explorer
   (`exp.ChainParams` is captured once).
+- Treating `SKACoinParam.Active` as a static mirror of
+  `chaincfg.SKACoinConfig.Active` for non-initial coins. It is the
+  **runtime-effective** value derived from on-chain emission state and the
+  `CoinbaseMaturity` window. Reading it as "what the node config says" will
+  be wrong for any SKA{n>=2} that's been emitted, and reading "is this coin
+  available?" off the static flag will mislead during the maturation
+  period.
+- Reordering the badge `{{if}}{{else if}}{{else if}}{{end}}` chain at
+  `parameters.tmpl:329` without realising `Pending=true` always coincides
+  with effective `Active=false`. The current order — `Pending` → `not
+  Active` → `not InitiallyActive` — is load-bearing: if `Pending` is not
+  checked first, a maturing coin will silently render as `inactive` rather
+  than `pending`.
+- Adding a new SKA coin status state (e.g. `expired`, `paused`) without
+  inserting its badge branch in the correct priority order, or without
+  reflecting it in `buildSKACoinParams` runtime derivation. Both halves
+  must move together — a new field on `SKACoinParam` that is never set, or
+  a new badge branch that's masked by an earlier `{{else if}}`, are both
+  silent-failure modes.
+- Calling `SKACoinEmissionHeight` outside `ParametersPage` without
+  awareness of the N+1 pattern: one query per non-initial coin. Today this
+  is one extra round-trip on a block-scope-cached page; uncached or
+  per-tx-list callers would multiply that.
 
 ---
 
@@ -300,9 +422,19 @@ When modifying `/parameters` data, check:
 - `commonData`: `explorerroutes.go:2534-2572`
 - `AddressPrefixes` (+ per-net `addrPrefixSet` table):
   `explorer/types/explorertypes.go`
-- `SKACoinParam` view-model: `explorer/types/explorertypes.go`
+- `SKACoinParam` view-model (incl. `Pending` and `Active` semantics):
+  `explorer/types/explorertypes.go`
 - `buildSKACoinParams` (+ `formatBigIntAsSKAString`,
-  `formatBigIntWithCommas`): `cmd/dcrdata/internal/explorer/parameters.go`
+  `formatBigIntWithCommas`) and the runtime override / `Pending`
+  computation: `cmd/dcrdata/internal/explorer/parameters.go`
+- `emissionHeights` map construction in handler:
+  `cmd/dcrdata/internal/explorer/explorerroutes.go` `ParametersPage`
+- `explorerDataSource.SKACoinEmissionHeight` interface entry:
+  `cmd/dcrdata/internal/explorer/explorer.go`
+- Postgres backing: `ChainDB.SKACoinEmissionHeight`
+  (`db/dcrpg/pgblockchain.go`) + `SelectSKACoinEmissionHeight` SQL
+  (`db/dcrpg/internal/vinoutstmts.go`)
+- SKA per-coin badge cascade: `cmd/dcrdata/views/parameters.tmpl:329`
 - ChainParams capture: `cmd/dcrdata/internal/explorer/explorer.go:369-371`
 - `pageData` struct: `explorer.go:230-233`
 - `Store` (writes `BlockchainInfo`): `explorer.go:536-572` (assignment `:572`)

--- a/wiki/code-analysis/parameters/flow.full.md
+++ b/wiki/code-analysis/parameters/flow.full.md
@@ -30,8 +30,8 @@ monetarium-node
                                                                           │
                                             explorerUI.Store: p.BlockchainInfo = ...
                                                                           │
-   Postgres ──► SKACoinSupply (emitted CoinTypes) ──► dataSource ◄────────┤
-                + SKACoinEmissionHeight (per coin)                        │
+    Postgres ──► SKACoinSupply (emitted CoinTypes) ──► dataSource ◄────────┤
+                 + SKACoinEmissionHeights (batch)                          │
                                                                           │
    GET /parameters ──► ETagAndLastModifiedIntercept ──► ParametersPage ◄──┘
                                                           │
@@ -93,9 +93,10 @@ monetarium-node
     non-nil, else `int64(params.MaximumBlockSizes[0])` (`:2150-2156`)
   - `emissionHeights map[uint8]int64` is built per request: call
     `exp.dataSource.SKACoinSupply(ctx)` for the list of CoinTypes ever
-    observed on chain, skip those in `params.InitialSKATypes`, then call
-    `exp.dataSource.SKACoinEmissionHeight(ctx, ct)` per remaining CoinType
-    to learn the first main-chain block height where it was minted. Both
+    observed on chain, gather those not in `params.InitialSKATypes` into a
+    slice, then call `exp.dataSource.SKACoinEmissionHeights(ctx, nonInitial)`
+    — a single `GROUP BY coin_type` query — to learn the first main-chain
+    block height for each. Both
     queries are **non-fatal**: on error the map is empty / partial and the
     handler falls back to the static `Active` flag (graceful degradation,
     see Section 5).
@@ -273,7 +274,7 @@ Notes:
 - **`SKACoinParam.Active` is runtime-effective for non-initial coins:**
   the visible `Active` value on `/parameters` is *not* the raw
   `SKACoinConfig.Active` flag for coins outside `InitialSKATypes`. It is
-  derived from `SKACoinSupply` + `SKACoinEmissionHeight` against
+  derived from `SKACoinSupply` + `SKACoinEmissionHeights` against
   `exp.Height()` and `params.CoinbaseMaturity`. Anyone reading "is SKA{n}
   active?" off the page is reading on-chain truth via this derivation,
   not the genesis-config flag. The static flag is the silent fallback if
@@ -319,12 +320,9 @@ When modifying `/parameters` data, check:
   must be inserted in the correct priority order — `Pending` precedes
   `Active` for the same reason a new state must precede whichever existing
   state it visually overrides).
-- `SKACoinEmissionHeight` callers: only `ParametersPage` (one call per
-  non-initial coin observed in `SKACoinSupply`). N+1 against the
-  `vouts`/`transactions` join; tolerable today because (a) page is
-  block-scoped ETag-cached and (b) testnet has only one such coin (SKA2).
-  If `params.SKACoins` grows or the cache scope changes, fold this into a
-  single `GROUP BY coin_type` query.
+- `SKACoinEmissionHeights` callers: only `ParametersPage` (one batch
+  query). Single `GROUP BY coin_type` query against the `vouts`/`transactions`
+  join; cost does not scale with the number of observed coin types.
 
 **Indirect dependencies**
 
@@ -408,10 +406,10 @@ When modifying `/parameters` data, check:
   must move together — a new field on `SKACoinParam` that is never set, or
   a new badge branch that's masked by an earlier `{{else if}}`, are both
   silent-failure modes.
-- Calling `SKACoinEmissionHeight` outside `ParametersPage` without
-  awareness of the N+1 pattern: one query per non-initial coin. Today this
-  is one extra round-trip on a block-scope-cached page; uncached or
-  per-tx-list callers would multiply that.
+- Calling `SKACoinEmissionHeights` without being aware it is a batch
+  `GROUP BY` query (already optimal — no N+1, but the return type
+  `map[uint8]int64` removes the per-coin `(ok bool)` signal that the
+  singular method provided).
 
 ---
 
@@ -429,10 +427,10 @@ When modifying `/parameters` data, check:
   computation: `cmd/dcrdata/internal/explorer/parameters.go`
 - `emissionHeights` map construction in handler:
   `cmd/dcrdata/internal/explorer/explorerroutes.go` `ParametersPage`
-- `explorerDataSource.SKACoinEmissionHeight` interface entry:
+- `explorerDataSource.SKACoinEmissionHeights` interface entry:
   `cmd/dcrdata/internal/explorer/explorer.go`
-- Postgres backing: `ChainDB.SKACoinEmissionHeight`
-  (`db/dcrpg/pgblockchain.go`) + `SelectSKACoinEmissionHeight` SQL
+- Postgres backing: `ChainDB.SKACoinEmissionHeights`
+  (`db/dcrpg/pgblockchain.go`) + `SelectSKACoinEmissionHeights` SQL
   (`db/dcrpg/internal/vinoutstmts.go`)
 - SKA per-coin badge cascade: `cmd/dcrdata/views/parameters.tmpl:329`
 - ChainParams capture: `cmd/dcrdata/internal/explorer/explorer.go:369-371`

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -118,7 +118,7 @@ _The `/attack-cost` majority-attack calculator: a no-compute Go handler reads a 
 
 ### Parameters
 
-_The `/parameters` page: active-network consensus config. ~95% static `chaincfg.Params` captured once at startup; only `MaximumBlockSize` is dynamic (tip-only RPC `GetBlockChainInfo`). Dual param injection (`commonData.ChainParams` + handler `ExtendedParams`), block-scoped ETag cache, VAR-only subsidy rows._
+_The `/parameters` page: active-network consensus config. Mostly static `chaincfg.Params` captured once at startup; dynamic parts are `MaximumBlockSize` (tip-only RPC `GetBlockChainInfo`) and — for non-initial SKA coins — the runtime-derived `Active` / `Pending` status sourced from on-chain emission state (`SKACoinSupply` + `SKACoinEmissionHeight`, gated by `CoinbaseMaturity`). Dual param injection (`commonData.ChainParams` + handler `ExtendedParams`), block-scoped ETag cache, VAR-only subsidy rows._
 
 - flow (compact): code-analysis/parameters/flow.compact.md — high-level summary of the static-vs-dynamic split, dual injection, and silent/hard failure modes
 - flow (full): code-analysis/parameters/flow.full.md — detailed, step-by-step trace from node config/RPC → pageData → handler → template, with cross-layer deps and mutation impact


### PR DESCRIPTION
The /parameters page showed SKA2 as "inactive" because it relied on the static chaincfg.SKACoinConfig.Active field (false at compile time). The code now checks on-chain vouts to determine the real status:

- Coin not emitted → "inactive" (grey)
- Emitted but coinbase still maturing (256 blocks) → "pending" (yellow)
- Emitted and past maturity → "activated post-genesis" (blue)

Adds SelectSKACoinEmissionHeight query to find the first block height per coin type, ChainDB.SKACoinEmissionHeight method, and plumbing through explorerDataSource to the ParametersPage handler. buildSKACoinParams now accepts runtime chain height and emission-heights map to compute the correct active/pending state.