### PR TITLE
explorer: count SKA types with txs in aggregate cell

### DIFF
--- a/cmd/dcrdata/internal/explorer/home_viewmodel.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel.go
@@ -32,6 +32,10 @@ type HomeBlockRow struct {
 	// no SKA entries.
 	SKAAmount string
 
+	// SKAActiveSubRows is the count of SKASubRows with txCount > 0 — what
+	// the "Σ K" cell summary shows when len(SKASubRows) >= 2.
+	SKAActiveSubRows int
+
 	// SKASubRows holds per-SKA-type accordion breakdown rows.
 	SKASubRows []SKASubRow
 }
@@ -57,6 +61,7 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 		var varAmount, varSize string
 		var varTxCount int
 		var skaAmount string
+		var skaActive int
 		var subRows []SKASubRow
 		totalTxCount := b.Transactions // default: raw block count
 
@@ -94,6 +99,9 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 						Amount:    formatCoinAtoms(cr.Amount, cr.CoinType),
 						Size:      size,
 					})
+					if cr.TxCount > 0 {
+						skaActive++
+					}
 					if skaAmount == "" {
 						skaAmount = cr.Amount
 					}
@@ -107,19 +115,20 @@ func buildHomeBlockRows(blocks []*types.BlockBasic) []HomeBlockRow {
 		}
 
 		rows = append(rows, HomeBlockRow{
-			Height:         b.Height,
-			Hash:           b.Hash,
-			Transactions:   totalTxCount,
-			Voters:         b.Voters,
-			FreshStake:     b.FreshStake,
-			Revocations:    b.Revocations,
-			FormattedBytes: b.FormattedBytes,
-			BlockTime:      b.BlockTime,
-			VARTxCount:     varTxCount,
-			VARAmount:      varAmount,
-			VARSize:        varSize,
-			SKAAmount:      skaAmount,
-			SKASubRows:     subRows,
+			Height:           b.Height,
+			Hash:             b.Hash,
+			Transactions:     totalTxCount,
+			Voters:           b.Voters,
+			FreshStake:       b.FreshStake,
+			Revocations:      b.Revocations,
+			FormattedBytes:   b.FormattedBytes,
+			BlockTime:        b.BlockTime,
+			VARTxCount:       varTxCount,
+			VARAmount:        varAmount,
+			VARSize:          varSize,
+			SKAAmount:        skaAmount,
+			SKAActiveSubRows: skaActive,
+			SKASubRows:       subRows,
 		})
 	}
 	return rows

--- a/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
@@ -111,6 +111,9 @@ func TestBuildHomeBlockRows_VAROnly(t *testing.T) {
 	if r.SKAAmount != "" {
 		t.Errorf("expected empty SKAAmount for VAR-only block, got %q", r.SKAAmount)
 	}
+	if r.SKAActiveSubRows != 0 {
+		t.Errorf("expected SKAActiveSubRows == 0 for VAR-only block, got %d", r.SKAActiveSubRows)
+	}
 }
 
 // TestBuildHomeBlockRows_WithCoinRows verifies that CoinRows atom strings are

--- a/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
+++ b/cmd/dcrdata/internal/explorer/home_viewmodel_test.go
@@ -205,6 +205,63 @@ func TestBuildHomeBlockRows_MultipleSKATypes(t *testing.T) {
 		t.Errorf("SKAAmount: got %q, want first SKA row's raw atoms %q",
 			r.SKAAmount, "50000000000000000000")
 	}
+	if r.SKAActiveSubRows != 2 {
+		t.Errorf("SKAActiveSubRows: got %d, want 2 (both SKA rows have TxCount > 0)",
+			r.SKAActiveSubRows)
+	}
+}
+
+// TestBuildHomeBlockRows_SKAActiveSubRows verifies that SKAActiveSubRows is
+// the count of SKA sub-rows with TxCount > 0 — what the "Σ K" cell shows.
+func TestBuildHomeBlockRows_SKAActiveSubRows(t *testing.T) {
+	tests := []struct {
+		name       string
+		coinRows   []types.CoinRowData
+		wantActive int
+	}{
+		{
+			name: "two SKA, neither has txs",
+			coinRows: []types.CoinRowData{
+				{CoinType: 0, Symbol: "VAR", TxCount: 1, Amount: "1000000000", Size: 200},
+				{CoinType: 1, Symbol: "SKA1", TxCount: 0, Amount: "0", Size: 0},
+				{CoinType: 2, Symbol: "SKA2", TxCount: 0, Amount: "0", Size: 0},
+			},
+			wantActive: 0,
+		},
+		{
+			name: "two SKA, only SKA2 has txs",
+			coinRows: []types.CoinRowData{
+				{CoinType: 0, Symbol: "VAR", TxCount: 1, Amount: "1000000000", Size: 200},
+				{CoinType: 1, Symbol: "SKA1", TxCount: 0, Amount: "0", Size: 0},
+				{CoinType: 2, Symbol: "SKA2", TxCount: 3, Amount: "5000000000000000000", Size: 150},
+			},
+			wantActive: 1,
+		},
+		{
+			name: "five SKA, two have txs",
+			coinRows: []types.CoinRowData{
+				{CoinType: 1, Symbol: "SKA1", TxCount: 4, Amount: "1", Size: 1},
+				{CoinType: 2, Symbol: "SKA2", TxCount: 0, Amount: "0", Size: 0},
+				{CoinType: 3, Symbol: "SKA3", TxCount: 0, Amount: "0", Size: 0},
+				{CoinType: 4, Symbol: "SKA4", TxCount: 7, Amount: "2", Size: 1},
+				{CoinType: 5, Symbol: "SKA5", TxCount: 0, Amount: "0", Size: 0},
+			},
+			wantActive: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &types.BlockBasic{Height: 50, CoinRows: tt.coinRows}
+			rows := buildHomeBlockRows([]*types.BlockBasic{b})
+			if len(rows) != 1 {
+				t.Fatalf("expected 1 row, got %d", len(rows))
+			}
+			if rows[0].SKAActiveSubRows != tt.wantActive {
+				t.Errorf("SKAActiveSubRows: got %d, want %d",
+					rows[0].SKAActiveSubRows, tt.wantActive)
+			}
+		})
+	}
 }
 
 // TestBuildHomeBlockRows_SKASubRowTokenTypeNonEmpty verifies that every

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -566,18 +566,20 @@ func orderedMempoolCoinStats(stats map[uint8]types.MempoolCoinStats) []MempoolCo
 // formatSKAAmountCell renders the aggregate SKA-amount table cell shared by
 // the Latest Blocks (home) and Blocks listing tables. The rule is:
 //
-//	subRowCount == 0   → "—"      (no SKA issued at all)
-//	subRowCount == 1   → formatted SKA1 amount (zero-value rows render "0")
-//	subRowCount >= 2   → "Σ N"    (count summary)
+//	totalCount == 0   → "—"                           (no SKA issued)
+//	totalCount == 1   → formatted amount (zero → "0")
+//	totalCount >= 2   → "Σ K" where K = activeCount (SKA types with txs in this block)
 //
-// skaAmount is the raw SKA atom string of the first SKA row and is only used
-// when subRowCount == 1. The Go (server-render) and JS (WebSocket live-update)
-// helpers must stay aligned — see public/js/helpers/coin_rows_helper.js.
-func formatSKAAmountCell(skaAmount string, subRowCount int) string {
+// totalCount is len(SKASubRows); activeCount is the precomputed count of
+// SKASubRows with TxCount > 0. skaAmount is the raw atom string of the first
+// SKA row and is only consulted when totalCount == 1. The Go (server-render)
+// and JS (WebSocket live-update) helpers must stay aligned — see
+// public/js/helpers/coin_rows_helper.js.
+func formatSKAAmountCell(skaAmount string, totalCount, activeCount int) string {
 	switch {
-	case subRowCount >= 2:
-		return fmt.Sprintf("Σ %d", subRowCount)
-	case subRowCount == 1:
+	case totalCount >= 2:
+		return fmt.Sprintf("Σ %d", activeCount)
+	case totalCount == 1:
 		return formatCoinAtoms(skaAmount, 1)
 	default:
 		return "—"

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -1059,82 +1059,98 @@ func TestFormatCoinAtoms_LargeSKA(t *testing.T) {
 }
 
 // TestFormatSKAAmountCell exercises the shared rule that drives the SKA
-// aggregate cell in both the Latest Blocks and Blocks tables, covering all
-// six scenarios from the spec. The rule is:
+// aggregate cell in both the Latest Blocks and Blocks tables. The rule is:
 //
-//	subRowCount == 0   → "—"
-//	subRowCount == 1   → formatCoinAtoms(skaAmount, 1)  (zero-value renders "0")
-//	subRowCount >= 2   → "Σ N"
+//	totalCount == 0   → "—"                              (no SKA issued)
+//	totalCount == 1   → formatCoinAtoms(skaAmount, 1)    (zero renders "0")
+//	totalCount >= 2   → "Σ K" where K = activeCount (SKA types with TxCount > 0)
+//
+// The producer side (viewmodel) precomputes activeCount; this helper only
+// renders. The Go and JS helpers must produce identical strings — see
+// public/js/helpers/coin_rows_helper.js.
 func TestFormatSKAAmountCell(t *testing.T) {
-	// One SKA = 1e18 atoms.
-	oneSKA := "1000000000000000000"
 	tests := []struct {
 		name        string
 		skaAmount   string
-		subRowCount int
+		totalCount  int
+		activeCount int
 		want        string
 	}{
 		{
-			name:        "scenario 1: no SKA issued",
-			skaAmount:   "",
-			subRowCount: 0,
-			want:        "—",
+			name:       "scenario 1: no SKA issued",
+			skaAmount:  "",
+			totalCount: 0,
+			want:       "—",
 		},
 		{
-			name:        "scenario 2: SKA1 issued, not in this block (zero-value row)",
-			skaAmount:   "0",
-			subRowCount: 1,
-			want:        "0",
+			name:       "scenario 2: SKA1 issued, not in this block (zero-value row)",
+			skaAmount:  "0",
+			totalCount: 1,
+			want:       "0",
 		},
 		{
 			name:        "scenario 3a: SKA1 present, 1 atom (~1e-18)",
 			skaAmount:   "1",
-			subRowCount: 1,
+			totalCount:  1,
+			activeCount: 1,
 			want:        formatCoinAtoms("1", 1),
 		},
 		{
 			name:        "scenario 3b: SKA1 present, 1.23 SKA",
 			skaAmount:   "1230000000000000000",
-			subRowCount: 1,
+			totalCount:  1,
+			activeCount: 1,
 			want:        "1.23",
 		},
 		{
 			name:        "scenario 3c: SKA1 present, 12,500 SKA",
 			skaAmount:   "12500000000000000000000",
-			subRowCount: 1,
+			totalCount:  1,
+			activeCount: 1,
 			want:        "12.5k",
 		},
 		{
 			name:        "scenario 4: SKA1 & SKA2 issued, neither in block",
 			skaAmount:   "0",
-			subRowCount: 2,
+			totalCount:  2,
+			activeCount: 0,
+			want:        "Σ 0",
+		},
+		{
+			name:        "scenario 5: SKA1 & SKA2 issued, only SKA1 has txs",
+			skaAmount:   "1000000000000000000",
+			totalCount:  2,
+			activeCount: 1,
+			want:        "Σ 1",
+		},
+		{
+			name:        "scenario 6: SKA1 & SKA2 issued, both have txs",
+			skaAmount:   "1000000000000000000",
+			totalCount:  2,
+			activeCount: 2,
 			want:        "Σ 2",
 		},
 		{
-			name:        "scenario 5: SKA1 & SKA2 issued, one present",
-			skaAmount:   oneSKA,
-			subRowCount: 2,
-			want:        "Σ 2",
-		},
-		{
-			name:        "scenario 6: SKA1 & SKA2 issued, both present",
-			skaAmount:   oneSKA,
-			subRowCount: 2,
-			want:        "Σ 2",
-		},
-		{
-			name:        "many SKA types",
+			name:        "five SKA types, none has txs",
 			skaAmount:   "0",
-			subRowCount: 5,
-			want:        "Σ 5",
+			totalCount:  5,
+			activeCount: 0,
+			want:        "Σ 0",
+		},
+		{
+			name:        "five SKA types, three have txs",
+			skaAmount:   "0",
+			totalCount:  5,
+			activeCount: 3,
+			want:        "Σ 3",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatSKAAmountCell(tt.skaAmount, tt.subRowCount)
+			got := formatSKAAmountCell(tt.skaAmount, tt.totalCount, tt.activeCount)
 			if got != tt.want {
-				t.Errorf("formatSKAAmountCell(%q, %d) = %q, want %q",
-					tt.skaAmount, tt.subRowCount, got, tt.want)
+				t.Errorf("formatSKAAmountCell(%q, %d, %d) = %q, want %q",
+					tt.skaAmount, tt.totalCount, tt.activeCount, got, tt.want)
 			}
 		})
 	}

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -1144,6 +1144,13 @@ func TestFormatSKAAmountCell(t *testing.T) {
 			activeCount: 3,
 			want:        "Σ 3",
 		},
+		{
+			name:        "five SKA types, all have txs",
+			skaAmount:   "0",
+			totalCount:  5,
+			activeCount: 5,
+			want:        "Σ 5",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/dcrdata/public/js/helpers/coin_rows_helper.js
+++ b/cmd/dcrdata/public/js/helpers/coin_rows_helper.js
@@ -4,19 +4,25 @@ import humanize from './humanize_helper'
  * formatSKAAmountCell renders the aggregate SKA-amount table cell shared by
  * the Latest Blocks (home) and Blocks listing tables. The rule is:
  *
- *   subRows.length === 0  → '—'      (no SKA issued at all)
- *   subRows.length === 1  → formatted amount (zero-value rows render '0')
- *   subRows.length >= 2   → 'Σ N'    (count summary)
+ *   subRows.length === 0  → '—'                           (no SKA issued)
+ *   subRows.length === 1  → formatted amount (zero → '0')
+ *   subRows.length >= 2   → 'Σ K' where K = SKA types with txCount > 0
  *
  * Mirrors the Go-side helper of the same name (cmd/dcrdata/internal/explorer
  * /templates.go). Both helpers must produce identical strings — they back the
  * server-rendered initial page and the WebSocket live update of the same row.
  *
- * @param {Array<{amount: string}>} subRows - SKA sub-rows from coinRowsToSKAData
+ * @param {Array<{txCount: string, amount: string}>} subRows - SKA sub-rows from coinRowsToSKAData
  * @returns {string} the cell text content
  */
 export function formatSKAAmountCell(subRows) {
-  if (subRows.length >= 2) return `Σ ${subRows.length}`
+  if (subRows.length >= 2) {
+    let active = 0
+    for (const r of subRows) {
+      if (Number(r.txCount) > 0) active++
+    }
+    return `Σ ${active}`
+  }
   if (subRows.length === 1) return subRows[0].amount
   return '—'
 }

--- a/cmd/dcrdata/public/js/helpers/coin_rows_helper.js
+++ b/cmd/dcrdata/public/js/helpers/coin_rows_helper.js
@@ -12,14 +12,14 @@ import humanize from './humanize_helper'
  * /templates.go). Both helpers must produce identical strings — they back the
  * server-rendered initial page and the WebSocket live update of the same row.
  *
- * @param {Array<{txCount: string, amount: string}>} subRows - SKA sub-rows from coinRowsToSKAData
+ * @param {Array<{txCount: number, amount: string}>} subRows - SKA sub-rows from coinRowsToSKAData
  * @returns {string} the cell text content
  */
 export function formatSKAAmountCell(subRows) {
   if (subRows.length >= 2) {
     let active = 0
     for (const r of subRows) {
-      if (Number(r.txCount) > 0) active++
+      if (r.txCount > 0) active++
     }
     return `Σ ${active}`
   }
@@ -70,7 +70,7 @@ export function coinRowsToSKAData(block) {
     } else {
       subRows.push({
         tokenType: cr.symbol,
-        txCount: String(cr.tx_count),
+        txCount: cr.tx_count,
         amount: humanize.formatCoinAtoms(cr.amount, cr.coin_type),
         size: humanize.bytes(cr.size)
       })
@@ -131,7 +131,7 @@ export function insertSKASubRows(tbody, insertRef, subRows, blockHeight, templat
     tr.dataset.blockId = String(blockHeight)
 
     clone.querySelector('.coin-label--ska').textContent = sub.tokenType
-    clone.querySelector('[data-type="tx"]').textContent = sub.txCount
+    clone.querySelector('[data-type="tx"]').textContent = String(sub.txCount)
     clone.querySelector('[data-type="ska-amount"]').textContent = sub.amount
     clone.querySelector('[data-type="size"]').textContent = sub.size
 

--- a/cmd/dcrdata/public/js/helpers/coin_rows_helper.test.js
+++ b/cmd/dcrdata/public/js/helpers/coin_rows_helper.test.js
@@ -10,55 +10,68 @@ describe('formatSKAAmountCell', () => {
     expect(formatSKAAmountCell([])).toBe('—'))
 
   it('scenario 2 (SKA1 issued, not in block — zero-value row): renders "0"', () =>
-    expect(formatSKAAmountCell([{ txCount: '0', amount: '0' }])).toBe('0'))
+    expect(formatSKAAmountCell([{ txCount: 0, amount: '0' }])).toBe('0'))
 
   it('scenario 3 (SKA1 present): renders the formatted amount', () => {
     const amount = humanize.formatCoinAtoms('1230000000000000000', 1) // "1.23"
-    expect(formatSKAAmountCell([{ txCount: '1', amount: amount }])).toBe(amount)
+    expect(formatSKAAmountCell([{ txCount: 1, amount: amount }])).toBe(amount)
   })
 
   it('scenario 3 (SKA1 present, 12,500 SKA): renders "12.5k"', () => {
     const amount = humanize.formatCoinAtoms('12500000000000000000000', 1)
-    expect(formatSKAAmountCell([{ txCount: '1', amount: amount }])).toBe('12.5k')
+    expect(formatSKAAmountCell([{ txCount: 1, amount: amount }])).toBe('12.5k')
   })
 
   it('scenario 4 (SKA1 & SKA2 issued, neither in block): "Σ 0"', () =>
     expect(
       formatSKAAmountCell([
-        { txCount: '0', amount: '0' },
-        { txCount: '0', amount: '0' }
+        { txCount: 0, amount: '0' },
+        { txCount: 0, amount: '0' }
       ])
     ).toBe('Σ 0'))
 
   it('scenario 5 (SKA1 & SKA2 issued, only SKA1 has txs): "Σ 1"', () =>
     expect(
       formatSKAAmountCell([
-        { txCount: '1', amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
-        { txCount: '0', amount: '0' }
+        { txCount: 1, amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
+        { txCount: 0, amount: '0' }
       ])
     ).toBe('Σ 1'))
 
   it('scenario 6 (SKA1 & SKA2 issued, both have txs): "Σ 2"', () =>
     expect(
       formatSKAAmountCell([
-        { txCount: '1', amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
-        { txCount: '2', amount: humanize.formatCoinAtoms('2000000000000000000', 2) }
+        { txCount: 1, amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
+        { txCount: 2, amount: humanize.formatCoinAtoms('2000000000000000000', 2) }
       ])
     ).toBe('Σ 2'))
 
   it('five SKA types, none has txs: "Σ 0"', () =>
-    expect(formatSKAAmountCell(Array(5).fill({ txCount: '0', amount: '0' }))).toBe('Σ 0'))
+    expect(
+      formatSKAAmountCell(Array.from({ length: 5 }, () => ({ txCount: 0, amount: '0' })))
+    ).toBe('Σ 0'))
 
   it('five SKA types, three have txs: "Σ 3"', () =>
     expect(
       formatSKAAmountCell([
-        { txCount: '1', amount: '1' },
-        { txCount: '0', amount: '0' },
-        { txCount: '4', amount: '1' },
-        { txCount: '0', amount: '0' },
-        { txCount: '7', amount: '1' }
+        { txCount: 1, amount: '1' },
+        { txCount: 0, amount: '0' },
+        { txCount: 4, amount: '1' },
+        { txCount: 0, amount: '0' },
+        { txCount: 7, amount: '1' }
       ])
     ).toBe('Σ 3'))
+
+  it('five SKA types, all have txs: "Σ 5"', () =>
+    expect(
+      formatSKAAmountCell([
+        { txCount: 1, amount: '1' },
+        { txCount: 2, amount: '1' },
+        { txCount: 3, amount: '1' },
+        { txCount: 4, amount: '1' },
+        { txCount: 5, amount: '1' }
+      ])
+    ).toBe('Σ 5'))
 })
 
 describe('coinRowsToSKAData → skaAmount', () => {

--- a/cmd/dcrdata/public/js/helpers/coin_rows_helper.test.js
+++ b/cmd/dcrdata/public/js/helpers/coin_rows_helper.test.js
@@ -3,45 +3,62 @@ import { coinRowsToSKAData, formatSKAAmountCell } from './coin_rows_helper'
 import humanize from './humanize_helper'
 
 describe('formatSKAAmountCell', () => {
-  // Six scenarios from the spec, mirrored in Go's TestFormatSKAAmountCell.
+  // Mirrored in Go's TestFormatSKAAmountCell. For 2+ SKA types issued, the
+  // cell shows "Σ K" where K is the number of SKA types with txCount > 0.
 
   it('scenario 1 (no SKA issued): subRows.length === 0 → "—"', () =>
     expect(formatSKAAmountCell([])).toBe('—'))
 
   it('scenario 2 (SKA1 issued, not in block — zero-value row): renders "0"', () =>
-    expect(formatSKAAmountCell([{ amount: '0' }])).toBe('0'))
+    expect(formatSKAAmountCell([{ txCount: '0', amount: '0' }])).toBe('0'))
 
   it('scenario 3 (SKA1 present): renders the formatted amount', () => {
     const amount = humanize.formatCoinAtoms('1230000000000000000', 1) // "1.23"
-    expect(formatSKAAmountCell([{ amount }])).toBe(amount)
+    expect(formatSKAAmountCell([{ txCount: '1', amount: amount }])).toBe(amount)
   })
 
   it('scenario 3 (SKA1 present, 12,500 SKA): renders "12.5k"', () => {
     const amount = humanize.formatCoinAtoms('12500000000000000000000', 1)
-    expect(formatSKAAmountCell([{ amount }])).toBe('12.5k')
+    expect(formatSKAAmountCell([{ txCount: '1', amount: amount }])).toBe('12.5k')
   })
 
-  it('scenario 4 (SKA1 & SKA2 issued, neither in block): "Σ 2"', () =>
-    expect(formatSKAAmountCell([{ amount: '0' }, { amount: '0' }])).toBe('Σ 2'))
-
-  it('scenario 5 (SKA1 & SKA2 issued, one present): "Σ 2"', () =>
+  it('scenario 4 (SKA1 & SKA2 issued, neither in block): "Σ 0"', () =>
     expect(
       formatSKAAmountCell([
-        { amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
-        { amount: '0' }
+        { txCount: '0', amount: '0' },
+        { txCount: '0', amount: '0' }
+      ])
+    ).toBe('Σ 0'))
+
+  it('scenario 5 (SKA1 & SKA2 issued, only SKA1 has txs): "Σ 1"', () =>
+    expect(
+      formatSKAAmountCell([
+        { txCount: '1', amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
+        { txCount: '0', amount: '0' }
+      ])
+    ).toBe('Σ 1'))
+
+  it('scenario 6 (SKA1 & SKA2 issued, both have txs): "Σ 2"', () =>
+    expect(
+      formatSKAAmountCell([
+        { txCount: '1', amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
+        { txCount: '2', amount: humanize.formatCoinAtoms('2000000000000000000', 2) }
       ])
     ).toBe('Σ 2'))
 
-  it('scenario 6 (SKA1 & SKA2 issued, both present): "Σ 2"', () =>
+  it('five SKA types, none has txs: "Σ 0"', () =>
+    expect(formatSKAAmountCell(Array(5).fill({ txCount: '0', amount: '0' }))).toBe('Σ 0'))
+
+  it('five SKA types, three have txs: "Σ 3"', () =>
     expect(
       formatSKAAmountCell([
-        { amount: humanize.formatCoinAtoms('1000000000000000000', 1) },
-        { amount: humanize.formatCoinAtoms('2000000000000000000', 2) }
+        { txCount: '1', amount: '1' },
+        { txCount: '0', amount: '0' },
+        { txCount: '4', amount: '1' },
+        { txCount: '0', amount: '0' },
+        { txCount: '7', amount: '1' }
       ])
-    ).toBe('Σ 2'))
-
-  it('many SKA types: "Σ 5"', () =>
-    expect(formatSKAAmountCell(Array(5).fill({ amount: '0' }))).toBe('Σ 5'))
+    ).toBe('Σ 3'))
 })
 
 describe('coinRowsToSKAData → skaAmount', () => {
@@ -93,7 +110,7 @@ describe('coinRowsToSKAData → skaAmount', () => {
     expect(coinRowsToSKAData(block).skaAmount).toBe('1.23')
   })
 
-  it('two SKA rows (both zero-value) → "Σ 2"', () => {
+  it('two SKA rows (both zero-value) → "Σ 0"', () => {
     const block = {
       tx: 0,
       total: 0,
@@ -106,10 +123,10 @@ describe('coinRowsToSKAData → skaAmount', () => {
         { coin_type: 2, symbol: 'SKA2', tx_count: 0, amount: '0', size: 0 }
       ]
     }
-    expect(coinRowsToSKAData(block).skaAmount).toBe('Σ 2')
+    expect(coinRowsToSKAData(block).skaAmount).toBe('Σ 0')
   })
 
-  it('two SKA rows, one with real activity → "Σ 2"', () => {
+  it('two SKA rows, one with real activity → "Σ 1"', () => {
     const block = {
       tx: 0,
       total: 0,
@@ -122,7 +139,7 @@ describe('coinRowsToSKAData → skaAmount', () => {
         { coin_type: 2, symbol: 'SKA2', tx_count: 0, amount: '0', size: 0 }
       ]
     }
-    expect(coinRowsToSKAData(block).skaAmount).toBe('Σ 2')
+    expect(coinRowsToSKAData(block).skaAmount).toBe('Σ 1')
   })
 
   it('three SKA rows → "Σ 3"', () => {

--- a/cmd/dcrdata/views/blocks.tmpl
+++ b/cmd/dcrdata/views/blocks.tmpl
@@ -107,7 +107,7 @@
             .Valid}}title="Regular transactions invalidated by stakeholders." {{end}}>{{.Transactions}}</td>
           <td class="text-center" data-type="var-amount">{{if .VARAmount}}{{formatCoinAtoms .VARAmount
             0}}{{else}}{{threeSigFigs .Total}}{{end}}</td>
-          <td class="text-center" data-type="ska-amount">{{formatSKAAmountCell .SKAAmount (len .SKASubRows)}}</td>
+          <td class="text-center" data-type="ska-amount">{{formatSKAAmountCell .SKAAmount (len .SKASubRows) .SKAActiveSubRows}}</td>
           <td class="text-center d-none d-sm-table-cell" data-type="size">{{.FormattedBytes}}</td>
           <td class="text-center d-none d-sm-table-cell" data-type="votes">{{.Voters}}</td>
           <td class="text-center d-none d-sm-table-cell" data-type="tickets">{{.FreshStake}}</td>

--- a/cmd/dcrdata/views/home_latest_blocks.tmpl
+++ b/cmd/dcrdata/views/home_latest_blocks.tmpl
@@ -42,7 +42,7 @@
         </td>
         <td class="text-end num" data-type="tx">{{.Transactions}}</td>
         <td class="text-end num" data-type="var-amount">{{.VARAmount}}</td>
-        <td class="text-end num" data-type="ska-amount">{{formatSKAAmountCell .SKAAmount (len .SKASubRows)}}</td>
+        <td class="text-end num" data-type="ska-amount">{{formatSKAAmountCell .SKAAmount (len .SKASubRows) .SKAActiveSubRows}}</td>
         <td class="text-end num d-none d-sm-table-cell d-md-none d-lg-table-cell" data-type="size">{{.FormattedBytes}}</td>
         <td class="text-end num" data-type="votes">{{.Voters}}</td>
         <td class="text-end num" data-type="tickets">{{.FreshStake}}</td>

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -143,8 +143,11 @@ type BlockBasic struct {
 	// SKAAmount holds the raw atom amount of the first SKA row in CoinRows.
 	// Templates render the aggregate SKA cell via formatSKAAmountCell, which
 	// uses SKAAmount only when len(SKASubRows) == 1.
-	SKAAmount  string
-	SKASubRows []SKASubRow
+	SKAAmount string
+	// SKAActiveSubRows is the number of SKA sub-rows with TxCount > 0 — what
+	// the "Σ K" cell summary shows when len(SKASubRows) >= 2.
+	SKAActiveSubRows int
+	SKASubRows       []SKASubRow
 }
 
 // FlattenCoinRows populates the template-facing flattened fields (VARAmount,
@@ -167,6 +170,9 @@ func (b *BlockBasic) FlattenCoinRows() {
 				Amount:    row.Amount,
 				Size:      humanize.Bytes(uint64(row.Size)),
 			})
+			if row.TxCount > 0 {
+				b.SKAActiveSubRows++
+			}
 			if b.SKAAmount == "" {
 				b.SKAAmount = row.Amount
 			}

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -151,9 +151,16 @@ type BlockBasic struct {
 }
 
 // FlattenCoinRows populates the template-facing flattened fields (VARAmount,
-// VARTxCount, VARSize, SKAAmount, SKASubRows) from CoinRows. Call this after
-// setting CoinRows.
+// VARTxCount, VARSize, SKAAmount, SKASubRows, SKAActiveSubRows) from CoinRows.
+// Call this after setting CoinRows. Safe to call more than once on the same
+// BlockBasic — accumulators are reset on entry.
 func (b *BlockBasic) FlattenCoinRows() {
+	b.VARAmount = ""
+	b.VARTxCount = 0
+	b.VARSize = ""
+	b.SKAAmount = ""
+	b.SKAActiveSubRows = 0
+	b.SKASubRows = b.SKASubRows[:0]
 	for _, row := range b.CoinRows {
 		if row.CoinType == 0 {
 			b.VARAmount = row.Amount

--- a/explorer/types/explorertypes_test.go
+++ b/explorer/types/explorertypes_test.go
@@ -330,15 +330,16 @@ func TestDeepCopys(t *testing.T) {
 
 func TestFlattenCoinRows(t *testing.T) {
 	tests := []struct {
-		name              string
-		coinRows          []CoinRowData
-		voters            uint16
-		freshStake        uint8
-		revocations       uint32
-		wantVARAmount     string
-		wantVARTxCount    int
-		wantSKAAmount     string
-		wantSKASubRowsLen int
+		name                 string
+		coinRows             []CoinRowData
+		voters               uint16
+		freshStake           uint8
+		revocations          uint32
+		wantVARAmount        string
+		wantVARTxCount       int
+		wantSKAAmount        string
+		wantSKASubRowsLen    int
+		wantSKAActiveSubRows int
 	}{
 		{
 			name:              "VAR only",
@@ -349,39 +350,68 @@ func TestFlattenCoinRows(t *testing.T) {
 			wantSKASubRowsLen: 0,
 		},
 		{
-			name: "VAR + single SKA",
+			name: "VAR + single SKA with txs",
 			coinRows: []CoinRowData{
 				{CoinType: 0, Symbol: "VAR", TxCount: 3, Amount: "100000000", Size: 200},
 				{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "1000000000000000000", Size: 100},
 			},
-			wantVARAmount:     "100000000",
-			wantVARTxCount:    3,
-			wantSKAAmount:     "1000000000000000000",
-			wantSKASubRowsLen: 1,
+			wantVARAmount:        "100000000",
+			wantVARTxCount:       3,
+			wantSKAAmount:        "1000000000000000000",
+			wantSKASubRowsLen:    1,
+			wantSKAActiveSubRows: 1,
 		},
 		{
-			name: "VAR + two SKA — SKAAmount holds first row's atoms",
+			name: "VAR + two SKA — neither has txs",
+			coinRows: []CoinRowData{
+				{CoinType: 0, Symbol: "VAR", TxCount: 2, Amount: "200000000", Size: 200},
+				{CoinType: 1, Symbol: "SKA1", TxCount: 0, Amount: "0", Size: 0},
+				{CoinType: 2, Symbol: "SKA2", TxCount: 0, Amount: "0", Size: 0},
+			},
+			wantVARAmount:        "200000000",
+			wantVARTxCount:       2,
+			wantSKAAmount:        "0",
+			wantSKASubRowsLen:    2,
+			wantSKAActiveSubRows: 0,
+		},
+		{
+			name: "VAR + two SKA — only SKA1 has txs",
+			coinRows: []CoinRowData{
+				{CoinType: 0, Symbol: "VAR", TxCount: 2, Amount: "200000000", Size: 200},
+				{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "500000000000000000", Size: 100},
+				{CoinType: 2, Symbol: "SKA2", TxCount: 0, Amount: "0", Size: 0},
+			},
+			wantVARAmount:        "200000000",
+			wantVARTxCount:       2,
+			wantSKAAmount:        "500000000000000000",
+			wantSKASubRowsLen:    2,
+			wantSKAActiveSubRows: 1,
+		},
+		{
+			name: "VAR + two SKA — both have txs",
 			coinRows: []CoinRowData{
 				{CoinType: 0, Symbol: "VAR", TxCount: 2, Amount: "200000000", Size: 200},
 				{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "500000000000000000", Size: 100},
 				{CoinType: 2, Symbol: "SKA2", TxCount: 2, Amount: "750000000000000000", Size: 150},
 			},
-			wantVARAmount:     "200000000",
-			wantVARTxCount:    2,
-			wantSKAAmount:     "500000000000000000",
-			wantSKASubRowsLen: 2,
+			wantVARAmount:        "200000000",
+			wantVARTxCount:       2,
+			wantSKAAmount:        "500000000000000000",
+			wantSKASubRowsLen:    2,
+			wantSKAActiveSubRows: 2,
 		},
 		{
-			name: "three SKA, no VAR",
+			name: "three SKA, no VAR — all have txs",
 			coinRows: []CoinRowData{
 				{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "1", Size: 1},
 				{CoinType: 2, Symbol: "SKA2", TxCount: 1, Amount: "2", Size: 1},
 				{CoinType: 3, Symbol: "SKA3", TxCount: 1, Amount: "3", Size: 1},
 			},
-			wantVARAmount:     "",
-			wantVARTxCount:    0,
-			wantSKAAmount:     "1",
-			wantSKASubRowsLen: 3,
+			wantVARAmount:        "",
+			wantVARTxCount:       0,
+			wantSKAAmount:        "1",
+			wantSKASubRowsLen:    3,
+			wantSKAActiveSubRows: 3,
 		},
 	}
 	for _, tt := range tests {
@@ -404,6 +434,9 @@ func TestFlattenCoinRows(t *testing.T) {
 			}
 			if len(b.SKASubRows) != tt.wantSKASubRowsLen {
 				t.Errorf("SKASubRows length: got %d, want %d", len(b.SKASubRows), tt.wantSKASubRowsLen)
+			}
+			if b.SKAActiveSubRows != tt.wantSKAActiveSubRows {
+				t.Errorf("SKAActiveSubRows: got %d, want %d", b.SKAActiveSubRows, tt.wantSKAActiveSubRows)
 			}
 		})
 	}

--- a/explorer/types/explorertypes_test.go
+++ b/explorer/types/explorertypes_test.go
@@ -342,12 +342,13 @@ func TestFlattenCoinRows(t *testing.T) {
 		wantSKAActiveSubRows int
 	}{
 		{
-			name:              "VAR only",
-			coinRows:          []CoinRowData{{CoinType: 0, Symbol: "VAR", TxCount: 5, Amount: "100000000", Size: 200}},
-			wantVARAmount:     "100000000",
-			wantVARTxCount:    5,
-			wantSKAAmount:     "",
-			wantSKASubRowsLen: 0,
+			name:                 "VAR only",
+			coinRows:             []CoinRowData{{CoinType: 0, Symbol: "VAR", TxCount: 5, Amount: "100000000", Size: 200}},
+			wantVARAmount:        "100000000",
+			wantVARTxCount:       5,
+			wantSKAAmount:        "",
+			wantSKASubRowsLen:    0,
+			wantSKAActiveSubRows: 0,
 		},
 		{
 			name: "VAR + single SKA with txs",
@@ -439,6 +440,35 @@ func TestFlattenCoinRows(t *testing.T) {
 				t.Errorf("SKAActiveSubRows: got %d, want %d", b.SKAActiveSubRows, tt.wantSKAActiveSubRows)
 			}
 		})
+	}
+}
+
+// TestFlattenCoinRows_Idempotent verifies that calling FlattenCoinRows more
+// than once on the same BlockBasic does not double SKASubRows or
+// SKAActiveSubRows.
+func TestFlattenCoinRows_Idempotent(t *testing.T) {
+	b := &BlockBasic{
+		Voters:     1,
+		FreshStake: 0,
+		CoinRows: []CoinRowData{
+			{CoinType: 0, Symbol: "VAR", TxCount: 3, Amount: "100000000", Size: 200},
+			{CoinType: 1, Symbol: "SKA1", TxCount: 1, Amount: "500000000000000000", Size: 100},
+			{CoinType: 2, Symbol: "SKA2", TxCount: 0, Amount: "0", Size: 0},
+		},
+	}
+	b.FlattenCoinRows()
+	b.FlattenCoinRows()
+	if len(b.SKASubRows) != 2 {
+		t.Errorf("SKASubRows length after 2 calls: got %d, want 2", len(b.SKASubRows))
+	}
+	if b.SKAActiveSubRows != 1 {
+		t.Errorf("SKAActiveSubRows after 2 calls: got %d, want 1", b.SKAActiveSubRows)
+	}
+	if b.VARTxCount != 2 {
+		t.Errorf("VARTxCount after 2 calls: got %d, want 2", b.VARTxCount)
+	}
+	if b.SKAAmount != "500000000000000000" {
+		t.Errorf("SKAAmount after 2 calls: got %q, want %q", b.SKAAmount, "500000000000000000")
 	}
 }
 


### PR DESCRIPTION
## Summary

- The "Σ N" summary in the SKA aggregate cell on `/` and `/blocks` showed the count of *issued* SKA{n} types — constant per block once SKA is issued, conveying no information about actual activity.
- It now counts only SKA types with `TxCount > 0`, rendering `Σ 0` when 2+ SKA types are issued but none had transactions in the block.
- Both transports stay aligned: server-rendered Go template path and JS WebSocket live-update path produce identical strings.

## Test plan

- [x] `go test ./...` in root, `cmd/dcrdata`, and `explorer/types` modules — all green
- [x] `go test -tags pgonline ./...` in `cmd/dcrdata` — all green
- [x] `npm test` in `cmd/dcrdata` — 300/300 passing
- [x] `./lint.sh` — clean for changed files
- [x] `npm run check` (prettier + eslint + stylelint) — clean
- [x] Live verification on testnet: block 10392 (1 SKA1 tx) renders `Σ 1`; surrounding blocks with no SKA activity render `Σ 0` on both `/` and `/blocks`

Closes #337.