### PR TITLE
cmd/dcrdata: fix address chart-card coin selector layout

### DIFF
--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -138,7 +138,7 @@
 }
 
 .btn-set > label,
-.btn-set > span {
+.btn-set > span.btn-set-label {
   position: absolute;
   top: -0.7em;
   line-height: 1em;

--- a/cmd/dcrdata/views/address.tmpl
+++ b/cmd/dcrdata/views/address.tmpl
@@ -172,7 +172,7 @@
             <div class="d-flex flex-wrap justify-content-around align-items-start">
               <div class="loader-v2 loading" data-address-target="chartLoader"></div>
               <div class="btn-set secondary-card d-inline-flex flex-nowrap mx-2">
-                <span>Chart</span>
+                <span class="btn-set-label">Chart</span>
                 <select
                     id="address-chart-type"
                     class="chart-box d-inline-flex dropdown"
@@ -185,7 +185,7 @@
                 </select>
               </div>
               <div class="btn-set secondary-card d-inline-flex flex-nowrap mx-2">
-                <span>Coin</span>
+                <span class="btn-set-label">Coin</span>
                 {{- if gt (len .ActiveCoins) 1}}
                 <select
                     class="chart-box d-inline-flex dropdown"
@@ -228,7 +228,7 @@
                   data-address-target="zoom"
                   data-action="click->address#onZoom"
               >
-                <span>Zoom</span>
+                <span class="btn-set-label">Zoom</span>
                 <button class="btn-selected" name="all" data-fixed="1">All</button>
                 <button name="year">Year</button>
                 <button name="month">Month</button>
@@ -242,7 +242,7 @@
                   data-address-target="interval"
                   data-action="click->address#changeBin"
               >
-                  <span class="d-inline-flex pe-1">Group By </span>
+                  <span class="btn-set-label d-inline-flex pe-1">Group By </span>
                   <button name="year">Year</button>
                   <button class="btn-selected" name="month">Month</button>
                   <button name="week">Week</button>


### PR DESCRIPTION
## Summary

- Fixes #341. On `/address/{address}` the chart-card **Coin** selector collapsed when the address had a single active coin: the `<span title="...">` wrapper used to host the tooltip on the disabled `<select>` is a direct child of `.btn-set`, and was matched by the rule that positions section labels (`Chart`, `Coin`, `Zoom`, `Group By`) absolutely above the row — so the disabled select disappeared from the row flow.
- Fix is structural, not a `:not(...)` bandaid: section-label spans now carry an explicit `btn-set-label` class, and `.btn-set > span.btn-set-label` replaces `.btn-set > span` in the SCSS rule. The treasury page's `<label>` form keeps working via the unchanged `.btn-set > label` clause.
- No template change needed at the tooltip wrappers themselves (`address.tmpl:202, 213, 386, 397`) — the markup contract from `wiki/specs/address-charts/spec.md` §3.1 is preserved.

## Test plan

- [x] Reproduced the broken layout on a single-coin address (`/address/TsioNcxYnLstbYBZ314HtqNnGrYqeZy1FGJ`).
- [x] After fix, all four section labels (`Chart` / `Coin` / `Zoom` / `Group By`) render absolutely-positioned above their `.btn-set` row, and the disabled SKA2 selector renders inline with the rest of the controls (verified via computed styles + screenshot).
- [x] Multi-coin chart card uses a bare `<select>` (no wrapper span) — confirmed unaffected by the CSS scope change.
- [x] Treasury page uses `<label>` for section labels (`treasury.tmpl:80, 97, 111`) — confirmed unaffected.
- [x] `npm run check` passes (prettier + eslint + stylelint).
- [x] `vitest` 301/301 passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)