### PR TITLE
Fix/ska reward block links per coin

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -803,7 +803,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	// taken from the authoritative "MF"-marked SSFee split (issue #273). This
 	// mirrors the "Vote SKA Fee Reward" (PoS) derivation above so the HTTP and
 	// WebSocket paths stay consistent and no heuristic /2 or 100% guess is used.
-	var powRewardsBlockHeight int64
+	powRewardsBlockHeight := make(map[uint8]int64)
 	powRewardsMap := make(map[uint8]string)
 
 	// Prefer the current block; otherwise fall back to the most recent block
@@ -813,7 +813,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 			continue
 		}
 		powRewardsMap[ct] = txhelpers.FormatSKAAtoms(split.PoW)
-		powRewardsBlockHeight = newBlockData.Height
+		powRewardsBlockHeight[ct] = newBlockData.Height
 	}
 	for i := len(sum30) - 1; i >= 0; i-- {
 		for ct, split := range sum30[i].SSFeeTotalsByCoin {
@@ -824,8 +824,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 				continue
 			}
 			powRewardsMap[ct] = txhelpers.FormatSKAAtoms(split.PoW)
-			if powRewardsBlockHeight == 0 {
-				powRewardsBlockHeight = int64(sum30[i].Height)
+			if _, hasHeight := powRewardsBlockHeight[ct]; !hasHeight {
+				powRewardsBlockHeight[ct] = int64(sum30[i].Height)
 			}
 		}
 	}
@@ -837,7 +837,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 				CoinType:    ct,
 				Symbol:      fmt.Sprintf("SKA%d", ct),
 				Amount:      amountStr,
-				BlockHeight: powRewardsBlockHeight,
+				BlockHeight: powRewardsBlockHeight[ct],
 			})
 		}
 		sort.Slice(powRewards, func(i, j int) bool { return powRewards[i].CoinType < powRewards[j].CoinType })

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -29,6 +29,7 @@ type mockDataSource struct {
 	tpvCharts  [3]*dbtypes.PoolTicketsData
 	tpvHeight  int64
 	tpvErr     error
+	summaries  []*apitypes.BlockDataBasic
 }
 
 func (m *mockDataSource) BlockHeight(ctx context.Context, hash string) (int64, error) { return 0, nil }
@@ -171,7 +172,7 @@ func (m *mockDataSource) GetExplorerFullBlocks(ctx context.Context, start int, e
 func (m *mockDataSource) CurrentDifficulty(context.Context) (float64, error)      { return 0, nil }
 func (m *mockDataSource) Difficulty(ctx context.Context, timestamp int64) float64 { return 0 }
 func (m *mockDataSource) GetSummaryRange(ctx context.Context, idx0, idx1 int) []*apitypes.BlockDataBasic {
-	return nil
+	return m.summaries
 }
 func (m *mockDataSource) VARCoinSupply(ctx context.Context) (*explorerTypes.VARCoinSupply, error) {
 	return nil, nil
@@ -286,6 +287,40 @@ func TestStore_PoWSKARewardsFromMFMarker(t *testing.T) {
 		if exp.pageData.HomeInfo.PoWSKARewards != nil {
 			t.Errorf("expected no PoW reward without an MF marker, got %v",
 				exp.pageData.HomeInfo.PoWSKARewards)
+		}
+	})
+
+	t.Run("sum30 fallback yields per-coin BlockHeight for each SKA coin", func(t *testing.T) {
+		exp, mockDS := setup()
+		// Only SKA1 appears in the current block's MF SSFee.
+		// SKA2 exists only in a recent summary (sum30).
+		mockDS.summaries = []*apitypes.BlockDataBasic{
+			{
+				Height: 95,
+				Hash:   "0000000000000000000000000000000000000000000000000000000000000095",
+				SSFeeTotalsByCoin: map[uint8]rewardtypes.SSFeeSplit{
+					2: {PoW: big.NewInt(300000000000000000)},
+				},
+			},
+		}
+		storeBlock(exp, mockDS, apitypes.BlockExplorerExtraInfo{
+			SSFeeTotalsByCoin: map[uint8]rewardtypes.SSFeeSplit{
+				1: {PoW: big.NewInt(550000000000000000)},
+			},
+		})
+
+		exp.pageData.RLock()
+		defer exp.pageData.RUnlock()
+		got := exp.pageData.HomeInfo.PoWSKARewards
+		if len(got) != 2 {
+			t.Fatalf("expected 2 PoW rewards, got %d (%v)", len(got), got)
+		}
+		// Sorted by coin type; each coin must carry its own BlockHeight.
+		if got[0].CoinType != 1 || got[0].Amount != "550000000000000000" || got[0].BlockHeight != 100 {
+			t.Errorf("SKA1 = %+v, want CoinType=1 Amount=550000000000000000 BlockHeight=100", got[0])
+		}
+		if got[1].CoinType != 2 || got[1].Amount != "300000000000000000" || got[1].BlockHeight != 95 {
+			t.Errorf("SKA2 = %+v, want CoinType=2 Amount=300000000000000000 BlockHeight=95", got[1])
 		}
 	})
 

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -912,17 +912,18 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	// PoW SKA Fee Reward: the miner's portion of redistributed SKA tx fees
 	// from the authoritative "MF"-marked SSFee split (issue #273). Mirrors the
 	// explorer (HTTP) derivation so the two paths cannot drift.
-	powRewardsBlockHeight := int64(blockData.Header.Height)
+	powRewardsBlockHeight := make(map[uint8]int64)
 	powRewards := make([]exptypes.PoWSKAReward, 0)
 	for ct, split := range blockData.ExtraInfo.SSFeeTotalsByCoin {
 		if ct == 0 || split.PoW == nil || split.PoW.Sign() <= 0 {
 			continue
 		}
+		powRewardsBlockHeight[ct] = int64(blockData.Header.Height)
 		powRewards = append(powRewards, exptypes.PoWSKAReward{
 			CoinType:    ct,
 			Symbol:      fmt.Sprintf("SKA%d", ct),
 			Amount:      txhelpers.FormatSKAAtoms(split.PoW),
-			BlockHeight: powRewardsBlockHeight,
+			BlockHeight: powRewardsBlockHeight[ct],
 		})
 	}
 	if len(powRewards) > 0 {

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -821,12 +821,6 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	}
 
 	if len(coinTypes) > 0 {
-		// Only set block height when current block has SKA fee data.
-		var voteRewardsBlockHeight int64
-		if len(blockData.ExtraInfo.SSFeeTotalsByCoin) > 0 {
-			voteRewardsBlockHeight = int64(blockData.Header.Height)
-		}
-
 		rewards := make([]exptypes.SKAVoteReward, 0, len(coinTypes))
 		for ct := range coinTypes {
 			var perBlock string
@@ -906,7 +900,7 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 				Symbol:      fmt.Sprintf("SKA%d", ct),
 				PerBlock:    perBlock,
 				PerYear:     perYear,
-				BlockHeight: voteRewardsBlockHeight,
+				BlockHeight: blockHeight,
 			})
 		}
 		sort.Slice(rewards, func(i, j int) bool { return rewards[i].CoinType < rewards[j].CoinType })


### PR DESCRIPTION
## Description
Fixes a bug where SKA coin reward links on the home page all pointed to the same block instead of each coin's respective block.
### Root cause
`explorer.go:Store()` used a shared `int64` variable for `PoWSKARewards.BlockHeight`, so the last coin's height overwrote all others. Same pattern in `pubsubhub.go` for `SKAVoteRewards`.
### Changes
- **`explorer.go`**: `PoWSKARewards.BlockHeight` → `map[uint8]int64` for per-coin tracking
- **`pubsubhub.go`**: `SKAVoteRewards` uses per-coin `blockHeight` (removed shared `voteRewardsBlockHeight`)
- **`explorer_test.go`**: new test case `sum30_fallback_yields_per-coin_BlockHeight_for_each_SKA_coin` covering the fallback path