### PR TITLE
cmd/dcrdata: tx page revocation Ticket Status; hide empty tspend card

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -1257,6 +1257,29 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 		}
 	} // tx.IsTicket()
 
+	// For a revocation the revoked ticket is referenced by the first input's
+	// previous outpoint, not the revocation tx's own hash.
+	if tx.IsRevocation() && len(tx.Vin) > 0 {
+		ticketHash := tx.Vin[0].Txid
+		zeroHash := (chainhash.Hash{}).String()
+		if ticketHash != "" && ticketHash != zeroHash {
+			_, poolStatus, err := exp.dataSource.PoolStatusForTicket(ctx, ticketHash)
+			if exp.timeoutErrorPage(w, err, "PoolStatusForTicket(revocation)") {
+				return
+			}
+			switch {
+			case errors.Is(err, dbtypes.ErrNoResult):
+				log.Warnf("Pool status not found for revoked ticket %s (revocation %s)",
+					ticketHash, hash)
+			case err != nil:
+				log.Errorf("Unable to retrieve pool status for revoked ticket %s (revocation %s): %v",
+					ticketHash, hash, err)
+			default:
+				tx.TicketInfo.PoolStatus = poolStatus.String()
+			}
+		}
+	}
+
 	// Find atomic swaps related to this tx.
 	swapsInfo, err := exp.txAtomicSwapsInfo(ctx, tx)
 	if err != nil {

--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -211,6 +211,12 @@
                       {{end}}
                   {{end}}
               {{end}}
+              {{if and .IsRevocation .TicketInfo.PoolStatus}}
+                  <tr>
+                      <td class="text-end medium-sans text-nowrap pe-2 py-2">Ticket Status:</td>
+                      <td colspan="3" class="text-start py-1 text-secondary">{{.TicketInfo.PoolStatus}}</td>
+                  </tr>
+              {{end}}
               <tr>
                 <td class="text-end medium-sans text-nowrap pe-2 py-2">Raw Tx:</td>
                 <td class="text-start py-1 text-secondary">
@@ -598,8 +604,8 @@
             {{else}}
             <br>No recognized agenda votes in this transaction.
             {{end}}
-            <h5>Treasury Spend Choices</h5>
             {{if gt (len .TSpends) 0}}
+            <h5>Treasury Spend Choices</h5>
             <table class="table">
                 <thead>
                   <tr>
@@ -616,8 +622,6 @@
                     {{end}}
                 </tbody>
             </table>
-            {{else}}
-            No treasury spend choices in this transaction.
             {{end}}
         </div>
     </div>

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -497,7 +497,9 @@ func (t *TxInfo) BlocksToTicketMaturity() (blocks int64) {
 	return t.TicketInfo.TicketMaturity + 1 - t.Confirmations
 }
 
-// TicketInfo is used to represent data shown for a sstx transaction.
+// TicketInfo is used to represent data shown for a sstx transaction. On a
+// revocation tx page, PoolStatus is also populated with the revoked ticket's
+// pool status (the other fields stay zero).
 type TicketInfo struct {
 	TicketMaturity       int64
 	TimeTillMaturity     float64 // Time before a particular ticket reaches maturity, in hours


### PR DESCRIPTION
## Summary

Fixes #305 — two cosmetic problems on `/tx/{txid}`:

- **Revocation tx was missing the "Ticket Status" indicator** that `/block/{blockhash}` already shows in its Revocations table.
- **Vote tx rendered an empty "Treasury Spend Choices" card** when there were no choices.

Tx page is purely server-rendered (no WS update path), so this is HTML-render only — no JS / pubsub changes.

### Revocation Ticket Status

In `TxPage`, after the existing `if tx.IsTicket() { … }` block, added a sibling branch that calls `exp.dataSource.PoolStatusForTicket(ctx, tx.Vin[0].Txid)` — note the revoked ticket is referenced by Vin[0]'s previous-outpoint hash, not the revocation tx's own hash. Result is stored in `tx.TicketInfo.PoolStatus` (reused because all existing template references to that field are gated by `{{if .IsTicket}}`, so no clash). Error handling is intentionally soft-fail (log + continue) to match the block-page's behavior at `db/dcrpg/pgblockchain.go:6723-6735`.

Template adds a "Ticket Status:" row in the revocation/vote details table, gated by `{{if and .IsRevocation .TicketInfo.PoolStatus}}`.

### Empty Treasury Spend Choices

Moved the `<h5>Treasury Spend Choices</h5>` heading inside the existing `{{if gt (len .TSpends) 0}}` block and dropped the empty-state placeholder. The card now disappears entirely when there are no choices; when there are, it renders unchanged.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` — clean across all affected modules.
- [x] `golangci-lint run` — 0 issues.
- [x] Pre-commit hooks (gofmt + per-module `go test`) — passed.
- [x] **Playwright manual check on testnet** — visited an `expired` revocation tx (`/tx/0bab9bd2…`); page renders `Ticket Status: expired`, matching the value shown for the same tx in `/block/7055`'s Revocations table.
- [ ] Vote-tx verification (empty + non-empty tspends) — could not exercise on local testnet (no vote txs on chain); template change is mechanically verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)