### PR TITLE
explorer: render SKA tx fee rate as SKA{n}/B

### DIFF
--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -394,6 +394,7 @@ func threeSigFigs(v float64) string {
 // skaDecimals is 10^18 — the number of SKA atoms per coin.
 var skaDecimals = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
 var varDecimals = big.NewInt(1e8)
+var bytesPerKB = big.NewInt(1000)
 
 // parseInt64 parses a decimal atom string to int64, returning 0 on error.
 func parseInt64(s string) int64 {
@@ -500,6 +501,40 @@ func coinDecimalParts(atomStr string, coinType uint8, useCommas bool, boldNumPla
 		return float64Formatting(v, 8, useCommas, boldNumPlaces...)
 	}
 	return skaDecimalParts(atomStr, useCommas, boldNumPlaces...)
+}
+
+// coinFeeRateDecimalParts renders a fee-rate value carried on the contract as
+// atoms/kB. VAR delegates to coinDecimalParts and is displayed as VAR/kB.
+// SKA divides the big.Int atoms/kB by 1000 (giving atoms/B) and renders via
+// skaDecimalParts so the headline number reads as SKA/B — chosen because SKA
+// 18-decimal fee rates are too small per kB to be legible. No float64
+// conversion on the SKA path.
+func coinFeeRateDecimalParts(atomsPerKB string, coinType uint8, useCommas bool, boldNumPlaces ...int) []string {
+	if coinType == 0 {
+		return coinDecimalParts(atomsPerKB, 0, useCommas, boldNumPlaces...)
+	}
+	return skaDecimalParts(skaAtomsPerKBToPerByte(atomsPerKB), useCommas, boldNumPlaces...)
+}
+
+// skaAtomsPerKBToPerByte converts an SKA fee-rate string from atoms/kB to
+// atoms/B using big.Int integer division. Sub-atom-per-byte remainder is
+// unrepresentable and dropped. Empty or non-numeric input is returned
+// unchanged so skaDecimalParts can render the safe ["0","",""] fallback.
+func skaAtomsPerKBToPerByte(atomsPerKB string) string {
+	n, ok := new(big.Int).SetString(atomsPerKB, 10)
+	if !ok {
+		return atomsPerKB
+	}
+	return n.Quo(n, bytesPerKB).String()
+}
+
+// coinFeeRateUnit returns the fee-rate unit suffix. VAR uses /kB (matching the
+// on-the-wire atoms/kB contract); SKA uses /B (paired with coinFeeRateDecimalParts).
+func coinFeeRateUnit(coinType uint8) string {
+	if coinType == 0 {
+		return "VAR/kB"
+	}
+	return coinSymbol(coinType) + "/B"
 }
 
 // formatCoinAtoms converts a raw atom string to a threeSigFigs-formatted coin
@@ -764,6 +799,10 @@ func makeTemplateFuncMap(params *chaincfg.Params) template.FuncMap {
 		"coinDecimalParts": func(atomStr string, coinType uint8, useCommas bool, boldNumPlaces ...int) []string {
 			return coinDecimalParts(atomStr, coinType, useCommas, boldNumPlaces...)
 		},
+		"coinFeeRateDecimalParts": func(atomsPerKB string, coinType uint8, useCommas bool, boldNumPlaces ...int) []string {
+			return coinFeeRateDecimalParts(atomsPerKB, coinType, useCommas, boldNumPlaces...)
+		},
+		"coinFeeRateUnit": coinFeeRateUnit,
 		"skaDecimalParts": func(atomStr string, useCommas bool, boldNumPlaces ...int) []string {
 			return skaDecimalParts(atomStr, useCommas, boldNumPlaces...)
 		},

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -759,6 +759,114 @@ func TestSkaDecimalParts(t *testing.T) {
 	}
 }
 
+func TestCoinFeeRateDecimalParts(t *testing.T) {
+	tests := []struct {
+		name          string
+		atomStr       string
+		coinType      uint8
+		boldNumPlaces []int
+		expected      []string
+	}{
+		{
+			// VAR: 10000 atoms/kB = 0.0001 VAR/kB. Asserted as an exact
+			// literal so any drift in coinDecimalParts is caught here too.
+			name:     "VAR 10000 atoms/kB renders as 0.0001",
+			atomStr:  "10000",
+			coinType: 0,
+			expected: []string{"0", "0001", "0000"},
+		},
+		{
+			name:          "VAR bold-mode forwards variadic to coinDecimalParts",
+			atomStr:       "10000",
+			coinType:      0,
+			boldNumPlaces: []int{2},
+			expected:      []string{"0", "00", "01", "0000"},
+		},
+		{
+			// Issue #304 example: 0.545 SKA1/B.
+			// 0.545 SKA = 5.45e17 atoms (SKA has 18 decimals).
+			// atoms/kB = atoms/B * 1000 = 5.45e20 = "545" + 18 zeros.
+			// After helper /1000 -> 5.45e17 atoms/B -> skaDecimalParts:
+			//   dec = "545000000000000000" (18 chars)
+			//   right = "545", trailingZeros = "000000000000000" (15)
+			name:     "SKA fee rate produces 0.545 SKA1/B for issue example",
+			atomStr:  "545000000000000000000",
+			coinType: 1,
+			expected: []string{"0", "545", "000000000000000"},
+		},
+		{
+			name:          "SKA bold-mode forwards variadic to skaDecimalParts",
+			atomStr:       "545000000000000000000",
+			coinType:      1,
+			boldNumPlaces: []int{3},
+			expected:      []string{"0", "545", "", "000000000000000"},
+		},
+		{
+			name:     "SKA zero atoms/kB",
+			atomStr:  "0",
+			coinType: 1,
+			expected: []string{"0", "", ""},
+		},
+		{
+			name:     "SKA empty string (defensive)",
+			atomStr:  "",
+			coinType: 2,
+			expected: []string{"0", "", ""},
+		},
+		{
+			name:     "SKA non-numeric input falls through to skaDecimalParts parse-fail path",
+			atomStr:  "abc",
+			coinType: 1,
+			expected: []string{"abc", "", ""},
+		},
+		{
+			// Sub-kB precision below 1 atom/B is dropped by the big.Int /1000.
+			// 1500 atoms/kB -> 1 atom/B -> 1e-18 SKA -> dec = "000000000000000001".
+			name:     "SKA atoms/kB above 1000 truncates sub-atom remainder",
+			atomStr:  "1500",
+			coinType: 1,
+			expected: []string{"0", "000000000000000001", ""},
+		},
+		{
+			// Pins the documented truncation invariant: any value < 1000
+			// atoms/kB collapses to exactly 0 atoms/B and renders identically
+			// to a true-zero fee rate.
+			name:     "SKA atoms/kB below 1000 truncates to zero",
+			atomStr:  "999",
+			coinType: 1,
+			expected: []string{"0", "", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := coinFeeRateDecimalParts(tt.atomStr, tt.coinType, false, tt.boldNumPlaces...)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("unexpected result\nexpected: %#v\ngot:      %#v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestCoinFeeRateUnit(t *testing.T) {
+	tests := []struct {
+		coinType uint8
+		expected string
+	}{
+		{coinType: 0, expected: "VAR/kB"},
+		{coinType: 1, expected: "SKA1/B"},
+		{coinType: 2, expected: "SKA2/B"},
+		{coinType: 255, expected: "SKA255/B"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := coinFeeRateUnit(tt.coinType); got != tt.expected {
+				t.Errorf("coinFeeRateUnit(%d) = %q, want %q", tt.coinType, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestFloat64FormattingNoTrailing(t *testing.T) {
 	got := float64FormattingNoTrailing(3.2, 8, false, 2)
 

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -411,7 +411,7 @@
 					<td class="mono fs15 text-end">
 						{{template "decimalParts" (coinDecimalParts .FeeRaw .CoinType false)}} {{coinSymbol .CoinType}}
 					</td>
-					<td class="mono fs15 text-end">{{template "decimalParts" (coinDecimalParts .FeeRateRaw .CoinType false)}} {{coinSymbol .CoinType}}/kB</td>
+					<td class="mono fs15 text-end">{{template "decimalParts" (coinFeeRateDecimalParts .FeeRateRaw .CoinType false)}} {{coinFeeRateUnit .CoinType}}</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
 				</tr>
 			{{- end}}

--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -224,7 +224,7 @@
                 <td class="text-end medium-sans text-nowrap pe-2 py-2">Version:</td>
                 <td class="text-start py-1 text-secondary">{{.Version}}</td>
                 <td class="text-end medium-sans text-nowrap pe-2 py-2">Rate:</td>
-                <td class="text-start py-1 text-secondary">{{if eq .CoinType 0}}{{.FeeRate}}/kB{{else}}{{.FeeRateRaw}} {{coinSymbol .CoinType}}/kB{{end}}</td>
+                <td class="text-start py-1 text-secondary">{{template "decimalParts" (coinFeeRateDecimalParts .FeeRateRaw .CoinType false)}} {{coinFeeRateUnit .CoinType}}</td>
               </tr>
               <tr>
                 <td class="text-end medium-sans text-nowrap pe-2 py-2">Size:</td>

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -5487,8 +5487,9 @@ func (pgb *ChainDB) GetAPITransaction(ctx context.Context, txid *chainhash.Hash)
 	// Calculate high-precision total and fee.
 	if coinType == 0 { // VAR
 		tx.Total = strconv.FormatInt(int64(txhelpers.TotalVout(txraw.Vout)), 10)
-		fee, _ := txhelpers.TxFeeRate(msgTx)
+		fee, feeRate := txhelpers.TxFeeRate(msgTx)
 		tx.Fee = strconv.FormatInt(int64(fee), 10)
+		tx.FeeRateRaw = strconv.FormatInt(int64(feeRate), 10)
 	} else { // SKA
 		skaTotals := txhelpers.SKATotalsFromMsgTx(msgTx)
 		if total, ok := skaTotals[coinType]; ok {
@@ -6472,6 +6473,7 @@ func makeExplorerTxBasic(data *chainjson.TxRawResult, ticketPrice int64, msgTx *
 		fee, feeRate := txhelpers.TxFeeRate(msgTx)
 		tx.Fee, tx.FeeRate = fee, feeRate
 		tx.FeeRaw = strconv.FormatInt(int64(fee), 10)
+		tx.FeeRateRaw = strconv.FormatInt(int64(feeRate), 10)
 	} else { // SKA
 		// For SKA, Total is 0 in legacy float.
 		tx.Total = 0
@@ -6495,6 +6497,7 @@ func makeExplorerTxBasic(data *chainjson.TxRawResult, ticketPrice int64, msgTx *
 	case v0.IsCoinBase():
 		tx.Fee, tx.FeeRate = 0, 0
 		tx.FeeRaw = "0"
+		tx.FeeRateRaw = "0"
 		tx.Coinbase = true
 	case v0.Treasurybase:
 		tx.Treasurybase = true


### PR DESCRIPTION
## Summary

Implements issue #304 — the UI half of the block-page fee/fee-rate display work paired with backend issue #303 (closed by #314). After #314 landed, the remaining #304 gap was the SKA Fee Rate column display: the 18-decimal atoms/kB contract value is illegible at per-kB scale, and the issue specifies ``SKA{n}/B`` (e.g. ``0.545 SKA1/B``).

## What #314 already delivered (data layer, #303 scope)

- Header "Fee" total excludes Stake-type txs.
- SKA Fee Rate computed with big.Int precision; ``FeeRateRaw`` carried as atoms/kB across HTTP and WS contracts (parity test in ``visualblocks_contract_test.go``).
- Stake Fees table column renamed "Rewards" with non-zero SKA values.

## What this PR adds (display layer, #304 scope)

- Add ``coinFeeRateDecimalParts`` and ``coinFeeRateUnit`` helpers in [templates.go](cmd/dcrdata/internal/explorer/templates.go). SKA path divides the big.Int atoms/kB value by 1000 (atoms/B) before delegating to ``skaDecimalParts``. VAR stays at ``VAR/kB``. No float64 on the SKA path.
- Wire the helpers into [block.tmpl](cmd/dcrdata/views/block.tmpl) (Transactions table Fee Rate cell) and [tx.tmpl](cmd/dcrdata/views/tx.tmpl) (Rate field on tx detail page).
- Populate ``tx.FeeRateRaw`` on the VAR branch of ``makeExplorerTxBasic`` and ``GetAPITransaction`` so both the explorer template and the JSON API emit a non-empty value for VAR (was previously only set for SKA). Explicit ``FeeRateRaw = \"0\"`` on the coinbase override.
- Tests cover the issue example (0.545 SKA1/B), bold-mode variadic forwarding, sub-atom truncation, empty / non-numeric input, and the unit suffix for VAR and SKA{1,2,255}.

## #304 checklist after this PR

- [x] Header "Fee" excludes Stake Fees — landed via #314
- [x] Transactions table SKA Fee Rate in ``SKA{n}/B`` — **this PR**
- [x] Stake Fees table SKA non-zero — landed via #314 (column renamed Rewards)
- [x] HTTP/WS first-paint parity — landed via #314 (``visualblocks_contract_test.go``)

## Test plan

- [x] ``cd cmd/dcrdata && go test ./internal/explorer/ -run TestCoinFeeRate`` — all 13 subtests pass
- [x] ``cd db/dcrpg && go test -run TestTrimmedTxInfoFromMsgTx_Fees .`` — VAR / SKA / coinbase paths pass
- [x] Live verification on /block/10443 via Playwright:
  - Transactions table VAR row reads ``0.00010077 VAR/kB``
  - Transactions table SKA1 row reads ``0.004236363636363636 SKA1/B``
  - Tx detail page Rate field matches the block-page values
  - ``/api/tx/<varTxID>.fee_rate_raw`` now populated (was empty pre-fix)

Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)