### PR TITLE
explorer: drop dead Decred labels and template blocks (/charts, /tx)

### DIFF
--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -549,7 +549,7 @@ export default class extends Controller {
           valueRange: [0, windowSize * 20 * 8],
           axisLabelFormatter: (y) => Math.round(y)
         }
-        yFormatter = customYFormatter((y) => `${y.toFixed(8)} DCR`)
+        yFormatter = customYFormatter((y) => `${y.toFixed(8)} VAR`)
         break
 
       case 'ticket-pool-size': // pool size graph
@@ -595,10 +595,10 @@ export default class extends Controller {
         yFormatter = (div, data, i) => {
           addLegendEntryFmt(div, data.series[0], (y) => `${y.toFixed(4)}%`)
           div.appendChild(
-            legendEntry(`${legendMarker()} Ticket Pool Value: ${intComma(rawPoolValue[i])} DCR`)
+            legendEntry(`${legendMarker()} Ticket Pool Value: ${intComma(rawPoolValue[i])} VAR`)
           )
           div.appendChild(
-            legendEntry(`${legendMarker()} Coin Supply: ${intComma(rawCoinSupply[i])} DCR`)
+            legendEntry(`${legendMarker()} Coin Supply: ${intComma(rawCoinSupply[i])} VAR`)
           )
         }
         break
@@ -611,12 +611,12 @@ export default class extends Controller {
             d,
             [xlabel, 'Ticket Pool Value'],
             true,
-            'Ticket Pool Value (DCR)',
+            'Ticket Pool Value (VAR)',
             true,
             false
           )
         )
-        yFormatter = customYFormatter((y) => `${intComma(y)} DCR`)
+        yFormatter = customYFormatter((y) => `${intComma(y)} VAR`)
         break
 
       case 'block-size': // block size graph
@@ -723,7 +723,7 @@ export default class extends Controller {
         d = zip2D(data, data.fees, atomsToDCR)
         assign(
           gOptions,
-          mapDygraphOptions(d, [xlabel, 'Total Fee'], false, 'Total Fee (DCR)', true, false)
+          mapDygraphOptions(d, [xlabel, 'Total Fee'], false, 'Total Fee (VAR)', true, false)
         )
         break
 
@@ -734,11 +734,11 @@ export default class extends Controller {
         const label = 'Mix Rate'
         assign(
           gOptions,
-          mapDygraphOptions(d.data, [xlabel, label], false, `${label} (DCR)`, true, false)
+          mapDygraphOptions(d.data, [xlabel, label], false, `${label} (VAR)`, true, false)
         )
 
         yFormatter = (div, data, _i) => {
-          addLegendEntryFmt(div, data.series[0], (y) => (y > 0 ? intComma(y) : '0 DCR'))
+          addLegendEntryFmt(div, data.series[0], (y) => (y > 0 ? intComma(y) : '0 VAR'))
         }
         break
       }

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -17,7 +17,7 @@ let Dygraph // lazy loaded on connect
 
 const aDay = 86400 * 1000 // in milliseconds
 const aMonth = 30 // in days
-const atomsToDCR = 1e-8
+const atomsToVAR = 1e-8
 const windowScales = ['ticket-price', 'pow-difficulty', 'missed-votes']
 const hybridScales = ['privacy-participation']
 const lineScales = ['ticket-price', 'privacy-participation']
@@ -237,7 +237,7 @@ function anonymitySetFunc(data) {
           start = i
         }
         end = i
-        return [i, y * atomsToDCR]
+        return [i, y * atomsToVAR]
       })
     } else {
       d = data.anonymitySet.map((y, i) => {
@@ -245,7 +245,7 @@ function anonymitySetFunc(data) {
           start = i
         }
         end = data.h[i]
-        return [data.h[i], y * atomsToDCR]
+        return [data.h[i], y * atomsToVAR]
       })
     }
   } else {
@@ -254,15 +254,15 @@ function anonymitySetFunc(data) {
         start = t * 1000
       }
       end = t * 1000
-      return [new Date(t * 1000), data.anonymitySet[i] * atomsToDCR]
+      return [new Date(t * 1000), data.anonymitySet[i] * atomsToVAR]
     })
   }
   return { data: d, limits: [start, end] }
 }
 
 function ticketPriceFunc(data) {
-  if (data.t) return zipWindowTvYZ(data.t, data.price, data.count, atomsToDCR)
-  return zipWindowHvYZ(data.price, data.count, data.window, atomsToDCR)
+  if (data.t) return zipWindowTvYZ(data.t, data.price, data.count, atomsToVAR)
+  return zipWindowHvYZ(data.price, data.count, data.window, atomsToVAR)
 }
 
 function poolSizeFunc(data) {
@@ -282,8 +282,8 @@ function poolSizeFunc(data) {
 }
 
 function percentStakedFunc(data) {
-  rawCoinSupply = data.circulation.map((v) => v * atomsToDCR)
-  rawPoolValue = data.poolval.map((v) => v * atomsToDCR)
+  rawCoinSupply = data.circulation.map((v) => v * atomsToVAR)
+  rawPoolValue = data.poolval.map((v) => v * atomsToVAR)
   const ys = rawPoolValue.map((v, i) => [(v / rawCoinSupply[i]) * 100])
   if (data.axis === 'height') {
     if (data.bin === 'block') return zipIvY(ys)
@@ -303,7 +303,7 @@ function circulationFunc(chartData) {
   const addDough = (newHeight) => {
     while (h < newHeight) {
       h++
-      yMax += blockReward(h) * atomsToDCR
+      yMax += blockReward(h) * atomsToVAR
     }
   }
   const heights = chartData.h
@@ -324,7 +324,7 @@ function circulationFunc(chartData) {
     const height = hFunc(i)
     addDough(height)
     inflation.push(yMax)
-    return [xFunc(i), supplies[i] * atomsToDCR, null]
+    return [xFunc(i), supplies[i] * atomsToVAR, null]
   })
 
   const dailyBlocks = aDay / avgBlockTime
@@ -604,7 +604,7 @@ export default class extends Controller {
         break
 
       case 'ticket-pool-value': // pool value graph
-        d = zip2D(data, data.poolval, atomsToDCR)
+        d = zip2D(data, data.poolval, atomsToVAR)
         assign(
           gOptions,
           mapDygraphOptions(
@@ -720,7 +720,7 @@ export default class extends Controller {
         break
 
       case 'fees': // block fee graph
-        d = zip2D(data, data.fees, atomsToDCR)
+        d = zip2D(data, data.fees, atomsToVAR)
         assign(
           gOptions,
           mapDygraphOptions(d, [xlabel, 'Total Fee'], false, 'Total Fee (VAR)', true, false)

--- a/cmd/dcrdata/public/js/helpers/humanize_helper.js
+++ b/cmd/dcrdata/public/js/helpers/humanize_helper.js
@@ -210,9 +210,6 @@ const humanize = {
     if (Math.abs(v) < 1.0) return parseFloat(v).toPrecision(3)
     return parseFloat(v).toFixed(2)
   },
-  subsidyToString: function (x, y = 1) {
-    return `${x / 100000000 / y} DCR`
-  },
   bytes: function (s) {
     // from go-humanize
     const sizes = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB']

--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -286,6 +286,164 @@
         </div>
     </div>
 
+    {{$tip := $.CommonPageData.Tip.Height}}
+    {{with $.Data.TSpendMeta}}
+    {{$votingStarted := ge $tip .VoteStart}}
+    {{$votingEnded := or .Approved (ge $tip .VoteEnd)}}
+    <div class="row pt-2 px-2">
+        <div class="col-24 col-xl-11 bg-white px-2 px-xl-5 py-3 position-relative d-flex flex-column justify-content-between align-items-start">
+                <div class="fs22">Treasury Spend Approval</div>
+                {{if not $votingStarted}}
+                  <span class="fs16 lh1rem">Voting has not started for this Treasury Spend</span>
+                {{else if not $votingEnded}}
+                  <div>
+                      <span class="fs18 lh1rem">Voting now</span>
+                      <span class="float-right fs16">
+                       &nbsp;~&nbsp;{{formatDateTime .VoteEndDate}} remaining
+                      </span>
+                  </div>
+                {{else}}
+                  <div>
+                    <span class="fs18 lh1rem">Voting complete</span> &ndash;
+                    {{if .Approved}}
+                      {{if eq $.Data.BlockHeight 0}}
+                      <span>Mineable at Next TVI: {{.NextTVI}} (~ {{formatDateTime .NextTVITime}})</span>
+                      {{else if lt $.Data.BlockHeight .VoteEnd}}
+                      <span class="text-green">Fast Approval</span>
+                      {{else}}
+                      <span class="text-green">Approved</span>
+                      {{end}}
+                    {{else}}
+                      <span class="text-danger">Rejected</span>
+                    {{end}}
+                  </div>
+                {{end}}
+                <div class="d-flex w-100 justify-content-start p-2 my-2 secondary-card rounded">
+                  <div class="col-auto lilbox px-2">
+                    <div
+                      class="meter text-center js-only lil arch"
+                      data-tx-target="approvalMeter"
+                      data-value="{{.Approval}}"
+                      data-threshold="{{.PassPercent}}"
+                      >
+                      {{printf "%.1f" (f32x100 .Approval)}}%
+                    </div>
+                  </div>
+                  <div class="col-auto d-flex flex-column justify-content-between ps-3">
+                    <span class="fs17 lh1em">
+                      <span class="fs22 medium-sans">{{printf "%.1f" (f32x100 .Approval)}}%</span>
+                      approval of {{intComma .TotalVotes}} votes
+                    </span>
+                    {{if .QuorumAchieved}}
+                      <div class="d-flex align-items-center"><span class="fs20 monicon-affirm me-2"></span>
+                      <span class="lh1em pb-1">Quorum achieved ({{.TotalVotes}} of {{.QuorumCount}} needed votes)</span></div>
+                    {{else if $votingEnded}}
+                      <div class="d-flex align-items-center"><span class="fs20 monicon-reject me-2"></span>
+                      <span class="pb-1">Quorum not achieved ({{.TotalVotes}} of {{.QuorumCount}} needed votes)</span></div>
+                    {{else}}
+                       <span class="text-secondary fs13">Quorum</span>
+                       <div class="d-flex align-items-center"><span class="fs20 monicon-missing me-2"></span>
+                       <span class="pb-1">{{.TotalVotes}} of {{.QuorumCount}} needed votes</span>
+                        </div>
+                     {{end}}
+                  </div>
+                </div>
+        </div>
+        {{- /* ADDITIONAL DATA */ -}}
+        <div class="col-24 col-xl-13 secondary-card px-3 position-relative d-flex justify-content-center align-items-center">
+            <table class="fs14 my-3 text-start d-flex">
+              <tbody>
+                 <tr>
+                    <td class="text-end medium-sans text-nowrap pe-2 py-2">Politeia Key:</td>
+                    <td colspan="3" class="text-start py-1 text-secondary break-word lh1rem">{{.PoliteiaKey}}</td>
+                 </tr>
+                {{if .TotalVotes}}
+                  {{$yesPercent := percentage .YesVotes .TotalVotes}}
+                  {{$noPercent := percentage .NoVotes .TotalVotes}}
+                 <tr>
+                   <td class="text-end medium-sans text-nowrap pe-2 py-2">Yes Votes:</td>
+                   <td class="text-start py-1 text-secondary">
+                      {{.YesVotes}} votes ({{printf "%.1f" $yesPercent}}%)
+                   </td>
+                   <td class="text-end medium-sans text-nowrap pe-2 py-2">No Votes:</td>
+                   <td class="text-start py-1 text-secondary">
+                      {{.NoVotes}} votes  ({{printf "%.1f" $noPercent}}%)
+                   </td>
+                 </tr>
+                 {{end}}
+                 <tr>
+                   <td class="text-end medium-sans text-nowrap pe-2 py-2" >Eligible Votes:</td>
+                   <td class="text-start py-1 text-secondary">{{.EligibleVotes}} (of max possible {{.MaxVotes}})</td>
+                 {{if not $votingStarted}}
+                   <td class="text-end medium-sans text-nowrap pe-2 py-2">Voting Starts In:</td>
+                   <td class="text-start py-1 text-secondary"> ~ {{formatDateTime .VoteStartDate}}</td>
+                 {{else}}
+                   <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Started:</td>
+                   <td class="text-start py-1 text-secondary"> {{formatDateTime .VoteStartDate}}</td>
+                 {{end}}
+                 </tr>
+                 <tr>
+                   <td class="text-end medium-sans text-nowrap pe-2 py-2">Votes Cast:</td>
+                   <td class="text-start py-1 text-secondary"> {{.TotalVotes}}
+                    ({{if gt .TotalVotes 0}}{{printf "%.0f" (percentage .TotalVotes .EligibleVotes)}}{{else}}0{{end}}% turnout)
+                   </td>
+                 {{if not .Approved}}
+                    <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Ends In:</td>
+                    <td class="text-start py-1 text-secondary"> ~ {{formatDateTime .VoteEndDate}}</td>
+                 {{else}}
+                   {{if eq $.Data.BlockHeight 0}}
+                    <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Ends In:</td>
+                    <td class="text-start py-1 text-secondary"> ~ {{formatDateTime .NextTVITime}}</td>
+                   {{else if gt $.Data.BlockHeight .VoteEnd}}
+                    <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Ended:</td>
+                    <td class="text-start py-1 text-secondary">{{formatDateTime .VoteEndDate}}</td>
+                   {{else}}
+                    <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Ended:</td>
+                    <td class="text-start py-1 text-secondary" data-tx-target="formattedAge">{{$.Data.Time.String}}</td>
+                  {{end}}
+                 {{end}}
+                 </tr>
+                 <tr>
+                 {{if not .Approved}}
+                   <td class="text-end medium-sans text-nowrap pe-2 py-2" >Yes Votes Still Needed:</td>
+                   <td class="text-start py-1 text-secondary">
+                     {{$remainingYesVotes := subtract .RequiredYesVotes .YesVotes}}
+                     {{if gt $remainingYesVotes 0}}
+                       {{$remainingYesVotes}}
+                     {{end}}
+                   </td>
+                 {{end}}
+                   <td class="text-end medium-sans text-nowrap pe-2 py-2">Voting Period:</td>
+                   <td class="text-start py-1 text-secondary">
+                 {{if $votingStarted}}
+                   <a href="/block/{{.VoteStart}}">{{.VoteStart}}</a>
+                 {{else}}
+                   {{.VoteStart}}
+                 {{end}}
+                     &ndash;
+                 {{if not .Approved}}
+                   {{if ge $tip .VoteEnd}}
+                     <a href="/block/{{.VoteEnd}}">{{.VoteEnd}}</a>
+                 {{else}}
+                     {{.VoteEnd}}
+                   {{end}}
+                 {{else}}
+                   {{if eq $.Data.BlockHeight 0}}
+                        {{.NextTVI}}
+                   {{else if gt $.Data.BlockHeight .VoteEnd}}
+                      <a href="/block/{{.VoteEnd}}">{{.VoteEnd}}</a>
+                   {{else}}
+                      <a href="/block/{{$.Data.BlockHeight}}">{{$.Data.BlockHeight}}</a>
+                   {{end}}
+                 {{end}}
+                   </td>
+                 </tr>
+              </tbody>
+            </table>
+        </div>
+    </div>
+    {{end}}
+
     <div class="row mb-5">
         <div class="col-lg-12 mt-4 mb-2">
             <h5 class="pb-2">{{len .Vin}} Input{{if gt (len .Vin) 1}}s{{end}} Consumed</h5>
@@ -311,13 +469,17 @@
                                 {{range .Addresses}}
                                   {{template "hashElide" (hashlink . (print "/address/" .))}}
                                 {{end}}
+                            {{else if .TreasurySpend}}
+                                <a href="/treasury">Treasury</a>
                             {{else}}
                                 N/A
                             {{end}}
                         </td>
                         <td class="shrink-to-fit"{{if $isMempool}} data-tx-target="mempoolTd" data-txid="{{.Txid}}"{{end}}>
-                        {{if or .Coinbase .Stakebase}}
+                        {{if or .Treasurybase (or .Coinbase .Stakebase)}}
                             created
+                        {{else if .TreasurySpend}}
+                            N/A
                         {{else if eq .BlockHeight 0}}
                             pending
                         {{else}}
@@ -373,6 +535,10 @@
                                     <span class="break-word">{{.OP_RETURN}}</span>
                                 </div>
                                 {{end}}
+                            {{else if .OP_TADD}}
+                              <div>
+                                <span class="break-word"><a href="/treasury">Treasury</a></span>
+                              </div>
                             {{end}}
                         </td>
                         <td class="fs13 break-word shrink-to-fit">
@@ -385,7 +551,7 @@
                               {{if $spending.Hash}}
                                  <a href="/tx/{{$spending.Hash}}/in/{{$spending.Index}}">{{$v.Spent}}</a>
                               {{else}}
-                                {{if and (eq $v.CoinType 0) (le $v.Amount 0.0)}}
+                                {{if or $v.OP_TADD (and (eq $v.CoinType 0) (le $v.Amount 0.0))}}
                                   n/a
                                 {{else}}
                                   {{$v.Spent}}
@@ -410,6 +576,55 @@
             <h4>Vote Info</h4>
             <p>Last Block Valid: <span class="mono"><strong>{{.Validation.Validity}}</strong></span><br>
             Version: <span class="mono">{{.Version}}</span> | Bits: <span class="mono">{{printf "%#04x" .Bits}}</span></p>
+            <h5>Agenda Choices</h5>
+            {{if .Choices}}
+            <table class="table">
+                <thead>
+                  <tr>
+                    <th class="text-end">Issue ID</th>
+                    <th>Issue Description</th>
+                    <th>Choice ID</th>
+                    <th>Choice Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    {{range .Choices}}
+                    <tr>
+                        <td class="text-end"><span class="highlight-text"><a href="/agenda/{{.ID}}">{{.ID}}</a></span></td>
+                        <td>{{.Description}}</td>
+                        <td>
+                            <span class="agenda-voting-overview-option-dot _{{.Choice.Id}}"></span>
+                            {{.Choice.Id}}
+                        </td>
+                        <td>{{.Choice.Description}}</td>
+                    </tr>
+                    {{end}}
+                </tbody>
+            </table>
+            {{else}}
+            <br>No recognized agenda votes in this transaction.
+            {{end}}
+            <h5>Treasury Spend Choices</h5>
+            {{if gt (len .TSpends) 0}}
+            <table class="table">
+                <thead>
+                  <tr>
+                    <th>Treasury Spend Transaction</th>
+                    <th>Choice</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    {{range .TSpends}}
+                    <tr>
+                        <td><a href="/tx/{{.TSpend}}">{{.TSpend}}</a></td>
+                        <td>{{.Choice}}</td>
+                    </tr>
+                    {{end}}
+                </tbody>
+            </table>
+            {{else}}
+            No treasury spend choices in this transaction.
+            {{end}}
         </div>
     </div>
     {{end}}

--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -280,164 +280,6 @@
         </div>
     </div>
 
-    {{$tip := $.CommonPageData.Tip.Height}}
-    {{with $.Data.TSpendMeta}}
-    {{$votingStarted := ge $tip .VoteStart}}
-    {{$votingEnded := or .Approved (ge $tip .VoteEnd)}}
-    <div class="row pt-2 px-2">
-        <div class="col-24 col-xl-11 bg-white px-2 px-xl-5 py-3 position-relative d-flex flex-column justify-content-between align-items-start">
-                <div class="fs22">Treasury Spend Approval</div>
-                {{if not $votingStarted}}
-                  <span class="fs16 lh1rem">Voting has not started for this Treasury Spend</span>
-                {{else if not $votingEnded}}
-                  <div>
-                      <span class="fs18 lh1rem">Voting now</span>
-                      <span class="float-right fs16">
-                       &nbsp;~&nbsp;{{formatDateTime .VoteEndDate}} remaining
-                      </span>
-                  </div>
-                {{else}}
-                  <div>
-                    <span class="fs18 lh1rem">Voting complete</span> &ndash;
-                    {{if .Approved}}
-                      {{if eq $.Data.BlockHeight 0}}
-                      <span>Mineable at Next TVI: {{.NextTVI}} (~ {{formatDateTime .NextTVITime}})</span>
-                      {{else if lt $.Data.BlockHeight .VoteEnd}}
-                      <span class="text-green">Fast Approval</span>
-                      {{else}}
-                      <span class="text-green">Approved</span>
-                      {{end}}
-                    {{else}}
-                      <span class="text-danger">Rejected</span>
-                    {{end}}
-                  </div>
-                {{end}}
-                <div class="d-flex w-100 justify-content-start p-2 my-2 secondary-card rounded">
-                  <div class="col-auto lilbox px-2">
-                    <div
-                      class="meter text-center js-only lil arch"
-                      data-tx-target="approvalMeter"
-                      data-value="{{.Approval}}"
-                      data-threshold="{{.PassPercent}}"
-                      >
-                      {{printf "%.1f" (f32x100 .Approval)}}%
-                    </div>
-                  </div>
-                  <div class="col-auto d-flex flex-column justify-content-between ps-3">
-                    <span class="fs17 lh1em">
-                      <span class="fs22 medium-sans">{{printf "%.1f" (f32x100 .Approval)}}%</span>
-                      approval of {{intComma .TotalVotes}} votes
-                    </span>
-                    {{if .QuorumAchieved}}
-                      <div class="d-flex align-items-center"><span class="fs20 monicon-affirm me-2"></span>
-                      <span class="lh1em pb-1">Quorum achieved ({{.TotalVotes}} of {{.QuorumCount}} needed votes)</span></div>
-                    {{else if $votingEnded}}
-                      <div class="d-flex align-items-center"><span class="fs20 monicon-reject me-2"></span>
-                      <span class="pb-1">Quorum not achieved ({{.TotalVotes}} of {{.QuorumCount}} needed votes)</span></div>
-                    {{else}}
-                       <span class="text-secondary fs13">Quorum</span>
-                       <div class="d-flex align-items-center"><span class="fs20 monicon-missing me-2"></span>
-                       <span class="pb-1">{{.TotalVotes}} of {{.QuorumCount}} needed votes</span>
-                        </div>
-                     {{end}}
-                  </div>
-                </div>
-        </div>
-        {{- /* ADDITIONAL DATA */ -}}
-        <div class="col-24 col-xl-13 secondary-card px-3 position-relative d-flex justify-content-center align-items-center">
-            <table class="fs14 my-3 text-start d-flex">
-              <tbody>
-                 <tr>
-                    <td class="text-end medium-sans text-nowrap pe-2 py-2">Politeia Key:</td>
-                    <td colspan="3" class="text-start py-1 text-secondary break-word lh1rem">{{.PoliteiaKey}}</td>
-                 </tr>
-                {{if .TotalVotes}}
-                  {{$yesPercent := percentage .YesVotes .TotalVotes}}
-                  {{$noPercent := percentage .NoVotes .TotalVotes}}
-                 <tr>
-                   <td class="text-end medium-sans text-nowrap pe-2 py-2">Yes Votes:</td>
-                   <td class="text-start py-1 text-secondary">
-                      {{.YesVotes}} votes ({{printf "%.1f" $yesPercent}}%)
-                   </td>
-                   <td class="text-end medium-sans text-nowrap pe-2 py-2">No Votes:</td>
-                   <td class="text-start py-1 text-secondary">
-                      {{.NoVotes}} votes  ({{printf "%.1f" $noPercent}}%)
-                   </td>
-                 </tr>
-                 {{end}}
-                 <tr>
-                   <td class="text-end medium-sans text-nowrap pe-2 py-2" >Eligible Votes:</td>
-                   <td class="text-start py-1 text-secondary">{{.EligibleVotes}} (of max possible {{.MaxVotes}})</td>
-                 {{if not $votingStarted}}
-                   <td class="text-end medium-sans text-nowrap pe-2 py-2">Voting Starts In:</td>
-                   <td class="text-start py-1 text-secondary"> ~ {{formatDateTime .VoteStartDate}}</td>
-                 {{else}}
-                   <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Started:</td>
-                   <td class="text-start py-1 text-secondary"> {{formatDateTime .VoteStartDate}}</td>
-                 {{end}}
-                 </tr>
-                 <tr>
-                   <td class="text-end medium-sans text-nowrap pe-2 py-2">Votes Cast:</td>
-                   <td class="text-start py-1 text-secondary"> {{.TotalVotes}}
-                    ({{if gt .TotalVotes 0}}{{printf "%.0f" (percentage .TotalVotes .EligibleVotes)}}{{else}}0{{end}}% turnout)
-                   </td>
-                 {{if not .Approved}}
-                    <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Ends In:</td>
-                    <td class="text-start py-1 text-secondary"> ~ {{formatDateTime .VoteEndDate}}</td>
-                 {{else}}
-                   {{if eq $.Data.BlockHeight 0}}
-                    <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Ends In:</td>
-                    <td class="text-start py-1 text-secondary"> ~ {{formatDateTime .NextTVITime}}</td>
-                   {{else if gt $.Data.BlockHeight .VoteEnd}}
-                    <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Ended:</td>
-                    <td class="text-start py-1 text-secondary">{{formatDateTime .VoteEndDate}}</td>
-                   {{else}}
-                    <td class="text-end medium-sans text-nowrap pe-2 py-2" >Voting Ended:</td>
-                    <td class="text-start py-1 text-secondary" data-tx-target="formattedAge">{{$.Data.Time.String}}</td>
-                  {{end}}
-                 {{end}}
-                 </tr>
-                 <tr>
-                 {{if not .Approved}}
-                   <td class="text-end medium-sans text-nowrap pe-2 py-2" >Yes Votes Still Needed:</td>
-                   <td class="text-start py-1 text-secondary">
-                     {{$remainingYesVotes := subtract .RequiredYesVotes .YesVotes}}
-                     {{if gt $remainingYesVotes 0}}
-                       {{$remainingYesVotes}}
-                     {{end}}
-                   </td>
-                 {{end}}
-                   <td class="text-end medium-sans text-nowrap pe-2 py-2">Voting Period:</td>
-                   <td class="text-start py-1 text-secondary">
-                 {{if $votingStarted}}
-                   <a href="/block/{{.VoteStart}}">{{.VoteStart}}</a>
-                 {{else}}
-                   {{.VoteStart}}
-                 {{end}}
-                     &ndash;
-                 {{if not .Approved}}
-                   {{if ge $tip .VoteEnd}}
-                     <a href="/block/{{.VoteEnd}}">{{.VoteEnd}}</a>
-                 {{else}}
-                     {{.VoteEnd}}
-                   {{end}}
-                 {{else}}
-                   {{if eq $.Data.BlockHeight 0}}
-                        {{.NextTVI}}
-                   {{else if gt $.Data.BlockHeight .VoteEnd}}
-                      <a href="/block/{{.VoteEnd}}">{{.VoteEnd}}</a>
-                   {{else}}
-                      <a href="/block/{{$.Data.BlockHeight}}">{{$.Data.BlockHeight}}</a>
-                   {{end}}
-                 {{end}}
-                   </td>
-                 </tr>
-              </tbody>
-            </table>
-        </div>
-    </div>
-    {{end}}
-
     <div class="row mb-5">
         <div class="col-lg-12 mt-4 mb-2">
             <h5 class="pb-2">{{len .Vin}} Input{{if gt (len .Vin) 1}}s{{end}} Consumed</h5>
@@ -463,17 +305,13 @@
                                 {{range .Addresses}}
                                   {{template "hashElide" (hashlink . (print "/address/" .))}}
                                 {{end}}
-                            {{else if .TreasurySpend}}
-                                <a href="/treasury">Treasury</a>
                             {{else}}
                                 N/A
                             {{end}}
                         </td>
                         <td class="shrink-to-fit"{{if $isMempool}} data-tx-target="mempoolTd" data-txid="{{.Txid}}"{{end}}>
-                        {{if or .Treasurybase (or .Coinbase .Stakebase)}}
+                        {{if or .Coinbase .Stakebase}}
                             created
-                        {{else if .TreasurySpend}}
-                            N/A
                         {{else if eq .BlockHeight 0}}
                             pending
                         {{else}}
@@ -529,10 +367,6 @@
                                     <span class="break-word">{{.OP_RETURN}}</span>
                                 </div>
                                 {{end}}
-                            {{else if .OP_TADD}}
-                              <div>
-                                <span class="break-word"><a href="/treasury">Treasury</a></span>
-                              </div>
                             {{end}}
                         </td>
                         <td class="fs13 break-word shrink-to-fit">
@@ -545,7 +379,7 @@
                               {{if $spending.Hash}}
                                  <a href="/tx/{{$spending.Hash}}/in/{{$spending.Index}}">{{$v.Spent}}</a>
                               {{else}}
-                                {{if or $v.OP_TADD (and (eq $v.CoinType 0) (le $v.Amount 0.0))}}
+                                {{if and (eq $v.CoinType 0) (le $v.Amount 0.0)}}
                                   n/a
                                 {{else}}
                                   {{$v.Spent}}
@@ -570,55 +404,6 @@
             <h4>Vote Info</h4>
             <p>Last Block Valid: <span class="mono"><strong>{{.Validation.Validity}}</strong></span><br>
             Version: <span class="mono">{{.Version}}</span> | Bits: <span class="mono">{{printf "%#04x" .Bits}}</span></p>
-            <h5>Agenda Choices</h5>
-            {{if .Choices}}
-            <table class="table">
-                <thead>
-                  <tr>
-                    <th class="text-end">Issue ID</th>
-                    <th>Issue Description</th>
-                    <th>Choice ID</th>
-                    <th>Choice Description</th>
-                  </tr>
-                </thead>
-                <tbody>
-                    {{range .Choices}}
-                    <tr>
-                        <td class="text-end"><span class="highlight-text"><a href="/agenda/{{.ID}}">{{.ID}}</a></span></td>
-                        <td>{{.Description}}</td>
-                        <td>
-                            <span class="agenda-voting-overview-option-dot _{{.Choice.Id}}"></span>
-                            {{.Choice.Id}}
-                        </td>
-                        <td>{{.Choice.Description}}</td>
-                    </tr>
-                    {{end}}
-                </tbody>
-            </table>
-            {{else}}
-            <br>No recognized agenda votes in this transaction.
-            {{end}}
-            <h5>Treasury Spend Choices</h5>
-            {{if gt (len .TSpends) 0}}
-            <table class="table">
-                <thead>
-                  <tr>
-                    <th>Treasury Spend Transaction</th>
-                    <th>Choice</th>
-                  </tr>
-                </thead>
-                <tbody>
-                    {{range .TSpends}}
-                    <tr>
-                        <td><a href="/tx/{{.TSpend}}">{{.TSpend}}</a></td>
-                        <td>{{.Choice}}</td>
-                    </tr>
-                    {{end}}
-                </tbody>
-            </table>
-            {{else}}
-            No treasury spend choices in this transaction.
-            {{end}}
         </div>
     </div>
     {{end}}

--- a/wiki/code-analysis/charts/flow.full.md
+++ b/wiki/code-analysis/charts/flow.full.md
@@ -59,7 +59,7 @@ PostgreSQL `vins.value_in` deltas → `pgb.coinSupply` fetcher (registered as a 
   - **Transformations:**
     - `skaCoinTypeFromChart(name)` (line 60) — parses `coin-supply/{N}` → 0 if not 1..255.
     - `isCoinSupplyChart(name)` (line 70) — collapses both legacy `coin-supply` and `coin-supply/{N}` for the switch dispatch (`switchKey` at line 528).
-    - VAR branch (line 688) — `circulationFunc(data)` (line 300) does `supplies[i] * atomsToDCR` (i.e. `*1e-8`), tracks `inflation` via `blockReward(h)` per block, projects 6 months into the future. Legend uses `intComma(y)` + 'VAR'.
+    - VAR branch (line 688) — `circulationFunc(data)` (line 300) does `supplies[i] * atomsToVAR` (i.e. `*1e-8`), tracks `inflation` via `blockReward(h)` per block, projects 6 months into the future. Legend uses `intComma(y)` + 'VAR'.
     - SKA branch (line 661-687) — multiplies the supply string by `1e-18` via `Number(s) * 1e-18` for the plotted line (precision-lossy, accepted by spec §5), but for the **legend** it pulls `this._skaSupplyRaw[i]` and renders via `formatSkaAtomsExact(raw)` (which calls `splitSkaAtomsNoTrailing` from `ska_helper.js`). The legend therefore preserves all 18 decimals (spec §4); the plotted Y value does not.
     - `legendFormatter` (line 136) — now logs `console.warn` for unknown chart types (added by `ddf17358`'s `default:` case at line 806).
 
@@ -111,7 +111,7 @@ When modifying chart data structures or pipelines, check ALL of:
 
 ### 7. Common Pitfalls
 
-- Reusing the VAR pipeline (`Blocks.NewAtoms`, `accumulate`, `*atomsToDCR`) for SKA coins — it overflows, loses precision, and bypasses the per-coin map.
+- Reusing the VAR pipeline (`Blocks.NewAtoms`, `accumulate`, `*atomsToVAR`) for SKA coins — it overflows, loses precision, and bypasses the per-coin map.
 - Adding a new chart format that omits `h` for time-axis SKA responses (regression risk; `a9db4b3b` was a fix for exactly this).
 - Computing cumulative supply on the frontend — already done in Go, doing it again in JS produces a double-summed series.
 - Mutating `SKASupply[coinType]` from outside `LoadSKASupplyForCoin` without coordinating with `charts.mtx` — the existing loader writes without `Lock`, relying on idempotence.
@@ -137,6 +137,7 @@ When modifying chart data structures or pipelines, check ALL of:
 - **Key commits:** `538d5cd1` initial SKA chart support; `3e6d14cf` per-SKA endpoints; `19a114c1` cumulative + height alignment; `a9db4b3b` `h` field on time-axis; `ddf17358` frontend integration & default-case logging; `4af1009f` test/mock additions.
 
 See also:
+
 - /wiki/code-analysis/page-rendering/patterns.md (shares-pattern-with: out-of-band shared page state — handler reads `pageData.HomeInfo.SKACoinSupply`; `*CommonPageData` embedding)
 - /wiki/code-analysis/page-rendering/impact.md (depends-on: `commonData` nil render crash)
 - /wiki/core/constraints.md (depends-on: C1 numeric precision & bifurcation — applies to the SKA pipeline `string`-end-to-end rule; C2 dual pipeline — VAR delta+`accumulate` vs SKA `*big.Int` cumulation; C7 centralized coin-type label rendering — `renderCoinType` / `coinSymbol`)


### PR DESCRIPTION
## Summary

- `/charts`: replace remaining `DCR` literals with `VAR` on Dygraph legends and y-axis titles in `charts_controller.js`; drop the unused `subsidyToString` helper (last `DCR` label in the JS bundle).
- `/tx`: remove unreachable Treasury Spend Approval card, Politeia Key row, `OP_TADD` / `TreasurySpend` / `Treasurybase` vin/vout arms, and the Agenda Choices / Treasury Spend Choices tables — all gated on tx types and vote-data shapes that the Monetarium chain does not produce. Behavior-preserving: empty branches now fall through to the existing `N/A` / coinbase / regular paths.
- View-model fields (`TSpendMeta`, `Vin.TreasurySpend`/`Treasurybase`, `Vout.OP_TADD`, `VoteInfo.Choices`/`TSpends`, `TxBasic.Treasurybase`, `PoliteiaKey`) are populated by `db/dcrpg` or come from upstream `chainjson.Vin`, so they stay per CLAUDE.md's load-bearing-identifiers guidance.

Closes #339
Closes #340

## Test plan

- [x] `grep -nE 'href="/(treasury|agenda)' cmd/dcrdata/views/tx.tmpl` → empty
- [x] `grep -n '\bDCR\b' cmd/dcrdata/public/js/controllers/charts_controller.js` → empty
- [x] `go build ./...` from `cmd/dcrdata` passes
- [x] `gofmt -l .` clean
- [x] `npm run check` passes (0 errors)
- [x] `npm test` passes (301/301)
- [x] `go test ./internal/explorer/...` passes
- [x] `tx.tmpl` parses via `html/template.ParseFiles` (one-off smoke check)
- [ ] Manual: `/charts` renders fee rate, coin supply, ticket pool, total fee, and privacy participation with `VAR` on axes/legends
- [ ] Manual: `/tx/{txid}` on a real Monetarium block renders regular / coinbase / stakebase / vote / ticket / revocation fixtures correctly