### PR TITLE
cmd/dcrdata: partysocket WebSocket transport + liveness watchdog

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -313,7 +313,12 @@ func (exp *explorerUI) VisualBlocks(w http.ResponseWriter, r *http.Request) {
 	trimmedBlocks := make([]*types.TrimmedBlockInfo, 0, len(blocks))
 
 	exp.pageData.RLock()
-	maxBlockSize := float64(exp.pageData.BlockchainInfo.MaxBlockSize)
+	// BlockchainInfo is nil until the first block is collected; fall back to the
+	// default max block size during the startup window (mirrors StoreMPData).
+	maxBlockSize := 393216.0
+	if exp.pageData.BlockchainInfo != nil && exp.pageData.BlockchainInfo.MaxBlockSize > 0 {
+		maxBlockSize = float64(exp.pageData.BlockchainInfo.MaxBlockSize)
+	}
 	issuedSKA := make([]uint8, 0, len(exp.pageData.HomeInfo.SKACoinSupply))
 	for _, entry := range exp.pageData.HomeInfo.SKACoinSupply {
 		issuedSKA = append(issuedSKA, entry.CoinType)
@@ -2658,7 +2663,12 @@ func calcPages(rows, pageSize, offset int, link string) pageNumbers {
 func (exp *explorerUI) AttackCost(w http.ResponseWriter, r *http.Request) {
 	exp.pageData.RLock()
 
-	height := exp.pageData.BlockInfo.Height
+	// BlockInfo.BlockBasic (which Height is promoted from) is nil until the first
+	// block is collected; leave height at 0 during the startup window.
+	var height int64
+	if exp.pageData.BlockInfo.BlockBasic != nil {
+		height = exp.pageData.BlockInfo.Height
+	}
 	ticketPoolValue := exp.pageData.HomeInfo.PoolInfo.Value
 	ticketPoolSize := exp.pageData.HomeInfo.PoolInfo.Size
 	ticketPrice := exp.pageData.HomeInfo.StakeDiff

--- a/cmd/dcrdata/internal/explorer/websockethandlers.go
+++ b/cmd/dcrdata/internal/explorer/websockethandlers.go
@@ -190,8 +190,18 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				inv := exp.MempoolInventory()
 
 				exp.pageData.RLock()
-				maxBlockSize := float64(exp.pageData.BlockchainInfo.MaxBlockSize)
-				subsidy := exp.pageData.HomeInfo.NBlockSubsidy
+				bci := exp.pageData.BlockchainInfo
+				home := exp.pageData.HomeInfo
+				if bci == nil || home == nil {
+					// First block not collected yet (startup window), so the data
+					// Trim needs isn't available. Skip; the client re-requests on
+					// the next mempool push or on reconnect.
+					exp.pageData.RUnlock()
+					log.Debugf("getmempooltrimmed requested before blockchain info is ready; skipping")
+					continue
+				}
+				maxBlockSize := float64(bci.MaxBlockSize)
+				subsidy := home.NBlockSubsidy
 				exp.pageData.RUnlock()
 
 				mempoolInfo := inv.Trim(maxBlockSize) // Trim internally locks the MempoolInfo.

--- a/cmd/dcrdata/internal/explorer/websockethandlers_test.go
+++ b/cmd/dcrdata/internal/explorer/websockethandlers_test.go
@@ -1,0 +1,126 @@
+package explorer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/monetarium/monetarium-explorer/explorer/types"
+)
+
+// waitForClients polls the hub's client count until it reaches want or the
+// deadline passes. Registration and teardown happen asynchronously through the
+// hub's run loop, so a poll is the reliable way to observe the count settle.
+func waitForClients(t *testing.T, hub *WebsocketHub, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if hub.NumClients() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for NumClients()=%d, last saw %d", want, hub.NumClients())
+}
+
+// TestRootWebsocket_ReconnectLeavesNoLeak exercises a full
+// disconnect -> reconnect cycle against the explorer /ws handler and asserts
+// that the hub's client count returns to baseline each time. This locks in the
+// contract the frontend's reconnecting client relies on: each reconnect is a
+// fresh, cleanly-registered client, and a dropped client is fully unregistered
+// (no leaked client/goroutine).
+func TestRootWebsocket_ReconnectLeavesNoLeak(t *testing.T) {
+	hub := NewWebsocketHub()
+	go hub.run()
+	t.Cleanup(hub.Stop)
+
+	exp := &explorerUI{wsHub: hub}
+	srv := httptest.NewServer(http.HandlerFunc(exp.RootWebsocket))
+	t.Cleanup(srv.Close)
+	wsURL := "ws://" + strings.TrimPrefix(srv.URL, "http://")
+
+	dial := func() *websocket.Conn {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		conn, _, err := websocket.Dial(ctx, wsURL, nil)
+		if err != nil {
+			t.Fatalf("websocket.Dial(%s) failed: %v", wsURL, err)
+		}
+		return conn
+	}
+
+	// Initial connection registers exactly one client.
+	conn1 := dial()
+	waitForClients(t, hub, 1)
+
+	// Dropping the socket unregisters it.
+	if err := conn1.Close(websocket.StatusNormalClosure, "drop"); err != nil {
+		t.Fatalf("first close failed: %v", err)
+	}
+	waitForClients(t, hub, 0)
+
+	// Reconnecting with a brand-new socket registers cleanly again — no stale
+	// state, no leaked client from the previous connection.
+	conn2 := dial()
+	waitForClients(t, hub, 1)
+
+	if err := conn2.Close(websocket.StatusNormalClosure, "drop"); err != nil {
+		t.Fatalf("second close failed: %v", err)
+	}
+	waitForClients(t, hub, 0)
+}
+
+// TestRootWebsocket_GetMempoolTrimmedBeforeReady reproduces a server-wide panic:
+// a client requesting "getmempooltrimmed" during the startup window — before the
+// first block has been collected and pageData.BlockchainInfo is still nil — must
+// not crash the read loop. The frontend's visualblocks controller issues this
+// request on a mempool push and on reconnect, so it is reachable immediately
+// after a client connects.
+func TestRootWebsocket_GetMempoolTrimmedBeforeReady(t *testing.T) {
+	hub := NewWebsocketHub()
+	go hub.run()
+	t.Cleanup(hub.Stop)
+
+	// BlockchainInfo/HomeInfo are nil until the first block is stored.
+	exp := &explorerUI{
+		wsHub:    hub,
+		pageData: &pageData{},
+		invs:     new(types.MempoolInfo),
+	}
+	srv := httptest.NewServer(http.HandlerFunc(exp.RootWebsocket))
+	t.Cleanup(srv.Close)
+	wsURL := "ws://" + strings.TrimPrefix(srv.URL, "http://")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket.Dial(%s) failed: %v", wsURL, err)
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+	waitForClients(t, hub, 1)
+
+	// Must not panic the server even though BlockchainInfo is still nil.
+	if err := wsjson.Write(ctx, conn, WebSocketMessage{EventId: "getmempooltrimmed"}); err != nil {
+		t.Fatalf("write getmempooltrimmed failed: %v", err)
+	}
+
+	// Liveness probe: a subsequent request that does produce a response proves
+	// the read loop survived (rather than panicking the whole process).
+	if err := wsjson.Write(ctx, conn, WebSocketMessage{EventId: "getmempooltxs"}); err != nil {
+		t.Fatalf("write getmempooltxs failed: %v", err)
+	}
+	var resp WebSocketMessage
+	if err := wsjson.Read(ctx, conn, &resp); err != nil {
+		t.Fatalf("read response failed (server likely crashed): %v", err)
+	}
+	if resp.EventId != "getmempooltxsResp" {
+		t.Fatalf("unexpected response event %q, want getmempooltxsResp", resp.EventId)
+	}
+}

--- a/cmd/dcrdata/package-lock.json
+++ b/cmd/dcrdata/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "dcrdata",
-  "version": "1.1.0",
+  "name": "monetarium-explorer",
+  "version": "0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dcrdata",
-      "version": "1.1.0",
+      "name": "monetarium-explorer",
+      "version": "0.1",
       "license": "ISC",
       "dependencies": {
         "bootstrap": "^5.3.8",
         "dompurify": "^3.3.0",
         "lodash-es": "^4.17.21",
+        "partysocket": "^1.1.19",
         "qrcode": "^1.5.1",
         "regenerator-runtime": "^0.14.1",
         "url-parse": "^1.5.10"
@@ -5737,6 +5738,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -8395,6 +8402,23 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/partysocket": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.19.tgz",
+      "integrity": "sha512-hPwsXSdUc8PKNCinET6TD3JQOxzQ2JaP0bUZQXBVl6UM8UuLn1odgf1LcJXHy4UHSQwWL/RU3AnyhEsGM+W+sg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/path-exists": {

--- a/cmd/dcrdata/package.json
+++ b/cmd/dcrdata/package.json
@@ -80,6 +80,7 @@
     "bootstrap": "^5.3.8",
     "dompurify": "^3.3.0",
     "lodash-es": "^4.17.21",
+    "partysocket": "^1.1.19",
     "qrcode": "^1.5.1",
     "regenerator-runtime": "^0.14.1",
     "url-parse": "^1.5.10"

--- a/cmd/dcrdata/public/index.js
+++ b/cmd/dcrdata/public/index.js
@@ -27,7 +27,7 @@ export function notifyNewBlock(newBlock) {
   if (window.Notification.permission !== 'granted') return
   const block = newBlock.block
   const newBlockNtfn = new window.Notification('New Monetarium Block Mined', {
-    body: `Block mined at height <b>${block.height}</b>`,
+    body: `Block mined at height ${block.height}`,
     icon: '/images/monetarium144x128.png',
     notifyError: (e) => console.error('Error showing notification:', e)
   })

--- a/cmd/dcrdata/public/js/controllers/connection_controller.js
+++ b/cmd/dcrdata/public/js/controllers/connection_controller.js
@@ -29,6 +29,13 @@ export default class extends Controller {
     })
   }
 
+  disconnect() {
+    ws.deregisterEvtHandlers('open')
+    ws.deregisterEvtHandlers('close')
+    ws.deregisterEvtHandlers('error')
+    ws.deregisterEvtHandlers('ping')
+  }
+
   updateConnectionStatus(msg, connected) {
     if (connected) {
       this.indicatorTarget.classList.add('connected')

--- a/cmd/dcrdata/public/js/controllers/connection_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/connection_controller.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@hotwired/stimulus', () => ({
+  Controller: class {
+    constructor(element) {
+      this.element = element
+    }
+  }
+}))
+
+const deregisterEvtHandlers = vi.fn()
+
+vi.mock('../services/messagesocket_service', () => ({
+  default: {
+    registerEvtHandler: vi.fn(),
+    deregisterEvtHandler: vi.fn(),
+    deregisterEvtHandlers: deregisterEvtHandlers,
+    send: vi.fn()
+  }
+}))
+
+const { default: ConnectionController } = await import('./connection_controller.js')
+
+function makeController() {
+  const c = new ConnectionController()
+  c.indicatorTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
+  c.statusTarget = { textContent: '' }
+  return c
+}
+
+beforeEach(() => {
+  deregisterEvtHandlers.mockClear()
+})
+
+describe('connection_controller cleanup', () => {
+  it('deregisters its connection-status handlers on disconnect', () => {
+    const c = makeController()
+    c.connect()
+    c.disconnect()
+
+    expect(deregisterEvtHandlers).toHaveBeenCalledWith('open')
+    expect(deregisterEvtHandlers).toHaveBeenCalledWith('close')
+    expect(deregisterEvtHandlers).toHaveBeenCalledWith('error')
+    expect(deregisterEvtHandlers).toHaveBeenCalledWith('ping')
+  })
+})

--- a/cmd/dcrdata/public/js/controllers/homepage_controller.js
+++ b/cmd/dcrdata/public/js/controllers/homepage_controller.js
@@ -112,9 +112,15 @@ export default class extends Controller {
     })
     this.processBlock = this._processBlock.bind(this)
     globalEventBus.on('BLOCK_RECEIVED', this.processBlock)
+
+    // On reconnect, re-request the full mempool to refresh after downtime.
+    this.reconnectUnsub = ws.registerEvtHandler('reconnect', () => {
+      ws.send('getmempooltxs', '')
+    })
   }
 
   disconnect() {
+    this.reconnectUnsub()
     ws.deregisterEvtHandlers('newtxs')
     ws.deregisterEvtHandlers('mempool')
     ws.deregisterEvtHandlers('getmempooltxsResp')

--- a/cmd/dcrdata/public/js/controllers/homepage_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/homepage_controller.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@hotwired/stimulus', () => ({
+  Controller: class {
+    constructor(element) {
+      this.element = element
+    }
+  }
+}))
+
+vi.mock('../helpers/mempool_helper', () => ({
+  default: class {
+    constructor() {}
+  }
+}))
+
+vi.mock('../services/event_bus_service', () => ({
+  default: { on: vi.fn(), off: vi.fn() }
+}))
+
+// keyboard_navigation_service binds to DOM elements at module load, which jsdom
+// lacks; stub it so importing the controller doesn't crash.
+vi.mock('../services/keyboard_navigation_service', () => ({ keyNav: vi.fn() }))
+
+const registered = {}
+const send = vi.fn()
+const deregisterEvtHandlers = vi.fn()
+
+vi.mock('../services/messagesocket_service', () => ({
+  default: {
+    registerEvtHandler: vi.fn((event, handler) => {
+      const unsub = vi.fn()
+      ;(registered[event] = registered[event] || []).push({ handler, unsub })
+      return unsub
+    }),
+    deregisterEvtHandler: vi.fn(),
+    deregisterEvtHandlers: deregisterEvtHandlers,
+    send: send
+  }
+}))
+
+const { default: HomepageController } = await import('./homepage_controller.js')
+
+function makeController() {
+  const c = new HomepageController()
+  c.mempoolTarget = { dataset: { id: '0' } }
+  c.voteTallyTargets = []
+  return c
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(registered)) delete registered[key]
+  send.mockClear()
+  deregisterEvtHandlers.mockClear()
+})
+
+describe('homepage reconnect resync', () => {
+  it("re-requests the full mempool on 'reconnect'", () => {
+    const c = makeController()
+    c.connect()
+
+    expect(registered.reconnect).toHaveLength(1)
+    registered.reconnect[0].handler()
+
+    expect(send).toHaveBeenCalledWith('getmempooltxs', '')
+  })
+
+  it("removes its own 'reconnect' handler on disconnect", () => {
+    const c = makeController()
+    c.connect()
+    c.disconnect()
+
+    expect(registered.reconnect[0].unsub).toHaveBeenCalledTimes(1)
+  })
+})

--- a/cmd/dcrdata/public/js/controllers/mempool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.js
@@ -305,9 +305,16 @@ export default class extends Controller {
       this.sortVotesTable()
       keyNav(evt, false, true)
     })
+
+    // On reconnect, re-request the full mempool so the table reflects any
+    // activity that happened while the socket was down.
+    this.reconnectUnsub = ws.registerEvtHandler('reconnect', () => {
+      ws.send('getmempooltxs', '')
+    })
   }
 
   disconnect() {
+    this.reconnectUnsub()
     ws.deregisterEvtHandlers('newtxs')
     ws.deregisterEvtHandlers('mempool')
     ws.deregisterEvtHandlers('getmempooltxsResp')

--- a/cmd/dcrdata/public/js/controllers/mempool_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@hotwired/stimulus', () => ({
+  Controller: class {
+    constructor(element) {
+      this.element = element
+    }
+  }
+}))
+
+vi.mock('../helpers/mempool_helper', () => ({
+  default: class {
+    constructor() {}
+  }
+}))
+
+// keyboard_navigation_service binds to DOM elements at module load, which jsdom
+// lacks; stub it so importing the controller doesn't crash.
+vi.mock('../services/keyboard_navigation_service', () => ({ keyNav: vi.fn() }))
+
+const registered = {}
+const send = vi.fn()
+const deregisterEvtHandlers = vi.fn()
+
+vi.mock('../services/messagesocket_service', () => ({
+  default: {
+    registerEvtHandler: vi.fn((event, handler) => {
+      const unsub = vi.fn()
+      ;(registered[event] = registered[event] || []).push({ handler, unsub })
+      return unsub
+    }),
+    deregisterEvtHandler: vi.fn(),
+    deregisterEvtHandlers: deregisterEvtHandlers,
+    send: send
+  }
+}))
+
+const { default: MempoolController } = await import('./mempool_controller.js')
+
+function makeController() {
+  const c = new MempoolController()
+  c.mempoolTarget = { dataset: { id: '0' } }
+  c.voteTallyTargets = []
+  c.voteTransactionsTarget = {}
+  c.ticketTransactionsTarget = {}
+  c.revocationTransactionsTarget = {}
+  c.regularTransactionsTarget = {}
+  return c
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(registered)) delete registered[key]
+  send.mockClear()
+  deregisterEvtHandlers.mockClear()
+})
+
+describe('mempool reconnect resync', () => {
+  it("re-requests the full mempool on 'reconnect'", () => {
+    const c = makeController()
+    c.connect()
+
+    expect(registered.reconnect).toHaveLength(1)
+    registered.reconnect[0].handler()
+
+    expect(send).toHaveBeenCalledWith('getmempooltxs', '')
+  })
+
+  it("removes its own 'reconnect' handler on disconnect", () => {
+    const c = makeController()
+    c.connect()
+    c.disconnect()
+
+    expect(registered.reconnect[0].unsub).toHaveBeenCalledTimes(1)
+  })
+})

--- a/cmd/dcrdata/public/js/controllers/ticketpool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/ticketpool_controller.js
@@ -147,7 +147,9 @@ export default class extends Controller {
   }
 
   connect() {
-    ws.registerEvtHandler('newblock', () => {
+    // 'newblock' is also handled by the global producer in index.js, so keep
+    // the per-handler unsubscribe and remove only ours on disconnect.
+    this.newblockUnsub = ws.registerEvtHandler('newblock', () => {
       ws.send('getticketpooldata', this.bars)
     })
 
@@ -157,6 +159,12 @@ export default class extends Controller {
       }
       const data = JSON.parse(evt)
       this.processData(data)
+    })
+
+    // On reconnect, re-request the ticket pool data that may have changed while
+    // the socket was down.
+    this.reconnectUnsub = ws.registerEvtHandler('reconnect', () => {
+      ws.send('getticketpooldata', this.bars)
     })
 
     this.fetchAll()
@@ -199,11 +207,18 @@ export default class extends Controller {
   }
 
   disconnect() {
-    this.purchasesGraph.destroy()
-    this.priceGraph.destroy()
-
-    ws.deregisterEvtHandlers('ticketpool')
+    // Tear down websocket handlers first so a failure destroying a chart that
+    // never finished loading can't leak them. Use per-handler unsubscribe for
+    // 'newblock' (shared with the global producer); 'getticketpooldataResp' is
+    // private to this controller so a bulk clear is fine.
+    this.newblockUnsub()
+    this.reconnectUnsub()
     ws.deregisterEvtHandlers('getticketpooldataResp')
+
+    // initialize() is async; the graphs are still null until the dygraphs chunk
+    // resolves, so guard against an early disconnect.
+    this.purchasesGraph?.destroy()
+    this.priceGraph?.destroy()
   }
 
   onZoom(e) {

--- a/cmd/dcrdata/public/js/controllers/ticketpool_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/ticketpool_controller.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@hotwired/stimulus', () => ({
+  Controller: class {
+    constructor(element) {
+      this.element = element
+    }
+  }
+}))
+
+vi.mock('../helpers/http', () => ({
+  requestJSON: vi.fn(() => Promise.resolve({}))
+}))
+
+// Each registerEvtHandler call gets its own distinct unsubscribe spy, recorded
+// per event, so tests can assert the *specific* handler was torn down with the
+// per-handler API rather than a shared bulk clear.
+const registered = {}
+const send = vi.fn()
+const deregisterEvtHandlers = vi.fn()
+
+vi.mock('../services/messagesocket_service', () => ({
+  default: {
+    registerEvtHandler: vi.fn((event, handler) => {
+      const unsub = vi.fn()
+      ;(registered[event] = registered[event] || []).push({ handler, unsub })
+      return unsub
+    }),
+    deregisterEvtHandler: vi.fn(),
+    deregisterEvtHandlers: deregisterEvtHandlers,
+    send: send
+  }
+}))
+
+const { default: TicketpoolController } = await import('./ticketpool_controller.js')
+
+function makeController({ graphsLoaded = true } = {}) {
+  const c = new TicketpoolController()
+  c.bars = 'wk'
+  c.wrapperTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
+  if (graphsLoaded) {
+    c.purchasesGraph = { destroy: vi.fn(), updateOptions: vi.fn(), resetZoom: vi.fn() }
+    c.priceGraph = { destroy: vi.fn(), updateOptions: vi.fn() }
+  } else {
+    // initialize() is async; before the dygraphs chunk resolves the graphs are
+    // still null (their initial value in initialize()).
+    c.purchasesGraph = null
+    c.priceGraph = null
+  }
+  return c
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(registered)) delete registered[key]
+  send.mockClear()
+  deregisterEvtHandlers.mockClear()
+})
+
+describe('ticketpool reconnect resync', () => {
+  it("re-requests ticketpool data with the active bar range on 'reconnect'", () => {
+    const c = makeController()
+    c.connect()
+
+    expect(registered.reconnect).toHaveLength(1)
+    registered.reconnect[0].handler()
+
+    expect(send).toHaveBeenCalledWith('getticketpooldata', 'wk')
+  })
+
+  it('tears down its own newblock + reconnect handlers without bulk-wiping the shared newblock event', () => {
+    const c = makeController()
+    c.connect()
+    c.disconnect()
+
+    // The per-handler unsubscribes for this controller's own handlers must run.
+    expect(registered.newblock[0].unsub).toHaveBeenCalledTimes(1)
+    expect(registered.reconnect[0].unsub).toHaveBeenCalledTimes(1)
+
+    // Must NOT bulk-clear 'newblock': the global block producer in index.js
+    // shares that event and is never re-registered under Turbolinks.
+    expect(deregisterEvtHandlers).not.toHaveBeenCalledWith('newblock')
+  })
+
+  it('still runs websocket cleanup when disconnecting before the charts have loaded', () => {
+    const c = makeController({ graphsLoaded: false })
+    c.connect()
+
+    expect(() => c.disconnect()).not.toThrow()
+    expect(registered.newblock[0].unsub).toHaveBeenCalledTimes(1)
+    expect(registered.reconnect[0].unsub).toHaveBeenCalledTimes(1)
+  })
+})

--- a/cmd/dcrdata/public/js/controllers/visualBlocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/visualBlocks_controller.js
@@ -363,12 +363,18 @@ export default class extends Controller {
       ws.send('getmempooltrimmed', '')
     })
 
+    // On reconnect, re-request the trimmed mempool snapshot we render from.
+    this.reconnectUnsub = ws.registerEvtHandler('reconnect', () => {
+      ws.send('getmempooltrimmed', '')
+    })
+
     this.refreshBlocksDisplay = this._refreshBlocksDisplay.bind(this)
     window.addEventListener('resize', this.refreshBlocksDisplay)
     setTimeout(this.refreshBlocksDisplay, 500)
   }
 
   disconnect() {
+    this.reconnectUnsub()
     ws.deregisterEvtHandlers('getmempooltrimmedResp')
     ws.deregisterEvtHandlers('mempool')
     globalEventBus.off('BLOCK_RECEIVED', this.handleVisualBlocksUpdate)

--- a/cmd/dcrdata/public/js/controllers/visualBlocks_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/visualBlocks_controller.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@hotwired/stimulus', () => ({
   Controller: class {
@@ -12,11 +12,19 @@ vi.mock('../services/event_bus_service', () => ({
   default: { on: vi.fn(), off: vi.fn() }
 }))
 
+const wsRegistered = {}
+const wsSend = vi.fn()
+
 vi.mock('../services/messagesocket_service', () => ({
   default: {
-    registerEvtHandler: vi.fn(),
+    registerEvtHandler: vi.fn((event, handler) => {
+      const unsub = vi.fn()
+      ;(wsRegistered[event] = wsRegistered[event] || []).push({ handler, unsub })
+      return unsub
+    }),
+    deregisterEvtHandler: vi.fn(),
     deregisterEvtHandlers: vi.fn(),
-    send: vi.fn()
+    send: wsSend
   }
 }))
 
@@ -314,5 +322,35 @@ describe('normaliseWsBlock (WS wire shape regression)', () => {
     expect(tile.Votes[0].VinCount).toBe(1)
     expect(tile.Votes[0].VoutCount).toBe(2)
     expect(tile.Votes[1].Voted).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Reconnect resync — after a dropped socket comes back, the controller must
+// re-request the trimmed mempool it draws from, and clean up its handler.
+// ---------------------------------------------------------------------------
+
+describe('visualBlocks reconnect resync', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(wsRegistered)) delete wsRegistered[key]
+    wsSend.mockClear()
+  })
+
+  it("re-requests the trimmed mempool on 'reconnect'", () => {
+    const c = new mod.default()
+    c.connect()
+
+    expect(wsRegistered.reconnect).toHaveLength(1)
+    wsRegistered.reconnect[0].handler()
+
+    expect(wsSend).toHaveBeenCalledWith('getmempooltrimmed', '')
+  })
+
+  it("removes its own 'reconnect' handler on disconnect", () => {
+    const c = new mod.default()
+    c.connect()
+    c.disconnect()
+
+    expect(wsRegistered.reconnect[0].unsub).toHaveBeenCalledTimes(1)
   })
 })

--- a/cmd/dcrdata/public/js/services/messagesocket_service.js
+++ b/cmd/dcrdata/public/js/services/messagesocket_service.js
@@ -38,6 +38,15 @@ const reconnectOptions = {
   maxEnqueuedMessages: Infinity
 }
 
+// Client-side liveness watchdog. partysocket only reconnects when the browser
+// fires a close/error event, which never happens for a silently dropped socket
+// (offline tab, backgrounded iOS Safari, network partition): it lingers in OPEN
+// and the UI shows a stale "Connected". The server pushes an app-level `ping`
+// every 60 s, so any inbound frame is proof of life; if none arrives within this
+// window we force a reconnect, mirroring the server's own zombie-client
+// detection. 90 s = the 60 s server cadence plus grace for jitter.
+const livenessTimeout = 90000
+
 function forward(event, message, handlers) {
   const list = handlers[event]
   if (!list) return
@@ -55,6 +64,25 @@ class MessageSocket {
     this.preConnectQueue = []
     this.maxQlength = 5
     this.hasConnected = false
+    this.livenessTimer = undefined
+  }
+
+  // armLiveness (re)starts the silence watchdog. Called on open and on every
+  // inbound frame; a healthy connection resets it well within livenessTimeout.
+  armLiveness() {
+    if (this.connection === undefined) return
+    clearTimeout(this.livenessTimer)
+    this.livenessTimer = setTimeout(() => {
+      if (window.loggingDebug) console.log('WebSocket liveness timeout; forcing reconnect')
+      // Leave the watchdog disarmed: reconnect()'s close re-runs the normal
+      // backoff, and a successful open re-arms it. Re-arming here would reset
+      // partysocket's backoff on every timeout.
+      this.connection.reconnect()
+    }, livenessTimeout)
+  }
+
+  clearLiveness() {
+    clearTimeout(this.livenessTimer)
   }
 
   registerEvtHandler(eventID, handler) {
@@ -106,11 +134,15 @@ class MessageSocket {
 
     // unmarshal message, and forward the message to registered handlers
     this.connection.onmessage = (evt) => {
+      // Any inbound frame proves the connection is alive; reset before parsing
+      // so even a malformed frame counts.
+      this.armLiveness()
       const json = JSON.parse(evt.data)
       forward(json.event, json.message, this.handlers)
     }
 
     this.connection.onopen = () => {
+      this.armLiveness()
       forward('open', null, this.handlers)
       if (this.hasConnected) {
         forward('reconnect', null, this.handlers)
@@ -119,6 +151,9 @@ class MessageSocket {
     }
 
     this.connection.onclose = () => {
+      // partysocket now owns reconnection; disarm so the watchdog doesn't reset
+      // its backoff. The next open re-arms it.
+      this.clearLiveness()
       forward('close', null, this.handlers)
     }
 
@@ -129,6 +164,7 @@ class MessageSocket {
 
   // close terminates the connection without reconnecting (a clean close).
   close() {
+    this.clearLiveness()
     if (this.connection) this.connection.close()
   }
 }

--- a/cmd/dcrdata/public/js/services/messagesocket_service.js
+++ b/cmd/dcrdata/public/js/services/messagesocket_service.js
@@ -137,7 +137,15 @@ class MessageSocket {
       // Any inbound frame proves the connection is alive; reset before parsing
       // so even a malformed frame counts.
       this.armLiveness()
-      const json = JSON.parse(evt.data)
+      let json
+      try {
+        json = JSON.parse(evt.data)
+      } catch {
+        // A malformed frame must not throw out of the message loop; drop it and
+        // keep processing subsequent frames.
+        console.warn('MessageSocket: discarding unparseable frame')
+        return
+      }
       forward(json.event, json.message, this.handlers)
     }
 

--- a/cmd/dcrdata/public/js/services/messagesocket_service.js
+++ b/cmd/dcrdata/public/js/services/messagesocket_service.js
@@ -1,4 +1,7 @@
 // MessageSocket is a WebSocket manager with an assumed JSON message format.
+// It wraps partysocket's ReconnectingWebSocket, so a dropped connection is
+// re-established automatically with exponential backoff and outbound messages
+// are buffered across reconnects.
 //
 // JSON message format:
 // {
@@ -7,21 +10,39 @@
 // }
 //
 // Functions for external use:
-// register(id, handler_function) -- register a function to handle events of
-//     the given type
-// send(id, data) -- create a JSON message in the above format and send it
+// registerEvtHandler(id, handler) -- register a handler for events of the given
+//     type; returns an unsubscribe function that removes just that handler.
+// deregisterEvtHandler(id, handler) -- remove a single handler.
+// deregisterEvtHandlers(id) -- remove all handlers for an event.
+// send(id, data) -- create a JSON message in the above format and send it.
 //
-// Copyright (c) 2017, Jonathan Chappelow
-// See LICENSE for details.
+// Synthetic events, in addition to the server's event names:
+//   open      -- fired on every (re)connection
+//   reconnect -- fired on every connection after the first, so consumers can
+//                re-request server state that was missed while disconnected
+//   close     -- fired when the underlying socket drops
+//   error     -- fired on socket errors
 //
-// Based on ws_events_dispatcher.js by Ismael Celis
+import ReconnectingWebSocket from 'partysocket/ws'
+
+// reconnectOptions tune partysocket's own reconnection: exponential backoff
+// between attempts (min/max delay + grow factor), how long to wait for a socket
+// to open before retrying (connectionTimeout), and unbounded retries/outbound
+// buffering so a transient outage recovers without dropping queued sends.
+const reconnectOptions = {
+  minReconnectionDelay: 1000,
+  maxReconnectionDelay: 10000,
+  reconnectionDelayGrowFactor: 1.3,
+  connectionTimeout: 4000,
+  maxRetries: Infinity,
+  maxEnqueuedMessages: Infinity
+}
 
 function forward(event, message, handlers) {
-  if (typeof handlers[event] === 'undefined') return
-  // call each handler
-  for (let i = 0; i < handlers[event].length; i++) {
-    handlers[event][i](message)
-  }
+  const list = handlers[event]
+  if (!list) return
+  // Iterate a copy so a handler may unsubscribe itself during dispatch.
+  for (const handler of list.slice()) handler(message)
 }
 
 class MessageSocket {
@@ -29,13 +50,24 @@ class MessageSocket {
     this.uri = undefined
     this.connection = undefined
     this.handlers = {}
-    this.queue = []
+    // Buffers sends issued before connect() runs (controllers send on Stimulus
+    // connect, which precedes the deferred ws.connect in index.js).
+    this.preConnectQueue = []
     this.maxQlength = 5
+    this.hasConnected = false
   }
 
   registerEvtHandler(eventID, handler) {
-    this.handlers[eventID] = this.handlers[eventID] || []
-    this.handlers[eventID].push(handler)
+    const list = this.handlers[eventID] || (this.handlers[eventID] = [])
+    list.push(handler)
+    return () => this.deregisterEvtHandler(eventID, handler)
+  }
+
+  deregisterEvtHandler(eventID, handler) {
+    const list = this.handlers[eventID]
+    if (!list) return
+    const idx = list.indexOf(handler)
+    if (idx !== -1) list.splice(idx, 1)
   }
 
   deregisterEvtHandlers(eventID) {
@@ -44,15 +76,16 @@ class MessageSocket {
 
   // send a message back to the server
   send(eventID, message) {
-    if (this.connection === undefined) {
-      while (this.queue.length > this.maxQlength - 1) this.queue.shift()
-      this.queue.push([eventID, message])
-      return
-    }
     const payload = JSON.stringify({
       event: eventID,
       message: message
     })
+
+    if (this.connection === undefined) {
+      while (this.preConnectQueue.length > this.maxQlength - 1) this.preConnectQueue.shift()
+      this.preConnectQueue.push(payload)
+      return
+    }
 
     if (window.loggingDebug) console.log('send', payload)
     this.connection.send(payload)
@@ -60,13 +93,15 @@ class MessageSocket {
 
   connect(uri) {
     this.uri = uri
-    this.connection = new window.WebSocket(uri)
+    this.connection = new ReconnectingWebSocket(uri, [], {
+      ...reconnectOptions,
+      debug: Boolean(window.loggingDebug)
+    })
 
-    this.close = (reason) => {
-      console.log('close, reason:', reason, this.handlers)
-      clearTimeout(pinger)
-      this.handlers = {}
-      this.connection.close()
+    // Flush anything queued before the socket existed. partysocket buffers
+    // these internally until the connection actually opens.
+    while (this.preConnectQueue.length) {
+      this.connection.send(this.preConnectQueue.shift())
     }
 
     // unmarshal message, and forward the message to registered handlers
@@ -75,27 +110,29 @@ class MessageSocket {
       forward(json.event, json.message, this.handlers)
     }
 
-    // Stub out standard functions
+    this.connection.onopen = () => {
+      forward('open', null, this.handlers)
+      if (this.hasConnected) {
+        forward('reconnect', null, this.handlers)
+      }
+      this.hasConnected = true
+    }
+
     this.connection.onclose = () => {
       forward('close', null, this.handlers)
     }
-    this.connection.onopen = () => {
-      forward('open', null, this.handlers)
-      while (this.queue.length) {
-        const [eventID, message] = this.queue.shift()
-        this.send(eventID, message)
-      }
-    }
+
     this.connection.onerror = (evt) => {
       forward('error', evt, this.handlers)
     }
+  }
 
-    // Start ping pong
-    const pinger = setInterval(() => {
-      this.send('ping', 'sup')
-    }, 7000)
+  // close terminates the connection without reconnecting (a clean close).
+  close() {
+    if (this.connection) this.connection.close()
   }
 }
 
 const ws = new MessageSocket()
 export default ws
+export { MessageSocket }

--- a/cmd/dcrdata/public/js/services/messagesocket_service.test.js
+++ b/cmd/dcrdata/public/js/services/messagesocket_service.test.js
@@ -26,6 +26,10 @@ vi.mock('partysocket/ws', () => {
     close() {
       this.closed = true
     }
+
+    reconnect() {
+      this.reconnectCalls = (this.reconnectCalls || 0) + 1
+    }
   }
   return { default: FakeReconnectingWebSocket }
 })
@@ -127,6 +131,64 @@ describe('MessageSocket', () => {
 
       const pings = socket.sent.filter((p) => p.includes('"event":"ping"'))
       expect(pings).toHaveLength(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('forces a reconnect when the server goes silent past the liveness window', () => {
+    vi.useFakeTimers()
+    try {
+      ws.connect('ws://localhost/ws')
+      socket = instances[0]
+      socket.onopen()
+
+      // Inbound traffic within the window is proof of life (server pushes an
+      // app-level ping every 60 s), so the watchdog must not fire.
+      vi.advanceTimersByTime(60000)
+      socket.onmessage({ data: envelope('ping', '3') })
+      vi.advanceTimersByTime(60000)
+      expect(socket.reconnectCalls || 0).toBe(0)
+
+      // A silent drop: the browser never fires close, so without a watchdog the
+      // socket would linger in OPEN forever. The watchdog must force a reconnect.
+      vi.advanceTimersByTime(90000)
+      expect(socket.reconnectCalls).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('inbound pings keep the connection alive without reconnecting', () => {
+    vi.useFakeTimers()
+    try {
+      ws.connect('ws://localhost/ws')
+      socket = instances[0]
+      socket.onopen()
+
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(60000)
+        socket.onmessage({ data: envelope('ping', String(i)) })
+      }
+      vi.advanceTimersByTime(60000)
+
+      expect(socket.reconnectCalls || 0).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('a clean close stops the liveness watchdog', () => {
+    vi.useFakeTimers()
+    try {
+      ws.connect('ws://localhost/ws')
+      socket = instances[0]
+      socket.onopen()
+
+      ws.close()
+      vi.advanceTimersByTime(120000)
+
+      expect(socket.reconnectCalls || 0).toBe(0)
     } finally {
       vi.useRealTimers()
     }

--- a/cmd/dcrdata/public/js/services/messagesocket_service.test.js
+++ b/cmd/dcrdata/public/js/services/messagesocket_service.test.js
@@ -78,6 +78,24 @@ describe('MessageSocket', () => {
     expect(handler).toHaveBeenCalledWith('{"height":42}')
   })
 
+  test('discards an unparseable inbound frame without throwing or wedging the loop', () => {
+    ws.connect('ws://localhost/ws')
+    socket = instances[0]
+    const handler = vi.fn()
+    ws.registerEvtHandler('newblock', handler)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() => socket.onmessage({ data: 'not json' })).not.toThrow()
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledTimes(0)
+
+    // The next valid frame is still forwarded.
+    socket.onmessage({ data: envelope('newblock', '{"height":42}') })
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    warn.mockRestore()
+  })
+
   test("emits 'open' on every open but 'reconnect' only from the second open onward", () => {
     ws.connect('ws://localhost/ws')
     socket = instances[0]

--- a/cmd/dcrdata/public/js/services/messagesocket_service.test.js
+++ b/cmd/dcrdata/public/js/services/messagesocket_service.test.js
@@ -1,0 +1,141 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Capture every fake ReconnectingWebSocket the service constructs so tests can
+// drive its lifecycle callbacks and inspect what was sent.
+const instances = []
+
+vi.mock('partysocket/ws', () => {
+  class FakeReconnectingWebSocket {
+    constructor(url, protocols, options) {
+      this.url = url
+      this.protocols = protocols
+      this.options = options
+      this.sent = []
+      this.closed = false
+      this.onopen = null
+      this.onmessage = null
+      this.onclose = null
+      this.onerror = null
+      instances.push(this)
+    }
+
+    send(data) {
+      this.sent.push(data)
+    }
+
+    close() {
+      this.closed = true
+    }
+  }
+  return { default: FakeReconnectingWebSocket }
+})
+
+const { MessageSocket } = await import('./messagesocket_service')
+
+const envelope = (event, message) => JSON.stringify({ event, message })
+
+let ws
+let socket
+
+beforeEach(() => {
+  instances.length = 0
+  ws = new MessageSocket()
+})
+
+describe('MessageSocket', () => {
+  test('buffers sends made before connect and flushes them on connect', () => {
+    ws.send('getmempooltxs', 'id1')
+    expect(instances).toHaveLength(0)
+
+    ws.connect('ws://localhost/ws')
+    socket = instances[0]
+
+    expect(socket.sent).toEqual([envelope('getmempooltxs', 'id1')])
+  })
+
+  test('send after connect serializes the {event, message} envelope', () => {
+    ws.connect('ws://localhost/ws')
+    socket = instances[0]
+
+    ws.send('decodetx', 'deadbeef')
+
+    expect(socket.sent).toContain(envelope('decodetx', 'deadbeef'))
+  })
+
+  test('inbound message is forwarded to the matching event handler', () => {
+    ws.connect('ws://localhost/ws')
+    socket = instances[0]
+    const handler = vi.fn()
+    ws.registerEvtHandler('newblock', handler)
+
+    socket.onmessage({ data: envelope('newblock', '{"height":42}') })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith('{"height":42}')
+  })
+
+  test("emits 'open' on every open but 'reconnect' only from the second open onward", () => {
+    ws.connect('ws://localhost/ws')
+    socket = instances[0]
+    const openSpy = vi.fn()
+    const reconnectSpy = vi.fn()
+    ws.registerEvtHandler('open', openSpy)
+    ws.registerEvtHandler('reconnect', reconnectSpy)
+
+    socket.onopen() // initial connect
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    expect(reconnectSpy).toHaveBeenCalledTimes(0)
+
+    socket.onclose() // drop
+    socket.onopen() // partysocket reconnected on the same instance
+    expect(openSpy).toHaveBeenCalledTimes(2)
+    expect(reconnectSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('registerEvtHandler returns an unsubscribe that removes only that handler', () => {
+    ws.connect('ws://localhost/ws')
+    socket = instances[0]
+    const keep = vi.fn()
+    const remove = vi.fn()
+    ws.registerEvtHandler('newtxs', keep)
+    const unsubscribe = ws.registerEvtHandler('newtxs', remove)
+
+    unsubscribe()
+    socket.onmessage({ data: envelope('newtxs', '[]') })
+
+    expect(keep).toHaveBeenCalledTimes(1)
+    expect(remove).toHaveBeenCalledTimes(0)
+  })
+
+  test('close() closes the underlying socket', () => {
+    ws.connect('ws://localhost/ws')
+    socket = instances[0]
+
+    ws.close()
+
+    expect(socket.closed).toBe(true)
+  })
+
+  test('does not send periodic app-level pings', () => {
+    vi.useFakeTimers()
+    try {
+      ws.connect('ws://localhost/ws')
+      socket = instances[0]
+      socket.onopen()
+
+      vi.advanceTimersByTime(60000)
+
+      const pings = socket.sent.filter((p) => p.includes('"event":"ping"'))
+      expect(pings).toHaveLength(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('passes reconnection options to the underlying socket', () => {
+    ws.connect('ws://localhost/ws')
+    socket = instances[0]
+
+    expect(socket.options).toMatchObject({ maxRetries: Infinity })
+  })
+})

--- a/docs/manual-test-plan-websocket.md
+++ b/docs/manual-test-plan-websocket.md
@@ -1,0 +1,646 @@
+# Manual Test Plan — WebSocket Transport
+
+Scope: the real-time WebSocket channel between the browser and the explorer,
+as integrated on `feat/ws-client-lib-integration` (partysocket on the client,
+`coder/websocket` on the server).
+
+This plan covers the **transport** — connect, keepalive, reconnect, send/receive
+plumbing, buffering, and clean teardown — not the correctness of every rendered
+value. Where a content check is needed it is only used as a signal that a message
+arrived and was dispatched.
+
+**Related:** the code-grounded engineering reference for this transport is the wiki
+trace at [wiki/code-analysis/websocket/](../wiki/code-analysis/websocket/)
+([flow.full.md](../wiki/code-analysis/websocket/flow.full.md),
+[flow.compact.md](../wiki/code-analysis/websocket/flow.compact.md),
+[patterns.md](../wiki/code-analysis/websocket/patterns.md),
+[impact.md](../wiki/code-analysis/websocket/impact.md)). This document is the QA
+counterpart — what to verify; the wiki trace explains how the transport works.
+
+---
+
+## 1. What's under test
+
+Client (`cmd/dcrdata/public/`):
+
+- `js/services/messagesocket_service.js` — the `MessageSocket` wrapper around
+  partysocket `ReconnectingWebSocket`. Owns connect, the JSON `{event, message}`
+  envelope, handler registry, the pre-connect send queue, and the synthetic
+  `open` / `reconnect` / `close` / `error` events.
+- `index.js` — builds the socket URI from `window.location`, waits 300 ms, then
+  `ws.connect()`; registers the global `newblock` handler that fans out
+  `BLOCK_RECEIVED` on the event bus.
+- `js/controllers/connection_controller.js` — connection-status indicator;
+  listens to `open` / `close` / `error` / `ping`.
+- `js/controllers/homepage_controller.js`, `mempool_controller.js`,
+  `ticketpool_controller.js`, `visualBlocks_controller.js` — feature consumers
+  that send requests and re-request state on `reconnect`.
+
+Server (`cmd/dcrdata/internal/explorer/`):
+
+- `websockethandlers.go` — `RootWebsocket`, mounted at **`GET /ws`**
+  (`cmd/dcrdata/main.go:663`). Per-connection reader, send loop, and ping
+  goroutine.
+- `websocket.go` — `WebsocketHub` fan-out and the 60 s ping / user-count tick.
+
+### Transport facts to verify against (from the code)
+
+| Behavior | Value / source |
+| --- | --- |
+| Endpoint | `GET /ws` (`ws://` on http, `wss://` on https — `index.js getSocketURI`) |
+| Initial connect delay | 300 ms after page load (`index.js createWebSocket`) |
+| Reconnect backoff | min 1 s, max 10 s, grow ×1.3 (`reconnectOptions`) |
+| Connection open timeout | 4 s before a retry (`connectionTimeout`) |
+| Retries / outbound buffer | unbounded (`maxRetries`, `maxEnqueuedMessages` = `Infinity`) |
+| Pre-connect send queue | max 5 messages, flushed on `connect()` (`preConnectQueue`, `maxQlength`) |
+| Server keepalive | RFC-6455 ping every 60 s; missed pong tears the connection down (`pingInterval`, ping goroutine) |
+| App-level `ping` event | broadcast every 60 s, `message` = connected client count (`sigPingAndUserCount`) |
+| Server write timeout | 10 s per write (`wsWriteTimeout`) |
+| Read limit | 1 MiB per message (`SetReadLimit`) |
+| Origin policy | any origin accepted (`OriginPatterns: ["*"]`) |
+
+Client → server request events (response is `<event>Resp`):
+`decodetx`, `sendtx`, `getmempooltxs`, `getmempooltrimmed`, `getticketpooldata`.
+A client-sent `ping` is a server no-op. Unknown events are logged and ignored.
+
+Server → client push events:
+`newblock`, `mempool`, `newtxs`, `ping` (with user count), sync status.
+
+---
+
+## 2. Environment & tooling
+
+### Build & run
+
+```sh
+cd cmd/dcrdata
+npm clean-install && npm run build
+go build -o monetarium-explorer .
+./monetarium-explorer            # talks to the local node; web/API on :17778 (testnet)
+```
+
+The socket lives at `ws://localhost:17778/ws` for a local testnet instance
+(adjust host/port to your deployment; use `wss://` behind TLS).
+
+For live block / mempool / new-tx push events you need a node that is actually
+producing activity (a local testnet, ideally one that mines on demand). Pure
+connection-lifecycle tests (Sections A, E, G, H, I) do **not** require chain
+activity.
+
+### Generating chain activity & test data
+
+The explorer talks to an external `monetarium-node`; this repo ships no CLI for
+it, so the exact client binary/flags depend on your setup. Use your node's
+JSON-RPC client (the `dcrctl`-equivalent) for the following — substitute the real
+command name for your environment:
+
+- **Mine a block on demand** (simnet/regtest-style nodes): the node's `generate`
+  RPC. Needed for `newblock` (WS-C1), the ticket-pool refresh (WS-D4), and outage
+  recovery where new blocks land while offline.
+- **Create mempool activity / new txs** (WS-C2, WS-C3, WS-F1): send transactions
+  from the node's wallet (`sendrawtransaction`, or a wallet `sendtoaddress`-style
+  call). Each accepted tx produces a `newtxs` push and changes the mempool ID.
+- **A raw-tx hex string for `decodetx`** (WS-D5): you do **not** need an
+  unconfirmed or broadcastable tx — any serialized tx works. Fetch one from the
+  running explorer: `GET /api/tx/hex/{txid}` for any known txid (copy a txid from
+  a recent block page). Decoding is read-only and side-effect free.
+- **A broadcastable tx for `sendtx`** (WS-D6): this *must* be a freshly signed,
+  not-yet-broadcast tx spending real UTXOs — produce it with the node wallet
+  (`createrawtransaction` + `signrawtransaction`) on testnet. This is
+  environment-specific; mark Blocked if you lack a funded test wallet.
+
+If your node cannot mine on demand, run Sections C/D/F opportunistically against
+natural network activity and note the wait in the results table.
+
+### Observation tools
+
+1. **DevTools → Network → WS filter → click `/ws` → Messages tab.** Shows every
+   frame: `↑` outbound, `↓` inbound, plus control frames (ping/pong). This is the
+   ground truth for "did a frame go over the wire".
+2. **Console debug logging.** In the page console run `logDebug(true)` (persists
+   in `localStorage`). This sets `window.loggingDebug`, which:
+   - logs every outbound `send` payload,
+   - logs `Connected` / `Disconnected` and the `ping` user count,
+   - logs `Block received: …`,
+   - **enables partysocket's own internal logging** (connect attempts, backoff) —
+     the primary tool for watching reconnection. Turn off with `logDebug(false)`.
+3. **DevTools → Network → throttling dropdown → "Offline"** to drop the
+   connection on demand, and back to "No throttling" / "Online" to restore it.
+4. **Server logs** at debug/trace level for the matching server-side view
+   (`websocket client receive error`, `Signaling new block to N … clients`,
+   `Signaling ping/user count …`).
+
+### Pages exercising the socket
+
+- `/` (home) — `homepage_controller`, `visualBlocks_controller`, `newblock`.
+- `/mempool` — `mempool_controller`.
+- `/charts` ticket-pool view — `ticketpool_controller`.
+- Connection indicator (`connection_controller`) is present site-wide.
+
+---
+
+## 3. Pre-flight checklist
+
+- [ ] Frontend rebuilt from this branch (`npm run build`), binary rebuilt.
+- [ ] Server reachable; an ordinary page (e.g. `/`) renders.
+- [ ] Node is producing blocks/mempool activity (for Sections C/D/F).
+- [ ] DevTools open, WS frames visible, `logDebug(true)` set.
+- [ ] Note browser + OS for the run (repeat the matrix in Section 5).
+- [ ] *(Optional, for console-driven cases WS-D5/D7, G2, J2)* Expose a debug
+  handle on the socket — see Appendix (Section 7). Several cases are Blocked
+  without it unless the corresponding in-app UI action is available.
+
+---
+
+## 4. Test cases
+
+Each case: **Pre** (preconditions beyond pre-flight), **Steps**, **Expect**.
+Record Pass/Fail/Blocked and notes in the tracking table (Section 9).
+
+---
+
+### A. Connection & handshake
+
+#### WS-A1 — Socket opens on page load
+
+- Steps: Load `/` with the Network/WS panel open.
+- Expect: ~300 ms after load, a single `/ws` WebSocket appears with status
+  `101 Switching Protocols`. Console logs `Connected`. The connection indicator
+  shows the connected state.
+
+#### WS-A2 — Correct URI scheme
+
+- Steps: Load the page over `http://` then (if available) over `https://`,
+  checking the WS request URL each time.
+- Expect: `ws://<host>/ws` under http, `wss://<host>/ws` under https. Host/port
+  match the page origin.
+
+#### WS-A3 — Single connection per page
+
+- Steps: With the page loaded, confirm the WS list.
+- Expect: Exactly one `/ws` connection (no duplicate/churned sockets). Reloading
+  the page closes the old socket and opens exactly one new one.
+
+#### WS-A4 — Connect debounce on drive-by loads
+
+- Steps: With one settled tab open as a baseline (note its user count N from
+  WS-C4), rapidly reload a second tab ~10 times, abandoning each load within
+  ~200 ms. Then wait for the next `ping` tick (~60 s).
+- Expect: The 300 ms delay suppresses sockets for loads abandoned before connect.
+  After things settle, the user count returns to N (or N+1 if you left the second
+  tab open) — it must not be inflated by the ~10 abandoned loads. Any persistent
+  count above the number of genuinely open tabs is a fail.
+
+---
+
+### B. Connection-status indicator (`connection_controller`)
+
+#### WS-B1 — Connected state
+
+- Steps: With a healthy socket, observe the indicator.
+- Expect: Indicator is visible (not `hidden`), has `connected` class, status text
+  reads `Connected`.
+
+#### WS-B2 — Disconnected on drop
+
+- Steps: Toggle DevTools **Offline**.
+- Expect: Console logs `Disconnected`; indicator switches to `disconnected`,
+  status text `Disconnected`. (Triggered by the `close`/`error` synthetic events.)
+
+#### WS-B3 — Back to connected on restore
+
+- Steps: Toggle back **Online**.
+- Expect: Within the backoff window the socket reopens; indicator returns to
+  `Connected`.
+
+---
+
+### C. Receiving server-pushed events
+
+> Requires chain/mempool activity.
+
+#### WS-C1 — `newblock`
+
+- Pre: node will mine a block.
+- Steps: Sit on `/`; trigger/await a new block. Watch WS Messages and console.
+- Expect: Inbound frame with `event: "newblock"`; console `Block received: …`;
+  the visual-blocks strip prepends a new block tile; a desktop notification fires
+  if permission was granted.
+
+#### WS-C2 — `mempool` update
+
+- Steps: On `/` or `/mempool`, generate mempool activity.
+- Expect: Inbound `event: "mempool"` frame; mempool figures/tables refresh. On
+  `/mempool` and `/` a follow-up `getmempooltxs` request is sent automatically
+  (see WS-D2). On the home visual-blocks, a `getmempooltrimmed` follow-up is sent.
+
+#### WS-C3 — `newtxs` (buffered)
+
+- Steps: Submit several transactions so the mempool grows.
+- Expect: Inbound `event: "newtxs"` frames arriving either when 5 new txs have
+  buffered or on the ~5 s buffer tick (whichever first). New rows animate into the
+  latest-transactions list; fill indicators update.
+
+#### WS-C4 — `ping` / user count (server push)
+
+- Pre: `logDebug(true)`.
+- Steps: Keep the page open ≥ 60 s.
+- Expect: Roughly every 60 s an inbound `event: "ping"` frame whose `message` is
+  the current connected-client count; console logs `ping. users online: N`. Open
+  a second tab and confirm N increases; close it and confirm it decreases on the
+  next tick.
+
+#### WS-C5 — `blockchainSync` (sync status)
+
+- Pre: a node/explorer that is catching up — i.e. start the explorer while the DB
+  is still syncing, or against a node behind chain tip. This event
+  (`SigSyncStatus` → `blockchainSync`, consumed by `status_controller.js`) is
+  only emitted during sync, so it is **not observable on a fully-synced idle
+  node** — mark Blocked/NA in that case.
+- Steps: Load a page during sync and watch the sync-status UI and WS frames.
+- Expect: Inbound `event: "blockchainSync"` frames driving the sync-progress
+  display; frames stop once sync completes.
+
+---
+
+### D. Client-initiated request / response
+
+#### WS-D1 — Initial mempool request on connect
+
+- Steps: Load `/` (or `/mempool`); watch outbound frames immediately after open.
+- Expect: An outbound `getmempooltxs` (the home/mempool controller's `connect`
+  fires before the socket opens, so this is delivered via the buffer — see
+  Section G) followed by an inbound `getmempooltxsResp` that populates the tables.
+
+#### WS-D2 — `getmempooltxs` cache short-circuit
+
+- Steps: Trigger a `mempool` push (WS-C2) and watch the follow-up
+  `getmempooltxs` request — its `message` carries the current mempool ID. Allow a
+  ~2 s window for any response before concluding none was sent (it's a negative
+  observation).
+- Expect: When the supplied ID matches the server's current inventory ID, no
+  `getmempooltxsResp` arrives within the window (no redundant payload). When the
+  ID is stale/empty, a full `getmempooltxsResp` is returned. The most reliable
+  trip: on connect the controller sends `getmempooltxs` with the page's initial ID
+  and should get a response; the post-`mempool` re-request with the matching ID
+  should not.
+
+#### WS-D3 — `getmempooltrimmed` (visual blocks)
+
+- Steps: On `/`, trigger a `mempool` push.
+- Expect: Outbound `getmempooltrimmed` → inbound `getmempooltrimmedResp`; the
+  mempool tile in the visual-blocks strip re-renders.
+
+#### WS-D4 — `getticketpooldata` (charts)
+
+- Steps: Open the ticket-pool charts view; await a `newblock`.
+- Expect: Outbound `getticketpooldata` (with the current bars selection) →
+  inbound `getticketpooldataResp`; charts update without a full page reload.
+
+#### WS-D5 — `decodetx`
+
+- Pre: a raw tx hex string. Get one with `GET /api/tx/hex/{txid}` for any txid
+  copied from a recent block page (decode is read-only; the tx need not be
+  unconfirmed). Use the console handle from the Appendix, or the decode-tx UI if
+  present.
+- Steps: `ws.send('decodetx', '<hex>')`. Then repeat with deliberately invalid
+  hex (e.g. `'zzzz'`).
+- Expect: Valid hex → inbound `decodetxResp` containing the decoded JSON. Invalid
+  hex → `decodetxResp` whose `message` is an `Error: …` string; connection stays
+  open.
+
+#### WS-D6 — `sendtx` *(environment-specific; Blocked without a funded test wallet)*
+
+- Pre: a freshly signed, not-yet-broadcast testnet raw tx — see "Generating chain
+  activity & test data" in Section 2.
+- Steps: Submit via the send-tx UI, or `ws.send('sendtx', '<signed-hex>')`.
+- Expect: Inbound `sendtxResp` with `Transaction sent: <txid>` on success, or
+  `Error: …` on rejection. Connection unaffected either way.
+
+#### WS-D7 — Unknown event is ignored
+
+- Steps: From the console, `ws.send('bogusEvent', 'x')`.
+- Expect: No response frame; server logs `Unrecognized event ID: bogusEvent`;
+  connection remains open and continues to receive pushes.
+
+---
+
+### E. Reconnection & backoff
+
+#### WS-E1 — Reconnect after transient drop (Offline/Online)
+
+- Pre: `logDebug(true)`.
+- Steps: Offline for ~5 s, then Online.
+- Expect: On drop: `close`, indicator `Disconnected`. While offline: partysocket
+  logs retry attempts at ~1 s, ~1.3 s, ~1.7 s … (growing toward the 10 s cap).
+  On restore: socket reopens, indicator `Connected`, and the `reconnect`
+  synthetic event fires (verify via Section F recovery, not just `open`).
+
+#### WS-E2 — Reconnect after server restart
+
+- Steps: Kill and restart the explorer binary while the page stays open.
+- Expect: Client detects the drop, retries with backoff, reconnects once the
+  server is back, and recovers state (Section F). No page reload required.
+
+#### WS-E3 — Backoff cap
+
+- Steps: Stop the server and leave it down for ~1 min with partysocket logging on.
+- Expect: Retry interval grows but never exceeds ~10 s; retries continue
+  indefinitely (no "give up").
+
+#### WS-E4 — Connection-open timeout *(best-effort; needs a way to blackhole the port)*
+
+- Steps: Make the handshake hang rather than fail fast — DevTools throttling is
+  unreliable for this. Prefer a firewall rule that *drops* (not rejects) traffic
+  to the explorer port while a tab is open, e.g. macOS `pf` /
+  `sudo /sbin/pfctl` blocking the port, or Linux
+  `sudo iptables -A INPUT -p tcp --dport 17778 -j DROP`. Then keep the page open.
+- Expect: After ~4 s without an open, partysocket abandons the attempt and
+  schedules another (visible as repeated attempts in the partysocket log). If you
+  cannot blackhole the port, mark Blocked.
+
+#### WS-E5 — `open` vs `reconnect` semantics
+
+- Pre: `logDebug(true)`.
+- Steps: Watch the very first connect, then force one reconnect (WS-E1).
+- Expect: The first open fires `open` only. Every later open fires `open` **and**
+  `reconnect`. (This is what drives the re-request behavior in Section F.)
+
+---
+
+### F. State recovery on reconnect
+
+> The point of the `reconnect` event: re-pull anything missed while down.
+
+#### WS-F1 — Home/mempool re-request
+
+- Steps: On `/` or `/mempool`, go Offline; while offline let mempool change
+  (submit txs from elsewhere); go Online.
+- Expect: On reconnect an outbound `getmempooltxs` (empty ID) is sent and the
+  tables refresh to reflect activity that occurred during the outage — no manual
+  reload needed.
+
+#### WS-F2 — Visual-blocks re-request
+
+- Steps: Same outage on `/`, watching the visual-blocks strip.
+- Expect: On reconnect an outbound `getmempooltrimmed` is sent and the mempool
+  tile re-renders.
+
+#### WS-F3 — Ticket-pool re-request
+
+- Steps: Same outage on the charts view.
+- Expect: On reconnect an outbound `getticketpooldata` is sent and the charts
+  refresh.
+
+#### WS-F4 — No duplicate handlers after several reconnects
+
+- Steps: Force 3–4 reconnect cycles, then trigger one `mempool`/`newblock` push.
+- Expect: Each push is handled exactly once (one re-request per consumer, one row
+  inserted per tx). No multiplying requests or duplicated DOM rows — the symptom
+  of leaked handlers across reconnects.
+
+---
+
+### G. Outbound buffering
+
+#### WS-G1 — Pre-connect queue flush
+
+- Steps: Hard-reload `/` and watch outbound frames from the very first moment the
+  socket opens.
+- Expect: Requests issued by controllers during Stimulus `connect` (before the
+  300 ms-deferred `ws.connect`) are buffered, then delivered in order the instant
+  the socket opens (you should see `getmempooltxs` etc. go out right at open, not
+  be lost).
+
+#### WS-G2 — Pre-connect queue cap (max 5)
+
+- Steps: Before the socket opens (within the 300 ms window, or via the Appendix
+  trick of calling `ws.send` repeatedly before `connect`), issue > 5 sends.
+- Expect: Only the **last 5** are retained and flushed; the oldest are dropped
+  (`maxQlength`). No error thrown.
+
+#### WS-G3 — Send while temporarily disconnected
+
+- Steps: Go Offline, trigger an action that calls `ws.send` (e.g. change the
+  charts bars selection, or a manual `ws.send`), then go Online.
+- Expect: partysocket enqueues the outbound message and delivers it on reconnect
+  (unbounded `maxEnqueuedMessages`); the corresponding `*Resp` arrives after
+  reconnect. Nothing is silently lost.
+
+---
+
+### H. Keepalive / zombie detection
+
+#### WS-H1 — Protocol ping/pong
+
+- Steps: Idle on a page ≥ 60 s with the WS Messages panel open.
+- Expect: A control ping frame from the server roughly every 60 s, with an
+  automatic pong from the browser. Connection stays open across multiple cycles.
+
+#### WS-H2 — Server tears down a dead client *(best-effort; OS-dependent)*
+
+- Steps: Force a *half-open* connection — TCP silently dead with no close frame.
+  Best done by dropping (not rejecting) the port at the OS firewall while the tab
+  stays open (same `pf`/`iptables -j DROP` technique as WS-E4); suspending the
+  laptop or hard-killing Wi-Fi also works but is flakier on a shared box. Keep it
+  cut for > ~60–70 s (one ping cycle plus the 10 s write timeout), watching server
+  logs and the user count (WS-C4).
+- Expect: The server's ping write fails, it cancels the connection context and
+  unregisters the client; the reported user count drops by one within ~70 s. When
+  connectivity returns, partysocket reconnects. If you cannot blackhole the port,
+  mark Blocked.
+
+#### WS-H3 — Client sends no app-level pings
+
+- Steps: Idle with `logDebug(true)`; inspect outbound frames.
+- Expect: No periodic outbound `ping` frames originate from the client (keepalive
+  is protocol-level only). The only outbound traffic is genuine requests.
+
+---
+
+### I. Teardown & handler hygiene
+
+#### WS-I1 — Clean disconnect on navigation
+
+- Steps: Navigate between `/`, `/mempool`, and the charts view.
+- Expect: On each navigation, controllers' `disconnect` deregisters their
+  handlers and unsubscribes their `reconnect` handler; no console errors. The
+  socket itself persists across in-app navigation (it is a singleton) — verify it
+  is **not** reopened on every navigation.
+
+#### WS-I2 — No status-handler leak (connection_controller)
+
+- Steps: Navigate away from and back to a page that mounts the connection
+  indicator several times, then force one `open`/`close` cycle (WS-E1).
+- Expect: The status updates once per event, not N times — `disconnect`
+  deregistered the prior handlers. (Mirrors the automated cleanup test.)
+
+#### WS-I3 — Tab close unregisters server-side
+
+- Steps: Open a second tab (user count = 2 via WS-C4), close it.
+- Expect: On the next `ping` tick the count returns to 1; server logs the
+  unregistration. No leaked server-side client.
+
+---
+
+### J. Negative & edge cases
+
+#### WS-J1 — Malformed inbound JSON *(optional; needs frame-injection tooling)*
+
+- Steps: Requires injecting a non-JSON inbound frame, which the listed DevTools
+  cannot do. Use an intercepting WS proxy (e.g. `mitmproxy` with a script that
+  rewrites a `/ws` text frame, or a one-off local relay) to deliver a malformed
+  frame. If no such tooling is set up, mark Blocked/NA.
+- Expect: `onmessage` does `JSON.parse` with no try/catch, so a bad frame throws.
+  Confirm whether this wedges the socket or is shrugged off, and record the actual
+  behavior (this case exists to document the failure mode, not to assert a pass).
+
+#### WS-J2 — Oversized request
+
+- Steps: From the console, `ws.send('decodetx', 'a'.repeat(2*1024*1024))`
+  (≈ 2 MiB, over the 1 MiB read limit).
+- Expect: The server rejects the frame (read limit exceeded → connection torn
+  down, or the request dropped with `Request size over limit` logged). Confirm
+  the client recovers (reconnects) and stays usable; document which path occurs.
+
+#### WS-J3 — Server `getmempooltrimmed` before startup data ready
+
+- Steps: Immediately after a fresh server start (before the first block is
+  collected), load `/` and trigger a `getmempooltrimmed`.
+- Expect: Server skips the response (logs `getmempooltrimmed requested before
+  blockchain info is ready; skipping`); the client re-requests on the next
+  mempool push / reconnect. No crash, no stuck UI.
+
+#### WS-J4 — Rapid reconnect storm
+
+- Steps: Toggle Offline/Online quickly several times in a row.
+- Expect: No runaway socket creation, no unhandled promise rejections; the system
+  settles into a single healthy connection once Online is stable.
+
+---
+
+## 5. Cross-environment matrix
+
+Run the golden path (WS-A1, B1–B3, C1, E1, F1) on each:
+
+| Browser | Connect | Status UI | Receive push | Reconnect | Recovery |
+| --- | --- | --- | --- | --- | --- |
+| Chrome (desktop) | | | | | |
+| Firefox (desktop) | | | | | |
+| Safari (desktop) | | | | | |
+| Safari (iOS) | | | | | |
+| Chrome (Android) | | | | | |
+
+Also vary network: clean LAN, throttled (Slow 3G), and a flaky/intermittent link.
+iOS Safari is the documented motivation for the keepalive — give WS-H2 extra
+attention there (background the tab, then foreground it).
+
+---
+
+## 6. Exit criteria
+
+- All Section A, B, E (except E4), F, G, I cases Pass (transport core +
+  lifecycle).
+- Section C/D Pass given available chain activity / test data, else Blocked with a
+  stated reason (notably C5, D6 are environment-gated).
+- Section H: WS-H1 and WS-H3 Pass. WS-H2 and WS-E4 require OS-level port
+  blackholing — Pass if performed, otherwise Blocked with a reason (not a Fail).
+- Section J: behaviors documented. J2/J3 Pass; J1 may be Blocked if no
+  frame-injection tooling is available.
+- No console errors, no unhandled rejections, no leaked sockets/handlers across
+  navigation and reconnect cycles.
+- Cross-environment matrix green for at least Chrome + Firefox + one Safari.
+
+A case is **Blocked**, not **Failed**, when the environment lacks the tooling the
+case itself flags as required. Blocked cases do not gate release but must carry a
+reason so coverage gaps are visible.
+
+---
+
+## 7. Appendix — driving the socket from the console
+
+The service is a singleton module; the page does not expose it globally, so use
+DevTools to exercise raw frames. The cleanest approach is to add a temporary
+debug handle while testing, e.g. in `index.js` during a local build:
+
+```js
+// TEMP, do not commit:
+import ws from './js/services/messagesocket_service'
+window.ws = ws
+```
+
+Then in the console:
+
+```js
+ws.send('getmempooltxs', '')                 // force a full mempool request
+ws.send('getticketpooldata', 'all')          // request ticket-pool charts
+ws.send('decodetx', '<raw-tx-hex>')          // decode
+ws.send('bogusEvent', 'x')                    // unknown-event handling (WS-D7)
+ws.registerEvtHandler('newblock', m => console.log('block!', m))
+ws.close()                                    // clean close (no reconnect)
+```
+
+Without the temp handle, rely on the in-app actions plus the Network/WS Messages
+panel, which already shows every frame in both directions.
+
+---
+
+## 8. Notes for the tester
+
+- The connection is a **singleton** shared by all controllers — many behaviors
+  (reconnect, buffering, keepalive) are global, so test them once per page type
+  rather than per widget.
+- Distinguish the two "pings": the RFC-6455 **control** ping (binary keepalive,
+  WS-H1) vs. the application **`ping` event** carrying the user count (WS-C4).
+  They share the 60 s cadence but are different mechanisms.
+- A reconnect is only observable through the `reconnect` event's side effects
+  (the re-requests in Section F) — `open` alone fires on first connect too, so
+  use Section F to prove a true reconnect happened.
+
+---
+
+## 9. Results tracking
+
+| Case | Browser/Env | Result (P/F/B) | Notes / evidence |
+| --- | --- | --- | --- |
+| WS-A1 | | | |
+| WS-A2 | | | |
+| WS-A3 | | | |
+| WS-A4 | | | |
+| WS-B1 | | | |
+| WS-B2 | | | |
+| WS-B3 | | | |
+| WS-C1 | | | |
+| WS-C2 | | | |
+| WS-C3 | | | |
+| WS-C4 | | | |
+| WS-C5 | | | |
+| WS-D1 | | | |
+| WS-D2 | | | |
+| WS-D3 | | | |
+| WS-D4 | | | |
+| WS-D5 | | | |
+| WS-D6 | | | |
+| WS-D7 | | | |
+| WS-E1 | | | |
+| WS-E2 | | | |
+| WS-E3 | | | |
+| WS-E4 | | | |
+| WS-E5 | | | |
+| WS-F1 | | | |
+| WS-F2 | | | |
+| WS-F3 | | | |
+| WS-F4 | | | |
+| WS-G1 | | | |
+| WS-G2 | | | |
+| WS-G3 | | | |
+| WS-H1 | | | |
+| WS-H2 | | | |
+| WS-H3 | | | |
+| WS-I1 | | | |
+| WS-I2 | | | |
+| WS-I3 | | | |
+| WS-J1 | | | |
+| WS-J2 | | | |
+| WS-J3 | | | |
+| WS-J4 | | | |

--- a/docs/manual-test-plan-websocket.md
+++ b/docs/manual-test-plan-websocket.md
@@ -497,9 +497,11 @@ Record Pass/Fail/Blocked and notes in the tracking table (Section 9).
   cannot do. Use an intercepting WS proxy (e.g. `mitmproxy` with a script that
   rewrites a `/ws` text frame, or a one-off local relay) to deliver a malformed
   frame. If no such tooling is set up, mark Blocked/NA.
-- Expect: `onmessage` does `JSON.parse` with no try/catch, so a bad frame throws.
-  Confirm whether this wedges the socket or is shrugged off, and record the actual
-  behavior (this case exists to document the failure mode, not to assert a pass).
+- Expect: `onmessage` wraps `JSON.parse` in try/catch, so a malformed frame is
+  discarded with a `console.warn` ("MessageSocket: discarding unparseable frame")
+  and the loop keeps processing subsequent frames. Liveness is unaffected (the
+  watchdog re-arms before parsing). Confirm the warn fires and the next valid
+  frame still renders.
 
 #### WS-J2 — Oversized request
 

--- a/docs/manual-test-plan-websocket.md
+++ b/docs/manual-test-plan-websocket.md
@@ -55,6 +55,7 @@ Server (`cmd/dcrdata/internal/explorer/`):
 | Pre-connect send queue | max 5 messages, flushed on `connect()` (`preConnectQueue`, `maxQlength`) |
 | Server keepalive | RFC-6455 ping every 60 s; missed pong tears the connection down (`pingInterval`, ping goroutine) |
 | App-level `ping` event | broadcast every 60 s, `message` = connected client count (`sigPingAndUserCount`) |
+| Client liveness watchdog | ~90 s of inbound silence forces `partysocket.reconnect()` so silent drops surface as `close` (`livenessTimeout`) |
 | Server write timeout | 10 s per write (`wsWriteTimeout`) |
 | Read limit | 1 MiB per message (`SetReadLimit`) |
 | Origin policy | any origin accepted (`OriginPatterns: ["*"]`) |
@@ -203,9 +204,14 @@ Record Pass/Fail/Blocked and notes in the tracking table (Section 9).
 
 #### WS-B2 — Disconnected on drop
 
-- Steps: Toggle DevTools **Offline**.
+- Steps: Toggle DevTools **Offline** and wait up to ~90 s.
 - Expect: Console logs `Disconnected`; indicator switches to `disconnected`,
-  status text `Disconnected`. (Triggered by the `close`/`error` synthetic events.)
+  status text `Disconnected`. A silent offline drop sends no close frame, so the
+  browser's socket lingers in `OPEN` — detection comes from the **client liveness
+  watchdog** (`livenessTimeout` ≈ 90 s of inbound silence; the server pushes an
+  app-level `ping` every 60 s, so any healthy connection resets it). On timeout the
+  client forces `partysocket.reconnect()`, which emits the synthetic `close`. (A
+  server-originated drop — WS-E2 — fires `close`/`error` immediately instead.)
 
 #### WS-B3 — Back to connected on restore
 

--- a/wiki/code-analysis/websocket/flow.compact.md
+++ b/wiki/code-analysis/websocket/flow.compact.md
@@ -1,0 +1,40 @@
+# WebSocket Transport (explorer `/ws`) — Compact
+
+**Flow (push):** chain/mempool saver → `WebsocketHub.HubRelay <- {Signal}` →
+`run()` non-blocking fan-out to each client `hubSpoke` → `RootWebsocket` send-loop
+`switch sig.Signal` encodes payload → `wsjson.Write(WebSocketMessage{event,message})`
+→ partysocket `onmessage` → `forward(event,message)` → controller handler.
+**Flow (request):** `ws.send(id,msg)` → `{event,message}` JSON → `/ws` reader
+`wsjson.Read` → `switch EventId` → reply on `id+"Resp"`. Route:
+[main.go:663](../../../cmd/dcrdata/main.go#L663). Separate from the pubsub `/ps`
+server (`pubsub/pubsubhub.go`).
+
+**Key patterns:** (1) `{event,message}` envelope + `forward()` registry + synthetic
+`open`/`reconnect`/`close`/`error`. (2) Three per-connection goroutines (reader /
+send-loop / 60 s ping) coordinated by one cancellable `connCtx`. (3) Hub fan-out
+with non-blocking send + **unregister-on-backpressure**. (4) RPC-over-WS via
+`<event>Resp` naming. (5) `reconnect` event → each controller re-requests its
+state. (6) Two outbound buffers: `preConnectQueue` (cap 5) + partysocket unbounded
+enqueue. (7) `newtxs` batched at size 5 or 5 s.
+
+**Constraints:** C1 SKA precision survives only by pass-through (opaque string
+`Message`); C2 `/ws`+`/ps` symmetric; C3/C8 template↔WS field parity & shape
+asymmetry; C4 array stability.
+
+**Mutation checklist:**
+- New push: add send-loop `case`; ensure `run()` fans the signal; register the
+  exact `eventIDs` string in the controller; mirror on `/ps`.
+- New request: add reader `case`; reply on `+"Resp"`; controller `send`+`<id>Resp`.
+- Rename event: `eventIDs`/`Subscriptions` + both hub arms + every
+  `registerEvtHandler` + `/ps` (string-only, no compiler help).
+- New server event in a controller → also add a `reconnect` re-request **and**
+  unsubscribe it in `disconnect()`.
+- Never push SKA through float in the payload builder (C1).
+
+See also:
+- [/wiki/code-analysis/websocket/flow.full.md](flow.full.md) — full trace.
+- [/wiki/code-analysis/websocket/patterns.md](patterns.md) — reusable patterns.
+- [/wiki/code-analysis/websocket/impact.md](impact.md) — mutation-impact entries.
+- [/wiki/code-analysis/mempool/flow.compact.md](../mempool/flow.compact.md) (shares-pattern-with: dual-transport WS).
+- [/wiki/core/constraints.md](../../core/constraints.md) (depends-on: C1, C2, C3, C4, C8).
+- [/docs/manual-test-plan-websocket.md](../../../docs/manual-test-plan-websocket.md) (verified-by: manual transport test plan).

--- a/wiki/code-analysis/websocket/flow.full.md
+++ b/wiki/code-analysis/websocket/flow.full.md
@@ -224,8 +224,9 @@ When modifying the transport, check:
 
 **Silent failures:** event-name drift; missing controller handler; oversize
 request dropped without reply ([:127-131](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L127-L131)); pre-connect queue overflow drops the oldest of >5 early
-sends; malformed inbound frame throws in `JSON.parse` (no `try/catch` in
-`onmessage`); missing `reconnect` re-request leaves stale UI after an outage.
+sends; malformed inbound frame dropped with a `console.warn` and the message loop
+continues ([:141-148](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L141-L148));
+missing `reconnect` re-request leaves stale UI after an outage.
 
 **Hard failures:** removing `connCtx` cancellation/`defer`s (goroutine + socket
 leak); a payload encoder panicking inside the send loop; a blocking spoke send

--- a/wiki/code-analysis/websocket/flow.full.md
+++ b/wiki/code-analysis/websocket/flow.full.md
@@ -1,0 +1,281 @@
+# WebSocket Transport (explorer `/ws`) — Full Flow
+
+## Section 1 — Overview
+
+This domain traces the **explorer real-time transport**: the generic `/ws`
+WebSocket pipe that carries server→client pushes (new block, mempool, new txs,
+ping/user-count, sync status) and client→server request/response RPC
+(`getmempooltxs`, `getmempooltrimmed`, `getticketpooldata`, `decodetx`, `sendtx`).
+It is the shared mechanism that the per-feature domains (`mempool`,
+`visualblocks`, `decodetx`, `ticketpool`) ride on; those domains own their
+*payloads*, this domain owns the *connection lifecycle, fan-out, framing, and
+client dispatch*.
+
+**Scope boundary.** This is the explorer hub (`RootWebsocket` + `WebsocketHub`),
+**not** the separate pubsub server at `/ps` (`pubsub/pubsubhub.go`, envelope
+`{ID, RequestID, Data, Success}`). The two are independent transports of largely
+the same data — see C2/C8 and `decodetx` for the `/ps` twin.
+
+**Recent migration (this is the current source of truth).** The server moved from
+`golang.org/x/net/websocket` (`websocket.Handler`) to
+[`coder/websocket`](../../../cmd/dcrdata/internal/explorer/websockethandlers.go);
+the client moved from a hand-rolled reconnecting socket to
+[`partysocket`](../../../cmd/dcrdata/public/js/services/messagesocket_service.js)
+`ReconnectingWebSocket`. Comments in the handler call out the behaviors that were
+deliberately preserved across the migration (`OriginPatterns:["*"]` ≙ old
+open-origin `websocket.Handler`; `SetReadLimit(1<<20)` ≙ old 1 MiB cap).
+
+## Section 2 — End-to-End Data Flow
+
+**Route:** `webMux.Get("/ws", explore.RootWebsocket)`
+([main.go:663](../../../cmd/dcrdata/main.go#L663)).
+
+**Server → client (push):**
+```
+chain/mempool event
+  → blockdata / mempool savers (StoreMPData, Store)
+  → WebsocketHub.HubRelay <- HubMessage{Signal}        (websocket.go run())
+  → fan-out: per-client hubSpoke channel (*client <- {Signal})
+  → RootWebsocket send loop `select { case sig := <-updateSig }`
+  → encode payload by sig.Signal (switch)              (websockethandlers.go:279)
+  → wsjson.Write(WebSocketMessage{EventId: sig.String(), Message})
+  → browser ReconnectingWebSocket.onmessage
+  → JSON.parse → forward(json.event, json.message, handlers)
+  → controller handler registered for that event name
+```
+
+**Client → server (request / response):**
+```
+controller ws.send(eventID, msg)
+  → JSON.stringify({event, message})
+  → (preConnectQueue if connection===undefined) else connection.send
+  → /ws → RootWebsocket reader goroutine: wsjson.Read(&WebSocketMessage)
+  → switch msg.EventId { decodetx | sendtx | getmempooltxs |
+        getmempooltrimmed | getticketpooldata | ping | default }
+  → build webData.Message; webData.EventId = msg.EventId + "Resp"
+  → send(webData) → onmessage → forward → controller `<eventID>Resp` handler
+```
+
+**Lifecycle (synthetic events, client-only):**
+```
+connect()  → onopen  → forward('open')   [+ forward('reconnect') if hasConnected]
+drop       → onclose → forward('close')
+socket err → onerror → forward('error')
+```
+`reconnect` (fired on every open after the first) is the recovery trigger: each
+feature controller re-requests its state on `reconnect`.
+
+**Keepalive (two independent 60 s mechanisms):**
+- Per-connection RFC-6455 ping (`ws.Ping`) — protocol keepalive; missed pong
+  cancels `connCtx` and tears the connection down
+  ([websockethandlers.go:85-105](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L85-L105)).
+- Hub `pingClients` broadcast `sigPingAndUserCount` → `"ping"` event whose
+  `message` is `NumClients()`
+  ([websocket.go:172-191](../../../cmd/dcrdata/internal/explorer/websocket.go#L172-L191)).
+
+## Section 3 — Per-Layer Breakdown
+
+### Layer A — Hub (`websocket.go`)
+- **Location:** [cmd/dcrdata/internal/explorer/websocket.go](../../../cmd/dcrdata/internal/explorer/websocket.go).
+- **Data structures:** `WebsocketHub` (`clients map[*hubSpoke]*clientHubSpoke`,
+  `HubRelay chan hubMessage`, `newTxBuffer`); `hubSpoke = chan hubMessage`;
+  `clientHubSpoke{cl *client, c *hubSpoke}`; `client{ newTxs []*MempoolTx }`.
+  Signal aliases `sigNewBlock … sigSyncStatus` (`:38-47`).
+- **Transformations:** `run()` (`:201`) receives on `HubRelay`, validates, and for
+  most signals fan-outs `{Signal}` to every client spoke with a **non-blocking
+  send; on backpressure it unregisters the client** (`:263-267`). `sigNewTx` is
+  special: it is buffered (`maybeSendTxns` `:327`, buffer size `newTxBufferSize=5`)
+  and flushed as `sigNewTxs` either at capacity or every `bufferTickerInterval=5s`
+  (`periodicBufferSend` `:349`), copying the buffered slice into each client's
+  `newTxs` field and signaling `sigNewTxs` with a nil `Msg` (`:299-318`).
+- **Constants:** `wsWriteTimeout=10s` (`:19`), `pingInterval=60s` (`:23`),
+  `clientSignalSize=5`.
+
+### Layer B — Connection handler (`websockethandlers.go`)
+- **Location:** [RootWebsocket](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L26).
+- **Per-connection setup:** registers an `updateSig := make(hubSpoke, 3)` with the
+  hub (`:30-34`); `websocket.Accept` with `OriginPatterns:["*"]` (`:39-41`);
+  `SetReadLimit(1<<20)` (`:48-50`); `connCtx, cancel := context.WithCancel` shared
+  by all three goroutines (`:54`).
+- **Three goroutines + main loop, coordinated by `connCtx`:**
+  1. **Ping** (`:85-105`): `time.Ticker(pingInterval)`, `ws.Ping(ctx)`; on error
+     `cancel()` (tears everything down).
+  2. **Reader** (`:109-247`): `wsjson.Read` in a loop; `switch msg.EventId` builds
+     a response; sets `EventId = msg.EventId+"Resp"`; `send(webData)`. `defer
+     cancel()` so a read error collapses the connection. Oversize guard at
+     `:127-131` sets a message then `continue`s (**response never sent** — silent).
+  3. **Send loop** (`:250-377`): `select` over `updateSig` (encode by `sig.Signal`,
+     `:279-365`), `wsHub.quitWSHandler`, and `connCtx.Done()`.
+- **`send` closure** (`:68-81`): `wsjson.Write` under a `wsWriteTimeout` context;
+  on failure returns an error that collapses the loop.
+- **Helpers:** `buildTicketPoolChartsData` (`:388`) mirrors the REST handler so
+  `getticketpooldata` and `/api/ticketpool/charts` emit the same struct.
+
+### Layer C — Wire envelope
+- **Type:** `WebSocketMessage{ EventId string \`json:"event"\`; Message string
+  \`json:"message"\` }` ([websocket.go:51-54](../../../cmd/dcrdata/internal/explorer/websocket.go#L51-L54)).
+- **`Message` is always a string** — for data payloads it is a JSON document
+  *encoded into a string* (the controllers `JSON.parse(evt)` it again). Event names
+  come from `HubSignal.String()` → `eventIDs`
+  ([pubsub_types.go:131-147](../../../pubsub/types/pubsub_types.go#L131-L147)).
+
+### Layer D — Client service (`messagesocket_service.js`)
+- **Location:** [messagesocket_service.js](../../../cmd/dcrdata/public/js/services/messagesocket_service.js); singleton `ws` exported.
+- **Data structures:** `handlers {event: [fn]}`; `preConnectQueue` (cap
+  `maxQlength=5`); `hasConnected` flag.
+- **Transformations:** `connect(uri)` builds `ReconnectingWebSocket(uri, [],
+  reconnectOptions)`, flushes `preConnectQueue`, wires `onmessage`/`onopen`/
+  `onclose`/`onerror` to `forward(...)`. `send` buffers into `preConnectQueue`
+  while `connection===undefined`, else `connection.send`. `registerEvtHandler`
+  returns an unsubscribe closure. `reconnectOptions`: min 1 s, max 10 s, grow
+  ×1.3, `connectionTimeout` 4 s, `maxRetries`/`maxEnqueuedMessages` = `Infinity`
+  (`:32-39`).
+
+### Layer E — Bootstrap & consumers
+- **Bootstrap:** [index.js](../../../cmd/dcrdata/public/index.js) — `getSocketURI`
+  (`ws`/`wss` from `window.location`), 300 ms `sleep` then `ws.connect` (`:46-50`),
+  global `newblock` handler → `globalEventBus 'BLOCK_RECEIVED'` (`:60`).
+- **Consumers (event → handler):**
+  - `connection_controller.js`: `open`/`close`/`error` → status indicator; `ping`
+    → debug log of user count (`:12-29`).
+  - `homepage_controller.js` / `mempool_controller.js`: `newtxs`, `mempool`,
+    `getmempooltxsResp`; send `getmempooltxs`; **`reconnect` → re-send
+    `getmempooltxs`**.
+  - `visualBlocks_controller.js`: `getmempooltrimmedResp`, `mempool`
+    (→ `getmempooltrimmed`); **`reconnect` → `getmempooltrimmed`**;
+    `BLOCK_RECEIVED` for new tiles.
+  - `ticketpool_controller.js`: `newblock` → `getticketpooldata`,
+    `getticketpooldataResp`; **`reconnect` → `getticketpooldata`**; plus HTTP
+    `/api/ticketpool/charts`.
+  - `status_controller.js`: `blockchainSync` (sync progress).
+
+## Section 4 — Cross-Layer Dependencies
+
+- **Event-name triple coupling (brittle, untyped).** A push works only if three
+  independently-edited strings agree: the server `HubSignal` → `eventIDs` mapping,
+  the controller's `registerEvtHandler('<name>')`, and (for requests) the
+  `msg.EventId + "Resp"` suffix the controller listens for. There is no shared
+  enum across Go and JS — drift is silent (handler simply never fires). Cf.
+  `decodetx` R1 (the `decodetx`/`sendtx` pair spans 5 sites).
+- **Go struct ↔ JS payload (untyped JSON-in-string).** `Message` is an opaque
+  string; the JS side `JSON.parse`s it and reads fields by name. Adding/renaming a
+  Go JSON tag silently changes the shape the controller sees. The `newblock`
+  payload mixes PascalCase (untagged) and snake_case (tagged) fields, which is why
+  `visualBlocks_controller.js` carries `normaliseWsBlock`/`normaliseMempool`
+  reconcilers (see `visualblocks`).
+- **HTTP vs `/ws` vs `/ps` (three contracts).** `getticketpooldata` mirrors
+  `/api/ticketpool/charts`; mempool/block payloads have HTTP-trimmed vs WS-full
+  shapes. These must move together (C2, C8).
+- **Goroutine coupling via `connCtx`.** Reader, send loop, and ping share one
+  cancellable context; any one deciding the connection is dead (`cancel()`) must
+  unblock the others. Removing a `defer cancel()`/`closeWS()` leaks goroutines and
+  sockets.
+
+## Section 5 — Critical Constraints
+
+- **C1 (precision).** The transport is pass-through (opaque `Message` string), so
+  SKA precision survives **only because nothing here parses it**. Any payload
+  *builder* that funnels SKA atoms through `float64` before encoding silently
+  truncates — the risk lives in the per-feature encoders, not the transport, but
+  the transport guarantees nothing. *See* [/wiki/core/constraints.md](../../core/constraints.md) C1.
+- **C2 (dual pipeline).** Explorer `/ws` and pubsub `/ps` emit the same logical
+  events; real-time vs static (DB/API) paths must change symmetrically.
+- **C3 (template + WS parity)** and **C8 (dual-transport shape asymmetry).** A
+  field added to a server template must also be added to the WS payload *and* the
+  consuming controller, or new entities (arriving by WS) silently miss it while
+  initial-render entities show it. C8 names the existing per-page asymmetries.
+- **C4 (array stability).** The pubsub layer flattens maps→sorted arrays for the
+  wire; the explorer `/ws` still sends some maps (e.g. `coin_stats` keyed by
+  coin-type id) that controllers iterate — order is the controller's
+  responsibility there.
+- **Single-coin / fee-coin invariants** are payload concerns, preserved by
+  pass-through.
+
+## Section 6 — Mutation Impact
+
+When modifying the transport, check:
+
+- **Add a server→client push:** add a `case sigX` to the send-loop `switch`
+  ([websockethandlers.go:279](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L279)); ensure
+  `HubRelay`/`run()` actually fans the signal to client spokes (it skips
+  `sigNewTx`, `sigAddressTx`, `sigSubscribe/Unsubscribe`); register a matching
+  handler in the consuming controller using the exact `eventIDs` string; mirror on
+  `/ps` if the data is shared (C2). **Missing send-loop case → `Unhandled signal`
+  log and the client receives `Message:"error"` (loud-ish in logs, silent in UI).**
+- **Add a client→server request:** add a `case "<id>"` to the reader `switch`
+  ([:133](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L133)); the
+  server always replies on `<id>+"Resp"`; the controller must `registerEvtHandler('<id>Resp')`
+  and `ws.send('<id>', …)`. Unknown ids hit `default` → logged + ignored (silent
+  to the client).
+- **Rename an event:** update `eventIDs`/`Subscriptions`
+  ([pubsub_types.go](../../../pubsub/types/pubsub_types.go)), the send-loop/reader
+  arms, every `registerEvtHandler`, and the `/ps` twin. No compiler help — pure
+  string match.
+- **Touch reconnect recovery:** a controller that registers a server-event handler
+  but no `reconnect` re-request goes stale after an outage (silent); one that
+  forgets to unsubscribe its `reconnect` handler in `disconnect()` leaks handlers
+  and multiplies requests across reconnects.
+- **Change hub fan-out (buffer size / blocking send):** the spoke send is
+  non-blocking with unregister-on-full (`:263-267`); making it blocking risks
+  stalling `run()` for *all* clients (loud); enlarging buffers hides slow clients.
+- **Change keepalive cadence / removal:** zombie clients (dead TCP, e.g. iOS
+  Safari) accumulate; `NumClients()` inflates; the per-connection teardown that
+  the ping triggers no longer fires (silent resource leak).
+
+**Silent failures:** event-name drift; missing controller handler; oversize
+request dropped without reply ([:127-131](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L127-L131)); pre-connect queue overflow drops the oldest of >5 early
+sends; malformed inbound frame throws in `JSON.parse` (no `try/catch` in
+`onmessage`); missing `reconnect` re-request leaves stale UI after an outage.
+
+**Hard failures:** removing `connCtx` cancellation/`defer`s (goroutine + socket
+leak); a payload encoder panicking inside the send loop; a blocking spoke send
+stalling `run()`.
+
+## Section 7 — Common Pitfalls
+
+- Registering a handler for `"newblock"` but the server sends `"newblock"` only via
+  the global producer in `index.js`; per-controller `newblock` handlers must use
+  per-handler unsubscribe (cf. `ticketpool_controller` `newblockUnsub`) to avoid
+  clobbering the shared producer on `disconnect()`.
+- Assuming `open` means "reconnected" — `open` fires on the *first* connect too.
+  Reconnect-only logic must use the `reconnect` synthetic event.
+- Treating `Message` as already-parsed — it is a JSON **string**; controllers
+  `JSON.parse(evt)` it.
+- Building a new payload that pushes SKA through `float64`/JS `Number` (C1).
+- Editing the explorer `/ws` arm but not the pubsub `/ps` arm (C2) — they drift
+  silently and only show under live load.
+- Sending app-level pings from the client (unnecessary — keepalive is
+  protocol-level; the `ping` *event* is server→client user-count only).
+
+## Section 8 — Evidence
+
+- Route: [main.go:663](../../../cmd/dcrdata/main.go#L663).
+- Handler: [websockethandlers.go](../../../cmd/dcrdata/internal/explorer/websockethandlers.go)
+  — accept/read-limit `:39-50`, `connCtx` `:54`, `send` `:68-81`, ping goroutine
+  `:85-105`, reader+switch `:109-247` (oversize `:127-131`, `+"Resp"` `:241`),
+  send loop+switch `:250-377`, `buildTicketPoolChartsData` `:388`.
+- Hub: [websocket.go](../../../cmd/dcrdata/internal/explorer/websocket.go)
+  — constants `:16-34`, sig aliases `:38-47`, `WebSocketMessage` `:51-54`,
+  `RegisterClient` `:124`, `NumClients` `:112`, `pingClients` `:172-191`, `run()`
+  `:201-322`, `maybeSendTxns`/buffer `:327-366`.
+- Event-id map: [pubsub_types.go:121-147](../../../pubsub/types/pubsub_types.go#L121-L147).
+- Client service: [messagesocket_service.js](../../../cmd/dcrdata/public/js/services/messagesocket_service.js)
+  — `reconnectOptions` `:32-39`, `forward` `:41-46`, `send`/queue `:78-92`,
+  `connect`/synthetic events `:94-128`, `close` `:131-133`.
+- Bootstrap: [index.js:37-61](../../../cmd/dcrdata/public/index.js#L37-L61).
+- Consumers: [connection_controller.js](../../../cmd/dcrdata/public/js/controllers/connection_controller.js),
+  [homepage_controller.js:77-128](../../../cmd/dcrdata/public/js/controllers/homepage_controller.js#L77-L128),
+  [mempool_controller.js:264-321](../../../cmd/dcrdata/public/js/controllers/mempool_controller.js#L264-L321),
+  [visualBlocks_controller.js:354-382](../../../cmd/dcrdata/public/js/controllers/visualBlocks_controller.js#L354-L382),
+  [ticketpool_controller.js:149-222](../../../cmd/dcrdata/public/js/controllers/ticketpool_controller.js#L149-L222),
+  `status_controller.js:79`.
+- Automated coverage: `messagesocket_service.test.js`, `connection_controller.test.js`,
+  `websockethandlers_test.go`.
+
+See also:
+- /wiki/code-analysis/mempool/flow.full.md (shares-pattern-with: dual-transport WS delivery of `mempool`/`newtxs`)
+- /wiki/code-analysis/visualblocks/flow.full.md (depends-on: WS `newblock` shape + client-side normalisers)
+- /wiki/code-analysis/decodetx/flow.full.md (shares-pattern-with: RPC-over-WS request/response; documents the `/ps` twin)
+- /wiki/code-analysis/ticketpool/flow.full.md (depends-on: `getticketpooldata`→`Resp` mirrors REST)
+- /wiki/core/constraints.md (depends-on: C1 precision pass-through; C2 dual pipeline; C3/C8 template↔WS parity & shape asymmetry; C4 array stability)
+- /docs/manual-test-plan-websocket.md (verified-by: manual transport test plan — connect/reconnect/keepalive/buffering)

--- a/wiki/code-analysis/websocket/impact.md
+++ b/wiki/code-analysis/websocket/impact.md
@@ -79,10 +79,11 @@ Manual coverage: test plan WS-F4/I1/I2.
 
 ## R10 — Pre-connect queue overflow & malformed frames (silent)
 **Trigger:** issue >5 sends before `connect()` (oldest silently dropped,
-`maxQlength=5`); or a non-JSON inbound frame (`onmessage` does `JSON.parse` with no
-`try/catch`, [messagesocket_service.js:108-111](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L108-L111)).
-**Failure:** dropped early requests; a thrown parse error on a bad frame (behavior
-on the socket is undocumented — see test plan WS-J1).
+`maxQlength=5`); or a non-JSON inbound frame (`onmessage` wraps `JSON.parse` in a
+`try/catch`, [messagesocket_service.js:141-148](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L141-L148)).
+**Failure:** dropped early requests; a malformed frame is dropped with a
+`console.warn` and the message loop keeps processing subsequent frames (asserted by
+test plan WS-J1).
 
 See also:
 - /wiki/code-analysis/websocket/patterns.md (derived-from: these risks follow from P1–P7)

--- a/wiki/code-analysis/websocket/impact.md
+++ b/wiki/code-analysis/websocket/impact.md
@@ -1,0 +1,93 @@
+# WebSocket Transport — Mutation Impact
+
+Blast radius for changes to the explorer `/ws` transport. Each risk lists its
+trigger, failure mode (silent / loud), and the sites that must move together.
+
+## R1 — Event-name drift (silent)
+**Trigger:** rename or add an event without updating all string sites.
+**Sites:** `eventIDs` + `Subscriptions`
+([pubsub_types.go:121-147](../../../pubsub/types/pubsub_types.go#L121-L147)); the
+send-loop `case` and/or reader `case`
+([websockethandlers.go:133,279](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L133));
+the `+"Resp"` suffix the controller listens for; every `registerEvtHandler('<name>')`;
+the pubsub `/ps` twin. **Failure:** no compile error; the handler simply never
+fires and the UI silently stops updating. The `decodetx`/`sendtx` pair already
+spans 5 sites — see [/wiki/code-analysis/decodetx/impact.md](../decodetx/impact.md) R1.
+
+## R2 — New push signal not wired through `run()` (mixed)
+**Trigger:** add a `case sigX` to the send loop but the hub `run()` doesn't fan
+that signal to client spokes (it deliberately skips `sigNewTx`, `sigAddressTx`,
+`sigSubscribe/Unsubscribe` — [websocket.go:236-251](../../../cmd/dcrdata/internal/explorer/websocket.go#L236-L251)).
+**Failure:** the client never receives it (silent). The mirror trap: a signal that
+reaches the send loop with **no** matching `case` hits `default` → `Unhandled
+signal` log and the client gets `Message:"error"` (loud in logs, silent in UI).
+
+## R3 — `/ws` ↔ `/ps` ↔ HTTP payload drift (silent under load)
+**Trigger:** change a payload struct/JSON tag on one transport only.
+**Failure:** initial render (HTTP) and live update (WS) disagree; or `/ws` and
+`/ps` clients see different shapes. Manifests only under live traffic, never in
+`go build`/`go test`. Governed by C2 (dual pipeline) and C8 (dual-transport shape
+asymmetry); see [/wiki/core/constraints.md](../../core/constraints.md) and the
+`newblock` normalisers in [/wiki/code-analysis/visualblocks/impact.md](../visualblocks/impact.md).
+
+## R4 — SKA-through-float in a payload builder (silent corruption)
+**Trigger:** a new encoder reads SKA atoms as `float64` / JS `Number` before the
+string boundary. **Failure:** atomic precision truncates (~15 digits) or flips to
+scientific notation. The transport itself is pass-through (opaque `Message`
+string), so it offers no protection — the discipline must live in the builder.
+*Depends-on:* C1.
+
+## R5 — Hub fan-out backpressure change (loud or silent)
+**Trigger:** make the spoke send blocking, or resize `make(hubSpoke, 3)` /
+`clientSignalSize`. **Failure:** blocking send → one slow client stalls `run()` for
+**all** clients (loud, global). Larger buffers → slow clients linger instead of
+being unregistered, hiding the problem. See
+[websocket.go:263-267](../../../cmd/dcrdata/internal/explorer/websocket.go#L263-L267).
+
+## R6 — Broken connCtx teardown (hard, resource leak)
+**Trigger:** remove/short-circuit a `defer cancel()` / `defer closeWS()`, or stop
+one goroutine from observing `connCtx.Done()`. **Failure:** reader blocks forever
+on `wsjson.Read` (no read deadline by design), goroutines and sockets leak per
+dead connection. See [websockethandlers.go:54-66,85-105,374](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L54-L66).
+
+## R7 — Keepalive cadence change / removal (silent leak)
+**Trigger:** raise/remove `pingInterval` or the ping goroutine. **Failure:**
+half-open connections (dead TCP, classically iOS Safari backgrounded tabs) are no
+longer detected; clients are never unregistered; `NumClients()` (and the `ping`
+user-count event) inflate; server resources leak. See
+[websocket.go:23,172-191](../../../cmd/dcrdata/internal/explorer/websocket.go#L172-L191)
+and the per-connection ping at
+[websockethandlers.go:85-105](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L85-L105).
+Manual coverage: test plan WS-H1/H2.
+
+## R8 — Request size limits (silent drop / hard close)
+**Trigger:** send a client request near/over `1<<20`. **Failure:** a frame over
+`SetReadLimit(1<<20)` errors the read → connection torn down (client reconnects);
+the field-size branch at
+[websockethandlers.go:127-131](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L127-L131)
+sets a message then `continue`s — **the reply is never sent** (silent). Three
+independent limits exist across `/ws`, `/ps`, Insight — see decodetx R2/limits.
+
+## R9 — Reconnect-recovery omissions (silent staleness / leaks)
+**Trigger:** a controller consumes a server event but registers no `reconnect`
+re-request → UI is stale after any outage. Or it forgets to unsubscribe its
+`reconnect`/event handlers in `disconnect()` → handlers accumulate on the singleton
+socket, multiplying requests and duplicating DOM rows across reconnects/navigation.
+See the per-controller `reconnectUnsub` / `deregisterEvtHandlers` patterns
+([homepage_controller.js:117-128](../../../cmd/dcrdata/public/js/controllers/homepage_controller.js#L117-L128)).
+Manual coverage: test plan WS-F4/I1/I2.
+
+## R10 — Pre-connect queue overflow & malformed frames (silent)
+**Trigger:** issue >5 sends before `connect()` (oldest silently dropped,
+`maxQlength=5`); or a non-JSON inbound frame (`onmessage` does `JSON.parse` with no
+`try/catch`, [messagesocket_service.js:108-111](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L108-L111)).
+**Failure:** dropped early requests; a thrown parse error on a bad frame (behavior
+on the socket is undocumented — see test plan WS-J1).
+
+See also:
+- /wiki/code-analysis/websocket/patterns.md (derived-from: these risks follow from P1–P7)
+- /wiki/code-analysis/decodetx/impact.md (shares-pattern-with: R1 event-name drift, oversize silent drop, `/ws`↔`/ps` duality)
+- /wiki/code-analysis/mempool/impact.md (shares-pattern-with: WS schema drift, Go↔JS drift)
+- /wiki/code-analysis/visualblocks/impact.md (depends-on: `newblock` WS shape + client normalisers)
+- /wiki/core/constraints.md (depends-on: C1 precision; C2 dual pipeline; C3/C8 parity & shape asymmetry)
+- /docs/manual-test-plan-websocket.md (verified-by: manual transport test plan)

--- a/wiki/code-analysis/websocket/patterns.md
+++ b/wiki/code-analysis/websocket/patterns.md
@@ -73,6 +73,26 @@ the slice into each client's `newTxs` field
 **Constraint:** the broadcast carries a nil `Msg`; the per-client slice is the real
 payload — fan-out and per-client state are decoupled here.
 
+## P8 — Client-side liveness watchdog (counterpart to P2)
+partysocket only reconnects when the browser fires a `close`/`error` event. A
+**silently** dropped socket (offline tab, backgrounded iOS Safari, network
+partition) never gets one — it lingers in `OPEN`, partysocket never retries, and
+the UI shows a stale "Connected". The client mirrors the server's ping-based
+zombie detection (P2) with a passive watchdog: any inbound frame re-arms a timer
+([messagesocket_service.js:72-86](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L72-L86)),
+re-armed on `onopen`/`onmessage` and cleared on `onclose`/clean `close()`
+([:136-159](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L136-L159)).
+After `livenessTimeout` (90 s) of silence it forces `connection.reconnect()`,
+which drops the zombie and emits the synthetic `close` — surfacing the
+disconnect to the indicator (P1) and driving the re-request flow (P5). The
+watchdog stays **passive**: it never sends a client→server frame, so the
+"client sends no app-level pings" contract holds; the inbound app-level `ping`
+(broadcast every 60 s by P2's ticker) is the guaranteed proof-of-life that keeps
+it from firing on a healthy connection. **Constraint:** `livenessTimeout` must
+stay above the server's 60 s ping cadence (with margin) or healthy connections
+false-positive; the timeout handler must **not** re-arm (that would reset
+partysocket's backoff every cycle) — a successful `onopen` re-arms it instead.
+
 See also:
 - /wiki/code-analysis/websocket/impact.md (depends-on: these patterns define the mutation risks)
 - /wiki/code-analysis/decodetx/patterns.md (shares-pattern-with: RPC-over-WS)

--- a/wiki/code-analysis/websocket/patterns.md
+++ b/wiki/code-analysis/websocket/patterns.md
@@ -1,0 +1,80 @@
+# WebSocket Transport — Patterns
+
+Reusable architectural behavior in the explorer `/ws` transport. Payload-specific
+patterns live in the per-feature domains (`mempool`, `visualblocks`, `decodetx`,
+`ticketpool`); these are the transport-level mechanics.
+
+## P1 — Envelope-and-dispatch with synthetic lifecycle events
+Every frame is `WebSocketMessage{ event, message }`
+([websocket.go:51-54](../../../cmd/dcrdata/internal/explorer/websocket.go#L51-L54)).
+The client keeps a `{event: [handler]}` registry and `forward()`s each inbound
+message to the matching handlers, iterating a **copy** of the list so a handler may
+unsubscribe itself mid-dispatch
+([messagesocket_service.js:41-46](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L41-L46)).
+On top of server event names the client synthesizes `open`, `reconnect`, `close`,
+`error` so consumers reason about the connection without touching partysocket.
+**Constraint:** event names are plain strings shared across Go and JS with no
+common enum — they must match exactly (see impact R1).
+
+## P2 — Three-goroutine connection model under one `connCtx`
+Each accepted socket runs a **reader**, a **send loop**, and a **ping** goroutine,
+all sharing a single `context.WithCancel(ctx)`
+([websockethandlers.go:54](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L54)).
+Whichever goroutine first decides the connection is dead calls `cancel()`, which
+unblocks the others; `defer cancel()` / `defer closeWS()` guarantee teardown.
+Liveness is enforced by the ping goroutine, **not** a per-read deadline, so the
+reader blocks indefinitely on `wsjson.Read` until ping failure or client close
+collapses `connCtx`. **Constraint:** the `defer cancel`/`closeWS` chain is
+load-bearing; dropping one leaks a goroutine and a socket.
+
+## P3 — Hub fan-out with unregister-on-backpressure
+`run()` delivers a signal to every client with a **non-blocking** channel send;
+if the client's buffered spoke (`make(hubSpoke, 3)`) is full, the `default` arm
+unregisters that client rather than blocking the hub
+([websocket.go:263-267](../../../cmd/dcrdata/internal/explorer/websocket.go#L263-L267)).
+This keeps one slow consumer from stalling broadcast to all others.
+**Constraint:** the send must stay non-blocking; converting it to a blocking send
+couples every client's liveness to the slowest one.
+
+## P4 — RPC-over-WebSocket via `<event>Resp`
+Client requests (`getmempooltxs`, `getmempooltrimmed`, `getticketpooldata`,
+`decodetx`, `sendtx`) are answered on the same socket with `EventId =
+msg.EventId + "Resp"`
+([websockethandlers.go:241](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L241)).
+Both success and error ride the same `Resp` event; the body is a free string the
+controller interprets. `getmempooltxs` also carries a client-supplied inventory id
+so the server can short-circuit when the client is already current
+([:159-174](../../../cmd/dcrdata/internal/explorer/websockethandlers.go#L159-L174)).
+**Shared with:** [/wiki/code-analysis/decodetx/patterns.md](../decodetx/patterns.md) (P1 form-shell over WS-RPC).
+
+## P5 — Reconnect-driven state re-request
+The first `open` fires `open` only; every later `open` also fires `reconnect`
+([messagesocket_service.js:113-119](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L113-L119)).
+Each feature controller subscribes to `reconnect` and re-requests the state it may
+have missed during the outage (`getmempooltxs` / `getmempooltrimmed` /
+`getticketpooldata`). **Constraint:** a controller that consumes a server event
+should pair it with a `reconnect` re-request, and must unsubscribe that handler in
+`disconnect()` (the registry persists; the singleton socket outlives controllers).
+
+## P6 — Two-layer outbound buffering
+Sends issued before `connect()` runs (controllers `send` during Stimulus
+`connect`, which precedes the 300 ms-deferred `ws.connect` in `index.js`) are held
+in a bounded `preConnectQueue` (cap `maxQlength=5`, oldest dropped) and flushed on
+connect; thereafter partysocket's own unbounded `maxEnqueuedMessages` buffers across
+reconnects ([messagesocket_service.js:78-105](../../../cmd/dcrdata/public/js/services/messagesocket_service.js#L78-L105)).
+**Constraint:** the pre-connect cap is small and lossy by design — do not rely on
+it for more than the handful of initial requests.
+
+## P7 — Server-side new-tx batching
+`sigNewTx` is not broadcast per tx; the hub buffers txs (`newTxBufferSize=5`) and
+flushes them as a single `sigNewTxs` either at capacity or on a 5 s ticker, writing
+the slice into each client's `newTxs` field
+([websocket.go:327-366](../../../cmd/dcrdata/internal/explorer/websocket.go#L327-L366)).
+**Constraint:** the broadcast carries a nil `Msg`; the per-client slice is the real
+payload — fan-out and per-client state are decoupled here.
+
+See also:
+- /wiki/code-analysis/websocket/impact.md (depends-on: these patterns define the mutation risks)
+- /wiki/code-analysis/decodetx/patterns.md (shares-pattern-with: RPC-over-WS)
+- /wiki/code-analysis/mempool/patterns.md (shares-pattern-with: dual-transport WS, rAF indicator batching downstream of P1)
+- /wiki/core/constraints.md (depends-on: C2 dual pipeline; C3/C8 parity & shape asymmetry)

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -150,6 +150,15 @@ _The `/decodetx` page: a static HTML form whose handler carries no data; all int
 - patterns: code-analysis/decodetx/patterns.md — P1 form-shell over WS-RPC, P2 three-transport surface for the same node RPC, P3 multi-coin pass-through via opaque JSON
 - impact: code-analysis/decodetx/impact.md — R1 event-string drift across 5 sites, R2 oversize-request silent drop, R3 `/ws`/`/ps` dual-pipeline drift, R4 interface fan-out (+ mock), R5 latent SKA precision loss, R6 same-event success/error multiplexing, R7 shared receive loop, R8 legacy `/explorer/decodetx` redirect
 
+### WebSocket Transport
+
+_The explorer `/ws` real-time pipe shared by all live pages: `RootWebsocket` + `WebsocketHub` (server, migrated to `coder/websocket`) and the `partysocket`-based `MessageSocket` client wrapper. Owns the connection lifecycle, hub fan-out, `{event,message}` framing, RPC-over-WS (`<event>Resp`), synthetic `open`/`reconnect`/`close`/`error` events, two-layer outbound buffering, and 60 s keepalive — distinct from per-feature payload domains (mempool/visualblocks/decodetx/ticketpool) and from the separate pubsub `/ps` server._
+
+- flow (compact): code-analysis/websocket/flow.compact.md — one-line push/request flow, 7 transport patterns, constraints, mutation checklist
+- flow (full): code-analysis/websocket/flow.full.md — end-to-end trace: hub → 3-goroutine connection handler → wire envelope → partysocket client → consumers; event-id triple coupling; keepalive
+- patterns: code-analysis/websocket/patterns.md — envelope-and-dispatch + synthetic events, 3-goroutine/`connCtx` model, fan-out unregister-on-backpressure, RPC-over-WS, reconnect-driven re-request, two-layer buffering, new-tx batching
+- impact: code-analysis/websocket/impact.md — R1 event-name drift, R2 unwired push signal, R3 `/ws`↔`/ps`↔HTTP drift, R4 SKA-through-float, R5 backpressure change, R6 connCtx teardown, R7 keepalive removal, R8 size limits, R9 reconnect-recovery omissions, R10 queue overflow / malformed frame
+
 ### Ticketpool
 
 _The `/ticketpool` page: form-shell HTML + three live data channels (HTTP `/api/ticketpool/charts`, HTTP `/api/ticketpool/bydate/{tp}`, WS `getticketpooldata`→`Resp`). Server `Ticketpool` handler injects only `commonData`; `sigNewBlock` carries no ticket data, the JS controller re-requests on every `newblock`. One `PoolTicketsData` struct populated by three positional Scans; process-global stale-while-revalidate cache keyed `(interval, height)` with `trylock.Mutex` updater election and an inner retry loop to keep all three sub-charts at one block. VAR-only float64 pipeline (tickets are a VAR PoS instrument by chain design); same JSON field `mempool.price` carries two different semantics across REST vs WS — a C8 manifestation inside a single field._


### PR DESCRIPTION
## Summary

Replaces the hand-rolled WebSocket client with [partysocket](https://github.com/partykit/partysocket)'s `ReconnectingWebSocket` and hardens the real-time transport:

- **partysocket integration** (`messagesocket_service.js`): auto-reconnect with exponential backoff (min 1 s, max 10 s, ×1.3), unbounded retries, and unbounded outbound buffering across reconnects. Adds synthetic `open` / `reconnect` / `close` / `error` events on top of the server's event stream.
- **State recovery on reconnect**: home, mempool, and ticket-pool controllers now re-request server state on the synthetic `reconnect` event (and deregister their handlers on `disconnect`, preventing handler leaks across reconnects/navigation). Unit tests added for each consumer.
- **Client liveness watchdog**: a ~90 s inbound-silence timer forces `partysocket.reconnect()` so silently dropped sockets (offline tab, backgrounded iOS Safari, network partition) surface as a `close` instead of lingering in a stale "Connected" state — the client-side mirror of the server's zombie-client detection.
- **Docs**: code-grounded transport trace under `wiki/code-analysis/websocket/` and a QA `docs/manual-test-plan-websocket.md`.

## Manual verification (Playwright, against a local testnet `:17778`)

Drove the running app and instrumented the socket. Verified:

- Connect/handshake, single socket per page, 300 ms connect debounce (drive-by loads don't inflate user count).
- Status indicator transitions Connected ⇄ Disconnected.
- **Liveness watchdog fires at ~90 s** of inbound silence (`WebSocket liveness timeout; forcing reconnect`) and flips the UI to Disconnected on a silent offline drop.
- **Backoff** observed growing `1000 → 1300 → 1690 → … → 8157` ms (×1.3), approaching the 10 s cap, retrying indefinitely; recovers cleanly on restore.
- Reconnect re-requests (`getmempooltxs` empty-id, `getticketpooldata`) fire exactly once per consumer across repeated reconnects and 6× navigation re-mounts (no handler leak).
- Request/response: `decodetx` (valid + invalid), `getmempooltxs` cache short-circuit, unknown-event ignored, oversized (2 MiB) request → server close `1009` → client reconnects.
- App-level `ping` every ~60 s carrying user count (increments/decrements with tabs); client sends no app-level pings.
- Rapid reconnect storm settles to a single healthy connection, 0 unhandled rejections.

Note for reviewers: the home page mounts `home-latest-blocks`, not `visualBlocks_controller`, so the `getmempooltrimmed` path isn't exercised on `/` in the current build.

## Test plan

- [ ] `cd cmd/dcrdata && npm ci && npm test` (vitest — new socket + controller tests)
- [ ] `npm run check` (prettier + eslint + stylelint)
- [ ] `npm run build` and smoke-test `/`, `/mempool`, `/ticketpool` against a live node
- [ ] Manual: follow `docs/manual-test-plan-websocket.md` (Sections A, B, E, F, G, I core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)