### PR TITLE
txhelpers: handle DB extension types 101-105 in TxTypeToString

### DIFF
--- a/db/dbtypes/types_test.go
+++ b/db/dbtypes/types_test.go
@@ -367,6 +367,27 @@ func TestReduceAddressHistory_MixedCoin(t *testing.T) {
 // TestFormatSKACoins covers the label-free SKA atoms→coins formatter used by
 // the CSV export (the amount column must be a bare parseable number, with the
 // coin disambiguated by the separate coin_type column).
+func TestFormatSKACoins(t *testing.T) {
+	cases := []struct {
+		atoms string
+		want  string
+	}{
+		{"", "0"},
+		{"not-a-number", "0"},
+		{"0", "0"},
+		{"500", "0.0000000000000005"},
+		{"70000000", "0.00000000007"},
+		{"1000000000000000000", "1"},
+		{"5000000000000000000000", "5000"},
+		{"1230000000000000000", "1.23"},
+	}
+	for _, c := range cases {
+		if got := FormatSKACoins(c.atoms); got != c.want {
+			t.Errorf("FormatSKACoins(%q) = %q, want %q", c.atoms, got, c.want)
+		}
+	}
+}
+
 // TestTxTypeToString_MatchesDBExtensions asserts that txhelpers.TxTypeToString
 // correctly maps the canonical db/dbtypes extension constants (101–105) to the
 // expected display strings. If a db/dbtypes constant value changes, this test
@@ -386,27 +407,6 @@ func TestTxTypeToString_MatchesDBExtensions(t *testing.T) {
 		got := txhelpers.TxTypeToString(int(tt.dbValue))
 		if got != tt.want {
 			t.Errorf("TxTypeToString(%d) = %q, want %q", tt.dbValue, got, tt.want)
-		}
-	}
-}
-
-func TestFormatSKACoins(t *testing.T) {
-	cases := []struct {
-		atoms string
-		want  string
-	}{
-		{"", "0"},
-		{"not-a-number", "0"},
-		{"0", "0"},
-		{"500", "0.0000000000000005"},
-		{"70000000", "0.00000000007"},
-		{"1000000000000000000", "1"},
-		{"5000000000000000000000", "5000"},
-		{"1230000000000000000", "1.23"},
-	}
-	for _, c := range cases {
-		if got := FormatSKACoins(c.atoms); got != c.want {
-			t.Errorf("FormatSKACoins(%q) = %q, want %q", c.atoms, got, c.want)
 		}
 	}
 }

--- a/db/dbtypes/types_test.go
+++ b/db/dbtypes/types_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/monetarium/monetarium-explorer/txhelpers"
 )
 
 const (
@@ -365,6 +367,29 @@ func TestReduceAddressHistory_MixedCoin(t *testing.T) {
 // TestFormatSKACoins covers the label-free SKA atoms→coins formatter used by
 // the CSV export (the amount column must be a bare parseable number, with the
 // coin disambiguated by the separate coin_type column).
+// TestTxTypeToString_MatchesDBExtensions asserts that txhelpers.TxTypeToString
+// correctly maps the canonical db/dbtypes extension constants (101–105) to the
+// expected display strings. If a db/dbtypes constant value changes, this test
+// fails and signals that txhelpers must be updated too.
+func TestTxTypeToString_MatchesDBExtensions(t *testing.T) {
+	tests := []struct {
+		dbValue int16
+		want    string
+	}{
+		{TxTypeBlockRewardPoS, "Stake Reward"},
+		{TxTypeBlockRewardPoW, "PoW Reward"},
+		{TxTypeSSFeePoS, "Stake Fee"},
+		{TxTypeSSFeePoW, "Stake Fee"},
+		{TxTypeTicketPurchase, "Ticket"},
+	}
+	for _, tt := range tests {
+		got := txhelpers.TxTypeToString(int(tt.dbValue))
+		if got != tt.want {
+			t.Errorf("TxTypeToString(%d) = %q, want %q", tt.dbValue, got, tt.want)
+		}
+	}
+}
+
 func TestFormatSKACoins(t *testing.T) {
 	cases := []struct {
 		atoms string

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -1194,6 +1194,16 @@ const (
 	TxTypePoWReward     string = "PoW Reward"
 )
 
+// DB extension tx types mirroring db/dbtypes/types.go canonical constants.
+// Values ≥100 are dbtypes-only extensions to stake.TxType iota range (0–7).
+const (
+	txTypeBlockRewardPoS int = 101
+	txTypeBlockRewardPoW int = 102
+	txTypeSSFeePoS       int = 103
+	txTypeSSFeePoW       int = 104
+	txTypeTicketPurchase int = 105
+)
+
 // DetermineTxTypeString returns a string representing the transaction type
 // given a wire.MsgTx struct. If the caller does not know if treasure is active
 // for this txn, but the MsgTx is from from dcrd, it can be assumed to be valid
@@ -1233,15 +1243,15 @@ func TxTypeToString(txType int) string {
 	case stake.TxTypeSSFee:
 		return TxTypeSSFee
 	// DB extension subtypes (db/dbtypes/types.go)
-	case stake.TxType(101): // TxTypeBlockRewardPoS
+	case stake.TxType(txTypeBlockRewardPoS):
 		return TxTypeStakeReward
-	case stake.TxType(102): // TxTypeBlockRewardPoW
+	case stake.TxType(txTypeBlockRewardPoW):
 		return TxTypePoWReward
-	case stake.TxType(103): // TxTypeSSFeePoS
+	case stake.TxType(txTypeSSFeePoS):
 		return TxTypeSSFee
-	case stake.TxType(104): // TxTypeSSFeePoW
+	case stake.TxType(txTypeSSFeePoW):
 		return TxTypeSSFee
-	case stake.TxType(105): // TxTypeTicketPurchase
+	case stake.TxType(txTypeTicketPurchase):
 		return TxTypeTicket
 	default:
 		return TxTypeRegular

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -1190,6 +1190,8 @@ const (
 	TxTypeTreasurySpend string = "Treasury Spend"
 	TxTypeTreasuryAdd   string = "Treasury Add"
 	TxTypeSSFee         string = "Stake Fee"
+	TxTypeStakeReward   string = "Stake Reward"
+	TxTypePoWReward     string = "PoW Reward"
 )
 
 // DetermineTxTypeString returns a string representing the transaction type
@@ -1212,6 +1214,8 @@ func IsSSRtx(tx *wire.MsgTx) bool {
 
 // TxTypeToString returns a string representation of the provided transaction
 // type, which corresponds to the txn types defined for stake.TxType type.
+// Values 101-105 are db/dbtypes extensions (see db/dbtypes/types.go) for
+// split reward/fee/ticket subtypes stored in the addresses table.
 func TxTypeToString(txType int) string {
 	switch stake.TxType(txType) {
 	case stake.TxTypeSSGen:
@@ -1228,6 +1232,17 @@ func TxTypeToString(txType int) string {
 		return TxTypeTreasurybase
 	case stake.TxTypeSSFee:
 		return TxTypeSSFee
+	// DB extension subtypes (db/dbtypes/types.go)
+	case stake.TxType(101): // TxTypeBlockRewardPoS
+		return TxTypeStakeReward
+	case stake.TxType(102): // TxTypeBlockRewardPoW
+		return TxTypePoWReward
+	case stake.TxType(103): // TxTypeSSFeePoS
+		return TxTypeSSFee
+	case stake.TxType(104): // TxTypeSSFeePoW
+		return TxTypeSSFee
+	case stake.TxType(105): // TxTypeTicketPurchase
+		return TxTypeTicket
 	default:
 		return TxTypeRegular
 	}

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -182,6 +182,37 @@ func testIsZeroHashP2PHKAddress(t *testing.T, expectedAddress string, params *ch
 	}
 }
 
+func TestTxTypeToString(t *testing.T) {
+	tests := []struct {
+		txType int
+		want   string
+	}{
+		// Original stake types
+		{0, TxTypeRegular},
+		{1, TxTypeTicket},
+		{2, TxTypeVote},
+		{3, TxTypeRevocation},
+		{4, TxTypeTreasuryAdd},
+		{5, TxTypeTreasurySpend},
+		{6, TxTypeTreasurybase},
+		{7, TxTypeSSFee},
+		// DB extension subtypes
+		{101, TxTypeStakeReward},
+		{102, TxTypePoWReward},
+		{103, TxTypeSSFee},
+		{104, TxTypeSSFee},
+		{105, TxTypeTicket},
+		// Unknown falls through to Regular
+		{99, TxTypeRegular},
+		{255, TxTypeRegular},
+	}
+	for _, tt := range tests {
+		if got := TxTypeToString(tt.txType); got != tt.want {
+			t.Errorf("TxTypeToString(%d) = %q, want %q", tt.txType, got, tt.want)
+		}
+	}
+}
+
 func TestFeeRate(t *testing.T) {
 	// Ensure invalid fee rate is -1.
 	if FeeRate(0, 0, 0) != -1 {

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -199,8 +199,8 @@ func TestTxTypeToString(t *testing.T) {
 		// DB extension subtypes (mirrors db/dbtypes/types.go)
 		{txTypeBlockRewardPoS, TxTypeStakeReward},
 		{txTypeBlockRewardPoW, TxTypePoWReward},
-		{txTypeSSFeePoS,       TxTypeSSFee},
-		{txTypeSSFeePoW,       TxTypeSSFee},
+		{txTypeSSFeePoS, TxTypeSSFee},
+		{txTypeSSFeePoW, TxTypeSSFee},
 		{txTypeTicketPurchase, TxTypeTicket},
 		// Unknown falls through to Regular
 		{99, TxTypeRegular},

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -196,12 +196,12 @@ func TestTxTypeToString(t *testing.T) {
 		{5, TxTypeTreasurySpend},
 		{6, TxTypeTreasurybase},
 		{7, TxTypeSSFee},
-		// DB extension subtypes
-		{101, TxTypeStakeReward},
-		{102, TxTypePoWReward},
-		{103, TxTypeSSFee},
-		{104, TxTypeSSFee},
-		{105, TxTypeTicket},
+		// DB extension subtypes (mirrors db/dbtypes/types.go)
+		{txTypeBlockRewardPoS, TxTypeStakeReward},
+		{txTypeBlockRewardPoW, TxTypePoWReward},
+		{txTypeSSFeePoS,       TxTypeSSFee},
+		{txTypeSSFeePoW,       TxTypeSSFee},
+		{txTypeTicketPurchase, TxTypeTicket},
 		// Unknown falls through to Regular
 		{99, TxTypeRegular},
 		{255, TxTypeRegular},


### PR DESCRIPTION
The DB extraction layer (db/dbtypes/extraction.go) subdivides stake types into extension values 101-105 stored in the addresses.tx_type column. TxTypeToString only handled the core stake.TxType range (0-7), so the extension values fell through to 'Regular'.

Add cases for all five extension types:
  101 (TxTypeBlockRewardPoS)  -> 'Stake Reward'
  102 (TxTypeBlockRewardPoW)  -> 'PoW Reward'
  103 (TxTypeSSFeePoS)        -> 'Stake Fee'
  104 (TxTypeSSFeePoW)        -> 'Stake Fee'
  105 (TxTypeTicketPurchase)  -> 'Ticket'