### PR TITLE
cmd/dcrdata: bump version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Monetarium Explorer is a block explorer for the [Monetarium](https://monetarium.
 
 - [Go](https://golang.org) 1.21+
 - [Node.js](https://nodejs.org/en/download/) 16.x or later (build only, not runtime)
-- Running `monetarium-node` synchronized to the current best block
+- Running `monetarium-node` synchronized to the current best block (this release is built against `monetarium-node` v1.3.6)
 - PostgreSQL 13+
 
 ## Building

--- a/cmd/dcrdata/package-lock.json
+++ b/cmd/dcrdata/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monetarium-explorer",
-  "version": "0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monetarium-explorer",
-      "version": "0.1",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "bootstrap": "^5.3.8",

--- a/cmd/dcrdata/package.json
+++ b/cmd/dcrdata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monetarium-explorer",
-  "version": "0.1",
+  "version": "1.0.0",
   "main": "index.js",
   "private": true,
   "sideEffects": [

--- a/cmd/dcrdata/version.go
+++ b/cmd/dcrdata/version.go
@@ -24,8 +24,8 @@ const (
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	AppName  string = "monetarium-explorer"
-	AppMajor uint   = 0
-	AppMinor uint   = 1
+	AppMajor uint   = 1
+	AppMinor uint   = 0
 	AppPatch uint   = 0
 )
 
@@ -34,12 +34,12 @@ var (
 	// appPreRelease is defined as a variable so it can be overridden during the
 	// build process. It MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	appPreRelease = "pre"
+	appPreRelease = ""
 
 	// appBuild is defined as a variable so it can be overridden during the
 	// build process. It MUST only contain characters from semanticBuildAlphabet
 	// per the semantic versioning spec.
-	appBuild = "dev"
+	appBuild = ""
 )
 
 // Version returns the application version as a properly formed string per the


### PR DESCRIPTION
## Summary

- Bump the explorer app version from `0.1.0` to `1.0.0` — the first tagged release.
- Clear the `-pre`/`+dev` defaults in `version.go` so the Docker-built binary reports a clean `1.0.0` (the `appPreRelease`/`appBuild` ldflags overrides still work for CI builds).
- Update `package.json` / `package-lock.json` to `1.0.0` to keep the frontend in sync.
- Record node compatibility (`monetarium-node` v1.3.6) in the README Requirements section instead of coupling the explorer's version number to the node's.

The HTTP API contract version (`APIVersion = 1`) is intentionally left unchanged — that axis only moves on breaking API changes.

## Test plan

- [x] `gofmt` clean + `go test ./...` for `cmd/dcrdata` (ran via pre-commit hook)
- [x] `go build` + `./monetarium-explorer --version` reports `version 1.0.0`
- [ ] After merge: tag `v1.0.0` on the merge commit, then bump `develop` to the next dev version (`1.0.1` + `appPreRelease = "pre"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)