### PR TITLE
db/dcrpg,blockdata: fix SKA stake fee calculation for coinbase inputs

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -552,8 +552,13 @@ func BlockSKAFees(msgBlock *wire.MsgBlock) map[uint8]string {
 
 	skaFees := make(map[uint8]*big.Int)
 
-	// Process regular transactions (Transactions, not STransactions)
-	for _, tx := range msgBlock.Transactions {
+	// Process regular transactions (Transactions, not STransactions).
+	// Skip the coinbase transaction (i == 0) — its value is created
+	// ex nihilo, not transferred from prior UTXOs.
+	for i, tx := range msgBlock.Transactions {
+		if i == 0 {
+			continue
+		}
 		var inputSKA, outputSKA big.Int
 
 		// Sum SKA inputs

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -9,10 +9,15 @@ import (
 	"github.com/monetarium/monetarium-node/wire"
 )
 
-// mockBlock builds a wire.MsgBlock with the given regular transactions.
+// emptyTx is a placeholder for the coinbase transaction at index 0.
+// Real coinbase txs create value ex nihilo; BlockSKAFees skips index 0.
+var emptyTx = wire.NewMsgTx()
+
+// mockBlock builds a wire.MsgBlock with the given regular transactions,
+// inserting an empty placeholder at index 0 (coinbase slot).
 func mockBlock(txs ...*wire.MsgTx) *wire.MsgBlock {
 	blk := &wire.MsgBlock{}
-	blk.Transactions = txs
+	blk.Transactions = append([]*wire.MsgTx{emptyTx}, txs...)
 	return blk
 }
 
@@ -224,7 +229,9 @@ func TestBlockSKAPoWRewards_SKAOnly(t *testing.T) {
 	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(1), nil)) // SKA1 reward
 	coinbase.AddTxOut(wire.NewTxOutSKA(skaBig, cointype.CoinType(2), nil)) // SKA2 reward
 
-	got := BlockSKAPoWRewards(mockBlock(coinbase))
+	blk := &wire.MsgBlock{}
+	blk.Transactions = []*wire.MsgTx{coinbase}
+	got := BlockSKAPoWRewards(blk)
 	if got == nil {
 		t.Fatal("expected non-nil SKAPoWRewards")
 	}
@@ -246,7 +253,9 @@ func TestBlockSKAPoWRewards_NoSKA(t *testing.T) {
 	coinbase := wire.NewMsgTx()
 	coinbase.AddTxOut(wire.NewTxOut(100_000_000, nil)) // Only VAR
 
-	got := BlockSKAPoWRewards(mockBlock(coinbase))
+	blk := &wire.MsgBlock{}
+	blk.Transactions = []*wire.MsgTx{coinbase}
+	got := BlockSKAPoWRewards(blk)
 	if got != nil {
 		t.Errorf("expected nil for block without SKA rewards, got %v", got)
 	}
@@ -268,7 +277,11 @@ func TestBlockSKAPoWRewards_Summing(t *testing.T) {
 	coinbase.AddTxOut(wire.NewTxOutSKA(amt1, cointype.CoinType(1), nil))
 	coinbase.AddTxOut(wire.NewTxOutSKA(amt2, cointype.CoinType(1), nil))
 
-	got := BlockSKAPoWRewards(mockBlock(coinbase))
+	// BlockSKAPoWRewards reads Transactions[0] (the coinbase) directly.
+	// Do NOT use mockBlock() which inserts a dummy placeholder at index 0.
+	blk := &wire.MsgBlock{}
+	blk.Transactions = []*wire.MsgTx{coinbase}
+	got := BlockSKAPoWRewards(blk)
 	if got == nil {
 		t.Fatal("expected non-nil SKAPoWRewards")
 	}

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -9,15 +9,16 @@ import (
 	"github.com/monetarium/monetarium-node/wire"
 )
 
-// emptyTx is a placeholder for the coinbase transaction at index 0.
-// Real coinbase txs create value ex nihilo; BlockSKAFees skips index 0.
-var emptyTx = wire.NewMsgTx()
+// newEmptyTx returns a fresh empty transaction for the coinbase slot at
+// index 0. A package-level shared pointer would be dangerous — any test
+// that mutates it would corrupt subsequent tests.
+func newEmptyTx() *wire.MsgTx { return wire.NewMsgTx() }
 
 // mockBlock builds a wire.MsgBlock with the given regular transactions,
 // inserting an empty placeholder at index 0 (coinbase slot).
 func mockBlock(txs ...*wire.MsgTx) *wire.MsgBlock {
 	blk := &wire.MsgBlock{}
-	blk.Transactions = append([]*wire.MsgTx{emptyTx}, txs...)
+	blk.Transactions = append([]*wire.MsgTx{newEmptyTx()}, txs...)
 	return blk
 }
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6788,6 +6788,11 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 func ssFeeNetReward(msgTx *wire.MsgTx) *big.Int {
 	net := new(big.Int)
 	for _, vin := range msgTx.TxIn {
+		// Coinbase inputs create value ex nihilo — don't subtract them.
+		if vin.PreviousOutPoint.Index == wire.MaxPrevOutIndex &&
+			vin.PreviousOutPoint.Hash.IsEqual(&chainhash.Hash{}) {
+			continue
+		}
 		if vin.SKAValueIn != nil {
 			net.Sub(net, vin.SKAValueIn)
 		} else {

--- a/db/dcrpg/pgblockchain_internal_test.go
+++ b/db/dcrpg/pgblockchain_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/monetarium/monetarium-node/chaincfg"
+	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
 	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
 	"github.com/monetarium/monetarium-node/wire"
 )
@@ -57,6 +58,23 @@ func TestSSFeeNetReward(t *testing.T) {
 				},
 			},
 			want: "0",
+		},
+		{
+			name: "coinbase SKA input skipped",
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn: []*wire.TxIn{{
+					PreviousOutPoint: wire.OutPoint{
+						Hash:  chainhash.Hash{},
+						Index: wire.MaxPrevOutIndex,
+					},
+					SKAValueIn: big.NewInt(2382000000000000000),
+				}},
+				TxOut: []*wire.TxOut{
+					{CoinType: 1, SKAValue: big.NewInt(2382000000000000000)},
+				},
+			},
+			want: "2382000000000000000",
 		},
 	}
 


### PR DESCRIPTION
ssFeeNetReward in db/dcrpg/pgblockchain.go was missing the coinbase input guard (0000...000 + MaxPrevOutIndex) that blockSSFeeTotalsInternal already has. Coinbase inputs create value ex nihilo and must not be subtracted when computing net reward.

BlockSKAFees in blockdata/blockdata.go was not skipping the coinbase transaction (index 0), producing a spurious fee equal to the coinbase reward for SKA. Now skips i==0, matching computeMiningFee's pattern.

Adds coinbase SKA input test case to TestSSFeeNetReward.