### PR TITLE
explorer: display SKA tx fee rate in SKAn/kB

### DIFF
--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -394,7 +394,6 @@ func threeSigFigs(v float64) string {
 // skaDecimals is 10^18 — the number of SKA atoms per coin.
 var skaDecimals = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
 var varDecimals = big.NewInt(1e8)
-var bytesPerKB = big.NewInt(1000)
 
 // parseInt64 parses a decimal atom string to int64, returning 0 on error.
 func parseInt64(s string) int64 {
@@ -504,37 +503,25 @@ func coinDecimalParts(atomStr string, coinType uint8, useCommas bool, boldNumPla
 }
 
 // coinFeeRateDecimalParts renders a fee-rate value carried on the contract as
-// atoms/kB. VAR delegates to coinDecimalParts and is displayed as VAR/kB.
-// SKA divides the big.Int atoms/kB by 1000 (giving atoms/B) and renders via
-// skaDecimalParts so the headline number reads as SKA/B — chosen because SKA
-// 18-decimal fee rates are too small per kB to be legible. No float64
+// atoms/kB. VAR delegates to coinDecimalParts and is displayed as VAR/kB. SKA
+// renders the big.Int atoms/kB directly via skaDecimalParts so the headline
+// number reads as SKA/kB, matching the on-the-wire contract. No float64
 // conversion on the SKA path.
 func coinFeeRateDecimalParts(atomsPerKB string, coinType uint8, useCommas bool, boldNumPlaces ...int) []string {
 	if coinType == 0 {
 		return coinDecimalParts(atomsPerKB, 0, useCommas, boldNumPlaces...)
 	}
-	return skaDecimalParts(skaAtomsPerKBToPerByte(atomsPerKB), useCommas, boldNumPlaces...)
+	return skaDecimalParts(atomsPerKB, useCommas, boldNumPlaces...)
 }
 
-// skaAtomsPerKBToPerByte converts an SKA fee-rate string from atoms/kB to
-// atoms/B using big.Int integer division. Sub-atom-per-byte remainder is
-// unrepresentable and dropped. Empty or non-numeric input is returned
-// unchanged so skaDecimalParts can render the safe ["0","",""] fallback.
-func skaAtomsPerKBToPerByte(atomsPerKB string) string {
-	n, ok := new(big.Int).SetString(atomsPerKB, 10)
-	if !ok {
-		return atomsPerKB
-	}
-	return n.Quo(n, bytesPerKB).String()
-}
-
-// coinFeeRateUnit returns the fee-rate unit suffix. VAR uses /kB (matching the
-// on-the-wire atoms/kB contract); SKA uses /B (paired with coinFeeRateDecimalParts).
+// coinFeeRateUnit returns the fee-rate unit suffix. Both VAR and SKA use /kB,
+// matching the on-the-wire atoms/kB contract carried into
+// coinFeeRateDecimalParts.
 func coinFeeRateUnit(coinType uint8) string {
 	if coinType == 0 {
 		return "VAR/kB"
 	}
-	return coinSymbol(coinType) + "/B"
+	return coinSymbol(coinType) + "/kB"
 }
 
 // formatCoinAtoms converts a raw atom string to a threeSigFigs-formatted coin

--- a/cmd/dcrdata/internal/explorer/templates_test.go
+++ b/cmd/dcrdata/internal/explorer/templates_test.go
@@ -783,20 +783,29 @@ func TestCoinFeeRateDecimalParts(t *testing.T) {
 			expected:      []string{"0", "00", "01", "0000"},
 		},
 		{
-			// Issue #304 example: 0.545 SKA1/B.
-			// 0.545 SKA = 5.45e17 atoms (SKA has 18 decimals).
-			// atoms/kB = atoms/B * 1000 = 5.45e20 = "545" + 18 zeros.
-			// After helper /1000 -> 5.45e17 atoms/B -> skaDecimalParts:
-			//   dec = "545000000000000000" (18 chars)
+			// Issue #360 example: 4.247104247104247 SKA1/kB.
+			// On-the-wire fee rate is 4247104247104247000 atoms/kB.
+			// Rendered directly (no /1000 to atoms/B) via skaDecimalParts:
+			//   intPart = 4, fracPart = 247104247104247000
+			//   dec = "247104247104247000" (18 chars)
+			//   right = "247104247104247", trailingZeros = "000"
+			name:     "SKA fee rate renders atoms/kB directly for issue #360 example",
+			atomStr:  "4247104247104247000",
+			coinType: 1,
+			expected: []string{"4", "247104247104247", "000"},
+		},
+		{
+			// 0.545 SKA/kB = 5.45e17 atoms/kB, rendered directly:
+			//   intPart = 0, dec = "545000000000000000" (18 chars)
 			//   right = "545", trailingZeros = "000000000000000" (15)
-			name:     "SKA fee rate produces 0.545 SKA1/B for issue example",
-			atomStr:  "545000000000000000000",
+			name:     "SKA fractional fee rate renders atoms/kB directly",
+			atomStr:  "545000000000000000",
 			coinType: 1,
 			expected: []string{"0", "545", "000000000000000"},
 		},
 		{
 			name:          "SKA bold-mode forwards variadic to skaDecimalParts",
-			atomStr:       "545000000000000000000",
+			atomStr:       "545000000000000000",
 			coinType:      1,
 			boldNumPlaces: []int{3},
 			expected:      []string{"0", "545", "", "000000000000000"},
@@ -820,21 +829,22 @@ func TestCoinFeeRateDecimalParts(t *testing.T) {
 			expected: []string{"abc", "", ""},
 		},
 		{
-			// Sub-kB precision below 1 atom/B is dropped by the big.Int /1000.
-			// 1500 atoms/kB -> 1 atom/B -> 1e-18 SKA -> dec = "000000000000000001".
-			name:     "SKA atoms/kB above 1000 truncates sub-atom remainder",
+			// Sub-kB atoms/kB values are now rendered directly with full
+			// 18-decimal precision (the old /1000 atoms/B truncation is gone).
+			// 1500 atoms/kB -> dec = "000000000000001500" -> right keeps the
+			// significant digits, trailingZeros captures the two trailing zeros.
+			name:     "SKA small atoms/kB renders full precision (no truncation)",
 			atomStr:  "1500",
 			coinType: 1,
-			expected: []string{"0", "000000000000000001", ""},
+			expected: []string{"0", "0000000000000015", "00"},
 		},
 		{
-			// Pins the documented truncation invariant: any value < 1000
-			// atoms/kB collapses to exactly 0 atoms/B and renders identically
-			// to a true-zero fee rate.
-			name:     "SKA atoms/kB below 1000 truncates to zero",
+			// A value the old code truncated to zero now renders its true
+			// sub-atom-per-byte magnitude directly.
+			name:     "SKA atoms/kB below 1000 renders nonzero",
 			atomStr:  "999",
 			coinType: 1,
-			expected: []string{"0", "", ""},
+			expected: []string{"0", "000000000000000999", ""},
 		},
 	}
 
@@ -854,9 +864,9 @@ func TestCoinFeeRateUnit(t *testing.T) {
 		expected string
 	}{
 		{coinType: 0, expected: "VAR/kB"},
-		{coinType: 1, expected: "SKA1/B"},
-		{coinType: 2, expected: "SKA2/B"},
-		{coinType: 255, expected: "SKA255/B"},
+		{coinType: 1, expected: "SKA1/kB"},
+		{coinType: 2, expected: "SKA2/kB"},
+		{coinType: 255, expected: "SKA255/kB"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {


### PR DESCRIPTION
The Block page Transactions table rendered SKA-coin fee rates in SKAn/B by dividing the on-the-wire atoms/kB value down to atoms/B. Show it in SKAn/kB instead, matching the contract and the VAR path.

coinFeeRateDecimalParts now renders the atoms/kB string directly via skaDecimalParts (still a big.Int-string path, no float64), and coinFeeRateUnit returns the SKAn/kB suffix. The skaAtomsPerKBToPerByte helper and its bytesPerKB constant are removed as dead code.

Tests assert exact expected strings, including the issue #360 example (4.247104247104247 SKA1/kB).

Closes #360