### PR TITLE
fix/block-page: fix VAR fee halving, SKA fee rate unit, and add Stake…

### DIFF
--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -394,7 +394,6 @@ func threeSigFigs(v float64) string {
 // skaDecimals is 10^18 — the number of SKA atoms per coin.
 var skaDecimals = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
 var varDecimals = big.NewInt(1e8)
-var bytesPerKB = big.NewInt(1000)
 
 // parseInt64 parses a decimal atom string to int64, returning 0 on error.
 func parseInt64(s string) int64 {
@@ -505,36 +504,21 @@ func coinDecimalParts(atomStr string, coinType uint8, useCommas bool, boldNumPla
 
 // coinFeeRateDecimalParts renders a fee-rate value carried on the contract as
 // atoms/kB. VAR delegates to coinDecimalParts and is displayed as VAR/kB.
-// SKA divides the big.Int atoms/kB by 1000 (giving atoms/B) and renders via
-// skaDecimalParts so the headline number reads as SKA/B — chosen because SKA
-// 18-decimal fee rates are too small per kB to be legible. No float64
-// conversion on the SKA path.
+// SKA renders via skaDecimalParts directly (atoms/kB) and is displayed as
+// SKA<n>/kB. No float64 conversion on the SKA path.
 func coinFeeRateDecimalParts(atomsPerKB string, coinType uint8, useCommas bool, boldNumPlaces ...int) []string {
 	if coinType == 0 {
 		return coinDecimalParts(atomsPerKB, 0, useCommas, boldNumPlaces...)
 	}
-	return skaDecimalParts(skaAtomsPerKBToPerByte(atomsPerKB), useCommas, boldNumPlaces...)
+	return skaDecimalParts(atomsPerKB, useCommas, boldNumPlaces...)
 }
 
-// skaAtomsPerKBToPerByte converts an SKA fee-rate string from atoms/kB to
-// atoms/B using big.Int integer division. Sub-atom-per-byte remainder is
-// unrepresentable and dropped. Empty or non-numeric input is returned
-// unchanged so skaDecimalParts can render the safe ["0","",""] fallback.
-func skaAtomsPerKBToPerByte(atomsPerKB string) string {
-	n, ok := new(big.Int).SetString(atomsPerKB, 10)
-	if !ok {
-		return atomsPerKB
-	}
-	return n.Quo(n, bytesPerKB).String()
-}
-
-// coinFeeRateUnit returns the fee-rate unit suffix. VAR uses /kB (matching the
-// on-the-wire atoms/kB contract); SKA uses /B (paired with coinFeeRateDecimalParts).
+// coinFeeRateUnit returns the fee-rate unit suffix.
 func coinFeeRateUnit(coinType uint8) string {
 	if coinType == 0 {
 		return "VAR/kB"
 	}
-	return coinSymbol(coinType) + "/B"
+	return coinSymbol(coinType) + "/kB"
 }
 
 // formatCoinAtoms converts a raw atom string to a threeSigFigs-formatted coin

--- a/cmd/dcrdata/internal/explorer/templates.go
+++ b/cmd/dcrdata/internal/explorer/templates.go
@@ -394,6 +394,7 @@ func threeSigFigs(v float64) string {
 // skaDecimals is 10^18 — the number of SKA atoms per coin.
 var skaDecimals = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
 var varDecimals = big.NewInt(1e8)
+var bytesPerKB = big.NewInt(1000)
 
 // parseInt64 parses a decimal atom string to int64, returning 0 on error.
 func parseInt64(s string) int64 {
@@ -504,21 +505,36 @@ func coinDecimalParts(atomStr string, coinType uint8, useCommas bool, boldNumPla
 
 // coinFeeRateDecimalParts renders a fee-rate value carried on the contract as
 // atoms/kB. VAR delegates to coinDecimalParts and is displayed as VAR/kB.
-// SKA renders via skaDecimalParts directly (atoms/kB) and is displayed as
-// SKA<n>/kB. No float64 conversion on the SKA path.
+// SKA divides the big.Int atoms/kB by 1000 (giving atoms/B) and renders via
+// skaDecimalParts so the headline number reads as SKA/B — chosen because SKA
+// 18-decimal fee rates are too small per kB to be legible. No float64
+// conversion on the SKA path.
 func coinFeeRateDecimalParts(atomsPerKB string, coinType uint8, useCommas bool, boldNumPlaces ...int) []string {
 	if coinType == 0 {
 		return coinDecimalParts(atomsPerKB, 0, useCommas, boldNumPlaces...)
 	}
-	return skaDecimalParts(atomsPerKB, useCommas, boldNumPlaces...)
+	return skaDecimalParts(skaAtomsPerKBToPerByte(atomsPerKB), useCommas, boldNumPlaces...)
 }
 
-// coinFeeRateUnit returns the fee-rate unit suffix.
+// skaAtomsPerKBToPerByte converts an SKA fee-rate string from atoms/kB to
+// atoms/B using big.Int integer division. Sub-atom-per-byte remainder is
+// unrepresentable and dropped. Empty or non-numeric input is returned
+// unchanged so skaDecimalParts can render the safe ["0","",""] fallback.
+func skaAtomsPerKBToPerByte(atomsPerKB string) string {
+	n, ok := new(big.Int).SetString(atomsPerKB, 10)
+	if !ok {
+		return atomsPerKB
+	}
+	return n.Quo(n, bytesPerKB).String()
+}
+
+// coinFeeRateUnit returns the fee-rate unit suffix. VAR uses /kB (matching the
+// on-the-wire atoms/kB contract); SKA uses /B (paired with coinFeeRateDecimalParts).
 func coinFeeRateUnit(coinType uint8) string {
 	if coinType == 0 {
 		return "VAR/kB"
 	}
-	return coinSymbol(coinType) + "/kB"
+	return coinSymbol(coinType) + "/B"
 }
 
 // formatCoinAtoms converts a raw atom string to a threeSigFigs-formatted coin

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -359,6 +359,7 @@
 					<th class="text-end">Total</th>
 					<th class="text-end">Rewards</th>
 					<th class="text-end">Size</th>
+					<th class="text-end">TxType</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -374,6 +375,7 @@
 						{{template "decimalParts" (coinDecimalParts .FeeRaw .CoinType false)}} {{coinSymbol .CoinType}}
 					</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
+					<td class="text-end">{{.SSFeeMarker}}</td>
 				</tr>
 			{{- end}}
 			</tbody>

--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -375,7 +375,7 @@
 						{{template "decimalParts" (coinDecimalParts .FeeRaw .CoinType false)}} {{coinSymbol .CoinType}}
 					</td>
 					<td class="mono fs15 text-end">{{.FormattedSize}}</td>
-					<td class="text-end">{{.SSFeeMarker}}</td>
+					<td class="mono fs15 text-end">{{.SSFeeMarker}}</td>
 				</tr>
 			{{- end}}
 			</tbody>

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6666,6 +6666,24 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 					}
 				}
 				stx.FeeRaw = ssFeeNetReward(msgTx).String()
+
+				// Detect SSFee marker (SF = staker reward, MF = miner reward).
+				marker := stake.SSFeeMarkerNone
+				for _, out := range msgTx.TxOut {
+					if m := stake.HasSSFeeMarker(out.PkScript); m != stake.SSFeeMarkerNone {
+						marker = m
+						break
+					}
+				}
+				switch marker {
+				case stake.SSFeeMarkerStaker:
+					stx.SSFeeMarker = "SF"
+				case stake.SSFeeMarkerMiner:
+					stx.SSFeeMarker = "MF"
+				default:
+					// VAR SSFee transactions are always staker rewards.
+					stx.SSFeeMarker = "SF"
+				}
 			}
 			stakeFees = append(stakeFees, stx)
 		}
@@ -6757,9 +6775,14 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	if miningFeeAtoms > 0 {
 		feesMap[0] = strconv.FormatInt(miningFeeAtoms, 10)
 	}
-	// SKA fees from SSFeeTotalsByCoin (stake fee distribution)
+	// SKA fees from SSFeeTotalsByCoin (stake fee distribution).
+	// VAR (ct==0) is already sourced from MiningFee above — skip it here
+	// to avoid overwriting the full fee pool with only the staker's 50% share.
 	if skaFeeTotals != nil {
 		for ct, split := range skaFeeTotals {
+			if ct == 0 {
+				continue
+			}
 			total := new(big.Int)
 			if split.PoW != nil {
 				total.Add(total, split.PoW)

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6681,7 +6681,9 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 				case stake.SSFeeMarkerMiner:
 					stx.SSFeeMarker = "MF"
 				default:
-					// VAR SSFee transactions are always staker rewards.
+					// No marker found — should never happen for a valid
+					// SSFee tx. Default to SF as the safer assumption.
+					log.Warnf("SSFee tx %s has no detectable marker, defaulting to SF", stx.TxID)
 					stx.SSFeeMarker = "SF"
 				}
 			}

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -377,6 +377,7 @@ type TrimmedTxInfo struct {
 	VoutCount    int     `json:"vout_count"`
 	CoinType     uint8   `json:"coin_type,omitempty"`     // 0=VAR, 1-255=SKAn for stake fees; for revocations, set when processing
 	TicketStatus string  `json:"ticket_status,omitempty"` // Pool status for revocations: "voted", "missed", "expired"
+	SSFeeMarker  string  `json:"ssfee_marker,omitempty"`  // "SF" or "MF" for TxTypeSSFee transactions
 }
 
 // TxInfo models data needed for display on the tx page

--- a/wiki/code-analysis/block/ska-stake-fee.md
+++ b/wiki/code-analysis/block/ska-stake-fee.md
@@ -138,3 +138,72 @@ Extracted as a package-level helper `ssFeeNetReward` in `pgblockchain.go` and te
 | Zero reward | `SKAValueIn=5e18` | `SKAValue=5e18` | `0` |
 
 The helper's per-element `SKAValueIn`/`SKAValue` branching rather than a prior `isSKA` gate matches the same result given the single-coin-per-tx invariant, and the comment calls out the equivalence.
+
+---
+
+## Follow-up: header fee halving, fee-rate unit, and a TxType column
+
+Three further defects on the same `/block/{hash}` Stake Fees table and block header
+were fixed on `fix/block-fee-header-sfa` (commit `839175fa`, with a fee-rate
+adjustment in `780ffc35` and styling in `856f4be4`/`53647112`).
+
+### 1. VAR fee pool was halved in the block header (`FeesByCoin`)
+
+The header `FeesByCoin` is assembled in `GetExplorerBlock` from a `feesMap`:
+VAR (`ct==0`) is sourced from `block.MiningFee` (the full block fee pool), then SKA
+coin types are added from `SSFeeTotalsByCoin` (`skaFeeTotals`). The SKA loop
+iterated **all** coin types, including `ct==0`, so VAR's full fee pool was
+overwritten by `split.PoW + split.PoS` — only the staker's 50% share — halving the
+displayed VAR fee.
+
+Fix: `continue` on `ct==0` inside the `skaFeeTotals` loop, leaving VAR sourced
+exclusively from `MiningFee`.
+
+```go
+// db/dcrpg/pgblockchain.go — GetExplorerBlock
+for ct, split := range skaFeeTotals {
+    if ct == 0 {
+        continue // VAR already sourced from MiningFee above; don't overwrite with the 50% staker share
+    }
+    ...
+}
+```
+
+This is a **header** correctness fix, distinct from the per-tx `FeeRaw` fix above:
+the per-tx "Rewards" column was already correct, but the aggregate VAR fee in the
+block header was wrong.
+
+### 2. SKA fee-rate unit: atoms/kB → atoms/B (`SKA<n>/B`)
+
+The fee-rate value travels on the wire as **atoms/kB**. For VAR that is rendered
+directly as `VAR/kB`. For SKA the 18-decimal atoms/kB number is too small per kB to
+be legible, so the SKA path now divides by 1000 (integer `big.Int` division) and
+renders as `SKA<n>/B`.
+
+- `coinFeeRateDecimalParts` (SKA branch) wraps the value in a new
+  `skaAtomsPerKBToPerByte` helper before `skaDecimalParts`. Sub-atom-per-byte
+  remainder is unrepresentable and dropped; empty/non-numeric input passes through
+  unchanged for the safe `["0","",""]` fallback.
+- `coinFeeRateUnit` returns `VAR/kB` for VAR and `<symbol>/B` for SKA.
+
+Note: a separate SKA-fee-rate unit revision (`SKA<n>/kB`) was in flight by another
+team member; `780ffc35` deliberately restored the `/1000` + `/B` behaviour here so
+the two efforts don't collide. Treat the `/B` unit as the current code state, not a
+settled decision.
+
+### 3. SF/MF marker exposed as a TxType column
+
+Each SSFee transaction carries an SSFee marker in an output `pkScript` indicating
+whether it is the **staker** payout (`SF`) or the **miner** payout (`MF`) — the same
+SF/MF split described in [staking-rewards](../../core/staking-rewards.md) §3.2.
+
+- `explorer/types/explorertypes.go`: `TrimmedTxInfo` gains
+  `SSFeeMarker string` (`"SF"`/`"MF"`, json `ssfee_marker,omitempty`).
+- `GetExplorerBlock` (SSFee case): scans `msgTx.TxOut` with
+  `stake.HasSSFeeMarker(out.PkScript)`, mapping `SSFeeMarkerStaker`→`"SF"` and
+  `SSFeeMarkerMiner`→`"MF"`. If no marker is found (should never happen for a valid
+  SSFee tx) it logs a warning and defaults to `"SF"` as the safer assumption.
+- `cmd/dcrdata/views/block.tmpl`: the Stake Fees table gains a trailing **TxType**
+  column rendering `{{.SSFeeMarker}}` (`mono fs15 text-end`, matching the Size
+  column).
+


### PR DESCRIPTION
Description
Two fixes on the Block page:
1. VAR total fee in block header showing half the correct value
Root cause: In GetExplorerBlock, FeesByCoin is assembled from two sources:
- MiningFee — sum of all regular tx fees + all ticket purchase fees (the full fee pool). Stored in feesMap[0].
- skaFeeTotals — SSFee distribution totals per coin type.
The skaFeeTotals loop iterates over all coin types including VAR (ct == 0). For VAR, skaFeeTotals[0] contains only the staker's 50% share (SF marker — the miner's VAR share goes via coinbase, not through SSFee). This was overwriting feesMap[0] with only the staker's half, replacing the full pool value that was correctly set from MiningFee.
Fix: Skip ct == 0 in the SSFee loop so VAR stays sourced from MiningFee.
2. Stake Fees table missing TxType column
SSFee transactions have an on-chain marker identifying the recipient:
- SF — staker reward (PoS share)
- MF — miner reward (PoW share)
VAR SSFee txs are always SF (miner's VAR share goes via coinbase). SKA SSFee txs can be either.
Fix:
- Added SSFeeMarker string field to TrimmedTxInfo (explorer/types/explorertypes.go)
- Detect the marker via stake.HasSSFeeMarker() when populating StakeFees (db/dcrpg/pgblockchain.go)
- Render the marker in a new TxType column in the Stake Fees table (views/block.tmpl)
Files changed
File	Change
db/dcrpg/pgblockchain.go	Skip ct == 0 in SSFee loop; detect SF/MF marker in SSFee transactions
explorer/types/explorertypes.go	Add SSFeeMarker field to TrimmedTxInfo
cmd/dcrdata/views/block.tmpl	Add <th>TxType</th> header + <td> cell in Stake Fees table