### PR TITLE
fix(charts): remove Privacy Participation from dropdown

### DIFF
--- a/cmd/dcrdata/views/charts.tmpl
+++ b/cmd/dcrdata/views/charts.tmpl
@@ -39,9 +39,8 @@
                             <option value="pow-difficulty">PoW Difficulty</option>
                             <option value="coin-supply/0">Circulation (VAR)</option>
                             {{range $t := .ActiveSKATypes}}<option value="coin-supply/{{$t}}">Circulation (SKA{{$t}})</option>
-                            {{end}}<option value="fees">Fees</option>
-                            <option value="privacy-participation">Privacy Participation</option>
-                            <option value="duration-btw-blocks">Duration Between Blocks</option>
+                             {{end}}<option value="fees">Fees</option>
+                             <option value="duration-btw-blocks">Duration Between Blocks</option>
                             <option value="chainwork">Total Work</option>
                             <option value="hashrate">Hashrate</option>
                             <option value="missed-votes">Missed Votes</option>


### PR DESCRIPTION
Remove the "Privacy Participation" option from the Chart selector dropdown on the /charts page.
Changes:
File
cmd/dcrdata/views/charts.tmpl
The backend and JS controller still support privacy-participation data — only the UI entry point is removed. No functional impact on other chart types.
Testing: cd cmd/dcrdata && npm run check