### PR TITLE
fix(charts): store chainwork as big.Int to fix zero-value chart data

### DIFF
--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -25,8 +25,8 @@ const modeScales = ['ticket-price']
 const multiYAxisChart = ['ticket-price', 'coin-supply', 'privacy-participation']
 // index 0 represents y1 and 1 represents y2 axes.
 const yValueRanges = { 'ticket-price': [1] }
-const chainworkUnits = ['exahash', 'zettahash', 'yottahash']
-const hashrateUnits = ['Th/s', 'Ph/s', 'Eh/s']
+const chainworkUnits = ['H', 'kH', 'MH', 'GH', 'TH', 'PH', 'EH', 'ZH', 'YH']
+const hashrateUnits = ['H/s', 'kH/s', 'MH/s', 'GH/s', 'TH/s', 'PH/s', 'EH/s']
 let ticketPoolSizeTarget, premine, stakeValHeight, stakeShare
 let baseSubsidy, subsidyInterval, subsidyExponent, windowSize, avgBlockTime
 let rawCoinSupply, rawPoolValue
@@ -106,6 +106,12 @@ function axesToRestoreYRange(chartName, origYRange, newYRange) {
 function withBigUnits(v, units) {
   const i = v === 0 ? 0 : Math.floor(Math.log10(v) / 3)
   return `${(v / Math.pow(1000, i)).toFixed(3)} ${units[i]}`
+}
+
+function unitPrefix(value) {
+  if (value <= 0) return ''
+  const i = Math.min(Math.floor(Math.log10(value) / 3), 8)
+  return ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'][i]
 }
 
 function blockReward(height) {
@@ -759,34 +765,26 @@ export default class extends Controller {
 
       case 'chainwork': // Total chainwork over time
         d = zip2D(data, data.work)
-        assign(
-          gOptions,
-          mapDygraphOptions(
-            d,
-            [xlabel, 'Cumulative Chainwork (exahash)'],
-            false,
-            'Cumulative Chainwork (exahash)',
-            true,
-            false
-          )
-        )
+        {
+          const max = data.work.length ? Math.max(...data.work) : 0
+          const p = unitPrefix(max)
+          const label = p ? `Cumulative Chainwork (${p}H)` : 'Cumulative Chainwork'
+          assign(gOptions, mapDygraphOptions(d, [xlabel, label], false, label, true, false))
+        }
+        gOptions.axes.y = { valueRange: [null, null] }
         yFormatter = customYFormatter((y) => withBigUnits(y, chainworkUnits))
         break
 
-      case 'hashrate': // Total chainwork over time
-        d = zip2D(data, data.rate, 1e-3, data.offset)
-        assign(
-          gOptions,
-          mapDygraphOptions(
-            d,
-            [xlabel, 'Network Hashrate (petahash/s)'],
-            false,
-            'Network Hashrate (petahash/s)',
-            true,
-            false
-          )
-        )
-        yFormatter = customYFormatter((y) => withBigUnits(y * 1e3, hashrateUnits))
+      case 'hashrate': // Network hashrate over time
+        d = zip2D(data, data.rate, 1, data.offset)
+        {
+          const max = data.rate.length ? Math.max(...data.rate) : 0
+          const p = unitPrefix(max)
+          const label = p ? `Network Hashrate (${p}H/s)` : 'Network Hashrate'
+          assign(gOptions, mapDygraphOptions(d, [xlabel, label], false, label, true, false))
+        }
+        gOptions.axes.y = { valueRange: [null, null] }
+        yFormatter = customYFormatter((y) => withBigUnits(y, hashrateUnits))
         break
 
       case 'missed-votes':

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -227,6 +227,33 @@ func newChartFloats(size int) ChartFloats {
 	return make([]float64, 0, size)
 }
 
+// ChartBigInts is a slice of big ints. It satisfies the lengther interface.
+type ChartBigInts []*big.Int
+
+// Length returns the length of data. Satisfies the lengther interface.
+func (data ChartBigInts) Length() int {
+	return len(data)
+}
+
+// Truncate makes a subset of the underlying dataset. It satisfies the lengther
+// interface.
+func (data ChartBigInts) Truncate(l int) lengther {
+	return data[:l]
+}
+
+// If the data is longer than max, return a subset of length max.
+func (data ChartBigInts) snip(max int) ChartBigInts {
+	if len(data) < max {
+		max = len(data)
+	}
+	return data[:max]
+}
+
+// A constructor for a sized ChartBigInts.
+func newChartBigInts(size int) ChartBigInts {
+	return make(ChartBigInts, 0, size)
+}
+
 // ChartUints is a slice of uints. It satisfies the lengther interface, and
 // provides methods for taking averages or sums of segments.
 type ChartUints []uint64
@@ -292,7 +319,7 @@ type zoomSet struct {
 	BlockSize    ChartUints
 	TxCount      ChartUints
 	NewAtoms     ChartUints
-	Chainwork    ChartUints
+	Chainwork    ChartBigInts
 	Fees         ChartUints
 	TotalMixed   ChartUints
 	AnonymitySet ChartUints
@@ -336,7 +363,7 @@ func newBlockSet(size int) *zoomSet {
 		BlockSize:    newChartUints(size),
 		TxCount:      newChartUints(size),
 		NewAtoms:     newChartUints(size),
-		Chainwork:    newChartUints(size),
+		Chainwork:    newChartBigInts(size),
 		Fees:         newChartUints(size),
 		TotalMixed:   newChartUints(size),
 		AnonymitySet: newChartUints(size),
@@ -397,7 +424,7 @@ type ChartGobject struct {
 	BlockSize    ChartUints
 	TxCount      ChartUints
 	NewAtoms     ChartUints
-	Chainwork    ChartUints
+	Chainwork    ChartBigInts
 	Fees         ChartUints
 	WindowTime   ChartUints
 	PowDiff      ChartFloats
@@ -1243,32 +1270,43 @@ func blockchainSizeChart(charts *ChartData, bin binLevel, axis axisType) ([]byte
 	return nil, InvalidBinErr
 }
 
+func bigIntsToFloats(data ChartBigInts) ChartFloats {
+	out := make(ChartFloats, len(data))
+	for i, v := range data {
+		f, _ := new(big.Float).SetInt(v).Float64()
+		out[i] = f
+	}
+	return out
+}
+
 func chainWorkChart(charts *ChartData, bin binLevel, axis axisType) ([]byte, error) {
 	seed := binAxisSeed(bin, axis)
 	switch bin {
 	case BlockBin:
+		work := bigIntsToFloats(charts.Blocks.Chainwork)
 		switch axis {
 		case HeightAxis:
 			return encode(lengtherMap{
-				workKey: charts.Blocks.Chainwork,
+				workKey: work,
 			}, seed)
 		default:
 			return encode(lengtherMap{
 				timeKey: charts.Blocks.Time,
-				workKey: charts.Blocks.Chainwork,
+				workKey: work,
 			}, seed)
 		}
 	case DayBin:
+		work := bigIntsToFloats(charts.Days.Chainwork)
 		switch axis {
 		case HeightAxis:
 			return encode(lengtherMap{
 				heightKey: charts.Days.Height,
-				workKey:   charts.Days.Chainwork,
+				workKey:   work,
 			}, seed)
 		default:
 			return encode(lengtherMap{
 				timeKey: charts.Days.Time,
-				workKey: charts.Days.Chainwork,
+				workKey: work,
 			}, seed)
 		}
 	}
@@ -1356,14 +1394,14 @@ func durationBTWChart(charts *ChartData, bin binLevel, axis axisType) ([]byte, e
 // is HashrateAvgLength shorter than the provided chainwork. A time slice is
 // required as well, and a truncated time slice with the same length as the
 // hashrate slice is returned.
-func hashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
+func hashrate(time ChartUints, chainwork ChartBigInts) (ChartUints, ChartFloats) {
 	hrLen := len(chainwork) - HashrateAvgLength
 	if hrLen <= 0 {
-		return newChartUints(0), newChartUints(0)
+		return newChartUints(0), newChartFloats(0)
 	}
 	t := make(ChartUints, 0, hrLen)
-	y := make(ChartUints, 0, hrLen)
-	var rotator [HashrateAvgLength]uint64
+	y := make(ChartFloats, 0, hrLen)
+	var rotator [HashrateAvgLength]*big.Int
 	for i, work := range chainwork {
 		idx := i % HashrateAvgLength
 		rotator[idx] = work
@@ -1372,8 +1410,13 @@ func hashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
 			lastTime := time[i-HashrateAvgLength]
 			thisTime := time[i]
 			t = append(t, thisTime)
-			// 1e6: exahash -> terahash/s
-			y = append(y, (work-lastWork)*1e6/(thisTime-lastTime))
+			workDiff := new(big.Int).Sub(work, lastWork)
+			rate := new(big.Float).Quo(
+				new(big.Float).SetInt(workDiff),
+				new(big.Float).SetUint64(thisTime-lastTime),
+			)
+			f, _ := rate.Float64()
+			y = append(y, f)
 		}
 	}
 	return t, y
@@ -1383,12 +1426,12 @@ func hashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
 // Since hashrates are based on a difference, the returned arrays will be 1
 // element fewer than the number of days. A truncated time slice with the same
 // length as the hashrate slice is returned.
-func dailyHashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
+func dailyHashrate(time ChartUints, chainwork ChartBigInts) (ChartUints, ChartFloats) {
 	if len(time) == 0 || len(chainwork) == 0 {
-		return ChartUints{}, ChartUints{}
+		return ChartUints{}, ChartFloats{}
 	}
-	times := make([]uint64, 0, len(time)-1)
-	rates := make([]uint64, 0, len(time)-1)
+	times := make(ChartUints, 0, len(time)-1)
+	rates := make(ChartFloats, 0, len(time)-1)
 	var dupes int
 	for i, t := range time[1:] {
 		tDiff := int64(t - time[i])
@@ -1396,8 +1439,13 @@ func dailyHashrate(time, chainwork ChartUints) (ChartUints, ChartUints) {
 			tDiff = aDay
 			dupes++
 		}
-		workDiff := chainwork[i+1] - chainwork[i]
-		rates = append(rates, (workDiff)*1e6/uint64(tDiff))
+		workDiff := new(big.Int).Sub(chainwork[i+1], chainwork[i])
+		rate := new(big.Float).Quo(
+			new(big.Float).SetInt(workDiff),
+			new(big.Float).SetUint64(uint64(tDiff)),
+		)
+		f, _ := rate.Float64()
+		rates = append(rates, f)
 		times = append(times, t)
 	}
 	if dupes > 0 {

--- a/db/cache/charts_test.go
+++ b/db/cache/charts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -56,7 +57,7 @@ func TestChartsCache(t *testing.T) {
 		charts.Blocks.BlockSize = append(charts.Blocks.BlockSize, v)
 		charts.Blocks.TxCount = append(charts.Blocks.TxCount, v)
 		charts.Blocks.NewAtoms = append(charts.Blocks.NewAtoms, v)
-		charts.Blocks.Chainwork = append(charts.Blocks.Chainwork, v)
+		charts.Blocks.Chainwork = append(charts.Blocks.Chainwork, new(big.Int).SetUint64(v))
 		charts.Blocks.Fees = append(charts.Blocks.Fees, v)
 		charts.Blocks.TotalMixed = append(charts.Blocks.TotalMixed, v)
 		charts.Blocks.AnonymitySet = append(charts.Blocks.AnonymitySet, v)
@@ -68,9 +69,22 @@ func TestChartsCache(t *testing.T) {
 	}
 
 	seedUints := ChartUints{1, 2, 3, 4, 5, 6}
+	seedBigInts := ChartBigInts{
+		new(big.Int).SetUint64(1),
+		new(big.Int).SetUint64(2),
+		new(big.Int).SetUint64(3),
+		new(big.Int).SetUint64(4),
+		new(big.Int).SetUint64(5),
+		new(big.Int).SetUint64(6),
+	}
 	seedTimes := ChartUints{1, 2 + aDay, 3 + aDay, 4 + 2*aDay, 5 + 2*aDay, 6 + 3*aDay}
 	uintDaysAvg := ChartUints{1, 2, 4}
 	uintDaysSum := ChartUints{1, 5, 9}
+	dayChainwork := ChartBigInts{
+		new(big.Int).SetUint64(2),
+		new(big.Int).SetUint64(4),
+		new(big.Int).SetUint64(6),
+	}
 
 	resetCharts := func() {
 		charts = NewChartData(ctx, 0, chaincfg.MainNetParams())
@@ -138,7 +152,7 @@ func TestChartsCache(t *testing.T) {
 		comp("BlockSize before read", charts.Blocks.BlockSize, seedUints, false)
 		comp("TxCount before read", charts.Blocks.TxCount, seedUints, false)
 		comp("NewAtoms before read", charts.Blocks.NewAtoms, seedUints, false)
-		comp("Chainwork before read", charts.Blocks.Chainwork, seedUints, false)
+		comp("Chainwork before read", charts.Blocks.Chainwork, seedBigInts, false)
 		comp("Fees before read", charts.Blocks.Fees, seedUints, false)
 		comp("TotalMixed before read", charts.Blocks.TotalMixed, seedUints, false)
 		comp("AnonymitySet before read", charts.Blocks.AnonymitySet, seedUints, false)
@@ -155,7 +169,7 @@ func TestChartsCache(t *testing.T) {
 		comp("BlockSize after read", charts.Blocks.BlockSize, seedUints, true)
 		comp("TxCount after read", charts.Blocks.TxCount, seedUints, true)
 		comp("NewAtoms after read", charts.Blocks.NewAtoms, seedUints, true)
-		comp("Chainwork after read", charts.Blocks.Chainwork, seedUints, true)
+		comp("Chainwork after read", charts.Blocks.Chainwork, seedBigInts, true)
 		comp("Fees after read", charts.Blocks.Fees, seedUints, true)
 		comp("TotalMissed after read", charts.Blocks.TotalMixed, seedUints, true)
 		comp("AnonymitySet after read", charts.Blocks.AnonymitySet, seedUints, true)
@@ -168,7 +182,7 @@ func TestChartsCache(t *testing.T) {
 		comp("TxCount after Lengthen", charts.Days.TxCount, uintDaysSum, true)
 		comp("NewAtoms after Lengthen", charts.Days.NewAtoms, uintDaysSum, true)
 		// Chainwork will just be the last entry from each day
-		comp("Chainwork after Lengthen", charts.Days.Chainwork, ChartUints{2, 4, 6}, true)
+		comp("Chainwork after Lengthen", charts.Days.Chainwork, dayChainwork, true)
 		comp("Fees after Lengthen", charts.Days.Fees, uintDaysSum, true)
 		comp("TotalMixed after Lengthen", charts.Days.TotalMixed, uintDaysSum, true)
 		comp("AnonymitySet after Lengthen", charts.Days.AnonymitySet, uintDaysAvg, true)
@@ -265,6 +279,9 @@ func TestChartReorg(t *testing.T) {
 	defer shutdown()
 	newFloats := func() ChartFloats { return ChartFloats{1, 2, 3} }
 	newUints := func() ChartUints { return ChartUints{1, 2, 3} }
+	newBigInts := func() ChartBigInts {
+		return ChartBigInts{big.NewInt(1), big.NewInt(2), big.NewInt(3)}
+	}
 	charts := &ChartData{
 		ctx: ctx,
 	}
@@ -286,7 +303,7 @@ func TestChartReorg(t *testing.T) {
 			BlockSize: newUints(),
 			TxCount:   newUints(),
 			NewAtoms:  newUints(),
-			Chainwork: newUints(),
+			Chainwork: newBigInts(),
 			Fees:      newUints(),
 		}
 		charts.Blocks = &zoomSet{
@@ -297,7 +314,7 @@ func TestChartReorg(t *testing.T) {
 			BlockSize:  newUints(),
 			TxCount:    newUints(),
 			NewAtoms:   newUints(),
-			Chainwork:  newUints(),
+			Chainwork:  newBigInts(),
 			Fees:       newUints(),
 			TotalMixed: newUints(),
 		}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3420,9 +3420,6 @@ func retrieveChartBlocks(ctx context.Context, db *sql.DB, charts *cache.ChartDat
 func appendChartBlocks(charts *cache.ChartData, rows *sql.Rows) error {
 	defer closeRows(rows)
 
-	// In order to store chainwork values as uint64, they are represented
-	// as exahash (10^18) for work, and terahash/s (10^12) for hashrate.
-	bigExa := big.NewInt(int64(1e18))
 	badRows := 0
 	// badRow is used to log chainwork errors without returning an error from
 	// retrieveChartBlocks.
@@ -3443,21 +3440,13 @@ func appendChartBlocks(charts *cache.ChartData, rows *sql.Rows) error {
 			return err
 		}
 
-		// bigwork := new(big.Int).SetBytes(work)
 		bigwork, ok := new(big.Int).SetString(workhex, 16)
 		if !ok {
 			badRow()
 			continue
 		}
-		bigwork.Div(bigwork, bigExa)
-		if !bigwork.IsUint64() {
-			badRow()
-			// Something is wrong, but pretend that no work was done to keep the
-			// datasets sized properly.
-			bigwork = big.NewInt(int64(blocks.Chainwork[len(blocks.Chainwork)-1]))
-		}
 		blocks.Height = append(blocks.Height, height)
-		blocks.Chainwork = append(blocks.Chainwork, bigwork.Uint64())
+		blocks.Chainwork = append(blocks.Chainwork, bigwork)
 		blocks.TxCount = append(blocks.TxCount, count)
 		blocks.Time = append(blocks.Time, uint64(timeDef.T.Unix()))
 		blocks.BlockSize = append(blocks.BlockSize, size)


### PR DESCRIPTION
- Replace ChartUints Chainwork with ChartBigInts ([]*big.Int) across zoomSet, ChartGobject, and all helper functions
- Remove Div(bigwork, 1e18) in appendChartBlocks — raw big.Int stored
- Rewrite hashrate() and dailyHashrate() to use big.Int arithmetic and return ChartFloats for fractional hashrate values on small chains
- Add bigIntsToFloats() to convert ChartBigInts to ChartFloats at the API boundary in chainWorkChart()
- Update JS controller: remove hardcoded unit multipliers (1e-3, *1e3), update axis labels, expand unit arrays for proper SI prefix display, add explicit y-axis auto-scaling for both hashrate and chainwork
- Update tests to use ChartBigInts for chainwork comparisons