### PR TITLE
cmd/dcrdata: default charts BIN toggle to Blocks

### DIFF
--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -492,7 +492,7 @@ export default class extends Controller {
     if (this.settings.axis) this.setAxis(this.settings.axis) // set first
     if (this.settings.scale === 'log') this.setScale(this.settings.scale)
     if (this.settings.zoom) this.setZoom(this.settings.zoom)
-    this.setBin(this.settings.bin ? this.settings.bin : 'day')
+    this.setBin(this.settings.bin ? this.settings.bin : 'block')
     this.setMode(this.settings.mode ? this.settings.mode : 'smooth')
 
     const ogLegendGenerator = Dygraph.Plugins.Legend.generateLegendHTML


### PR DESCRIPTION
## Summary

On the `/charts` page, the **BIN(Day, Blocks)** toggle now defaults to **Blocks** instead of Day.

Single-line change in `drawInitialGraph()` — the no-setting fallback `'day'` → `'block'` ([charts_controller.js:495](https://github.com/monetarium/monetarium-explorer/blob/feat/charts-default-bin-blocks/cmd/dcrdata/public/js/controllers/charts_controller.js#L495)). Pure-frontend, no data contract change.

While tracing I confirmed the template (`charts.tmpl`) only defines `day`/`block` bin buttons (no `window` button), so the hybrid reset branch never executes and `selectedBin()` can only return `day`/`block` — no second edit needed.

## Preserved behavior

- An explicit `bin` from the URL / saved `TurboQuery` settings still wins over the default.
- Window-only charts (`ticket-price`, `pow-difficulty`, `missed-votes`) are still forced to `window` with the selector hidden — unaffected by the new default.

## Test plan

Verified live on a running testnet instance:

- [x] `tx-count` with no `?bin` → **Blocks** active, `/api/chart/tx-count?bin=block` → 200
- [x] Clicking **Day** → `bin=day` in URL, fetch → 200, Day active
- [x] `?bin=day` → Day active, Blocks inactive (explicit setting wins)
- [x] `ticket-price` (window-only) → selector hidden, forced `bin=window`
- [x] `npm run check` passes (0 errors)
- [x] `npm test` — 323 vitest tests pass

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)