### PR TITLE
fix(charts): clamp duration-btw-blocks Y-axis to 99th percentile to suppress outlier gaps

### DIFF
--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -761,6 +761,11 @@ export default class extends Controller {
             false
           )
         )
+        {
+          const vals = data.duration.slice().sort((a, b) => a - b)
+          const maxY = vals[Math.floor(vals.length * 0.99)] || vals[vals.length - 1]
+          gOptions.axes.y = { valueRange: [0, maxY] }
+        }
         break
 
       case 'chainwork': // Total chainwork over time


### PR DESCRIPTION
- Clamps Y-axis to the 99th percentile of duration values
- Handles all outliers (not just the first block)
- All data still present in the dataset — just visually clipped