### PR TITLE
fix(charts): normalize genesis block timestamp to close time-axis gap from block 0 to block 1

### DIFF
--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -145,7 +145,7 @@ const (
 // cacheVersion helps detect when the cache data stored has changed its
 // structure or content. A change on the cache version results to recomputing
 // all the charts data a fresh thereby making the cache to hold the latest changes.
-var cacheVersion = semver.NewSemver(6, 2, 0)
+var cacheVersion = semver.NewSemver(6, 3, 0)
 
 // versionedCacheData defines the cache data contents to be written into a .gob file.
 type versionedCacheData struct {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3457,6 +3457,9 @@ func appendChartBlocks(charts *cache.ChartData, rows *sql.Rows) error {
 	if badRows > 0 {
 		log.Errorf("%d rows have invalid chainwork values.", badRows)
 	}
+	if len(blocks.Time) >= 2 && blocks.Time[1] > blocks.Time[0]+3600 {
+		blocks.Time[0] = blocks.Time[1] - 1
+	}
 	chainLen := len(blocks.Chainwork)
 	if rowCount > 0 && uint64(chainLen-1) != height {
 		return fmt.Errorf("appendChartBlocks: height misalignment. last height = %d. data length = %d", height, chainLen)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3457,6 +3457,8 @@ func appendChartBlocks(charts *cache.ChartData, rows *sql.Rows) error {
 	if badRows > 0 {
 		log.Errorf("%d rows have invalid chainwork values.", badRows)
 	}
+	// Genesis gap normalization: no-op after first rebuild, since Time[0] is
+	// already set 1s before Time[1] and the threshold (3600s) is not exceeded.
 	if len(blocks.Time) >= 2 && blocks.Time[1] > blocks.Time[0]+3600 {
 		blocks.Time[0] = blocks.Time[1] - 1
 	}


### PR DESCRIPTION
On networks where block 1 was mined significantly later than block 0 (e.g. Monetarium testnet: ~205 days gap), the time axis on all charts was distorted — a long empty stretch followed by all data compressed into the remaining space.
Root cause: appendChartBlocks (db/dcrpg/queries.go:3451) stored raw Unix timestamps from the DB. Block 0's timestamp from genesis was ~205 days before block 1, stretching the X-axis range across all time-bin charts.
Fix: After the append loop, if Time[1] - Time[0] > 1 hour, shift Time[0] to 1 second before Time[1]. This runs once (self-correcting on first load after deploy) and only touches the in-memory cache — the DB is unchanged.
File	Change
db/dcrpg/queries.go	3 lines: normalize genesis timestamp when gap to block 1 exceeds 1 hour
db/cache/charts.go	Comment documenting no-op-after-first-rebuild invariant. Cache version bumped to 6.3.0 → clean version-mismatch log + rebuild on first start
Effect on all charts:
- Time-axis charts (coin-supply, fees, block-size, chainwork, hashrate, ticket-pool-size, etc.) no longer show the genesis gap
- blockTimes() reports diff[0] = 1s instead of 205 days
- Day-binning in Lengthen() anchors the first day bucket to block 1's day, not genesis
Interaction with duration-btw-blocks chart:
The normalization neutralizes the genesis outlier (diff[0] is now 1s). The separate 99th-percentile Y-axis clamp (fix/duration-chart-outlier-filter) is kept deliberately — it guards against other legitimately large gaps (network instability at launch, extended outages). The two fixes coexist for different concerns: normalization handles the one-time genesis gap on all time-axis charts; the clamp handles sporadic Y-axis outliers on the duration chart.
Test plan:
- go build ./... — all modules compile
- go test ./... — db/dcrpg and db/cache tests pass
- golangci-lint run — 0 issues
- Cache version mismatch verified in production logs (6.2.0 → 6.3.0 rebuild)
Notes for deploy:
- First startup after deploy logs expected cache version v6.3.0 but found v6.2.0 → cache rebuilds automatically from DB
- Subsequent startups load the 6.3.0 cache with normalized genesis timestamp — no delay