### PR TITLE
db/cache: normalize genesis block timestamp distorting time-axis charts

### DIFF
--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -681,11 +681,12 @@ export default class extends Controller {
             false
           )
         )
-        {
-          const vals = data.duration.slice().sort((a, b) => a - b)
-          const maxY = vals[Math.floor(vals.length * 0.99)] || vals[vals.length - 1]
-          gOptions.axes.y = { valueRange: [0, maxY] }
-        }
+        // Anchor the Y-axis floor at 0 (durations are non-negative) but leave the
+        // top unbounded, so genuine large gaps still render at full height and
+        // zoomed-in views keep an honest baseline. The genesis pre-launch gap is
+        // corrected server-side (NormalizeGenesisBlockTime), so the previous
+        // 99th-percentile outlier clamp is no longer needed.
+        gOptions.axes.y = { valueRange: [0, null] }
         break
 
       case 'chainwork': // Total chainwork over time

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -145,7 +145,7 @@ const (
 // cacheVersion helps detect when the cache data stored has changed its
 // structure or content. A change on the cache version results to recomputing
 // all the charts data a fresh thereby making the cache to hold the latest changes.
-var cacheVersion = semver.NewSemver(6, 2, 0)
+var cacheVersion = semver.NewSemver(6, 3, 0)
 
 // versionedCacheData defines the cache data contents to be written into a .gob file.
 type versionedCacheData struct {
@@ -1153,6 +1153,39 @@ func accumulate(data ChartUints) ChartUints {
 		d = append(d, accumulator)
 	}
 	return d
+}
+
+// genesisGapThreshold is the inter-block interval (seconds) above which the
+// genesis→block-1 gap is treated as a pre-launch dead period rather than a
+// real mining interval. On a healthy network block 0→1 is on the order of the
+// target block time (minutes), so the threshold is never crossed; only a long
+// pre-launch gap (e.g. Monetarium testnet's ~205 days) exceeds one hour.
+const genesisGapThreshold = 3600
+
+// NormalizeGenesisBlockTime collapses an abnormally large genesis→block-1 gap
+// in a block-time series so that time-axis charts begin at real network start
+// rather than the genesis date, and the duration-between-blocks chart does not
+// show the entire pre-launch gap as its first interval.
+//
+// It mutates times[0] in place, moving it to just before block 1, and returns
+// whether a correction was applied. It is genesis-only and self-no-op: after a
+// correction the gap is ~1s (< genesisGapThreshold), so re-running on
+// incremental syncs and after gob restarts changes nothing. A chain with only
+// the genesis block (len < 2) is left untouched so times[1] is never indexed.
+//
+// This is a derived-cache correction only; it must never feed back into the
+// canonical block timestamp in Postgres or the block-details/API responses.
+func NormalizeGenesisBlockTime(times ChartUints) bool {
+	if len(times) < 2 {
+		return false
+	}
+	if times[1]-times[0] <= genesisGapThreshold {
+		return false
+	}
+	// Keep timestamps strictly increasing (gap of 1s) so the height alignment
+	// and day-bin start both fold onto block 1's day.
+	times[0] = times[1] - 1
+	return true
 }
 
 // Translate the times slice to a slice of differences. The original dataset

--- a/db/cache/charts_test.go
+++ b/db/cache/charts_test.go
@@ -462,3 +462,81 @@ func TestAggregateSKASupply_DailyBins(t *testing.T) {
 		t.Fatalf("expected 3 heights, got %d", len(dayHeights))
 	}
 }
+
+func TestNormalizeGenesisBlockTime(t *testing.T) {
+	const block1 = 1_700_000_000 // an arbitrary block-1 unix time
+
+	tests := []struct {
+		name        string
+		in          ChartUints
+		wantChanged bool
+		want        ChartUints
+	}{
+		{
+			// Monetarium testnet: block 1 mined ~205 days after genesis.
+			name:        "long pre-launch gap is collapsed",
+			in:          ChartUints{block1 - 205*86400, block1, block1 + 300},
+			wantChanged: true,
+			want:        ChartUints{block1 - 1, block1, block1 + 300},
+		},
+		{
+			name:        "normal inter-block gap is untouched",
+			in:          ChartUints{block1, block1 + 300, block1 + 600},
+			wantChanged: false,
+			want:        ChartUints{block1, block1 + 300, block1 + 600},
+		},
+		{
+			name:        "gap exactly at threshold is untouched",
+			in:          ChartUints{block1, block1 + genesisGapThreshold},
+			wantChanged: false,
+			want:        ChartUints{block1, block1 + genesisGapThreshold},
+		},
+		{
+			name:        "gap one second past threshold is collapsed",
+			in:          ChartUints{block1, block1 + genesisGapThreshold + 1},
+			wantChanged: true,
+			want:        ChartUints{block1 + genesisGapThreshold, block1 + genesisGapThreshold + 1},
+		},
+		{
+			name:        "single genesis block does not index Time[1]",
+			in:          ChartUints{block1},
+			wantChanged: false,
+			want:        ChartUints{block1},
+		},
+		{
+			name:        "empty series is a no-op",
+			in:          ChartUints{},
+			wantChanged: false,
+			want:        ChartUints{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizeGenesisBlockTime(tc.in)
+			if got != tc.wantChanged {
+				t.Errorf("NormalizeGenesisBlockTime returned %v, want %v", got, tc.wantChanged)
+			}
+			if !reflect.DeepEqual(tc.in, tc.want) {
+				t.Errorf("after normalize: got %v, want %v", tc.in, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeGenesisBlockTime_Idempotent(t *testing.T) {
+	const block1 = 1_700_000_000
+	times := ChartUints{block1 - 205*86400, block1, block1 + 300}
+
+	if !NormalizeGenesisBlockTime(times) {
+		t.Fatal("first call should report a change")
+	}
+	first := append(ChartUints(nil), times...)
+
+	if NormalizeGenesisBlockTime(times) {
+		t.Error("second call should be a no-op (gap already collapsed)")
+	}
+	if !reflect.DeepEqual(times, first) {
+		t.Errorf("second call mutated data: got %v, want %v", times, first)
+	}
+}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3467,10 +3467,11 @@ func appendChartBlocks(charts *cache.ChartData, rows *sql.Rows) error {
 	}
 
 	// Collapse an abnormally large genesis→block-1 gap so all time-axis charts
-	// begin at real network start. The height-alignment check above guarantees
-	// blocks.Time[0] is genesis, and blocks.Time is the shared slice persisted
-	// to the gob. This is genesis-only and self-no-op, so it stays correct
-	// across incremental syncs and restarts (see NormalizeGenesisBlockTime).
+	// begin at real network start. The alignment check above (len-1 == last
+	// height) means the accumulated series is contiguous from height 0, so
+	// blocks.Time[0] is genesis; blocks.Time is the shared slice persisted to
+	// the gob. Genesis-only and self-no-op, so it stays correct across
+	// incremental syncs and restarts (see NormalizeGenesisBlockTime).
 	cache.NormalizeGenesisBlockTime(blocks.Time)
 
 	return nil

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3466,6 +3466,13 @@ func appendChartBlocks(charts *cache.ChartData, rows *sql.Rows) error {
 			chainLen, len(blocks.Time), len(blocks.TxCount))
 	}
 
+	// Collapse an abnormally large genesis→block-1 gap so all time-axis charts
+	// begin at real network start. The height-alignment check above guarantees
+	// blocks.Time[0] is genesis, and blocks.Time is the shared slice persisted
+	// to the gob. This is genesis-only and self-no-op, so it stays correct
+	// across incremental syncs and restarts (see NormalizeGenesisBlockTime).
+	cache.NormalizeGenesisBlockTime(blocks.Time)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
Fixes #385. On networks where block 1 is mined long after block 0 (Monetarium testnet: ~205 days), the genesis timestamp sits months before real network start. Every time-axis chart then begins at the genesis date with all real data compressed into the tail, and the duration-between-blocks chart shows the entire pre-launch gap as its first interval.

The correction lives in the **derived chart cache** (the layer that owns this data) — never in the canonical block timestamp (Postgres `blocks`) or the block-details/API responses, which keep showing the real genesis timestamp.

## Changes
- **`db/cache/charts.go`** — new `NormalizeGenesisBlockTime(times ChartUints) bool` + `genesisGapThreshold` (1h). If `Time[1] - Time[0]` exceeds the threshold it moves `Time[0]` to `Time[1] - 1`. Guards `len < 2` (a genesis-only chain never indexes `Time[1]`); self-no-op after the first correction (resulting gap ~1s < threshold), so incremental syncs and gob reloads are no-ops.
- **`db/dcrpg/queries.go`** — call it in `appendChartBlocks` *after* the height-alignment check, where `Time[0]` is guaranteed to be genesis and only the value (not slice length) is touched.
- **`db/cache/charts.go`** — `cacheVersion` 6.2.0 → 6.3.0 so deployed caches discard the stale `.gob` and rebuild from the DB with the correction applied (no manual cache wipe).
- **`charts_controller.js`** — remove the now-redundant 99th-percentile duration Y-axis clamp; instead anchor the duration Y-floor at 0 with an unbounded top, so genuine large gaps still render at full height and zoomed-in views keep an honest baseline.

One server-side correction fixes the X-axis of every time-axis chart (coin-supply, fees, block-size, chainwork, hashrate, duration) **and** the duration first-interval outlier, since duration is derived in Go from the same `Blocks.Time` array.

## Testing
- New unit tests `TestNormalizeGenesisBlockTime` (long gap, normal gap, threshold boundary, single-block, empty) and `TestNormalizeGenesisBlockTime_Idempotent` — written test-first.
- `db/cache` and `db/dcrpg` (offline) tests pass; both modules `golangci-lint` clean; `gofmt` clean.
- Frontend: prettier clean, eslint clean (only pre-existing warnings), 323/323 vitest pass.
- Verified locally on testnet: full cache recompute from height -1 ran on startup; duration chart first interval is now ~1s, time-axis charts start at real network start, block-0 details still show the real genesis timestamp.

## Notes
- The DB is read-only in this path — no migration or re-sync needed; the `cacheVersion` bump triggers the rebuild automatically.
- Threshold is a documented constant (1h) rather than derived from `TargetTimePerBlock`: `appendChartBlocks` is a free function with no chain params in scope, and `db/cache` does not depend on chainparams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)