### PR TITLE
fix(charts): default Tickets Bought visibility to checked on Ticket Price chart

### DIFF
--- a/cmd/dcrdata/views/charts.tmpl
+++ b/cmd/dcrdata/views/charts.tmpl
@@ -138,6 +138,7 @@
                                 <label class="customcheck mx-2 d-inline-flex">Tickets Bought
                                     <input
                                         type="checkbox"
+                                        checked="checked"
                                         data-action="click->charts#setVisibility"
                                         data-charts-target="ticketsPurchase"
                                     >


### PR DESCRIPTION
On the Ticket Price chart, the "Price" series was visible by default but "Tickets Bought" was not — both checkboxes should start checked.
Root cause: The ticketsPurchase checkbox in charts.tmpl had no checked="checked" attribute. The controller's fallback path on initial load reads checkbox state from markup, defaulting to [true, false].
Fix: Add checked="checked" to the Tickets Bought checkbox (cmd/dcrdata/views/charts.tmpl:140). One line.
- ?visibility=true-false URL param still overrides the default — setVisibilityFromSettings() sets checkbox states directly from the parsed param, bypassing the markup default.