### PR TITLE
fix: enable rpcclient auto-reconnect so explorer recovers after node restart

### DIFF
--- a/cmd/dcrdata/main.go
+++ b/cmd/dcrdata/main.go
@@ -1104,7 +1104,7 @@ func _main(ctx context.Context) error {
 
 func connectNodeRPC(cfg *config, ntfnHandlers *rpcclient.NotificationHandlers) (*rpcclient.Client, semver.Semver, error) {
 	return rpcutils.ConnectNodeRPC(cfg.DcrdServ, cfg.DcrdUser, cfg.DcrdPass,
-		cfg.DcrdCert, cfg.DisableDaemonTLS, true, ntfnHandlers)
+		cfg.DcrdCert, cfg.DisableDaemonTLS, false, ntfnHandlers)
 }
 
 func listenAndServeProto(ctx context.Context, wg *sync.WaitGroup, listen, proto string, mux http.Handler) {


### PR DESCRIPTION
When the monetarium-node process is restarted, the explorer's RPC WebSocket connection drops with close 1006 (abnormal closure). After that, updateNodeConnections logs "the client has been shutdown" every 5 seconds forever — the explorer never reconnects.
Root cause: connectNodeRPC in cmd/dcrdata/main.go:1107 hardcodes disableReconnect = true, which passes DisableAutoReconnect: true to the rpcclient ConnConfig. When the WebSocket drops, Disconnect() calls doShutdown() — permanently killing the client instead of attempting to reconnect.
Fix: Change the disableReconnect argument from true to false.
The rpcclient library (v1.3.10) has a built-in wsReconnectHandler (infrastructure.go:661-744) that:
- Listens on the disconnect channel after a WebSocket drop
- Re-dials the node with exponential backoff (5s → 10s → ... → 1min cap)
- Calls resendRequests() on successful reconnection to re-register NotifyBlocks, NotifyNewTransactions, and other pending RPC requests
- The explorer's superQueue goroutine naturally resumes processing notifications after reconnect — no additional state tracking needed
File	Change
cmd/dcrdata/main.go:1107	true → false (one line)