### PR TITLE
wiki: add /agendas code-analysis trace; mark page as dormant/re-enablable

### DIFF
--- a/wiki/code-analysis/agendas/flow.compact.md
+++ b/wiki/code-analysis/agendas/flow.compact.md
@@ -1,0 +1,48 @@
+# Agendas — Compact (LLM-Optimized)
+
+**Flow:** node RPC (`GetVoteInfo` / `GetStakeVersion*` / `GetBlockChainInfo.Deployments`) →
+`gov/agendas.AgendaDB` (BoltDB metadata cache) + `VoteTracker` (live RCI/SVI/quorum) **and**
+`db/dcrpg` `agendas`/`agenda_votes` tables (historical tallies, written by `insertVotes` during
+`StoreBlock` via `SSGenVoteChoices`) → `explorer.AgendasPage`/`AgendaPage` →
+`agendas.tmpl`/`agenda.tmpl` → `agendas_controller.js` (meters) + `agenda_controller.js`
+(Dygraphs ← `/api/agenda/{id}`).
+
+**Current status:** HTML pages **dormant** — [main.go:780-785](../../../cmd/dcrdata/main.go#L780-L785)
+returns HTTP 410. Handlers, JSON API (`/api/agendas`, `/api/agenda/{id}` — still live at
+[apirouter.go:211-218](../../../cmd/dcrdata/internal/api/apirouter.go#L211-L218)), and full DB
+pipeline are intact. Stubbed defensively in commit `52ea3cf1` alongside treasury/proposals — not
+a real removal. Original wiring: `explore.AgendasPage` / `explore.AgendaPage` (+ `AgendaPathCtx`).
+
+**Key architectural patterns:**
+1. **Dormant-feature route stub** — handler + data pipeline live; only the HTTP route is a 410
+   closure. Re-enable = revert 2 route lines + re-add navbar link.
+2. **Dual-source governance data** — live metadata/progress from node RPC (BoltDB + in-mem
+   tracker); historical per-block tallies from Postgres `agenda_votes`. `AgendaPage` joins them
+   by string agenda ID + choice ID ("yes"/"no"/"abstain").
+3. **Untyped Go→JS contracts** — meter `data-progress/threshold/approval` floats; chart JSON
+   `by_time/by_height` with `yes/no/abstain/height/time` arrays.
+
+**Critical constraints:**
+- **No multi-coin / precision work needed.** Agendas carry **zero** VAR/SKA amounts — counts are
+  `uint32`, rates `float32`, heights/quorum integers. C1 (precision), C3 (WS parity — no WS path),
+  C7 (coin labels) all **N/A**. This is the answer to "adapt to the Monetarium model": don't.
+- **Node must expose consensus deployments** — confirmed in `monetarium-node@v1.3.10` (mainnet 48
+  / testnet 52 agenda IDs; `VoteIDMaxBlockSize`, `ChangeSubsidySplit`, `Blake3Pow`,
+  `ChangeSubsidySplitR2`). Data is real.
+- `VoteTracker` fatal on non-simnet if 0 stake versions (main.go:434); `nil` tracker (simnet) →
+  "agendas disabled on simnet" status page.
+
+**Mutation checklist (re-enable):**
+- [ ] main.go:780-785 → `explore.AgendasPage` + `explorer.AgendaPathCtx`/`explore.AgendaPage`.
+- [ ] extras.tmpl navbar → re-add "Agendas" → `/agendas` (else page is orphaned).
+- [ ] No backend/API/template/JS edits required.
+- [ ] Expect historical vote charts populated **forward** from sync; pre-sync completed votes
+      need a genesis resync to backfill.
+- [ ] Update market-removal spec (lists /agendas as removed).
+- [ ] Verify on non-simnet (tracker non-nil); simnet shows the disabled status page by design.
+
+See also:
+- /wiki/code-analysis/agendas/flow.full.md (derived-from)
+- /wiki/code-analysis/agendas/patterns.md
+- /wiki/code-analysis/agendas/impact.md
+- /wiki/core/constraints.md (C1/C3/C7 — N/A for agendas)

--- a/wiki/code-analysis/agendas/flow.full.md
+++ b/wiki/code-analysis/agendas/flow.full.md
@@ -1,0 +1,301 @@
+# Agendas — Full Flow (`/agendas`, `/agenda/{id}`)
+
+> Scope: re-enabling the consensus-deployment **Agendas** pages and assessing whether they
+> need adaptation to the Monetarium multi-coin model. Status as of this trace: the HTML pages
+> are **dormant** (route-stubbed to HTTP 410), but the handlers, the JSON API, and the full
+> backend data pipeline are intact and functional.
+
+## Section 1 — Overview
+
+The Agendas feature surfaces Decred-style **stake-version consensus voting**: each
+`ConsensusDeployment` ("agenda") is voted on by ticket holders via vote (`ssgen`) transactions.
+Two pages exist:
+
+- `/agendas` — list of all agendas + live Rule-Change-Interval (RCI) / Stake-Version-Interval
+  (SVI) / miner / voter / quorum / approval progress.
+- `/agenda/{id}` — one agenda's metadata, choice tally table, and two Dygraphs charts
+  (cumulative vote choices over time, vote choices by block).
+
+**The whole feature carries no monetary amounts.** Every displayed value is a vote *count*
+(`uint32`), a *percentage* (`float32`), a block *height*, a *status* string, or a *timestamp*.
+There is no VAR/SKA value anywhere in the agendas flow, so the precision bifurcation (C1) and
+coin-label rules (C7) **do not apply** — this is the central finding for the "adapt to the
+Monetarium model" question (see Section 5).
+
+**Current disabled state.** [cmd/dcrdata/main.go:780-785](../../../cmd/dcrdata/main.go#L780-L785)
+replaces the two HTML routes with closures returning `http.StatusGone` ("agendas not
+available"). The original wiring was:
+
+```go
+withCache.Get("/agendas", explore.AgendasPage)
+withCache.With(explorer.AgendaPathCtx).Get("/agenda/{agendaid}", explore.AgendaPage)
+```
+
+It was stubbed in commit `52ea3cf1` *("feat: multi-coin data in explorer routes and template
+structs")* in the same bulk edit that stubbed `/treasury`, `/proposals`, and (later) `/market`.
+Unlike treasury (genuinely absent from Monetarium) and proposals (Politeia), agendas was a
+**defensive stub during migration**, not a removal: the node, the handlers, and the DB pipeline
+all still support it.
+
+## Section 2 — End-to-End Data Flow
+
+Two complementary data origins feed the pages (a **dual-source** design):
+
+```text
+                              ┌─ Node RPC: GetVoteInfo / GetStakeVersionInfo / GetStakeVersions
+   monetarium-node ───────────┤   (live voting metadata + tallies, per stake version)
+                              └─ Node RPC: GetBlockChainInfo .Deployments (agenda status/milestones)
+        │                                   │
+        ▼                                   ▼
+  gov/agendas.AgendaDB (storm/Bolt)   db/dcrpg ChainDB.deployments.chainInfo.AgendaMileStones
+  gov/agendas.VoteTracker (in-mem)    db/dcrpg agendas + agenda_votes tables (Postgres)
+        │                                   │   ▲
+        │                                   │   └── insertVotes() during StoreBlock
+        ▼                                   ▼        (SSGenVoteChoices → vote bits → choice rows)
+  explorer.AgendasPage / AgendaPage   api.getAgendasData / api.getAgendaData
+        │                                   │
+        ▼                                   ▼
+  views/agendas.tmpl, agenda.tmpl     /api/agendas (JSON), /api/agenda/{id} (JSON charts)
+        │                                   │
+        ▼                                   ▼
+  agendas_controller.js (meters)      agenda_controller.js (Dygraphs ← /api/agenda/{id})
+```
+
+HTML pages are **request-scoped HTTP only** — there is no WebSocket push path for agendas, so
+the Template+WebSocket parity concern (C3) does not arise here.
+
+## Section 3 — Per-Layer Breakdown
+
+### Layer A — Node RPC (source of truth for live state)
+- **Location:** `DeploymentSource`/`VoteDataSource` interfaces in
+  [gov/agendas/deployments.go:56-58](../../../gov/agendas/deployments.go#L56-L58),
+  [gov/agendas/tracker.go:26-31](../../../gov/agendas/tracker.go#L26-L31).
+- **Data structures:** `chainjson.GetVoteInfoResult`, `chainjson.Agenda`, `chainjson.Choice`
+  (node `rpc/jsonrpc/types`: `ID, Description, Bits, IsAbstain, IsNo, Count, Progress`),
+  `GetStakeVersionInfoResult`, `GetStakeVersionsResult`, and
+  `GetBlockChainInfoResult.Deployments` (`map[string]AgendaInfo` with `Status`, `Since`,
+  `StartTime`, `ExpireTime`).
+- **Transformations:** none — raw RPC results.
+
+### Layer B — `gov/agendas` (metadata cache + live tracker)
+- **Location:** [gov/agendas/deployments.go](../../../gov/agendas/deployments.go),
+  [gov/agendas/tracker.go](../../../gov/agendas/tracker.go).
+- **Data structures:**
+  - `AgendaTagged` ([deployments.go:33-43](../../../gov/agendas/deployments.go#L33-L43)) —
+    storm-tagged copy of `chainjson.Agenda` + `VoteVersion`, primary key `ID`. Persisted to a
+    BoltDB file (`agendas.db`, default name [config.go:67](../../../cmd/dcrdata/config.go#L67)).
+  - `VoteSummary` ([tracker.go:65-91](../../../gov/agendas/tracker.go#L65-L91)) and
+    `AgendaSummary` ([tracker.go:38-61](../../../gov/agendas/tracker.go#L38-L61)) — live RCI/SVI
+    progress, quorum/approval, per-agenda `IsVoting/IsLocked/IsFailed/IsActive` flags. All
+    counts `uint32`, all rates/progress `float32`.
+- **Transformations:**
+  - `agendasForVoteVersion` ([deployments.go:194](../../../gov/agendas/deployments.go#L194)) maps
+    `chainjson.Agenda` → `AgendaTagged`; `Status` via `dbtypes.AgendaStatusFromStr`.
+  - `UpdateAgendas` ([deployments.go:254](../../../gov/agendas/deployments.go#L254)) refreshes
+    all stake versions; invoked once at startup
+    ([main.go:981](../../../cmd/dcrdata/main.go#L981)) and **every 5 blocks**
+    ([explorer.go:892-894](../../../cmd/dcrdata/internal/explorer/explorer.go#L892-L894)).
+  - `VoteTracker.Summary()` builds `VoteSummary` from RPC + chaincfg params (quorum, thresholds,
+    interval sizes). Constructed only when **not simnet**
+    ([main.go:433-440](../../../cmd/dcrdata/main.go#L433-L440)); `nil` tracker is a sentinel.
+
+### Layer C — `db/dcrpg` (historical tally + milestones)
+- **Location:** [db/dcrpg/pgblockchain.go](../../../db/dcrpg/pgblockchain.go),
+  [db/dcrpg/queries.go](../../../db/dcrpg/queries.go), `db/dcrpg/internal/stakestmts.go`.
+- **Data structures:** Postgres tables `agendas` + `agenda_votes`
+  ([tables.go:26-27](../../../db/dcrpg/tables.go#L26-L27)); `dbtypes.MileStone`
+  ([db/dbtypes/types.go:973](../../../db/dbtypes/types.go#L973)); `dbtypes.AgendaSummary`
+  ([types.go:986](../../../db/dbtypes/types.go#L986)); `dbtypes.AgendaVoteChoices`
+  ([types.go:2164](../../../db/dbtypes/types.go#L2164)) with parallel arrays
+  `Yes/No/Abstain/Total []uint64`, `Height []uint64`, `Time []TimeDef`.
+- **Transformations / writes:**
+  - **`agenda_votes` IS populated** — `insertVotes`
+    ([queries.go:382](../../../db/dcrpg/queries.go#L382)), called from the `StoreBlock` path at
+    [pgblockchain.go:4340](../../../db/dcrpg/pgblockchain.go#L4340). For each vote tx it calls
+    `txhelpers.SSGenVoteChoices` ([queries.go:558](../../../db/dcrpg/queries.go#L558)) and
+    inserts choice rows via `MakeAgendaInsertStatement` / `MakeAgendaVotesInsertStatement`
+    (→ `InsertAgendaRow` / `InsertAgendaVotesRow` / upsert variants in
+    `internal/stakestmts.go`). Status changes are diffed against the `storedAgendas` cache
+    ([pgblockchain.go:77](../../../db/dcrpg/pgblockchain.go#L77)) and the
+    `votesMilestones.AgendaMileStones` map.
+  - **`AgendaMileStones`** is rebuilt on each chain-info update
+    ([pgblockchain.go:3118-3157](../../../db/dcrpg/pgblockchain.go#L3118-L3157)) from
+    `GetBlockChainInfo.Deployments`, deriving `VotingStarted/VotingDone/Activated` from
+    `RuleChangeActivationInterval` and the agenda `Status`.
+  - **Reads:** `AgendaVotes(ctx, id, chartType)`
+    ([pgblockchain.go:1588](../../../db/dcrpg/pgblockchain.go#L1588)) → `retrieveAgendaVoteChoices`;
+    `AgendasVotesSummary` ([1607](../../../db/dcrpg/pgblockchain.go#L1607)),
+    `AgendaVoteCounts` ([1630](../../../db/dcrpg/pgblockchain.go#L1630)) →
+    `retrieveTotalAgendaVotesCount`; `AllAgendas()`
+    ([1647](../../../db/dcrpg/pgblockchain.go#L1647)) → `retrieveAllAgendas` (milestone map).
+    All three first short-circuit if `agendaInfo.StartTime` is in the future.
+
+### Layer D — Handlers (HTML + JSON API)
+- **HTML — `AgendasPage`** ([explorerroutes.go:2066-2098](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L2066-L2098)):
+  `nil` voteTracker → status page *"agendas disabled on simnet"*; else `agendasSource.AllAgendas()`
+  plus `voteTracker.Summary()` → template `agendas`.
+- **HTML — `AgendaPage`** ([explorerroutes.go:1977-2063](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L1977-L2063)):
+  `agendasSource.AgendaInfo(id)` (BoltDB) + `dataSource.AgendasVotesSummary(ctx, id)` (Postgres);
+  overrides each `Choices[i].Count` with the DB tally (`abstain/yes/no`), computes
+  `qVotes = RuleChangeActivationQuorum * QuorumProgress`, time-left, → template `agenda`.
+- **JSON — `getAgendasData`** ([apiroutes.go:2046-2076](../../../cmd/dcrdata/internal/api/apiroutes.go#L2046-L2076)):
+  `AgendaDB.AllAgendas()` + `DataSource.AllAgendas()` (milestones) → `[]apitypes.AgendasInfo`.
+  **This route is still live** ([apirouter.go:211-213](../../../cmd/dcrdata/internal/api/apirouter.go#L211-L213)).
+- **JSON — `getAgendaData`** ([apiroutes.go:2005-2041](../../../cmd/dcrdata/internal/api/apiroutes.go#L2005-L2041)):
+  `AgendaVotes(id, 0)` (by time) + `AgendaVotes(id, 1)` (by height) →
+  `apitypes.AgendaAPIResponse{ByHeight, ByTime}` (JSON `by_height`/`by_time`). **Still live**
+  ([apirouter.go:216-218](../../../cmd/dcrdata/internal/api/apirouter.go#L216-L218)), guarded by
+  `m.AgendaIdCtx`.
+
+### Layer E — Templates + JS
+- **`views/agendas.tmpl`** — `data-controller="agendas"`; renders `VoteSummary.Agendas`,
+  RCI/SVI progress bars, and meter `<div>`s with `data-agendas-target` +
+  `data-progress`/`data-threshold`/`data-approval`. Uses template func `f32x100`
+  ([templates.go:754](../../../cmd/dcrdata/internal/explorer/templates.go#L754)),
+  `secondsToShortDurationString`, `dateTimeWithoutTimeZone`. No coin amounts.
+- **`views/agenda.tmpl`** — choice table (`ID/Description/Bits/Count/Progress`) +
+  `data-controller="agenda" data-agenda-id="{{.ID}}"` with two chart target `<div>`s.
+- **`agendas_controller.js`** — builds `ProgressMeter`/`VoteMeter` from the meter `data-*`
+  attrs; re-themes on `NIGHT_MODE`.
+- **`agenda_controller.js`** — on connect, `requestJSON('/api/agenda/${id}')`, maps
+  `by_time → [Date, yes, abstain, no]` and `by_height → [height, yes, abstain, no]` into two
+  Dygraphs. Empty/missing arrays fall back to `[[0,0,0,0]]`.
+
+## Section 4 — Cross-Layer Dependencies
+
+- **Dual data origin coupling.** `AgendaPage` joins BoltDB metadata (`AgendaInfo`) with Postgres
+  tallies (`AgendasVotesSummary`) by **string agenda ID** and by **choice ID string** (`"yes"`,
+  `"no"`, `"abstain"`, matched lower-cased at
+  [explorerroutes.go:2003-2011](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L2003-L2011)).
+  A renamed choice ID would silently drop the override.
+- **Go→JS meter contract (untyped).** `agendas.tmpl` emits `data-progress`, `data-threshold`,
+  `data-approval` (raw `float32` 0–1); `agendas_controller.js` reads them positionally. No
+  compile-time check.
+- **Go→JS chart contract (untyped JSON).** `dbtypes.AgendaVoteChoices` field tags
+  (`yes/no/abstain/height/time`) must match the keys read in `agenda_controller.js`
+  (`d.yes/d.abstain/d.no/d.time/d.height`). Adding/renaming a field changes the wire shape
+  silently.
+- **Milestone dependency.** Every Postgres read keys `ChainInfo().AgendaMileStones[agendaID]`;
+  if `GetBlockChainInfo` stops returning a deployment, that agenda's tallies become unreachable
+  even though `agenda_votes` rows still exist.
+- **Consensus gating reuse.** The same `AgendaMileStones` map drives `IsDCP0010Active` /
+  `IsDCP0011Active` / `IsDCP0012Active`
+  ([pgblockchain.go:5064-5152](../../../db/dcrpg/pgblockchain.go#L5064-L5152)) — subsidy-split and
+  blake3pow activation. Re-enabling the pages does **not** touch this, but it shows agenda data
+  is load-bearing beyond the UI.
+- **Nav coupling.** The navbar ([extras.tmpl:79-87](../../../cmd/dcrdata/views/extras.tmpl#L79-L87))
+  has **no Agendas link** — it was removed when the page was stubbed. Re-enabling the route
+  without re-adding the link leaves the page reachable only by direct URL.
+
+## Section 5 — Critical Constraints
+
+- **C1 (numeric precision) — N/A here, and that is the answer to "adapt to Monetarium?".**
+  Agendas carry no VAR/SKA values: tallies are `uint32`, rates `float32`, heights/quorum
+  integers. There is no `.ToCoin()`, no `big.Int`, no atom string. **No multi-coin or precision
+  adaptation is required.** See [/wiki/core/constraints.md](../../core/constraints.md) C1 for the
+  rule this flow is exempt from.
+- **C3 (template + WebSocket parity) — N/A.** No WebSocket push path for agendas; both pages are
+  request-scoped HTTP. (Contrast block/tx, which must mirror fields across template + WS.)
+- **C7 (coin-type labels) — N/A.** No coin labels are rendered.
+- **Real Monetarium-specific dependency: node must expose consensus deployments + stake-version
+  voting.** Verified present in `monetarium-node` chaincfg **v1.3.10**: mainnet defines **48**
+  agenda IDs, testnet **52**, across vote versions; vote IDs include `VoteIDMaxBlockSize`,
+  `VoteIDChangeSubsidySplit`, `VoteIDBlake3Pow`, `VoteIDChangeSubsidySplitR2`. RPC result types
+  `GetVoteInfoResult`, `Agenda`, `Choice`, `GetStakeVersionsResult`,
+  `GetStakeVersionInfoResult` all exist. So the data pipeline produces real data; agendas were
+  **not** removed for lack of node support.
+- **VoteTracker is mandatory on non-simnet.** `NewVoteTracker` returns an error if
+  `len(stakeVersions) == 0` ([tracker.go:136-138](../../../gov/agendas/tracker.go#L136-L138)), and
+  `_main` treats that as fatal ([main.go:434-439](../../../cmd/dcrdata/main.go#L434-L439)). Since
+  the explorer already starts on non-simnet, the tracker already initializes — re-enabling the
+  page does not add a new startup risk.
+
+## Section 6 — Mutation Impact
+
+**To re-enable the pages (the requested change):**
+
+1. **Restore the two routes** at [main.go:780-785](../../../cmd/dcrdata/main.go#L780-L785):
+   `withCache.Get("/agendas", explore.AgendasPage)` and
+   `withCache.With(explorer.AgendaPathCtx).Get("/agenda/{agendaid}", explore.AgendaPage)`. Both
+   handlers and `AgendaPathCtx`/`getAgendaIDCtx`
+   ([explorermiddleware.go:228,276](../../../cmd/dcrdata/internal/explorer/explorermiddleware.go#L228))
+   already exist and compile.
+2. **Re-add the navbar link** in
+   [extras.tmpl:79-87](../../../cmd/dcrdata/views/extras.tmpl#L79-L87) (e.g. an "Agendas"
+   `menu-item` → `/agendas`). Without this the page is orphaned.
+3. **No backend, API, template, or JS changes are needed** — they are intact.
+4. **Reconcile docs:** the market-removal spec
+   ([wiki/specs/market-removal/spec.md](../../specs/market-removal/spec.md), indexed at
+   [wiki/index.md:32](../../index.md)) lists `/agendas` among "made unavailable (like
+   `/treasury`, `/proposals`)". Update that note — agendas is being re-enabled, not removed.
+
+**Direct deps to check when changing agenda data structures:** `AgendaTagged`,
+`VoteSummary`/`AgendaSummary`, `dbtypes.MileStone`, `dbtypes.AgendaVoteChoices`,
+`apitypes.AgendasInfo`/`AgendaAPIResponse`, the two templates, the two JS controllers, and the
+`/api/agendas` + `/api/agenda/{id}` consumers.
+
+**Silent failures:**
+- Re-enable route but forget the nav link → page works only via direct URL (no error).
+- `agenda_votes` charts render but are **empty** (`[[0,0,0,0]]`) for any agenda whose votes
+  were not seen during the explorer's DB sync, or if `SSGenVoteChoices` returns no choices
+  (deployment absent for that vote version). Data is populated **forward** during sync; a full
+  resync from genesis is the only way to backfill completed historical votes.
+- Renaming a choice ID string ("yes"/"no"/"abstain") or a `AgendaVoteChoices` JSON tag → counts
+  silently mis-mapped / charts blank.
+- A Postgres timeout in `AgendaVotes` returns `nil` → blank chart, page still 200.
+
+**Hard failures:**
+- Unknown `agendaid` → `AgendaInfo` error → `ExpStatusNotFound` page.
+- `AllAgendas()` DB error → `ExpStatusError` page.
+- On non-simnet, a node with **zero** stake versions would fail `NewVoteTracker` → explorer
+  won't start (pre-existing risk, unchanged by re-enabling).
+- On simnet, `voteTracker == nil` → `/agendas` shows the *"agendas disabled on simnet"* status
+  page by design.
+
+## Section 7 — Common Pitfalls
+
+- **Assuming agendas needs multi-coin work.** It does not — no VAR/SKA values flow through it.
+  Don't add coin-type maps, `.ToCoin()` calls, or atom-string handling here.
+- **Re-enabling the route but not the navbar item** — leaves the page discoverable only by URL.
+- **Expecting historical vote charts to be fully populated immediately** — `agenda_votes` is
+  built during forward sync; pre-sync completed votes won't appear without a genesis resync.
+- **Treating agendas like treasury/proposals** — those are genuine removals; agendas is dormant
+  but fully wired. Don't delete the handlers or DB tables.
+- **Forgetting the BoltDB↔Postgres join** — `AgendaPage` needs *both* `agendasSource`
+  (metadata) and `dataSource` (tallies); a nil `agendasSource` or missing milestone breaks it.
+
+## Section 8 — Evidence
+
+- Route stubs / original wiring: [main.go:780-785](../../../cmd/dcrdata/main.go#L780-L785);
+  commit `52ea3cf1` diff replaced `explore.AgendasPage`/`explore.AgendaPage` with 410 closures.
+- Handlers: `AgendasPage`
+  [explorerroutes.go:2066](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L2066),
+  `AgendaPage` [explorerroutes.go:1975-2063](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L1975-L2063).
+- Backend interface: `agendaBackend`
+  [explorer.go:134-137](../../../cmd/dcrdata/internal/explorer/explorer.go#L134-L137); wiring
+  [main.go:415-452](../../../cmd/dcrdata/main.go#L415-L452).
+- DB pipeline: `insertVotes` [queries.go:382](../../../db/dcrpg/queries.go#L382) +
+  [queries.go:537-604](../../../db/dcrpg/queries.go#L537-L604); caller
+  [pgblockchain.go:4340](../../../db/dcrpg/pgblockchain.go#L4340); milestones
+  [pgblockchain.go:3118-3157](../../../db/dcrpg/pgblockchain.go#L3118-L3157);
+  `SSGenVoteChoices` [txhelpers.go:1020](../../../txhelpers/txhelpers.go#L1020).
+- API: [apirouter.go:211-218](../../../cmd/dcrdata/internal/api/apirouter.go#L211-L218),
+  [apiroutes.go:2005-2076](../../../cmd/dcrdata/internal/api/apiroutes.go#L2005-L2076);
+  types [apitypes.go:135-147](../../../api/types/apitypes.go#L135-L147).
+- Templates: [agendas.tmpl](../../../cmd/dcrdata/views/agendas.tmpl),
+  [agenda.tmpl](../../../cmd/dcrdata/views/agenda.tmpl); JS
+  [agendas_controller.js](../../../cmd/dcrdata/public/js/controllers/agendas_controller.js),
+  [agenda_controller.js](../../../cmd/dcrdata/public/js/controllers/agenda_controller.js).
+- Node support: `monetarium-node/chaincfg@v1.3.10` `mainnetparams.go:148`/`testnetparams.go:147`
+  `Deployments` maps; vote IDs at `mainnetparams.go:405-461`; RPC types
+  `rpc/jsonrpc/types@v1.3.10/chainsvrresults.go:497-527` (`Choice`, `Agenda`,
+  `GetVoteInfoResult`).
+- Navbar (no agendas link): [extras.tmpl:79-87](../../../cmd/dcrdata/views/extras.tmpl#L79-L87).
+
+See also:
+- /wiki/code-analysis/agendas/flow.compact.md (derived-from: this file)
+- /wiki/code-analysis/agendas/patterns.md (shares-pattern-with: dormant-feature stub, dual-source governance data)
+- /wiki/code-analysis/agendas/impact.md (depends-on: re-enable blast radius)
+- /wiki/core/constraints.md (depends-on: C1 numeric precision — explicitly N/A for agendas; C3 parity — N/A, no WS path; C7 coin labels — N/A)
+- /wiki/code-analysis/parameters/flow.full.md (shares-pattern-with: near-static chaincfg.Params + node-RPC page)
+- /wiki/specs/market-removal/spec.md (contradicts: lists /agendas as removed; reconcile on re-enable)

--- a/wiki/code-analysis/agendas/impact.md
+++ b/wiki/code-analysis/agendas/impact.md
@@ -1,0 +1,73 @@
+# Agendas — Mutation Impact / Blast Radius
+
+Primary scenario: **re-enabling** `/agendas` and `/agenda/{id}`. Secondary: changing agenda data
+structures.
+
+## Risk: Orphaned page (route re-enabled, nav not)
+- **Trigger:** restore the handlers at [main.go:780-785](../../../cmd/dcrdata/main.go#L780-L785)
+  but leave the navbar unchanged.
+- **Affected:** [extras.tmpl:79-87](../../../cmd/dcrdata/views/extras.tmpl#L79-L87) (no Agendas
+  `menu-item`).
+- **Failure mode:** silent. Page returns 200 but is reachable only by direct URL or via the
+  vote-tx link in [tx.tmpl:593](../../../cmd/dcrdata/views/tx.tmpl#L593).
+- **Fix:** add an "Agendas" menu item → `/agendas`.
+
+## Risk: Empty historical vote charts
+- **Trigger:** re-enable `/agenda/{id}` on a DB that synced *after* an agenda's votes were cast,
+  or for a vote version with no deployments (`SSGenVoteChoices` returns `[]`).
+- **Affected:** `agenda_votes` table; `AgendaVotes`
+  ([pgblockchain.go:1588](../../../db/dcrpg/pgblockchain.go#L1588)); `/api/agenda/{id}`;
+  `agenda_controller.js` (falls back to `[[0,0,0,0]]`).
+- **Failure mode:** silent — charts render blank, page is otherwise correct.
+- **Fix / note:** `agenda_votes` is populated **forward** during sync via `insertVotes`
+  ([queries.go:382](../../../db/dcrpg/queries.go#L382), called at
+  [pgblockchain.go:4340](../../../db/dcrpg/pgblockchain.go#L4340)). Backfilling completed
+  pre-sync votes requires a resync from genesis. The choice *table* on the page (counts via
+  `AgendasVotesSummary`) shares the same data source, so it is subject to the same gap.
+
+## Risk: VoteTracker startup dependency (non-simnet)
+- **Trigger:** running on a network whose node reports **zero** stake versions.
+- **Affected:** `NewVoteTracker` ([tracker.go:131-138](../../../gov/agendas/tracker.go#L131-L138));
+  fatal at [main.go:434-439](../../../cmd/dcrdata/main.go#L434-L439).
+- **Failure mode:** hard — explorer fails to start. **Pre-existing**, unchanged by re-enabling
+  the page; if the explorer already runs on the target net, the tracker already initializes.
+- **Simnet:** `voteTracker == nil` → `AgendasPage` returns the "agendas disabled on simnet"
+  status page by design ([explorerroutes.go:2067-2071](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L2067-L2071)).
+
+## Risk: Choice-ID / JSON-tag drift
+- **Trigger:** rename a vote choice ID or a `dbtypes.AgendaVoteChoices` JSON tag.
+- **Affected:** the lower-cased switch at
+  [explorerroutes.go:2003-2011](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L2003-L2011)
+  (`"abstain"/"yes"/"no"`); `agenda_controller.js` keys (`d.yes/d.abstain/d.no/d.time/d.height`);
+  meter `data-*` attrs in `agendas.tmpl`.
+- **Failure mode:** silent — counts mis-mapped or charts blank; no build/test error
+  (Go↔JS boundary is untyped).
+- **Fix:** change both ends together; treat the JSON shape as a contract.
+
+## Risk: Milestone unavailability
+- **Trigger:** `GetBlockChainInfo` stops returning a deployment whose `agenda_votes` rows exist.
+- **Affected:** `ChainInfo().AgendaMileStones[id]` lookups in `AgendaVotes`/`AgendasVotesSummary`/
+  `AgendaVoteCounts` ([pgblockchain.go:1593,1612,1635](../../../db/dcrpg/pgblockchain.go#L1593));
+  also the consensus-gating helpers `IsDCP0010/0011/0012Active`
+  ([pgblockchain.go:5064-5152](../../../db/dcrpg/pgblockchain.go#L5064-L5152)).
+- **Failure mode:** silent for the UI (empty/zero); potentially behavioral for subsidy/blake3pow
+  gating (separate concern, not touched by re-enabling).
+
+## Doc reconciliation
+- [wiki/specs/market-removal/spec.md](../../specs/market-removal/spec.md) and
+  [wiki/index.md:32](../../index.md) currently classify `/agendas` as "made unavailable (like
+  `/treasury`, `/proposals`)". Re-enabling contradicts that; update the note so the corpus does
+  not claim agendas is removed.
+
+## What is NOT at risk
+- **No multi-coin / precision blast radius.** Agendas carry no VAR/SKA amounts; re-enabling
+  introduces zero exposure to the SKA-through-float64 class of bugs. Do not add coin-type
+  handling here.
+- **No WebSocket parity surface.** Agendas has no push path, so the live-overwrites-static class
+  (C3) does not apply.
+
+See also:
+- /wiki/code-analysis/agendas/flow.full.md (depends-on: full trace)
+- /wiki/code-analysis/agendas/patterns.md (shares-pattern-with: dormant-feature stub)
+- /wiki/core/constraints.md (depends-on: C1/C3/C7 — explicitly N/A for agendas)
+- /wiki/specs/market-removal/spec.md (contradicts: agendas listed as removed)

--- a/wiki/code-analysis/agendas/patterns.md
+++ b/wiki/code-analysis/agendas/patterns.md
@@ -1,0 +1,56 @@
+# Agendas — Patterns
+
+## Dormant-Feature Route Stub (handler + pipeline retained)
+A page is "disabled" by replacing **only its HTTP route** with a closure returning
+`http.StatusGone`, while the handler, data sources, JSON API, templates, and JS controllers stay
+compiled and functional.
+
+- **Where:** [main.go:780-785](../../../cmd/dcrdata/main.go#L780-L785) (agendas); the same edit
+  (commit `52ea3cf1`) stubbed `/treasury`, `/treasurytable`, `/proposals`; `/market` later.
+- **Re-enable cost:** revert the route line(s) back to the real handler (e.g.
+  `explore.AgendasPage`, `explorer.AgendaPathCtx` + `explore.AgendaPage`) and re-add the navbar
+  link. No backend work.
+- **Caveat — distinguish dormant from removed.** Treasury/market are *genuine* Monetarium
+  removals (no node support / feature dropped). **Agendas is dormant-but-wired**: the node
+  fully supports it and the DB pipeline keeps populating `agenda_votes`. Don't lump them
+  together when reasoning about deletion.
+- **Constraint:** when stubbing/unstubbing, keep the route table and the navbar
+  ([extras.tmpl:79-87](../../../cmd/dcrdata/views/extras.tmpl#L79-L87)) in sync — a re-enabled
+  route with no nav link is an orphaned page; a removed route with a live nav link is a dead link.
+
+## Dual-Source Governance Data (RPC-live + Postgres-historical)
+Agenda pages compose two independent origins for the same logical entity:
+
+- **Live metadata + progress** — node RPC cached in `gov/agendas.AgendaDB` (BoltDB/storm,
+  `AgendaTagged`) and computed in-memory by `VoteTracker` (`VoteSummary`/`AgendaSummary`),
+  refreshed at startup and **every 5 blocks**
+  ([explorer.go:892-894](../../../cmd/dcrdata/internal/explorer/explorer.go#L892-L894)).
+- **Historical tallies** — Postgres `agenda_votes`, written during `StoreBlock` by `insertVotes`
+  ([queries.go:382](../../../db/dcrpg/queries.go#L382)) using `txhelpers.SSGenVoteChoices` on each
+  vote tx; milestones rebuilt from `GetBlockChainInfo.Deployments`
+  ([pgblockchain.go:3118-3157](../../../db/dcrpg/pgblockchain.go#L3118-L3157)).
+- **Join key:** string agenda `ID` + lower-cased choice ID (`"yes"`/`"no"`/`"abstain"`) at
+  [explorerroutes.go:2003-2011](../../../cmd/dcrdata/internal/explorer/explorerroutes.go#L2003-L2011).
+- **Constraint:** the live source determines *which agendas exist*; the Postgres source supplies
+  *how votes were cast over time*. The two can disagree (a deployment dropped from
+  `GetBlockChainInfo` orphans its still-present `agenda_votes` rows). Historical data is only as
+  complete as the forward sync that produced it — no automatic backfill of pre-sync votes.
+
+## Coin-Agnostic Feature (precision rules do not apply)
+Some explorer features carry **no monetary values** and are therefore exempt from the multi-coin
+precision pipeline. Agendas is the canonical example: every value is a vote `uint32`, a `float32`
+percentage, a block height, a status, or a timestamp.
+
+- **Where:** [agendas.tmpl](../../../cmd/dcrdata/views/agendas.tmpl),
+  [agenda.tmpl](../../../cmd/dcrdata/views/agenda.tmpl) — no `.ToCoin()`, no atom strings, no
+  coin-type label helper.
+- **Constraint:** do **not** introduce VAR/SKA maps, `float64` coin conversion, or `big.Int`
+  string handling into this flow. C1/C3/C7 of [/wiki/core/constraints.md](../../core/constraints.md)
+  are intentionally not in scope here. The relevant invariant instead is **node capability**:
+  the data only exists if the node exposes consensus deployments + stake-version voting.
+
+See also:
+- /wiki/code-analysis/agendas/flow.full.md (derived-from)
+- /wiki/code-analysis/agendas/impact.md (shares-pattern-with: dormant-feature stub)
+- /wiki/code-analysis/parameters/patterns.md (shares-pattern-with: near-static chaincfg.Params + node-RPC page)
+- /wiki/core/constraints.md (depends-on: C1/C3/C7 marked N/A for agendas)

--- a/wiki/core/pages.md
+++ b/wiki/core/pages.md
@@ -12,52 +12,50 @@ Non-page endpoints (WebSockets, JSON APIs under `/api` and `/insight/api`, `/dow
 
 ## Active pages
 
-| URL | Handler | Description |
-|---|---|---|
-| `/` | `Home` | Landing dashboard: header metrics (height, supply, hashrate, ticket info), latest blocks, mempool snapshot, multi-coin supply card. |
-| `/visualblocks` | `VisualBlocks` | Visual grid of recent blocks rendered as colored tiles by tx type/size — alternative to the table view. |
-| `/blocks` | `Blocks` | Paginated table of recent blocks (height, time, size, tx counts, voters, fees). |
-| `/block/{blockhash}` | `Block` (with `BlockHashPathOrIndexCtx`) | Block details: header, votes/tickets/regular tx tables, navigation to neighbor blocks. Accepts either a block hash or a height in `{blockhash}`. |
-| `/side` | `SideChains` | List of side-chain (orphaned) blocks the node has seen. |
-| `/disapproved` | `DisapprovedBlocks` | List of blocks disapproved by the next block's stake voters (their regular tx were invalidated). |
-| `/days` | `DayBlocksListing` | Blocks aggregated by day (count, total fees, per-period summary). |
-| `/weeks` | `WeekBlocksListing` | Blocks aggregated by week. |
-| `/months` | `MonthBlocksListing` | Blocks aggregated by month. |
-| `/years` | `YearBlocksListing` | Blocks aggregated by year. |
-| `/mempool` | `Mempool` | Unconfirmed transactions split by coin (VAR + SKA{n}) and by tx type, with totals and per-coin tables. |
-| `/tx/{txid}` | `TxPage` | Transaction details: inputs, outputs, fees, confirmations, block link. Single-coin per tx (VAR or one SKA{n}); fee paid in same coin. |
-| `/tx/{txid}/{inout}/{inoutid}` | `TxPage` (scrolled to a specific input/output) | Same view as `/tx/{txid}` but anchored to a specific `in` or `out` index. |
-| `/address/{address}` | `AddressPage` | Address overview: balance, sent/received totals, paginated tx table, chart selectors (kind, zoom, group-by). URL state is the source of truth for chart settings. |
-| `/addresstable/{address}` | `AddressTable` (AJAX fragment) | Server-rendered HTML fragment for the address tx table — used by the address page for pagination/filtering without a full reload. |
-| `/decodetx` | `DecodeTxPage` | Form that decodes a raw transaction hex string into structured input/output details without broadcasting. |
-| `/search` | `Search` | Dispatcher that inspects the query and redirects to the matching page (block hash, height, tx hash, or address). Renders an error page on no match. |
-| `/charts` | `Charts` | Historical charts (supply, hashrate, fees, block size, ticket metrics, etc.) including the per-coin SKA `coin-supply/{N}` pipeline. |
-| `/parameters` | `ParametersPage` | Static-ish chain parameters: subsidy schedule, ticket parameters, network constants, consensus rules. |
-| `/ticketpool` | `Ticketpool` | Live ticket pool view: distribution by price, age, and other dimensions. |
-| `/ticketpricewindows` | `StakeDiffWindows` | Stake-difficulty (ticket-price) windows — past windows plus the in-progress one with projected next price. |
-| `/attack-cost` | `AttackCost` | 51%-style attack-cost calculator using current hashrate, ticket price, and supply numbers. |
-| `/verify-message` | `VerifyMessagePage` (GET) / `VerifyMessageHandler` (POST) | Form that verifies an address+message+signature triple is valid. POST is rate-limited via tollbooth. |
-| `/insight` | `InsightRootPage` (static assets also mirrored under `/insight/*`) | Landing page for the Insight-compatible JSON API; documents `/insight/api/...` endpoints. |
+| URL                            | Handler                                                            | Description                                                                                                                                                       |
+| ------------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/`                            | `Home`                                                             | Landing dashboard: header metrics (height, supply, hashrate, ticket info), latest blocks, mempool snapshot, multi-coin supply card.                               |
+| `/visualblocks`                | `VisualBlocks`                                                     | Visual grid of recent blocks rendered as colored tiles by tx type/size — alternative to the table view.                                                           |
+| `/blocks`                      | `Blocks`                                                           | Paginated table of recent blocks (height, time, size, tx counts, voters, fees).                                                                                   |
+| `/block/{blockhash}`           | `Block` (with `BlockHashPathOrIndexCtx`)                           | Block details: header, votes/tickets/regular tx tables, navigation to neighbor blocks. Accepts either a block hash or a height in `{blockhash}`.                  |
+| `/side`                        | `SideChains`                                                       | List of side-chain (orphaned) blocks the node has seen.                                                                                                           |
+| `/disapproved`                 | `DisapprovedBlocks`                                                | List of blocks disapproved by the next block's stake voters (their regular tx were invalidated).                                                                  |
+| `/days`                        | `DayBlocksListing`                                                 | Blocks aggregated by day (count, total fees, per-period summary).                                                                                                 |
+| `/weeks`                       | `WeekBlocksListing`                                                | Blocks aggregated by week.                                                                                                                                        |
+| `/months`                      | `MonthBlocksListing`                                               | Blocks aggregated by month.                                                                                                                                       |
+| `/years`                       | `YearBlocksListing`                                                | Blocks aggregated by year.                                                                                                                                        |
+| `/mempool`                     | `Mempool`                                                          | Unconfirmed transactions split by coin (VAR + SKA{n}) and by tx type, with totals and per-coin tables.                                                            |
+| `/tx/{txid}`                   | `TxPage`                                                           | Transaction details: inputs, outputs, fees, confirmations, block link. Single-coin per tx (VAR or one SKA{n}); fee paid in same coin.                             |
+| `/tx/{txid}/{inout}/{inoutid}` | `TxPage` (scrolled to a specific input/output)                     | Same view as `/tx/{txid}` but anchored to a specific `in` or `out` index.                                                                                         |
+| `/address/{address}`           | `AddressPage`                                                      | Address overview: balance, sent/received totals, paginated tx table, chart selectors (kind, zoom, group-by). URL state is the source of truth for chart settings. |
+| `/addresstable/{address}`      | `AddressTable` (AJAX fragment)                                     | Server-rendered HTML fragment for the address tx table — used by the address page for pagination/filtering without a full reload.                                 |
+| `/decodetx`                    | `DecodeTxPage`                                                     | Form that decodes a raw transaction hex string into structured input/output details without broadcasting.                                                         |
+| `/search`                      | `Search`                                                           | Dispatcher that inspects the query and redirects to the matching page (block hash, height, tx hash, or address). Renders an error page on no match.               |
+| `/charts`                      | `Charts`                                                           | Historical charts (supply, hashrate, fees, block size, ticket metrics, etc.) including the per-coin SKA `coin-supply/{N}` pipeline.                               |
+| `/parameters`                  | `ParametersPage`                                                   | Static-ish chain parameters: subsidy schedule, ticket parameters, network constants, consensus rules.                                                             |
+| `/ticketpool`                  | `Ticketpool`                                                       | Live ticket pool view: distribution by price, age, and other dimensions.                                                                                          |
+| `/ticketpricewindows`          | `StakeDiffWindows`                                                 | Stake-difficulty (ticket-price) windows — past windows plus the in-progress one with projected next price.                                                        |
+| `/attack-cost`                 | `AttackCost`                                                       | 51%-style attack-cost calculator using current hashrate, ticket price, and supply numbers.                                                                        |
+| `/verify-message`              | `VerifyMessagePage` (GET) / `VerifyMessageHandler` (POST)          | Form that verifies an address+message+signature triple is valid. POST is rate-limited via tollbooth.                                                              |
+| `/insight`                     | `InsightRootPage` (static assets also mirrored under `/insight/*`) | Landing page for the Insight-compatible JSON API; documents `/insight/api/...` endpoints.                                                                         |
 
 ---
 
 ---
-
-
 
 ## Disabled (return HTTP 410 Gone)
 
 Wired but intentionally off in this fork. No Monetarium adjustment required unless we decide to re-enable them. Source: [main.go](../../cmd/dcrdata/main.go) lines 770–809.
 
-| URL | Status | Description |
-|---|---|---|
-| `/treasury` | 410 — "treasury not available" | Decred treasury account balance and history page; Monetarium has no treasury. |
-| `/treasurytable` | 410 — same | AJAX fragment for the treasury tx table. |
-| `/agendas` | 410 — "agendas not available" | Consensus deployment vote agendas list; Monetarium does not run on-chain consensus voting. |
-| `/agenda/{agendaid}` | 410 — same | Single-agenda details (timeline, threshold, vote counts). |
-| `/proposals` | 410 — "proposals not available" | Politeia governance proposals list; not used in Monetarium. |
-| `/proposal/{proposaltoken}` | 410 — same | Single Politeia proposal details. |
-| `/market` | 410 — "market not available" | Exchange / market data; no Monetarium asset is traded on any exchange. |
+| URL                         | Status                          | Description                                                                                |
+| --------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------ |
+| `/treasury`                 | 410 — "treasury not available"  | Decred treasury account balance and history page; Monetarium has no treasury.              |
+| `/treasurytable`            | 410 — same                      | AJAX fragment for the treasury tx table.                                                   |
+| `/agendas`                  | 410 — "agendas not available"   | Consensus deployment vote agendas list. **Dormant, not removed** — `monetarium-node` defines consensus deployments and the handlers + DB pipeline are intact; can be re-enabled. See [code-analysis/agendas/](code-analysis/agendas/flow.compact.md). |
+| `/agenda/{agendaid}`        | 410 — same                      | Single-agenda details (timeline, threshold, vote counts). Dormant — can be re-enabled; see `/agendas` above.                            |
+| `/proposals`                | 410 — "proposals not available" | Politeia governance proposals list; not used in Monetarium.                                |
+| `/proposal/{proposaltoken}` | 410 — same                      | Single Politeia proposal details.                                                          |
+| `/market`                   | 410 — "market not available"    | Exchange / market data; no Monetarium asset is traded on any exchange.                     |
 
 ---
 
@@ -65,15 +63,15 @@ Wired but intentionally off in this fork. No Monetarium adjustment required unle
 
 Permanent redirects — no template content of their own, but they target pages on the active list above.
 
-| URL | Target |
-|---|---|
-| `/rejects` | `/disapproved` |
-| `/stats` | `/` |
-| `/explorer/` (legacy mount) | `/blocks` |
-| `/explorer/block/{x}` | `/block/{x}` |
-| `/explorer/tx/{x}` | `/tx/{x}` |
-| `/explorer/address/{x}` | `/address/{x}` |
-| `/explorer/decodetx` | `/decodetx` |
+| URL                         | Target         |
+| --------------------------- | -------------- |
+| `/rejects`                  | `/disapproved` |
+| `/stats`                    | `/`            |
+| `/explorer/` (legacy mount) | `/blocks`      |
+| `/explorer/block/{x}`       | `/block/{x}`   |
+| `/explorer/tx/{x}`          | `/tx/{x}`      |
+| `/explorer/address/{x}`     | `/address/{x}` |
+| `/explorer/decodetx`        | `/decodetx`    |
 
 ---
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -126,6 +126,15 @@ _The `/parameters` page: active-network consensus config. Mostly static `chaincf
 - patterns: code-analysis/parameters/patterns.md — near-static chaincfg.Params page: dual-source commonData/ExtendedParams split, hardcoded network-name prefix table, VAR-only subsidy rows, unchecked MaximumBlockSizes[0] fallback
 - impact: code-analysis/parameters/impact.md — commonData nil → .ChainParams deref crash, silent blank/misaligned address-prefix table on unknown network, stale/empty-slice MaximumBlockSize, unlocked pageData.BlockchainInfo race
 
+### Agendas — DORMANT (re-enablable, not removed)
+
+_The `/agendas` + `/agenda/{id}` consensus-deployment voting pages. HTML routes are currently stubbed to **HTTP 410** ([cmd/dcrdata/main.go:780-785](../cmd/dcrdata/main.go#L780-L785), commit `52ea3cf1`), but — unlike `/treasury` and `/market` — the handlers, the JSON API (`/api/agendas`, `/api/agenda/{id}`, still live), and the full DB pipeline (`agenda_votes` populated by `insertVotes` during `StoreBlock`) are intact and functional. Dual-source data: live metadata/progress from node RPC (`gov/agendas.AgendaDB` BoltDB + `VoteTracker`), historical tallies from Postgres. **Coin-agnostic** — vote counts/percentages/heights only, no VAR/SKA amounts, so C1/C3/C7 do not apply and **no multi-coin adaptation is needed**. Node support confirmed in `monetarium-node@v1.3.10` (mainnet 48 / testnet 52 agenda IDs). Re-enable = revert 2 route lines + re-add the navbar link._
+
+- flow (compact): code-analysis/agendas/flow.compact.md — dormant-stub status, dual-source flow, why no multi-coin work is needed, re-enable mutation checklist
+- flow (full): code-analysis/agendas/flow.full.md — end-to-end trace: node RPC → gov/agendas (BoltDB + VoteTracker) + db/dcrpg agenda_votes → handlers → templates → JS; node-support evidence; silent/hard failures
+- patterns: code-analysis/agendas/patterns.md — dormant-feature route stub (handler+pipeline retained), dual-source governance data (RPC-live + Postgres-historical), coin-agnostic feature (precision rules N/A)
+- impact: code-analysis/agendas/impact.md — re-enable blast radius: orphaned-page nav gap, empty forward-only vote charts, VoteTracker startup dep, choice-ID/JSON-tag drift, milestone unavailability, market-removal-spec reconciliation
+
 ### Sidechain
 
 _The `/side` page: read-only HTML table of every block with `is_mainchain=false`. Single SQL query (`blocks JOIN block_chain`), no WebSocket, no Stimulus, no amounts — the simplest page-rendering shape in the codebase. Writers are two independent paths: startup `ImportSideChains` (off by default, inserts rows) and live reorg `TipToSideChain` (flips existing rows). `BlockStatus` is shared with 3 sibling endpoints (`/disapproved`, `/block/{hash}` status, height-keyed status) each Scanning a different column subset — positional Scan invariant._


### PR DESCRIPTION
## What

Documentation-only. Adds a code-analysis trace for the `/agendas` + `/agenda/{id}`
consensus-deployment voting pages and wires it into the wiki index. Also corrects the
`/agendas` entry in `core/pages.md` (whitespace reformat of the page tables came along
with it).

New files under `wiki/code-analysis/agendas/`:
- `flow.full.md` — Sections 1–8: end-to-end dual-source trace (node RPC → `gov/agendas`
  BoltDB + `VoteTracker` and `db/dcrpg` `agenda_votes` → handlers → templates → JS),
  node-support evidence, silent/hard failure modes, re-enable steps.
- `flow.compact.md` — Section 9 LLM-optimized summary + mutation checklist.
- `patterns.md` — dormant-feature route stub, dual-source governance data, coin-agnostic feature.
- `impact.md` — re-enable blast radius (orphaned nav, forward-only vote charts, VoteTracker
  startup dep, choice-ID/JSON-tag drift, milestone unavailability).

## Key finding

`/agendas` is **dormant, not removed**. The HTML routes return HTTP 410
(`cmd/dcrdata/main.go:780-785`, stubbed in `52ea3cf1` alongside treasury/proposals), but the
handlers, the JSON API (`/api/agendas`, `/api/agenda/{id}` — still live), and the DB pipeline
(`agenda_votes` populated by `insertVotes` during `StoreBlock`) are all intact. Node support
is real: `monetarium-node@v1.3.10` defines consensus deployments (mainnet 48 / testnet 52
agenda IDs). The pages carry **no VAR/SKA amounts**, so C1/C3/C7 do not apply and no multi-coin
adaptation is needed. Re-enabling = revert the 2 route lines + re-add the navbar link.

This contradicted the prior `core/pages.md` claim that "Monetarium does not run on-chain
consensus voting," which this PR corrects.

## Not included

No code changes — this PR does not re-enable the routes; it documents the path to do so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)