### PR TITLE
db/cache, db/dcrpg, explorer: fix fees chart zeros, add per-coin SKA fee endpoint 

### DIFF
--- a/cmd/dcrdata/internal/api/apirouter.go
+++ b/cmd/dcrdata/internal/api/apirouter.go
@@ -232,6 +232,8 @@ func NewAPIRouter(app *appContext, JSONIndent string, useRealIP, compressLarge b
 	mux.Route("/chart", func(r chi.Router) {
 		// Handle coin-supply/N pattern (SKA coin types)
 		r.With(m.CoinSupplyChartTypeCtx).Get("/coin-supply/{charttype}", app.ChartTypeData)
+		// Handle fees/N pattern (per-coin fee charts)
+		r.With(m.SKAFeeChartTypeCtx).Get("/fees/{charttype}", app.ChartTypeData)
 		// Handle standard single-segment chart types
 		r.With(m.ChartTypeCtx).Get("/{charttype}", app.ChartTypeData)
 	})

--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -110,6 +110,7 @@ type DataSource interface {
 	GetAddressTransactionsRawWithSkip(ctx context.Context, addr string, count, skip int) []*apitypes.AddressTxRaw
 	GetMempoolPriceCountTime() *apitypes.PriceCountTime
 	LoadSKASupplyForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
+	LoadSKAFeesForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
 }
 
 // dcrdata application context used by all route handlers
@@ -1911,6 +1912,27 @@ func (c *appContext) ChartTypeData(w http.ResponseWriter, r *http.Request) {
 			if reload {
 				if err := c.DataSource.LoadSKASupplyForCoin(r.Context(), c.charts, coinType); err != nil {
 					log.Warnf("ChartTypeData: failed to load SKA supply for coin type %d: %v", coinType, err)
+				}
+			}
+		}
+	}
+
+	// Check if this is an SKA fee chart and if data needs to be loaded
+	if c.charts != nil && cache.IsSKAFeeChart(chartType) {
+		coinType := cache.FeeCoinType(chartType)
+		if coinType > 0 {
+			reload := !c.charts.SKAFeesExists(coinType)
+			if currHeight, err := c.DataSource.GetHeight(r.Context()); err == nil {
+				if cachedHeight, ok := c.charts.SKAFeesHeight(coinType); !ok || currHeight-cachedHeight > skaSupplyStaleHeightThreshold {
+					reload = true
+				}
+			} else {
+				log.Warnf("ChartTypeData: failed to get current height: %v", err)
+			}
+
+			if reload {
+				if err := c.DataSource.LoadSKAFeesForCoin(r.Context(), c.charts, coinType); err != nil {
+					log.Warnf("ChartTypeData: failed to load SKA fees for coin type %d: %v", coinType, err)
 				}
 			}
 		}

--- a/cmd/dcrdata/internal/api/noop_ds_test.go
+++ b/cmd/dcrdata/internal/api/noop_ds_test.go
@@ -127,3 +127,6 @@ func (noopDS) GetMempoolPriceCountTime() *apitypes.PriceCountTime { return nil }
 func (noopDS) LoadSKASupplyForCoin(_ context.Context, _ *cache.ChartData, _ uint8) error {
 	return nil
 }
+func (noopDS) LoadSKAFeesForCoin(_ context.Context, _ *cache.ChartData, _ uint8) error {
+	return nil
+}

--- a/cmd/dcrdata/internal/middleware/apimiddleware.go
+++ b/cmd/dcrdata/internal/middleware/apimiddleware.go
@@ -792,6 +792,17 @@ func ChartTypeCtx(next http.Handler) http.Handler {
 	})
 }
 
+// SKAFeeChartTypeCtx returns a http.HandlerFunc that embeds "fees/" + {charttype}
+// into the request context for handling fees/N requests.
+func SKAFeeChartTypeCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		charttype := chi.URLParam(r, "charttype")
+		ctx := context.WithValue(r.Context(), ctxChartType,
+			"fees/"+charttype)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 // CoinSupplyChartTypeCtx returns a http.HandlerFunc that embeds "coin-supply/" + {charttype}
 // into the request context for handling coin-supply/N requests.
 func CoinSupplyChartTypeCtx(next http.Handler) http.Handler {

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -68,6 +68,10 @@ function isCoinSupplyChart(name) {
   return name === 'coin-supply' || (typeof name === 'string' && name.startsWith('coin-supply/'))
 }
 
+function isSKAFeeChart(name) {
+  return typeof name === 'string' && /^fees\/[1-9]\d*$/.test(name)
+}
+
 function formatSkaAtomsExact(atomStr) {
   const p = splitSkaAtomsNoTrailing(atomStr, true, 0)
   return p.rest ? `${p.intPart}.${p.rest}` : p.intPart
@@ -475,7 +479,7 @@ export default class extends Controller {
     const isSKA = isSKASupplyChart(chartName)
     const coinType = skaCoinTypeFromChart(chartName)
     const coinLabel = isSKA ? renderCoinType(coinType) : 'VAR'
-    const switchKey = isCoinSupplyChart(chartName) ? 'coin-supply' : chartName
+    const switchKey = isCoinSupplyChart(chartName) ? 'coin-supply' : isSKAFeeChart(chartName) ? 'fees' : chartName
 
     switch (switchKey) {
       case 'ticket-price': // price graph
@@ -646,6 +650,25 @@ export default class extends Controller {
         break
 
       case 'fees': // block fee graph
+        if (isSKAFeeChart(chartName)) {
+          const coinType = parseInt(chartName.split('/')[1], 10)
+          const coinLabel = renderCoinType(coinType)
+          this._skaFeeRaw = data.fees
+          const ys = data.fees.map((s) => Number(s) * 1e-18)
+          d = zip2D(data, ys)
+          assign(
+            gOptions,
+            mapDygraphOptions(d, [xlabel, 'Total Fee'], false, `Total Fee (${coinLabel})`, true, false)
+          )
+          yFormatter = (div, data, i) => {
+            const raw = this._skaFeeRaw && this._skaFeeRaw[i]
+            const exact = raw != null ? formatSkaAtomsExact(raw) : data.series[0].y.toString()
+            div.appendChild(
+              legendEntry(`${data.series[0].dashHTML} ${data.series[0].labelHTML}: ${exact} ${coinLabel}`)
+            )
+          }
+          break
+        }
         d = zip2D(data, data.fees, atomsToVAR)
         assign(
           gOptions,

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -479,7 +479,11 @@ export default class extends Controller {
     const isSKA = isSKASupplyChart(chartName)
     const coinType = skaCoinTypeFromChart(chartName)
     const coinLabel = isSKA ? renderCoinType(coinType) : 'VAR'
-    const switchKey = isCoinSupplyChart(chartName) ? 'coin-supply' : isSKAFeeChart(chartName) ? 'fees' : chartName
+    const switchKey = isCoinSupplyChart(chartName)
+      ? 'coin-supply'
+      : isSKAFeeChart(chartName)
+        ? 'fees'
+        : chartName
 
     switch (switchKey) {
       case 'ticket-price': // price graph
@@ -658,13 +662,22 @@ export default class extends Controller {
           d = zip2D(data, ys)
           assign(
             gOptions,
-            mapDygraphOptions(d, [xlabel, 'Total Fee'], false, `Total Fee (${coinLabel})`, true, false)
+            mapDygraphOptions(
+              d,
+              [xlabel, 'Total Fee'],
+              false,
+              `Total Fee (${coinLabel})`,
+              true,
+              false
+            )
           )
           yFormatter = (div, data, i) => {
             const raw = this._skaFeeRaw && this._skaFeeRaw[i]
             const exact = raw != null ? formatSkaAtomsExact(raw) : data.series[0].y.toString()
             div.appendChild(
-              legendEntry(`${data.series[0].dashHTML} ${data.series[0].labelHTML}: ${exact} ${coinLabel}`)
+              legendEntry(
+                `${data.series[0].dashHTML} ${data.series[0].labelHTML}: ${exact} ${coinLabel}`
+              )
             )
           }
           break

--- a/cmd/dcrdata/views/charts.tmpl
+++ b/cmd/dcrdata/views/charts.tmpl
@@ -32,7 +32,9 @@
                             <option value="pow-difficulty">PoW Difficulty</option>
                             <option value="coin-supply/0">Circulation (VAR)</option>
                             {{range $t := .ActiveSKATypes}}<option value="coin-supply/{{$t}}">Circulation (SKA{{$t}})</option>
-                             {{end}}<option value="fees">Fees</option>
+                             {{end}}<option value="fees">Fees (VAR)</option>
+                             {{range $t := .ActiveSKATypes}}<option value="fees/{{$t}}">Fees (SKA{{$t}})</option>
+                              {{end}}
                              <option value="duration-btw-blocks">Duration Between Blocks</option>
                             <option value="chainwork">Total Work</option>
                             <option value="hashrate">Hashrate</option>

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -1958,13 +1958,13 @@ func (charts *ChartData) skaFeeChart(chartID string, bin binLevel, axis axisType
 		return nil, fmt.Errorf("invalid SKA fee chart: %s", chartID)
 	}
 
-	charts.mtx.RLock()
+	charts.SKAFeesMtx.RLock()
 	if charts.SKAFees == nil {
-		charts.mtx.RUnlock()
+		charts.SKAFeesMtx.RUnlock()
 		return nil, fmt.Errorf("SKA fee data not initialized for coin type %d", coinType)
 	}
 	data, ok := charts.SKAFees[coinType]
-	charts.mtx.RUnlock()
+	charts.SKAFeesMtx.RUnlock()
 	if !ok || len(data.Fees) == 0 {
 		return nil, fmt.Errorf("no SKA fee data found for coin type %d", coinType)
 	}

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -62,6 +62,9 @@ const (
 
 	// SKA coin supply chart prefix (coin-supply/N where N is coin type)
 	SKASupplyPrefix = "coin-supply/"
+
+	// SKA fee chart prefix (fees/N where N is coin type)
+	SKAFeePrefix = "fees/"
 )
 
 // binLevel specifies the granularity of data.
@@ -108,6 +111,25 @@ func SkaCoinType(chartID string) uint8 {
 	return coinType
 }
 
+// IsSKAFeeChart checks if the chart ID is an SKA fee chart (fees/N).
+func IsSKAFeeChart(chartID string) bool {
+	return len(chartID) > len(SKAFeePrefix) && chartID[:len(SKAFeePrefix)] == SKAFeePrefix
+}
+
+// FeeCoinType extracts the coin type number from an SKA fee chart ID.
+// Returns 0 if the chart ID is invalid.
+func FeeCoinType(chartID string) uint8 {
+	if !IsSKAFeeChart(chartID) {
+		return 0
+	}
+	var coinType uint8
+	_, err := fmt.Sscanf(chartID[len(SKAFeePrefix):], "%d", &coinType)
+	if err != nil {
+		return 0
+	}
+	return coinType
+}
+
 // DefaultBinLevel will be used if a bin level is not specified to
 // (*ChartData).Chart (via empty string), or if the provided BinLevel is
 // invalid.
@@ -145,7 +167,7 @@ const (
 // cacheVersion helps detect when the cache data stored has changed its
 // structure or content. A change on the cache version results to recomputing
 // all the charts data a fresh thereby making the cache to hold the latest changes.
-var cacheVersion = semver.NewSemver(6, 3, 0)
+var cacheVersion = semver.NewSemver(6, 4, 0)
 
 // versionedCacheData defines the cache data contents to be written into a .gob file.
 type versionedCacheData struct {
@@ -334,6 +356,17 @@ type SKASupplyChartData struct {
 // SKASupplyData stores per-coin-type cumulative supply data (strings for precision).
 type SKASupplyData map[uint8]SKASupplyChartData
 
+// SKAFeeChartData holds per-block fee data for a single SKA coin type.
+// Fees are stored as exact-precision strings to preserve 18 decimal places.
+type SKAFeeChartData struct {
+	Heights    []int64
+	Timestamps []int64
+	Fees       []string
+}
+
+// SKAFeesData stores per-coin-type SKA fee data.
+type SKAFeesData map[uint8]SKAFeeChartData
+
 // Snip truncates the zoomSet to a provided length.
 func (set *zoomSet) Snip(length int) {
 	if length < 0 {
@@ -488,6 +521,9 @@ type ChartData struct {
 	SKASupply    SKASupplyData
 	// Lock() must be held when mutating SKASupply.
 	SKASupplyMtx sync.RWMutex
+	SKAFees      SKAFeesData
+	// Lock() must be held when mutating SKAFees.
+	SKAFeesMtx sync.RWMutex
 }
 
 // ValidateLengths checks that the length of all arguments is equal.
@@ -921,6 +957,34 @@ func (charts *ChartData) SKASupplyHeight(coinType uint8) (int64, bool) {
 	return data.Heights[len(data.Heights)-1], true
 }
 
+// SKAFeesExists checks if SKA fee data exists for the given coin type.
+func (charts *ChartData) SKAFeesExists(coinType uint8) bool {
+	if charts == nil {
+		return false
+	}
+	charts.SKAFeesMtx.RLock()
+	defer charts.SKAFeesMtx.RUnlock()
+	if charts.SKAFees == nil {
+		return false
+	}
+	data, ok := charts.SKAFees[coinType]
+	return ok && len(data.Fees) > 0
+}
+
+// SKAFeesHeight returns the height of the last recorded block for the given coin type.
+func (charts *ChartData) SKAFeesHeight(coinType uint8) (int64, bool) {
+	charts.SKAFeesMtx.RLock()
+	defer charts.SKAFeesMtx.RUnlock()
+	if charts.SKAFees == nil {
+		return 0, false
+	}
+	data, ok := charts.SKAFees[coinType]
+	if !ok || len(data.Heights) == 0 {
+		return 0, false
+	}
+	return data.Heights[len(data.Heights)-1], true
+}
+
 // PoolSizeTip is the height of the PoolSize data.
 func (charts *ChartData) PoolSizeTip() int32 {
 	charts.mtx.RLock()
@@ -1017,6 +1081,7 @@ func NewChartData(ctx context.Context, height uint32, chainParams *chaincfg.Para
 		cache:        make(map[string]*cachedChart),
 		updaters:     make([]ChartUpdater, 0),
 		SKASupply:    make(SKASupplyData),
+		SKAFees:      make(SKAFeesData),
 	}
 }
 
@@ -1105,6 +1170,10 @@ func (charts *ChartData) Chart(chartID, binString, axisString string) ([]byte, e
 		// Check if it's an SKA supply chart
 		if IsSKASupplyChart(chartID) {
 			return charts.skaSupplyChart(chartID, bin, axis)
+		}
+		// Check if it's an SKA fee chart
+		if IsSKAFeeChart(chartID) {
+			return charts.skaFeeChart(chartID, bin, axis)
 		}
 		return nil, UnknownChartErr
 	}
@@ -1879,6 +1948,96 @@ func (charts *ChartData) skaSupplyChart(chartID string, bin binLevel, axis axisT
 	return nil, InvalidBinErr
 }
 
+// skaFeeChart generates chart data for an SKA coin type's transaction fees.
+// Data is pre-loaded in the SKAFees map. Values are returned as exact-precision
+// strings to preserve 18 decimal places. coinType 0 is not handled here (it
+// uses the existing VAR fees path via the chartMakers registry).
+func (charts *ChartData) skaFeeChart(chartID string, bin binLevel, axis axisType) ([]byte, error) {
+	coinType := FeeCoinType(chartID)
+	if !IsSKAFeeChart(chartID) || coinType == 0 {
+		return nil, fmt.Errorf("invalid SKA fee chart: %s", chartID)
+	}
+
+	charts.mtx.RLock()
+	if charts.SKAFees == nil {
+		charts.mtx.RUnlock()
+		return nil, fmt.Errorf("SKA fee data not initialized for coin type %d", coinType)
+	}
+	data, ok := charts.SKAFees[coinType]
+	charts.mtx.RUnlock()
+	if !ok || len(data.Fees) == 0 {
+		return nil, fmt.Errorf("no SKA fee data found for coin type %d", coinType)
+	}
+
+	switch bin {
+	case BlockBin:
+		switch axis {
+		case HeightAxis:
+			resp := struct {
+				Bin  string   `json:"bin"`
+				Axis string   `json:"axis"`
+				H    []int64  `json:"h"`
+				Fees []string `json:"fees"`
+			}{
+				Bin:  string(bin),
+				Axis: string(axis),
+				H:    data.Heights,
+				Fees: data.Fees,
+			}
+			return json.Marshal(resp)
+		default:
+			resp := struct {
+				Bin  string   `json:"bin"`
+				Axis string   `json:"axis"`
+				H    []int64  `json:"h"`
+				T    []int64  `json:"t"`
+				Fees []string `json:"fees"`
+			}{
+				Bin:  string(bin),
+				Axis: string(axis),
+				H:    data.Heights,
+				T:    data.Timestamps,
+				Fees: data.Fees,
+			}
+			return json.Marshal(resp)
+		}
+	case DayBin:
+		timestamps, heights, values := aggregateSKAFees(data.Timestamps, data.Heights, data.Fees)
+		switch axis {
+		case HeightAxis:
+			resp := struct {
+				Bin  string   `json:"bin"`
+				Axis string   `json:"axis"`
+				H    []int64  `json:"h"`
+				Fees []string `json:"fees"`
+			}{
+				Bin:  string(bin),
+				Axis: string(axis),
+				H:    heights,
+				Fees: values,
+			}
+			return json.Marshal(resp)
+		default:
+			resp := struct {
+				Bin  string   `json:"bin"`
+				Axis string   `json:"axis"`
+				H    []int64  `json:"h"`
+				T    []int64  `json:"t"`
+				Fees []string `json:"fees"`
+			}{
+				Bin:  string(bin),
+				Axis: string(axis),
+				H:    heights,
+				T:    timestamps,
+				Fees: values,
+			}
+			return json.Marshal(resp)
+		}
+	}
+
+	return nil, InvalidBinErr
+}
+
 // skaSupplyChartData holds raw SKA supply data from the database.
 type skaSupplyChartData struct {
 	Heights []int64
@@ -1948,6 +2107,59 @@ func aggregateSKASupply(timestamps []int64, heights []int64, values []string) ([
 		dayTimestamps = append(dayTimestamps, day*86400)
 		dayHeights = append(dayHeights, d.height)
 		dayValues = append(dayValues, d.value.String())
+	}
+
+	return dayTimestamps, dayHeights, dayValues
+}
+
+// aggregateSKAFees aggregates per-block SKA fee data into daily bins by summing
+// fees within each day.
+func aggregateSKAFees(timestamps []int64, heights []int64, values []string) ([]int64, []int64, []string) {
+	if len(timestamps) == 0 {
+		return nil, nil, nil
+	}
+
+	type dailyData struct {
+		timestamp int64
+		height    int64
+		total     *big.Int
+	}
+	dailyMap := make(map[int64]*dailyData)
+
+	for i, t := range timestamps {
+		dayKey := t / 86400
+		if i >= len(values) || i >= len(heights) {
+			continue
+		}
+		v, ok := new(big.Int).SetString(values[i], 10)
+		if !ok {
+			continue
+		}
+		if d, exists := dailyMap[dayKey]; exists {
+			d.total.Add(d.total, v)
+		} else {
+			dailyMap[dayKey] = &dailyData{
+				timestamp: t - (t % 86400),
+				height:    heights[i],
+				total:     new(big.Int).Set(v),
+			}
+		}
+	}
+
+	dayKeys := make([]int64, 0, len(dailyMap))
+	for day := range dailyMap {
+		dayKeys = append(dayKeys, day)
+	}
+	sort.Slice(dayKeys, func(i, j int) bool { return dayKeys[i] < dayKeys[j] })
+
+	dayTimestamps := make([]int64, 0, len(dailyMap))
+	dayHeights := make([]int64, 0, len(dailyMap))
+	dayValues := make([]string, 0, len(dailyMap))
+	for _, day := range dayKeys {
+		d := dailyMap[day]
+		dayTimestamps = append(dayTimestamps, d.timestamp)
+		dayHeights = append(dayHeights, d.height)
+		dayValues = append(dayValues, d.total.String())
 	}
 
 	return dayTimestamps, dayHeights, dayValues

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -189,19 +189,20 @@ const (
 	// RetrieveVoutDbIDs = `SELECT unnest(vout_db_ids) FROM transactions WHERE id = $1;`
 	// RetrieveVoutDbID  = `SELECT vout_db_ids[$2] FROM transactions WHERE id = $1;`
 
-	// SelectFeesPerBlockAboveHeight fetches per-block VAR fee totals by
-	// summing -fees across all transactions and subtracting the block subsidy.
-	// LEFT JOINs from blocks so every block appears in the result.
-	// The fee per block is: SUM(-t.fees) - (PoW + PoS + developer subsidy).
-	// b.voters is returned so the caller can compute the subsidy via RewardsAtBlock.
+	// SelectFeesPerBlockAboveHeight fetches per-block VAR fee totals by summing
+	// the fees column of non-coinbase, non-vote, non-revocation, non-SSFee
+	// transactions. This matches the MiningFee computation used by the block
+	// explorer: SUM(fees) excluding coinbase (tree=0,block_index=0), votes
+	// (tx_type=2), revocations (tx_type=3), and SSFee distributions (103,104).
 	SelectFeesPerBlockAboveHeight = `
-		SELECT b.height, b.voters,
-			COALESCE(SUM(-t.fees), 0) AS fees
-		FROM blocks b
-		LEFT JOIN transactions t ON t.block_height = b.height AND t.is_mainchain
-		WHERE b.is_mainchain AND b.height > $1
-		GROUP BY b.height, b.voters
-		ORDER BY b.height;`
+		SELECT block_height, COALESCE(SUM(fees), 0) AS fees
+		FROM transactions
+		WHERE is_mainchain
+			AND block_height > $1
+			AND NOT (tree = 0 AND block_index = 0)
+			AND tx_type NOT IN (2, 3, 103, 104)
+		GROUP BY block_height
+		ORDER BY block_height;`
 
 	// SelectSKAFeesPerBlockAboveHeight fetches per-block SKA fee totals for a
 	// specific coin type from blocks.ssfee_totals (pow + pos per coin type).

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -200,17 +200,24 @@ const (
 
 	// SelectSKAFeesPerBlockAboveHeight fetches per-block SKA fee totals for a
 	// specific coin type (e.g. ska_fees->>'1' for SKA1). SSFee reward distributions
-	// (tx_type 103/104) are excluded. Joins blocks for timestamps.
+	// (tx_type 103/104) are excluded. LEFT JOINs from blocks so every block appears
+	// in the result — blocks with no matching transactions get 0 fees.
 	SelectSKAFeesPerBlockAboveHeight = `
-		SELECT t.block_height, b.time,
-			COALESCE(SUM(CAST(t.ska_fees->>$2 AS NUMERIC)), 0) AS fees
-		FROM transactions t
-		JOIN blocks b ON t.block_height = b.height AND b.is_mainchain
-		WHERE t.is_mainchain
-			AND t.block_height > $1
-			AND t.tx_type NOT IN (103, 104)
-			AND t.ska_fees ? $2
-		GROUP BY t.block_height, b.time
+		SELECT t.block_height, t.block_time,
+			COALESCE(fee_sum.fees::text, '0') AS fees
+		FROM (
+			SELECT height AS block_height, time AS block_time
+			FROM blocks
+			WHERE is_mainchain AND height > $1
+		) t
+		LEFT JOIN (
+			SELECT block_height, SUM(CAST(ska_fees->>$2 AS NUMERIC)) AS fees
+			FROM transactions
+			WHERE is_mainchain
+				AND tx_type NOT IN (103, 104)
+				AND ska_fees ? $2
+			GROUP BY block_height
+		) fee_sum ON t.block_height = fee_sum.block_height
 		ORDER BY t.block_height;`
 
 	SelectMixedTotalPerBlock = `

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -194,8 +194,24 @@ const (
 		FROM transactions
 		WHERE is_mainchain
 			AND block_height > $1
+			AND tx_type NOT IN (103, 104)
 		GROUP BY block_height
 		ORDER BY block_height;`
+
+	// SelectSKAFeesPerBlockAboveHeight fetches per-block SKA fee totals for a
+	// specific coin type (e.g. ska_fees->>'1' for SKA1). SSFee reward distributions
+	// (tx_type 103/104) are excluded. Joins blocks for timestamps.
+	SelectSKAFeesPerBlockAboveHeight = `
+		SELECT t.block_height, b.time,
+			COALESCE(SUM(CAST(t.ska_fees->>$2 AS NUMERIC)), 0) AS fees
+		FROM transactions t
+		JOIN blocks b ON t.block_height = b.height AND b.is_mainchain
+		WHERE t.is_mainchain
+			AND t.block_height > $1
+			AND t.tx_type NOT IN (103, 104)
+			AND t.ska_fees ? $2
+		GROUP BY t.block_height, b.time
+		ORDER BY t.block_height;`
 
 	SelectMixedTotalPerBlock = `
 		SELECT block_height AS block_height, 

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -189,36 +189,31 @@ const (
 	// RetrieveVoutDbIDs = `SELECT unnest(vout_db_ids) FROM transactions WHERE id = $1;`
 	// RetrieveVoutDbID  = `SELECT vout_db_ids[$2] FROM transactions WHERE id = $1;`
 
+	// SelectFeesPerBlockAboveHeight fetches per-block VAR fee totals by
+	// summing -fees across all transactions and subtracting the block subsidy.
+	// LEFT JOINs from blocks so every block appears in the result.
+	// The fee per block is: SUM(-t.fees) - (PoW + PoS + developer subsidy).
+	// b.voters is returned so the caller can compute the subsidy via RewardsAtBlock.
 	SelectFeesPerBlockAboveHeight = `
-		SELECT block_height, SUM(fees) AS fees
-		FROM transactions
-		WHERE is_mainchain
-			AND block_height > $1
-			AND tx_type NOT IN (103, 104)
-		GROUP BY block_height
-		ORDER BY block_height;`
+		SELECT b.height, b.voters,
+			COALESCE(SUM(-t.fees), 0) AS fees
+		FROM blocks b
+		LEFT JOIN transactions t ON t.block_height = b.height AND t.is_mainchain
+		WHERE b.is_mainchain AND b.height > $1
+		GROUP BY b.height, b.voters
+		ORDER BY b.height;`
 
 	// SelectSKAFeesPerBlockAboveHeight fetches per-block SKA fee totals for a
-	// specific coin type (e.g. ska_fees->>'1' for SKA1). SSFee reward distributions
-	// (tx_type 103/104) are excluded. LEFT JOINs from blocks so every block appears
-	// in the result — blocks with no matching transactions get 0 fees.
+	// specific coin type from blocks.ssfee_totals (pow + pos per coin type).
+	// LEFT JOINs from blocks so every block appears — blocks without SSFee
+	// get 0 fees.
 	SelectSKAFeesPerBlockAboveHeight = `
-		SELECT t.block_height, t.block_time,
-			COALESCE(fee_sum.fees::text, '0') AS fees
-		FROM (
-			SELECT height AS block_height, time AS block_time
-			FROM blocks
-			WHERE is_mainchain AND height > $1
-		) t
-		LEFT JOIN (
-			SELECT block_height, SUM(CAST(ska_fees->>$2 AS NUMERIC)) AS fees
-			FROM transactions
-			WHERE is_mainchain
-				AND tx_type NOT IN (103, 104)
-				AND ska_fees ? $2
-			GROUP BY block_height
-		) fee_sum ON t.block_height = fee_sum.block_height
-		ORDER BY t.block_height;`
+		SELECT b.height, b.time,
+			COALESCE(CAST(ssfee_totals->$2->>'pow' AS NUMERIC), 0) +
+			COALESCE(CAST(ssfee_totals->$2->>'pos' AS NUMERIC), 0) AS fees
+		FROM blocks b
+		WHERE b.is_mainchain AND b.height > $1
+		ORDER BY b.height;`
 
 	SelectMixedTotalPerBlock = `
 		SELECT block_height AS block_height, 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1146,6 +1146,21 @@ func (pgb *ChainDB) LoadSKASupplyForCoin(ctx context.Context, charts *cache.Char
 	return fmt.Errorf("no data found for coin type %d", coinType)
 }
 
+// LoadSKAFeesForCoin loads per-block SKA fee data for the specified coin type
+// into charts.SKAFees. Loads all available data (start height 0).
+func (pgb *ChainDB) LoadSKAFeesForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error {
+	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
+	defer cancel()
+
+	rows, err := retrieveSKAFees(ctx, pgb.db, charts, coinType)
+	if err != nil {
+		return fmt.Errorf("LoadSKAFeesForCoin: query failed for coin type %d: %w", coinType, err)
+	}
+	defer rows.Close()
+
+	return appendSKAFees(charts, rows, coinType)
+}
+
 // appears, along with the index of the transaction in each of the blocks. The
 // next and previous block hashes are NOT SET in each BlockStatus.
 func (pgb *ChainDB) TransactionBlocks(ctx context.Context, txHash string) ([]*dbtypes.BlockStatus, []uint32, error) {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1152,7 +1152,7 @@ func (pgb *ChainDB) LoadSKAFeesForCoin(ctx context.Context, charts *cache.ChartD
 	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
 	defer cancel()
 
-	rows, err := retrieveSKAFees(ctx, pgb.db, charts, coinType)
+	rows, err := retrieveSKAFees(ctx, pgb.db, coinType)
 	if err != nil {
 		return fmt.Errorf("LoadSKAFeesForCoin: query failed for coin type %d: %w", coinType, err)
 	}

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -980,7 +980,7 @@ func (pgb *ChainDB) RegisterCharts(charts *cache.ChartData) {
 	charts.AddUpdater(cache.ChartUpdater{
 		Tag:      "fees",
 		Fetcher:  pgb.blockFees,
-		Appender: appendBlockFees,
+		Appender: pgb.appendBlockFees,
 	})
 
 	charts.AddUpdater(cache.ChartUpdater{

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -980,7 +980,7 @@ func (pgb *ChainDB) RegisterCharts(charts *cache.ChartData) {
 	charts.AddUpdater(cache.ChartUpdater{
 		Tag:      "fees",
 		Fetcher:  pgb.blockFees,
-		Appender: pgb.appendBlockFees,
+		Appender: appendBlockFees,
 	})
 
 	charts.AddUpdater(cache.ChartUpdater{

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1156,8 +1156,6 @@ func (pgb *ChainDB) LoadSKAFeesForCoin(ctx context.Context, charts *cache.ChartD
 	if err != nil {
 		return fmt.Errorf("LoadSKAFeesForCoin: query failed for coin type %d: %w", coinType, err)
 	}
-	defer rows.Close()
-
 	return appendSKAFees(charts, rows, coinType)
 }
 

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3624,30 +3624,17 @@ func retrieveBlockFees(ctx context.Context, db *sql.DB, charts *cache.ChartData)
 
 // Append the result from retrieveBlockFees to the provided ChartData. This
 // is the Appender half of a pair that make up a cache.ChartUpdater.
-// Fee per block = SUM(-t.fees) - total_subsidy(PoW + PoS + developer).
-func (pgb *ChainDB) appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
+func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 	defer rows.Close()
 	blocks := charts.Blocks
 	for rows.Next() {
 		var blockHeight uint64
-		var voters uint16
 		var fees int64
-		if err := rows.Scan(&blockHeight, &voters, &fees); err != nil {
+		if err := rows.Scan(&blockHeight, &fees); err != nil {
 			log.Errorf("Unable to scan for FeeInfoPerBlock fields: %v", err)
 			return err
 		}
-
-		// Subtract the block subsidy to isolate actual fee revenue.
-		// SUM(-t.fees) across all transactions includes the subsidy
-		// contributed by both the coinbase and SSFee transactions.
-		subsidy := pgb.BlockSubsidy(context.TODO(), int64(blockHeight), voters)
-		totalSubsidy := subsidy.PoW + subsidy.PoS + subsidy.Developer
-		fee := fees - totalSubsidy
-		if fee < 0 {
-			fee = 0
-		}
-
-		blocks.Fees = append(blocks.Fees, uint64(fee))
+		blocks.Fees = append(blocks.Fees, uint64(fees))
 	}
 	return rows.Err()
 }

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3634,14 +3634,57 @@ func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 			log.Errorf("Unable to scan for FeeInfoPerBlock fields: %v", err)
 			return err
 		}
-		if fees < 0 {
-			fees *= -1
-		}
 
 		// Converting to atoms.
 		blocks.Fees = append(blocks.Fees, uint64(fees))
 	}
 	return rows.Err()
+}
+
+// retrieveBlockFees retrieves per-block SKA fee data above the tip for a given
+// coin type. This is the Fetcher half of a pair that make up a cache.ChartUpdater.
+func retrieveSKAFees(ctx context.Context, db *sql.DB, charts *cache.ChartData, coinType uint8) (*sql.Rows, error) {
+	rows, err := db.QueryContext(ctx, internal.SelectSKAFeesPerBlockAboveHeight, 0 /* startHeight */, strconv.FormatUint(uint64(coinType), 10))
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// appendSKAFees appends the results from retrieveSKAFees to the provided
+// ChartData. This is the Appender half of a pair that make up a cache.ChartUpdater.
+func appendSKAFees(charts *cache.ChartData, rows *sql.Rows, coinType uint8) error {
+	defer rows.Close()
+	var heights []int64
+	var timestamps []int64
+	var fees []string
+	for rows.Next() {
+		var blockHeight uint64
+		var blockTime time.Time
+		var fee string
+		if err := rows.Scan(&blockHeight, &blockTime, &fee); err != nil {
+			log.Errorf("Unable to scan for SKA fee fields: %v", err)
+			return err
+		}
+		heights = append(heights, int64(blockHeight))
+		timestamps = append(timestamps, blockTime.Unix())
+		fees = append(fees, fee)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	charts.SKAFeesMtx.Lock()
+	if charts.SKAFees == nil {
+		charts.SKAFees = make(map[uint8]cache.SKAFeeChartData)
+	}
+	charts.SKAFees[coinType] = cache.SKAFeeChartData{
+		Heights:    heights,
+		Timestamps: timestamps,
+		Fees:       fees,
+	}
+	charts.SKAFeesMtx.Unlock()
+	return nil
 }
 
 // retrievePrivacyParticipation retrieves the sum of all mixed vouts that is

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3624,25 +3624,37 @@ func retrieveBlockFees(ctx context.Context, db *sql.DB, charts *cache.ChartData)
 
 // Append the result from retrieveBlockFees to the provided ChartData. This
 // is the Appender half of a pair that make up a cache.ChartUpdater.
-func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
+// Fee per block = SUM(-t.fees) - total_subsidy(PoW + PoS + developer).
+func (pgb *ChainDB) appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 	defer rows.Close()
 	blocks := charts.Blocks
 	for rows.Next() {
 		var blockHeight uint64
+		var voters uint16
 		var fees int64
-		if err := rows.Scan(&blockHeight, &fees); err != nil {
+		if err := rows.Scan(&blockHeight, &voters, &fees); err != nil {
 			log.Errorf("Unable to scan for FeeInfoPerBlock fields: %v", err)
 			return err
 		}
 
-		// Converting to atoms.
-		blocks.Fees = append(blocks.Fees, uint64(fees))
+		// Subtract the block subsidy to isolate actual fee revenue.
+		// SUM(-t.fees) across all transactions includes the subsidy
+		// contributed by both the coinbase and SSFee transactions.
+		subsidy := pgb.BlockSubsidy(context.TODO(), int64(blockHeight), voters)
+		totalSubsidy := subsidy.PoW + subsidy.PoS + subsidy.Developer
+		fee := fees - totalSubsidy
+		if fee < 0 {
+			fee = 0
+		}
+
+		blocks.Fees = append(blocks.Fees, uint64(fee))
 	}
 	return rows.Err()
 }
 
-// retrieveBlockFees retrieves per-block SKA fee data above the tip for a given
-// coin type. This is the Fetcher half of a pair that make up a cache.ChartUpdater.
+// retrieveSKAFees retrieves per-block SKA fee data above the tip for a given
+// coin type from blocks.ssfee_totals (pow + pos). This is the Fetcher half of
+// a pair that make up a cache.ChartUpdater.
 func retrieveSKAFees(ctx context.Context, db *sql.DB, charts *cache.ChartData, coinType uint8) (*sql.Rows, error) {
 	rows, err := db.QueryContext(ctx, internal.SelectSKAFeesPerBlockAboveHeight, 0 /* startHeight */, strconv.FormatUint(uint64(coinType), 10))
 	if err != nil {
@@ -3653,6 +3665,7 @@ func retrieveSKAFees(ctx context.Context, db *sql.DB, charts *cache.ChartData, c
 
 // appendSKAFees appends the results from retrieveSKAFees to the provided
 // ChartData. This is the Appender half of a pair that make up a cache.ChartUpdater.
+// Fee per block = ssfee_totals[coinType].pow + ssfee_totals[coinType].pos.
 func appendSKAFees(charts *cache.ChartData, rows *sql.Rows, coinType uint8) error {
 	defer rows.Close()
 	var heights []int64

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3655,7 +3655,7 @@ func (pgb *ChainDB) appendBlockFees(charts *cache.ChartData, rows *sql.Rows) err
 // retrieveSKAFees retrieves per-block SKA fee data above the tip for a given
 // coin type from blocks.ssfee_totals (pow + pos). This is the Fetcher half of
 // a pair that make up a cache.ChartUpdater.
-func retrieveSKAFees(ctx context.Context, db *sql.DB, charts *cache.ChartData, coinType uint8) (*sql.Rows, error) {
+func retrieveSKAFees(ctx context.Context, db *sql.DB, coinType uint8) (*sql.Rows, error) {
 	rows, err := db.QueryContext(ctx, internal.SelectSKAFeesPerBlockAboveHeight, 0 /* startHeight */, strconv.FormatUint(uint64(coinType), 10))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Problem                                                                                                                                                                
                                                                                                                                                                         
  GET /api/chart/fees returned [0, 0, 0, ...] for all blocks. Two root causes:                                                                                           
                                                                                                                                                                         
  1. The SUM(-t.fees) - BlockSubsidy formula was algebraically self-cancelling on pre-PoS blocks: the coinbase stores fees = -(subsidy + collected_fees), so SUM(-t.fees)
  = subsidy, and subtracting the subsidy gives exactly 0.                                                                                                                
  2. SSFee reward-distribution transactions (tx_type 103/104) were included in the sum, further corrupting results on post-PoS blocks.                                   
  3. SKA transaction fees were completely ignored — no per-coin-type fee chart existed.                                                                                  
                                                                                                                                                                         
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                                                                         
  Changes                                                                                                                                                                
                                                                                                                                                                         
  VAR fee chart fix (`/api/chart/fees`)                                                                                                                                  
                                                                                                                                                                         
  Computes fees the same way the block explorer's Fees header does via MiningFee: SUM(fees) excluding coinbase (tree=0, block_index=0), votes (tx_type=2), revocations   
  (tx_type=3), and SSFee distributions (tx_type=103, 104). appendBlockFees reverts to a plain free function — the pgb receiver and BlockSubsidy RPC call are no longer   
  needed.                                                                                                                                                                
                                                                                                                                                                         
  New per-coin SKA fee endpoint (`/api/chart/fees/{N}`)                                                                                                                  
                                                                                                                                                                         
  - New route GET /api/chart/fees/{N} serving per-coin SKA fee charts (e.g. /api/chart/fees/1 for SKA1).                                                                 
  - SQL reads ssfee_totals->N->>'pow' + ssfee_totals->N->>'pos' from the blocks table.                                                                                   
  - SKAFeeChartData / SKAFeesData added to ChartData; lazy-loaded on first request via LoadSKAFeesForCoin, same pattern as SKA supply charts.                            
  - Supports bin=block and bin=day, axis=time and axis=height. Values returned as exact-precision strings (18 decimal places).                                           
  - skaFeeChart reads SKAFees under SKAFeesMtx.RLock(), correctly matching the writer.                                                                                   
                                                                                                                                                                         
  Frontend                                                                                                                                                               
                                                                                                                                                                         
  - SKA fee options added to the charts dropdown in charts.tmpl.                                                                                                         
  - charts_controller.js gains an isSKAFeeChart helper and a rendering branch that handles big-integer precision strings.                                                
  - Note: chart Y-axis and rendering use Number(s) * 1e-18 which loses significand bits for large SKA atom values. The hover tooltip uses formatSkaAtomsExact and remains
  precise. This is the same trade-off accepted for coin-supply charts — visualization accuracy is sufficient, exact values are available on hover.                       
                                                                                                                                                                         
  Testing                                                                                                                                                                
                                                                                                                                                                         
  Verified on mainnet (pre-PoS, height ~2412) and testnet (post-PoS): GET /api/chart/fees?bin=block&axis=time returns non-zero values matching the Fees field on         
  individual block pages. SKA fee charts return correct per-block data for active coin types on testnet.           