### PR TITLE
db/dcrpg: fix zero Fees chart by excluding coinbase from per-block sum

### DIFF
--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -145,7 +145,14 @@ const (
 // cacheVersion helps detect when the cache data stored has changed its
 // structure or content. A change on the cache version results to recomputing
 // all the charts data a fresh thereby making the cache to hold the latest changes.
-var cacheVersion = semver.NewSemver(6, 3, 0)
+//
+// 6.4.0: issue #405 fixed SelectFeesPerBlockAboveHeight so per-block Fees no
+// longer cancel to zero against the coinbase. Already-synced deployments cached
+// the wrong (all-zero) Fees series; bumping the version forces a full recompute
+// of the charts cache on next start so the corrected query reruns over every
+// block. No database resync or backfill is needed — transactions.fees was
+// always stored correctly.
+var cacheVersion = semver.NewSemver(6, 4, 0)
 
 // versionedCacheData defines the cache data contents to be written into a .gob file.
 type versionedCacheData struct {

--- a/db/dbtypes/extraction_test.go
+++ b/db/dbtypes/extraction_test.go
@@ -178,6 +178,93 @@ func Test_processTransactions_VAROnly(t *testing.T) {
 	}
 }
 
+// Test_processTransactions_FeeCancellationInvariant pins the storage invariant
+// behind the issue #405 Fees-chart fix. transactions.fees is stored as
+// spent - sent, so the coinbase — which mints the block subsidy and emits the
+// block's collected fees as outputs — carries a NEGATIVE fee equal to -(all
+// real fees in the block). Summing every tx in a block (as the old chart query
+// did) cancels the real fees against the coinbase to exactly zero.
+//
+// The Block# header instead reports getTotalFee(block.Tx) +
+// getTotalFee(block.Tickets) — regular-tree non-coinbase txs plus ticket
+// purchases. SelectFeesPerBlockAboveHeight must match that by excluding the
+// coinbase, which is identified as (tree 0, block_index 0); this test asserts
+// the coinbase indeed lands at block_index 0 so that predicate is sound.
+func Test_processTransactions_FeeCancellationInvariant(t *testing.T) {
+	const (
+		subsidy    = 1_000_000
+		regularFee = 100
+		ticketFee  = 50
+		blockFees  = regularFee + ticketFee // 150 — the per-block header/chart value
+	)
+
+	// Regular tree: coinbase (absorbs ALL block fees as outputs) + one VAR tx.
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: math.MaxUint32}, subsidy, nil))
+	coinbase.AddTxOut(wire.NewTxOut(subsidy+blockFees, nil))
+
+	regular := wire.NewMsgTx()
+	regular.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 1000, nil))
+	regular.AddTxOut(wire.NewTxOut(1000-regularFee, nil))
+
+	regBlk := &wire.MsgBlock{}
+	regBlk.Transactions = []*wire.MsgTx{coinbase, regular}
+	regTxs, _, _ := processTransactions(regBlk, wire.TxTreeRegular, chaincfg.SimNetParams(), true, true)
+	if len(regTxs) != 2 {
+		t.Fatalf("regular tree: expected 2 txs, got %d", len(regTxs))
+	}
+
+	// Stake tree: one ticket purchase with a real positive fee.
+	ticket := wire.NewMsgTx()
+	ticket.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 2000+ticketFee, nil))
+	ticket.AddTxOut(wire.NewTxOut(2000, opSSTXP2PKH()))
+
+	stakeBlk := &wire.MsgBlock{}
+	stakeBlk.STransactions = []*wire.MsgTx{ticket}
+	stakeTxs, _, _ := processTransactions(stakeBlk, wire.TxTreeStake, chaincfg.SimNetParams(), true, true)
+	if len(stakeTxs) != 1 {
+		t.Fatalf("stake tree: expected 1 tx, got %d", len(stakeTxs))
+	}
+
+	cb, reg, tkt := regTxs[0], regTxs[1], stakeTxs[0]
+
+	// The coinbase must sit at block_index 0 — the SQL predicate relies on it.
+	if cb.BlockIndex != 0 {
+		t.Errorf("coinbase BlockIndex: want 0, got %d", cb.BlockIndex)
+	}
+	if reg.BlockIndex != 1 {
+		t.Errorf("regular tx BlockIndex: want 1, got %d", reg.BlockIndex)
+	}
+
+	// Per-tx fees: coinbase negative, regular and ticket positive.
+	if cb.Fees != -blockFees {
+		t.Errorf("coinbase Fees: want %d, got %d", -blockFees, cb.Fees)
+	}
+	if reg.Fees != regularFee {
+		t.Errorf("regular Fees: want %d, got %d", regularFee, reg.Fees)
+	}
+	if tkt.TxType != TxTypeTicketPurchase {
+		t.Errorf("ticket TxType: want %d (TicketPurchase), got %d", TxTypeTicketPurchase, tkt.TxType)
+	}
+	if tkt.Fees != ticketFee {
+		t.Errorf("ticket Fees: want %d, got %d", ticketFee, tkt.Fees)
+	}
+
+	// The bug: summing every tx including the coinbase cancels to zero.
+	if got := cb.Fees + reg.Fees + tkt.Fees; got != 0 {
+		t.Errorf("sum over all txs incl. coinbase: want 0 (the bug's cancellation), got %d", got)
+	}
+	// The fix: summing the header set (regular non-coinbase + tickets) yields
+	// the real per-block fee.
+	if got := reg.Fees + tkt.Fees; got != blockFees {
+		t.Errorf("sum excluding coinbase: want %d, got %d", blockFees, got)
+	}
+	// The coinbase carries exactly the negative of the real fees.
+	if cb.Fees != -(reg.Fees + tkt.Fees) {
+		t.Errorf("coinbase fee should equal -(real fees): want %d, got %d", -(reg.Fees + tkt.Fees), cb.Fees)
+	}
+}
+
 func Test_processTransactions_SKAOnly(t *testing.T) {
 	// SKA1 amount exceeding int64 max: 2^63 + 1
 	bigAmt := new(big.Int).Add(new(big.Int).SetInt64(1<<62), big.NewInt(1<<62))

--- a/db/dcrpg/fee_clamp_test.go
+++ b/db/dcrpg/fee_clamp_test.go
@@ -1,0 +1,37 @@
+package dcrpg
+
+import (
+	"math"
+	"testing"
+)
+
+// TestClampNonNegativeFee pins the appendBlockFees invariant from issue #405:
+// per-block fee totals from SelectFeesPerBlockAboveHeight are non-negative (the
+// negative-fee coinbase and votes/stakebase are excluded by the query's
+// FILTER). A negative value is a data anomaly that must be clamped to 0 — not
+// abs()'d into a misleading spike, and not turned into an error that would abort
+// the whole charts update mid-pipeline and desync the block series. ok reports
+// whether the value was already valid so the caller can warn on anomalies.
+func TestClampNonNegativeFee(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     int64
+		want   uint64
+		wantOK bool
+	}{
+		{"positive passes through", 19500, 19500, true},
+		{"zero passes through", 0, 0, true},
+		{"max int64 passes through", math.MaxInt64, math.MaxInt64, true},
+		{"negative clamps to zero and flags anomaly", -19500, 0, false},
+		{"min int64 clamps to zero (no wrap)", math.MinInt64, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := clampNonNegativeFee(tc.in)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("clampNonNegativeFee(%d) = (%d, %v), want (%d, %v)",
+					tc.in, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}

--- a/db/dcrpg/fees_chart_test.go
+++ b/db/dcrpg/fees_chart_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/monetarium/monetarium-explorer/db/dbtypes"
 	"github.com/monetarium/monetarium-explorer/db/dcrpg/internal"
 )
 
@@ -43,32 +44,35 @@ func TestSelectFeesPerBlockExcludesCoinbase(t *testing.T) {
 		}
 	}
 
-	// Shadow the real transactions table with the columns the query touches.
+	// Shadow the real transactions table with the columns the query touches,
+	// matching their production types (see CreateTransactionTable).
 	mustExec(`CREATE TEMP TABLE transactions (
 		block_height INT8,
 		tree         INT2,
-		tx_type      INT2,
+		tx_type      INT4,
 		block_index  INT4,
 		fees         INT8,
 		is_mainchain BOOLEAN
 	) ON COMMIT DROP;`)
 
 	// One mainchain block (height 100) mirroring real mainnet rows:
-	//   - coinbase    (tree 0, index 0): fee = -(all collected fees)  <- the bug
-	//   - regular tx  (tree 0, index 1): fee  13460
-	//   - ticket buy  (tree 1, type 105): fee  3020
-	//   - ticket buy  (tree 1, type 105): fee  3020
-	// Block# header value = 13460 + 3020 + 3020 = 19500 atoms.
+	//   - coinbase    (tree 0, index 0):            fee = -(all collected fees)  <- the bug
+	//   - regular tx  (tree 0, index 1):            fee  13460
+	//   - ticket buy  (tree 1, TxTypeTicketPurchase): fee  3020
+	//   - ticket buy  (tree 1, TxTypeTicketPurchase): fee  3020
+	// Block# header value = 13460 + 3020 + 3020 = 19500 atoms. The ticket
+	// tx_type is bound from dbtypes.TxTypeTicketPurchase — the same constant the
+	// query interpolates — so the two stay tied to one source of truth.
 	const regularFee = 13460
 	const ticketFee = 3020
 	const realBlockFee = regularFee + 2*ticketFee // 19500
 	mustExec(`INSERT INTO transactions
 		(block_height, tree, tx_type, block_index, fees, is_mainchain) VALUES
-		(100, 0,   0, 0, $1, TRUE),
-		(100, 0,   0, 1, $2, TRUE),
-		(100, 1, 105, 0, $3, TRUE),
-		(100, 1, 105, 1, $3, TRUE);`,
-		-realBlockFee, regularFee, ticketFee)
+		(100, 0,  0, 0, $1, TRUE),
+		(100, 0,  0, 1, $2, TRUE),
+		(100, 1, $4, 0, $3, TRUE),
+		(100, 1, $4, 1, $3, TRUE);`,
+		-realBlockFee, regularFee, ticketFee, int(dbtypes.TxTypeTicketPurchase))
 
 	// Guard the premise: the naive SUM(fees) cancels to exactly zero, which is
 	// the symptom the chart exhibited. If this ever stops holding, the fix's

--- a/db/dcrpg/fees_chart_test.go
+++ b/db/dcrpg/fees_chart_test.go
@@ -1,0 +1,117 @@
+//go:build pgonline || chartdata
+
+package dcrpg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/monetarium/monetarium-explorer/db/dcrpg/internal"
+)
+
+// TestSelectFeesPerBlockExcludesCoinbase is a regression test for issue #405:
+// the Fees chart rendered zero for every mainnet block. The per-block query
+// SUM(fees) GROUP BY block_height summed transactions.fees over *all* txs in a
+// block, including the coinbase. A coinbase mints the block subsidy and emits
+// the collected fees as outputs, so with fees = spent - sent its stored fee is
+// negative and equal to -(sum of all real fees in the block). Summing it
+// alongside the real (positive) fees cancels them to exactly zero.
+//
+// The Block# page header instead reports getTotalFee(block.Tx) +
+// getTotalFee(block.Tickets) — regular-tree non-coinbase txs plus ticket
+// purchases, excluding coinbase/votes/stake fees (pgblockchain.go). The chart
+// must match that, so SelectFeesPerBlockAboveHeight must sum only that set.
+//
+// The test seeds one synthetic block into a session-local temp table that
+// shadows the real transactions table, then runs the exact production query.
+func TestSelectFeesPerBlockExcludesCoinbase(t *testing.T) {
+	ctx := context.Background()
+
+	// A transaction binds all statements to a single connection so the temp
+	// table is visible to the query, and ON COMMIT DROP cleans it up even if
+	// the test fails (we always Rollback).
+	tx, err := sqlDb.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	mustExec := func(q string, args ...interface{}) {
+		t.Helper()
+		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("exec failed: %v\nquery: %s", err, q)
+		}
+	}
+
+	// Shadow the real transactions table with the columns the query touches.
+	mustExec(`CREATE TEMP TABLE transactions (
+		block_height INT8,
+		tree         INT2,
+		tx_type      INT2,
+		block_index  INT4,
+		fees         INT8,
+		is_mainchain BOOLEAN
+	) ON COMMIT DROP;`)
+
+	// One mainchain block (height 100) mirroring real mainnet rows:
+	//   - coinbase    (tree 0, index 0): fee = -(all collected fees)  <- the bug
+	//   - regular tx  (tree 0, index 1): fee  13460
+	//   - ticket buy  (tree 1, type 105): fee  3020
+	//   - ticket buy  (tree 1, type 105): fee  3020
+	// Block# header value = 13460 + 3020 + 3020 = 19500 atoms.
+	const regularFee = 13460
+	const ticketFee = 3020
+	const realBlockFee = regularFee + 2*ticketFee // 19500
+	mustExec(`INSERT INTO transactions
+		(block_height, tree, tx_type, block_index, fees, is_mainchain) VALUES
+		(100, 0,   0, 0, $1, TRUE),
+		(100, 0,   0, 1, $2, TRUE),
+		(100, 1, 105, 0, $3, TRUE),
+		(100, 1, 105, 1, $3, TRUE);`,
+		-realBlockFee, regularFee, ticketFee)
+
+	// Guard the premise: the naive SUM(fees) cancels to exactly zero, which is
+	// the symptom the chart exhibited. If this ever stops holding, the fix's
+	// rationale (and this test) must be revisited.
+	var naive int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(fees), 0) FROM transactions WHERE is_mainchain AND block_height > 0`,
+	).Scan(&naive); err != nil {
+		t.Fatalf("naive sum query: %v", err)
+	}
+	if naive != 0 {
+		t.Fatalf("premise broken: expected naive SUM(fees)=0 (coinbase cancellation), got %d", naive)
+	}
+
+	// The production query must report the real per-block fee, not zero.
+	rows, err := tx.QueryContext(ctx, internal.SelectFeesPerBlockAboveHeight, int64(0))
+	if err != nil {
+		t.Fatalf("SelectFeesPerBlockAboveHeight: %v", err)
+	}
+	defer rows.Close()
+
+	var gotRows int
+	var gotHeight uint64
+	var gotFees int64
+	for rows.Next() {
+		gotRows++
+		if err := rows.Scan(&gotHeight, &gotFees); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+
+	// One row per block must be returned (appendBlockFees aligns blocks.Fees to
+	// block height by row order); the coinbase-only grouping must not drop it.
+	if gotRows != 1 {
+		t.Fatalf("expected exactly 1 block row, got %d", gotRows)
+	}
+	if gotHeight != 100 {
+		t.Errorf("block_height: want 100, got %d", gotHeight)
+	}
+	if gotFees != realBlockFee {
+		t.Errorf("issue #405: fees for block 100: want %d, got %d", realBlockFee, gotFees)
+	}
+}

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -189,8 +189,26 @@ const (
 	// RetrieveVoutDbIDs = `SELECT unnest(vout_db_ids) FROM transactions WHERE id = $1;`
 	// RetrieveVoutDbID  = `SELECT vout_db_ids[$2] FROM transactions WHERE id = $1;`
 
+	// SelectFeesPerBlockAboveHeight returns the per-block fee total for the Fees
+	// chart. It must equal the Block# page header value, which is
+	// getTotalFee(block.Tx) + getTotalFee(block.Tickets) (pgblockchain.go):
+	// regular-tree non-coinbase transactions plus ticket purchases.
+	//
+	// transactions.fees is stored as spent - sent, so the coinbase carries a
+	// negative fee (it mints the subsidy and emits collected fees as outputs)
+	// equal to -(all real fees in the block). A plain SUM(fees) therefore
+	// cancels to exactly zero for every block. The FILTER restricts the sum to
+	// the fee-bearing set the header counts: the coinbase (tree 0, index 0) and
+	// the stake tree's votes/revocations/stake-fees are excluded; only ticket
+	// purchases (tx_type 105, dbtypes.TxTypeTicketPurchase) contribute from the
+	// stake tree. COALESCE keeps fee-only-coinbase blocks at 0 rather than NULL.
+	// See issue #405.
 	SelectFeesPerBlockAboveHeight = `
-		SELECT block_height, SUM(fees) AS fees
+		SELECT block_height,
+			COALESCE(SUM(fees) FILTER (
+				WHERE (tree = 0 AND block_index > 0)
+					OR tx_type = 105
+			), 0) AS fees
 		FROM transactions
 		WHERE is_mainchain
 			AND block_height > $1

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -4,6 +4,12 @@
 
 package internal
 
+import (
+	"fmt"
+
+	"github.com/monetarium/monetarium-explorer/db/dbtypes"
+)
+
 // These queries relate primarily to the "transactions" table.
 const (
 	CreateTransactionTable = `CREATE TABLE IF NOT EXISTS transactions (
@@ -189,32 +195,6 @@ const (
 	// RetrieveVoutDbIDs = `SELECT unnest(vout_db_ids) FROM transactions WHERE id = $1;`
 	// RetrieveVoutDbID  = `SELECT vout_db_ids[$2] FROM transactions WHERE id = $1;`
 
-	// SelectFeesPerBlockAboveHeight returns the per-block fee total for the Fees
-	// chart. It must equal the Block# page header value, which is
-	// getTotalFee(block.Tx) + getTotalFee(block.Tickets) (pgblockchain.go):
-	// regular-tree non-coinbase transactions plus ticket purchases.
-	//
-	// transactions.fees is stored as spent - sent, so the coinbase carries a
-	// negative fee (it mints the subsidy and emits collected fees as outputs)
-	// equal to -(all real fees in the block). A plain SUM(fees) therefore
-	// cancels to exactly zero for every block. The FILTER restricts the sum to
-	// the fee-bearing set the header counts: the coinbase (tree 0, index 0) and
-	// the stake tree's votes/revocations/stake-fees are excluded; only ticket
-	// purchases (tx_type 105, dbtypes.TxTypeTicketPurchase) contribute from the
-	// stake tree. COALESCE keeps fee-only-coinbase blocks at 0 rather than NULL.
-	// See issue #405.
-	SelectFeesPerBlockAboveHeight = `
-		SELECT block_height,
-			COALESCE(SUM(fees) FILTER (
-				WHERE (tree = 0 AND block_index > 0)
-					OR (tx_type = 105 AND tree = 1)
-			), 0) AS fees
-		FROM transactions
-		WHERE is_mainchain
-			AND block_height > $1
-		GROUP BY block_height
-		ORDER BY block_height;`
-
 	SelectMixedTotalPerBlock = `
 		SELECT block_height AS block_height, 
 			SUM(mix_count * mix_denom) AS total_mixed
@@ -234,6 +214,39 @@ const (
 			AND fund_tx.is_mainchain
 		ORDER BY fund_tx.block_height;`
 )
+
+// SelectFeesPerBlockAboveHeight returns the per-block fee total for the Fees
+// chart. It must equal the Block# page header value, which is
+// getTotalFee(block.Tx) + getTotalFee(block.Tickets) (pgblockchain.go):
+// regular-tree non-coinbase transactions plus ticket purchases.
+//
+// transactions.fees is stored as spent - sent, so the coinbase carries a
+// negative fee (it mints the subsidy and emits collected fees as outputs)
+// equal to -(all real fees in the block). A plain SUM(fees) therefore cancels
+// to exactly zero for every block. The FILTER restricts the sum to the
+// fee-bearing set the header counts: the coinbase (tree 0, index 0) and the
+// stake tree's votes/revocations/stake-fees are excluded; only ticket purchases
+// (tx_type = dbtypes.TxTypeTicketPurchase, interpolated below so this can never
+// drift from the value extraction.go stores) contribute from the stake tree.
+// COALESCE keeps fee-only-coinbase blocks at 0 rather than NULL.
+//
+// The sum is restricted to is_mainchain only, deliberately NOT is_valid:
+// getTotalFee runs over the node's block txs without a validity filter, so a
+// stakeholder-disapproved block's regular-tree fees count toward both the chart
+// and the header. Adding an is_valid filter here would re-diverge them. See
+// issue #405.
+var SelectFeesPerBlockAboveHeight = fmt.Sprintf(`
+	SELECT block_height,
+		COALESCE(SUM(fees) FILTER (
+			WHERE (tree = 0 AND block_index > 0)
+				OR (tx_type = %d AND tree = 1)
+		), 0) AS fees
+	FROM transactions
+	WHERE is_mainchain
+		AND block_height > $1
+	GROUP BY block_height
+	ORDER BY block_height;`,
+	dbtypes.TxTypeTicketPurchase)
 
 /*
 var (

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -207,7 +207,7 @@ const (
 		SELECT block_height,
 			COALESCE(SUM(fees) FILTER (
 				WHERE (tree = 0 AND block_index > 0)
-					OR tx_type = 105
+					OR (tx_type = 105 AND tree = 1)
 			), 0) AS fees
 		FROM transactions
 		WHERE is_mainchain

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6768,6 +6768,11 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	}
 	block.TotalSent = (getTotalSent(block.Tx) + getTotalSent(block.Treasury) + getTotalSent(block.Revs) +
 		getTotalSent(block.Tickets) + getTotalSent(block.Votes) + getTotalSent(block.StakeFees)).ToCoin()
+	// This per-block fee total (regular-tree non-coinbase txs + ticket purchases)
+	// is the definition the Fees chart must mirror. Its SQL twin is
+	// internal.SelectFeesPerBlockAboveHeight; if you change which txs count here,
+	// update that query too or the chart and this header will silently diverge
+	// (issue #405).
 	block.MiningFee = (getTotalFee(block.Tx) + getTotalFee(block.Tickets)).ToCoin()
 
 	// Aggregate fees per coin type (VAR from MiningFee, SKA from SSFeeTotalsByCoin)

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3622,6 +3622,21 @@ func retrieveBlockFees(ctx context.Context, db *sql.DB, charts *cache.ChartData)
 	return rows, nil
 }
 
+// clampNonNegativeFee guards the appendBlockFees invariant that a per-block fee
+// total from SelectFeesPerBlockAboveHeight is non-negative: the only txs with a
+// negative stored fee (the subsidy-minting coinbase and votes/stakebase) are
+// excluded by that query's FILTER, so the fee-bearing set (regular-tree
+// non-coinbase txs + ticket purchases) sums to >= 0. A negative value is a data
+// anomaly. It is clamped to 0 rather than wrapped via uint64() into a huge chart
+// spike, and ok=false lets the caller log the anomaly without aborting. See
+// issue #405.
+func clampNonNegativeFee(fees int64) (value uint64, ok bool) {
+	if fees < 0 {
+		return 0, false
+	}
+	return uint64(fees), true
+}
+
 // Append the result from retrieveBlockFees to the provided ChartData. This
 // is the Appender half of a pair that make up a cache.ChartUpdater.
 func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
@@ -3635,20 +3650,21 @@ func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 			return err
 		}
 
-		// fees is the per-block total in atoms over the fee-bearing set
-		// (regular-tree non-coinbase txs + ticket purchases); see
-		// SelectFeesPerBlockAboveHeight. It is always >= 0, so a negative value
-		// signals a real data anomaly. Surface it as an error rather than let
-		// uint64(fees) silently wrap it into a huge spike on the chart (the old
-		// code abs()'d it, which hid the same anomaly) (issue #405). We return
-		// rather than skip the row: blocks.Fees is index-aligned with the other
-		// per-block series, so dropping an entry would desync them and make
-		// Lengthen truncate every block chart to the shortest series.
-		if fees < 0 {
-			return fmt.Errorf("appendBlockFees: negative per-block fee total %d at height %d", fees, blockHeight)
+		// A negative per-block total should be impossible (see
+		// clampNonNegativeFee / SelectFeesPerBlockAboveHeight), so warn loudly,
+		// but do NOT return an error here: appendBlockFees runs mid-pipeline as
+		// the "fees" updater, and (*ChartData).Update aborts on the first
+		// appender error before Lengthen() runs. Returning would strand the
+		// already-appended sibling series (Time, Height, …) ahead of a frozen
+		// Fees series with no reconciliation, permanently wedging chart updates
+		// on the offending block. Clamping to 0 keeps blocks.Fees index-aligned
+		// with the other per-block series and lets the update proceed. (#405)
+		fee, ok := clampNonNegativeFee(fees)
+		if !ok {
+			log.Warnf("appendBlockFees: negative per-block fee total %d at height %d; clamping to 0", fees, blockHeight)
 		}
 
-		blocks.Fees = append(blocks.Fees, uint64(fees))
+		blocks.Fees = append(blocks.Fees, fee)
 	}
 	return rows.Err()
 }

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3634,11 +3634,12 @@ func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 			log.Errorf("Unable to scan for FeeInfoPerBlock fields: %v", err)
 			return err
 		}
-		if fees < 0 {
-			fees *= -1
-		}
 
-		// Converting to atoms.
+		// fees is the per-block total in atoms over the fee-bearing set
+		// (regular-tree non-coinbase txs + ticket purchases); see
+		// SelectFeesPerBlockAboveHeight. It is always >= 0, so a value below
+		// zero would signal a real data anomaly and should surface, not be
+		// silently abs()'d as before (issue #405).
 		blocks.Fees = append(blocks.Fees, uint64(fees))
 	}
 	return rows.Err()

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3637,9 +3637,17 @@ func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 
 		// fees is the per-block total in atoms over the fee-bearing set
 		// (regular-tree non-coinbase txs + ticket purchases); see
-		// SelectFeesPerBlockAboveHeight. It is always >= 0, so a value below
-		// zero would signal a real data anomaly and should surface, not be
-		// silently abs()'d as before (issue #405).
+		// SelectFeesPerBlockAboveHeight. It is always >= 0, so a negative value
+		// signals a real data anomaly. Surface it as an error rather than let
+		// uint64(fees) silently wrap it into a huge spike on the chart (the old
+		// code abs()'d it, which hid the same anomaly) (issue #405). We return
+		// rather than skip the row: blocks.Fees is index-aligned with the other
+		// per-block series, so dropping an entry would desync them and make
+		// Lengthen truncate every block chart to the shortest series.
+		if fees < 0 {
+			return fmt.Errorf("appendBlockFees: negative per-block fee total %d at height %d", fees, blockHeight)
+		}
+
 		blocks.Fees = append(blocks.Fees, uint64(fees))
 	}
 	return rows.Err()


### PR DESCRIPTION
## Summary

The Fees chart on `/charts` showed zero for every mainnet block although VAR transactions pay real fees. The bug is in the read query, not storage.

`transactions.fees` is stored as `spent - sent`, so the **coinbase** carries a **negative** fee equal to `-(all real fees in the block)` (it mints the subsidy and emits the collected fees as outputs). `SelectFeesPerBlockAboveHeight` summed `fees` over **every** tx in a block, so the real fees cancelled to exactly zero. Other per-block charts (`tx-count`, etc.) use `COUNT(*)`, which is why only fees were affected.

## Fix

- **`db/dcrpg/internal/txstmts.go`** — `FILTER` the per-block `SUM(fees)` to the set the Block# header counts (`getTotalFee(block.Tx) + getTotalFee(block.Tickets)`): regular-tree non-coinbase txs + ticket purchases. Excludes the coinbase `(tree 0, block_index 0)` and stake votes/revocations/fees; only ticket purchases (`tx_type 105`) contribute from the stake tree. Tickets are rows in `transactions`, so the `tickets` table is **not** summed — no double-count.
- **`db/dcrpg/queries.go`** — remove the dead `abs()` band-aid in `appendBlockFees`; fees are now always ≥ 0 and a negative would be a real anomaly worth surfacing.
- **`db/cache/charts.go`** — bump `cacheVersion` 6.3.0 → 6.4.0. `FeesTip()` gates the query incrementally, so the persisted `chartscache.gob` keeps its zeros otherwise; the bump forces a full charts-cache recompute on next start. **No DB resync or backfill needed** — `transactions.fees` was always correct.

## Tests

- `TestSelectFeesPerBlockExcludesCoinbase` (pgonline) — runs the production query against a synthetic block via a temp table; **red (got 0) → green (got 19500)**.
- `Test_processTransactions_FeeCancellationInvariant` — pins the coinbase cancellation invariant the SQL filter relies on (no DB; runs in the standard suite).

## Verification

- Confirmed on mainnet that the corrected query equals `-(coinbase fee)` for **every** block (the Block# header value), returns one row per block, and has no negatives.
- After rebuild + restart (cache rebuild triggered by the version bump), live `/api/chart/fees` returns real fees: **2150 / 2415 blocks non-zero**, top block 1585 = 0.0011788 VAR (was all zero).

Fixes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)