### PR TITLE
netparams: fix JSONRPCClientPort to use RPC port, not P2P port

### DIFF
--- a/netparams/netparams.go
+++ b/netparams/netparams.go
@@ -20,7 +20,7 @@ type Params struct {
 // monetarium-node on the main network (wire.MainNet).
 var MainNetParams = Params{
 	Params:            chaincfg.MainNetParams(),
-	JSONRPCClientPort: "9508",
+	JSONRPCClientPort: "9509",
 	JSONRPCServerPort: "9509",
 	GRPCServerPort:    "9510",
 }
@@ -29,7 +29,7 @@ var MainNetParams = Params{
 // monetarium-node on the test network (version 3) (wire.TestNet3).
 var TestNet3Params = Params{
 	Params:            chaincfg.TestNet3Params(),
-	JSONRPCClientPort: "19508",
+	JSONRPCClientPort: "19509",
 	JSONRPCServerPort: "19509",
 	GRPCServerPort:    "19510",
 }
@@ -38,7 +38,7 @@ var TestNet3Params = Params{
 // (wire.SimNet).
 var SimNetParams = Params{
 	Params:            chaincfg.SimNetParams(),
-	JSONRPCClientPort: "19556",
+	JSONRPCClientPort: "19557",
 	JSONRPCServerPort: "19557",
 	GRPCServerPort:    "19558",
 }


### PR DESCRIPTION
JSONRPCClientPort was set to the P2P port (9508/19508/19556) instead of the RPC port (9509/19509/19557). Both config.go call sites that default dcrdserv use this field, so a host-only dcrdserv= would connect to the P2P listener and fail. Correct the values to match JSONRPCServerPort. Fixes #409 