### PR TITLE
db/cache, db/dcrpg, explorer: fix zero Fees chart + add per-coin SKA fee charts

### DIFF
--- a/cmd/dcrdata/internal/api/apirouter.go
+++ b/cmd/dcrdata/internal/api/apirouter.go
@@ -232,6 +232,8 @@ func NewAPIRouter(app *appContext, JSONIndent string, useRealIP, compressLarge b
 	mux.Route("/chart", func(r chi.Router) {
 		// Handle coin-supply/N pattern (SKA coin types)
 		r.With(m.CoinSupplyChartTypeCtx).Get("/coin-supply/{charttype}", app.ChartTypeData)
+		// Handle fees/N pattern (per-coin fee charts)
+		r.With(m.SKAFeeChartTypeCtx).Get("/fees/{charttype}", app.ChartTypeData)
 		// Handle standard single-segment chart types
 		r.With(m.ChartTypeCtx).Get("/{charttype}", app.ChartTypeData)
 	})

--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -110,6 +110,7 @@ type DataSource interface {
 	GetAddressTransactionsRawWithSkip(ctx context.Context, addr string, count, skip int) []*apitypes.AddressTxRaw
 	GetMempoolPriceCountTime() *apitypes.PriceCountTime
 	LoadSKASupplyForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
+	LoadSKAFeesForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
 }
 
 // dcrdata application context used by all route handlers
@@ -1911,6 +1912,27 @@ func (c *appContext) ChartTypeData(w http.ResponseWriter, r *http.Request) {
 			if reload {
 				if err := c.DataSource.LoadSKASupplyForCoin(r.Context(), c.charts, coinType); err != nil {
 					log.Warnf("ChartTypeData: failed to load SKA supply for coin type %d: %v", coinType, err)
+				}
+			}
+		}
+	}
+
+	// Check if this is an SKA fee chart and if data needs to be loaded
+	if c.charts != nil && cache.IsSKAFeeChart(chartType) {
+		coinType := cache.FeeCoinType(chartType)
+		if coinType > 0 {
+			reload := !c.charts.SKAFeesExists(coinType)
+			if currHeight, err := c.DataSource.GetHeight(r.Context()); err == nil {
+				if cachedHeight, ok := c.charts.SKAFeesHeight(coinType); !ok || currHeight-cachedHeight > skaSupplyStaleHeightThreshold {
+					reload = true
+				}
+			} else {
+				log.Warnf("ChartTypeData: failed to get current height: %v", err)
+			}
+
+			if reload {
+				if err := c.DataSource.LoadSKAFeesForCoin(r.Context(), c.charts, coinType); err != nil {
+					log.Warnf("ChartTypeData: failed to load SKA fees for coin type %d: %v", coinType, err)
 				}
 			}
 		}

--- a/cmd/dcrdata/internal/api/noop_ds_test.go
+++ b/cmd/dcrdata/internal/api/noop_ds_test.go
@@ -127,3 +127,6 @@ func (noopDS) GetMempoolPriceCountTime() *apitypes.PriceCountTime { return nil }
 func (noopDS) LoadSKASupplyForCoin(_ context.Context, _ *cache.ChartData, _ uint8) error {
 	return nil
 }
+func (noopDS) LoadSKAFeesForCoin(_ context.Context, _ *cache.ChartData, _ uint8) error {
+	return nil
+}

--- a/cmd/dcrdata/internal/middleware/apimiddleware.go
+++ b/cmd/dcrdata/internal/middleware/apimiddleware.go
@@ -792,6 +792,17 @@ func ChartTypeCtx(next http.Handler) http.Handler {
 	})
 }
 
+// SKAFeeChartTypeCtx returns a http.HandlerFunc that embeds "fees/" + {charttype}
+// into the request context for handling fees/N requests.
+func SKAFeeChartTypeCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		charttype := chi.URLParam(r, "charttype")
+		ctx := context.WithValue(r.Context(), ctxChartType,
+			"fees/"+charttype)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 // CoinSupplyChartTypeCtx returns a http.HandlerFunc that embeds "coin-supply/" + {charttype}
 // into the request context for handling coin-supply/N requests.
 func CoinSupplyChartTypeCtx(next http.Handler) http.Handler {

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -68,6 +68,10 @@ function isCoinSupplyChart(name) {
   return name === 'coin-supply' || (typeof name === 'string' && name.startsWith('coin-supply/'))
 }
 
+function isSKAFeeChart(name) {
+  return typeof name === 'string' && /^fees\/[1-9]\d*$/.test(name)
+}
+
 function formatSkaAtomsExact(atomStr) {
   const p = splitSkaAtomsNoTrailing(atomStr, true, 0)
   return p.rest ? `${p.intPart}.${p.rest}` : p.intPart
@@ -475,7 +479,11 @@ export default class extends Controller {
     const isSKA = isSKASupplyChart(chartName)
     const coinType = skaCoinTypeFromChart(chartName)
     const coinLabel = isSKA ? renderCoinType(coinType) : 'VAR'
-    const switchKey = isCoinSupplyChart(chartName) ? 'coin-supply' : chartName
+    const switchKey = isCoinSupplyChart(chartName)
+      ? 'coin-supply'
+      : isSKAFeeChart(chartName)
+        ? 'fees'
+        : chartName
 
     switch (switchKey) {
       case 'ticket-price': // price graph
@@ -646,6 +654,34 @@ export default class extends Controller {
         break
 
       case 'fees': // block fee graph
+        if (isSKAFeeChart(chartName)) {
+          const coinType = parseInt(chartName.split('/')[1], 10)
+          const coinLabel = renderCoinType(coinType)
+          this._skaFeeRaw = data.fees
+          const ys = data.fees.map((s) => Number(s) * 1e-18)
+          d = zip2D(data, ys)
+          assign(
+            gOptions,
+            mapDygraphOptions(
+              d,
+              [xlabel, 'Total Fee'],
+              false,
+              `Total Fee (${coinLabel})`,
+              true,
+              false
+            )
+          )
+          yFormatter = (div, data, i) => {
+            const raw = this._skaFeeRaw && this._skaFeeRaw[i]
+            const exact = raw != null ? formatSkaAtomsExact(raw) : data.series[0].y.toString()
+            div.appendChild(
+              legendEntry(
+                `${data.series[0].dashHTML} ${data.series[0].labelHTML}: ${exact} ${coinLabel}`
+              )
+            )
+          }
+          break
+        }
         d = zip2D(data, data.fees, atomsToVAR)
         assign(
           gOptions,

--- a/cmd/dcrdata/views/charts.tmpl
+++ b/cmd/dcrdata/views/charts.tmpl
@@ -32,7 +32,9 @@
                             <option value="pow-difficulty">PoW Difficulty</option>
                             <option value="coin-supply/0">Circulation (VAR)</option>
                             {{range $t := .ActiveSKATypes}}<option value="coin-supply/{{$t}}">Circulation (SKA{{$t}})</option>
-                             {{end}}<option value="fees">Fees</option>
+                             {{end}}<option value="fees">Fees (VAR)</option>
+                             {{range $t := .ActiveSKATypes}}<option value="fees/{{$t}}">Fees (SKA{{$t}})</option>
+                              {{end}}
                              <option value="duration-btw-blocks">Duration Between Blocks</option>
                             <option value="chainwork">Total Work</option>
                             <option value="hashrate">Hashrate</option>

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -62,6 +62,9 @@ const (
 
 	// SKA coin supply chart prefix (coin-supply/N where N is coin type)
 	SKASupplyPrefix = "coin-supply/"
+
+	// SKA fee chart prefix (fees/N where N is coin type)
+	SKAFeePrefix = "fees/"
 )
 
 // binLevel specifies the granularity of data.
@@ -102,6 +105,25 @@ func SkaCoinType(chartID string) uint8 {
 	}
 	var coinType uint8
 	_, err := fmt.Sscanf(chartID[len(SKASupplyPrefix):], "%d", &coinType)
+	if err != nil {
+		return 0
+	}
+	return coinType
+}
+
+// IsSKAFeeChart checks if the chart ID is an SKA fee chart (fees/N).
+func IsSKAFeeChart(chartID string) bool {
+	return len(chartID) > len(SKAFeePrefix) && chartID[:len(SKAFeePrefix)] == SKAFeePrefix
+}
+
+// FeeCoinType extracts the coin type number from an SKA fee chart ID.
+// Returns 0 if the chart ID is invalid.
+func FeeCoinType(chartID string) uint8 {
+	if !IsSKAFeeChart(chartID) {
+		return 0
+	}
+	var coinType uint8
+	_, err := fmt.Sscanf(chartID[len(SKAFeePrefix):], "%d", &coinType)
 	if err != nil {
 		return 0
 	}
@@ -341,6 +363,17 @@ type SKASupplyChartData struct {
 // SKASupplyData stores per-coin-type cumulative supply data (strings for precision).
 type SKASupplyData map[uint8]SKASupplyChartData
 
+// SKAFeeChartData holds per-block fee data for a single SKA coin type.
+// Fees are stored as exact-precision strings to preserve 18 decimal places.
+type SKAFeeChartData struct {
+	Heights    []int64
+	Timestamps []int64
+	Fees       []string
+}
+
+// SKAFeesData stores per-coin-type SKA fee data.
+type SKAFeesData map[uint8]SKAFeeChartData
+
 // Snip truncates the zoomSet to a provided length.
 func (set *zoomSet) Snip(length int) {
 	if length < 0 {
@@ -495,6 +528,9 @@ type ChartData struct {
 	SKASupply    SKASupplyData
 	// Lock() must be held when mutating SKASupply.
 	SKASupplyMtx sync.RWMutex
+	SKAFees      SKAFeesData
+	// SKAFeesMtx must be held when reading or mutating SKAFees.
+	SKAFeesMtx sync.RWMutex
 }
 
 // ValidateLengths checks that the length of all arguments is equal.
@@ -928,6 +964,34 @@ func (charts *ChartData) SKASupplyHeight(coinType uint8) (int64, bool) {
 	return data.Heights[len(data.Heights)-1], true
 }
 
+// SKAFeesExists checks if SKA fee data exists for the given coin type.
+func (charts *ChartData) SKAFeesExists(coinType uint8) bool {
+	if charts == nil {
+		return false
+	}
+	charts.SKAFeesMtx.RLock()
+	defer charts.SKAFeesMtx.RUnlock()
+	if charts.SKAFees == nil {
+		return false
+	}
+	data, ok := charts.SKAFees[coinType]
+	return ok && len(data.Fees) > 0
+}
+
+// SKAFeesHeight returns the height of the last recorded block for the given coin type.
+func (charts *ChartData) SKAFeesHeight(coinType uint8) (int64, bool) {
+	charts.SKAFeesMtx.RLock()
+	defer charts.SKAFeesMtx.RUnlock()
+	if charts.SKAFees == nil {
+		return 0, false
+	}
+	data, ok := charts.SKAFees[coinType]
+	if !ok || len(data.Heights) == 0 {
+		return 0, false
+	}
+	return data.Heights[len(data.Heights)-1], true
+}
+
 // PoolSizeTip is the height of the PoolSize data.
 func (charts *ChartData) PoolSizeTip() int32 {
 	charts.mtx.RLock()
@@ -1024,6 +1088,7 @@ func NewChartData(ctx context.Context, height uint32, chainParams *chaincfg.Para
 		cache:        make(map[string]*cachedChart),
 		updaters:     make([]ChartUpdater, 0),
 		SKASupply:    make(SKASupplyData),
+		SKAFees:      make(SKAFeesData),
 	}
 }
 
@@ -1112,6 +1177,10 @@ func (charts *ChartData) Chart(chartID, binString, axisString string) ([]byte, e
 		// Check if it's an SKA supply chart
 		if IsSKASupplyChart(chartID) {
 			return charts.skaSupplyChart(chartID, bin, axis)
+		}
+		// Check if it's an SKA fee chart
+		if IsSKAFeeChart(chartID) {
+			return charts.skaFeeChart(chartID, bin, axis)
 		}
 		return nil, UnknownChartErr
 	}
@@ -1886,6 +1955,96 @@ func (charts *ChartData) skaSupplyChart(chartID string, bin binLevel, axis axisT
 	return nil, InvalidBinErr
 }
 
+// skaFeeChart generates chart data for an SKA coin type's transaction fees.
+// Data is pre-loaded in the SKAFees map. Values are returned as exact-precision
+// strings to preserve 18 decimal places. coinType 0 is not handled here (it
+// uses the existing VAR fees path via the chartMakers registry).
+func (charts *ChartData) skaFeeChart(chartID string, bin binLevel, axis axisType) ([]byte, error) {
+	coinType := FeeCoinType(chartID)
+	if !IsSKAFeeChart(chartID) || coinType == 0 {
+		return nil, fmt.Errorf("invalid SKA fee chart: %s", chartID)
+	}
+
+	charts.SKAFeesMtx.RLock()
+	if charts.SKAFees == nil {
+		charts.SKAFeesMtx.RUnlock()
+		return nil, fmt.Errorf("SKA fee data not initialized for coin type %d", coinType)
+	}
+	data, ok := charts.SKAFees[coinType]
+	charts.SKAFeesMtx.RUnlock()
+	if !ok || len(data.Fees) == 0 {
+		return nil, fmt.Errorf("no SKA fee data found for coin type %d", coinType)
+	}
+
+	switch bin {
+	case BlockBin:
+		switch axis {
+		case HeightAxis:
+			resp := struct {
+				Bin  string   `json:"bin"`
+				Axis string   `json:"axis"`
+				H    []int64  `json:"h"`
+				Fees []string `json:"fees"`
+			}{
+				Bin:  string(bin),
+				Axis: string(axis),
+				H:    data.Heights,
+				Fees: data.Fees,
+			}
+			return json.Marshal(resp)
+		default:
+			resp := struct {
+				Bin  string   `json:"bin"`
+				Axis string   `json:"axis"`
+				H    []int64  `json:"h"`
+				T    []int64  `json:"t"`
+				Fees []string `json:"fees"`
+			}{
+				Bin:  string(bin),
+				Axis: string(axis),
+				H:    data.Heights,
+				T:    data.Timestamps,
+				Fees: data.Fees,
+			}
+			return json.Marshal(resp)
+		}
+	case DayBin:
+		timestamps, heights, values := aggregateSKAFees(data.Timestamps, data.Heights, data.Fees)
+		switch axis {
+		case HeightAxis:
+			resp := struct {
+				Bin  string   `json:"bin"`
+				Axis string   `json:"axis"`
+				H    []int64  `json:"h"`
+				Fees []string `json:"fees"`
+			}{
+				Bin:  string(bin),
+				Axis: string(axis),
+				H:    heights,
+				Fees: values,
+			}
+			return json.Marshal(resp)
+		default:
+			resp := struct {
+				Bin  string   `json:"bin"`
+				Axis string   `json:"axis"`
+				H    []int64  `json:"h"`
+				T    []int64  `json:"t"`
+				Fees []string `json:"fees"`
+			}{
+				Bin:  string(bin),
+				Axis: string(axis),
+				H:    heights,
+				T:    timestamps,
+				Fees: values,
+			}
+			return json.Marshal(resp)
+		}
+	}
+
+	return nil, InvalidBinErr
+}
+
 // skaSupplyChartData holds raw SKA supply data from the database.
 type skaSupplyChartData struct {
 	Heights []int64
@@ -1955,6 +2114,62 @@ func aggregateSKASupply(timestamps []int64, heights []int64, values []string) ([
 		dayTimestamps = append(dayTimestamps, day*86400)
 		dayHeights = append(dayHeights, d.height)
 		dayValues = append(dayValues, d.value.String())
+	}
+
+	return dayTimestamps, dayHeights, dayValues
+}
+
+// aggregateSKAFees aggregates per-block SKA fee data into daily bins by summing
+// fees within each day. Sums are accumulated in big.Int because SKA atoms use
+// 18 decimals and overflow float64/int64. The bin's timestamp is the start of
+// the UTC day; the bin's height is the height of the first block seen for that
+// day (input is assumed ordered by ascending height/time, matching the query).
+func aggregateSKAFees(timestamps []int64, heights []int64, values []string) ([]int64, []int64, []string) {
+	if len(timestamps) == 0 {
+		return nil, nil, nil
+	}
+
+	type dailyData struct {
+		timestamp int64
+		height    int64
+		total     *big.Int
+	}
+	dailyMap := make(map[int64]*dailyData)
+
+	for i, t := range timestamps {
+		dayKey := t / 86400
+		if i >= len(values) || i >= len(heights) {
+			continue
+		}
+		v, ok := new(big.Int).SetString(values[i], 10)
+		if !ok {
+			continue
+		}
+		if d, exists := dailyMap[dayKey]; exists {
+			d.total.Add(d.total, v)
+		} else {
+			dailyMap[dayKey] = &dailyData{
+				timestamp: t - (t % 86400),
+				height:    heights[i],
+				total:     new(big.Int).Set(v),
+			}
+		}
+	}
+
+	dayKeys := make([]int64, 0, len(dailyMap))
+	for day := range dailyMap {
+		dayKeys = append(dayKeys, day)
+	}
+	sort.Slice(dayKeys, func(i, j int) bool { return dayKeys[i] < dayKeys[j] })
+
+	dayTimestamps := make([]int64, 0, len(dailyMap))
+	dayHeights := make([]int64, 0, len(dailyMap))
+	dayValues := make([]string, 0, len(dailyMap))
+	for _, day := range dayKeys {
+		d := dailyMap[day]
+		dayTimestamps = append(dayTimestamps, d.timestamp)
+		dayHeights = append(dayHeights, d.height)
+		dayValues = append(dayValues, d.total.String())
 	}
 
 	return dayTimestamps, dayHeights, dayValues

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -2122,8 +2122,9 @@ func aggregateSKASupply(timestamps []int64, heights []int64, values []string) ([
 // aggregateSKAFees aggregates per-block SKA fee data into daily bins by summing
 // fees within each day. Sums are accumulated in big.Int because SKA atoms use
 // 18 decimals and overflow float64/int64. The bin's timestamp is the start of
-// the UTC day; the bin's height is the height of the first block seen for that
-// day (input is assumed ordered by ascending height/time, matching the query).
+// the UTC day; the bin's height is the height of the first block that
+// contributes to that day — i.e. the first with a parseable fee value (input is
+// assumed ordered by ascending height/time, matching the query).
 func aggregateSKAFees(timestamps []int64, heights []int64, values []string) ([]int64, []int64, []string) {
 	if len(timestamps) == 0 {
 		return nil, nil, nil

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -145,7 +145,14 @@ const (
 // cacheVersion helps detect when the cache data stored has changed its
 // structure or content. A change on the cache version results to recomputing
 // all the charts data a fresh thereby making the cache to hold the latest changes.
-var cacheVersion = semver.NewSemver(6, 3, 0)
+//
+// 6.4.0: issue #405 fixed SelectFeesPerBlockAboveHeight so per-block Fees no
+// longer cancel to zero against the coinbase. Already-synced deployments cached
+// the wrong (all-zero) Fees series; bumping the version forces a full recompute
+// of the charts cache on next start so the corrected query reruns over every
+// block. No database resync or backfill is needed — transactions.fees was
+// always stored correctly.
+var cacheVersion = semver.NewSemver(6, 4, 0)
 
 // versionedCacheData defines the cache data contents to be written into a .gob file.
 type versionedCacheData struct {

--- a/db/cache/charts_ska_fees_test.go
+++ b/db/cache/charts_ska_fees_test.go
@@ -1,0 +1,88 @@
+package cache
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestAggregateSKAFees pins the daily-bin aggregation behind the per-coin SKA
+// fee chart (issue #405 follow-on). The function groups per-block fees into UTC
+// days, summing values within each day. The summation MUST use big.Int: SKA
+// uses 18 decimals, so a single block's atoms already exceed int64, and a day's
+// sum exceeds uint64 — any float64/int64 path would silently lose precision.
+// Bins are emitted ordered by ascending day; each bin's timestamp is the start
+// of its UTC day and its height is the first block observed for that day.
+func TestAggregateSKAFees(t *testing.T) {
+	const day = int64(86400)
+
+	tests := []struct {
+		name       string
+		timestamps []int64
+		heights    []int64
+		values     []string
+		wantTimes  []int64
+		wantHeight []int64
+		wantValues []string
+	}{
+		{
+			name: "empty input yields nil",
+		},
+		{
+			// Two blocks land in day 1, one in day 2. The day-1 sum
+			// (1e19 + (2e19+1)) overflows uint64; the day-2 value overflows
+			// every fixed-width integer — both must survive exactly.
+			name:       "big-int sums across two days",
+			timestamps: []int64{90000, 100000, 180000},
+			heights:    []int64{10, 11, 20},
+			values: []string{
+				"10000000000000000000", // 1e19  (> int64 max)
+				"20000000000000000001", // 2e19+1 (> uint64 max)
+				"123456789012345678901234567890",
+			},
+			wantTimes:  []int64{day, 2 * day}, // 86400, 172800
+			wantHeight: []int64{10, 20},       // first block per day
+			wantValues: []string{
+				"30000000000000000001", // exact 1e19 + (2e19+1)
+				"123456789012345678901234567890",
+			},
+		},
+		{
+			// An unparseable value is skipped without aborting the day or
+			// corrupting the running sum; the bin height stays that of the
+			// first VALID block seen for the day.
+			name:       "skips unparseable value",
+			timestamps: []int64{90000, 95000, 100000},
+			heights:    []int64{10, 11, 12},
+			values:     []string{"5", "not-a-number", "7"},
+			wantTimes:  []int64{day},
+			wantHeight: []int64{10},
+			wantValues: []string{"12"},
+		},
+		{
+			// Defensive: a values slice shorter than timestamps must not panic;
+			// the unmatched trailing index is skipped.
+			name:       "tolerates short values slice",
+			timestamps: []int64{90000, 100000},
+			heights:    []int64{10, 11},
+			values:     []string{"42"},
+			wantTimes:  []int64{day},
+			wantHeight: []int64{10},
+			wantValues: []string{"42"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTimes, gotHeights, gotValues := aggregateSKAFees(tc.timestamps, tc.heights, tc.values)
+			if !reflect.DeepEqual(gotTimes, tc.wantTimes) {
+				t.Errorf("timestamps = %v, want %v", gotTimes, tc.wantTimes)
+			}
+			if !reflect.DeepEqual(gotHeights, tc.wantHeight) {
+				t.Errorf("heights = %v, want %v", gotHeights, tc.wantHeight)
+			}
+			if !reflect.DeepEqual(gotValues, tc.wantValues) {
+				t.Errorf("values = %v, want %v", gotValues, tc.wantValues)
+			}
+		})
+	}
+}

--- a/db/dbtypes/extraction_test.go
+++ b/db/dbtypes/extraction_test.go
@@ -178,6 +178,93 @@ func Test_processTransactions_VAROnly(t *testing.T) {
 	}
 }
 
+// Test_processTransactions_FeeCancellationInvariant pins the storage invariant
+// behind the issue #405 Fees-chart fix. transactions.fees is stored as
+// spent - sent, so the coinbase — which mints the block subsidy and emits the
+// block's collected fees as outputs — carries a NEGATIVE fee equal to -(all
+// real fees in the block). Summing every tx in a block (as the old chart query
+// did) cancels the real fees against the coinbase to exactly zero.
+//
+// The Block# header instead reports getTotalFee(block.Tx) +
+// getTotalFee(block.Tickets) — regular-tree non-coinbase txs plus ticket
+// purchases. SelectFeesPerBlockAboveHeight must match that by excluding the
+// coinbase, which is identified as (tree 0, block_index 0); this test asserts
+// the coinbase indeed lands at block_index 0 so that predicate is sound.
+func Test_processTransactions_FeeCancellationInvariant(t *testing.T) {
+	const (
+		subsidy    = 1_000_000
+		regularFee = 100
+		ticketFee  = 50
+		blockFees  = regularFee + ticketFee // 150 — the per-block header/chart value
+	)
+
+	// Regular tree: coinbase (absorbs ALL block fees as outputs) + one VAR tx.
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: math.MaxUint32}, subsidy, nil))
+	coinbase.AddTxOut(wire.NewTxOut(subsidy+blockFees, nil))
+
+	regular := wire.NewMsgTx()
+	regular.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 1000, nil))
+	regular.AddTxOut(wire.NewTxOut(1000-regularFee, nil))
+
+	regBlk := &wire.MsgBlock{}
+	regBlk.Transactions = []*wire.MsgTx{coinbase, regular}
+	regTxs, _, _ := processTransactions(regBlk, wire.TxTreeRegular, chaincfg.SimNetParams(), true, true)
+	if len(regTxs) != 2 {
+		t.Fatalf("regular tree: expected 2 txs, got %d", len(regTxs))
+	}
+
+	// Stake tree: one ticket purchase with a real positive fee.
+	ticket := wire.NewMsgTx()
+	ticket.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, 2000+ticketFee, nil))
+	ticket.AddTxOut(wire.NewTxOut(2000, opSSTXP2PKH()))
+
+	stakeBlk := &wire.MsgBlock{}
+	stakeBlk.STransactions = []*wire.MsgTx{ticket}
+	stakeTxs, _, _ := processTransactions(stakeBlk, wire.TxTreeStake, chaincfg.SimNetParams(), true, true)
+	if len(stakeTxs) != 1 {
+		t.Fatalf("stake tree: expected 1 tx, got %d", len(stakeTxs))
+	}
+
+	cb, reg, tkt := regTxs[0], regTxs[1], stakeTxs[0]
+
+	// The coinbase must sit at block_index 0 — the SQL predicate relies on it.
+	if cb.BlockIndex != 0 {
+		t.Errorf("coinbase BlockIndex: want 0, got %d", cb.BlockIndex)
+	}
+	if reg.BlockIndex != 1 {
+		t.Errorf("regular tx BlockIndex: want 1, got %d", reg.BlockIndex)
+	}
+
+	// Per-tx fees: coinbase negative, regular and ticket positive.
+	if cb.Fees != -blockFees {
+		t.Errorf("coinbase Fees: want %d, got %d", -blockFees, cb.Fees)
+	}
+	if reg.Fees != regularFee {
+		t.Errorf("regular Fees: want %d, got %d", regularFee, reg.Fees)
+	}
+	if tkt.TxType != TxTypeTicketPurchase {
+		t.Errorf("ticket TxType: want %d (TicketPurchase), got %d", TxTypeTicketPurchase, tkt.TxType)
+	}
+	if tkt.Fees != ticketFee {
+		t.Errorf("ticket Fees: want %d, got %d", ticketFee, tkt.Fees)
+	}
+
+	// The bug: summing every tx including the coinbase cancels to zero.
+	if got := cb.Fees + reg.Fees + tkt.Fees; got != 0 {
+		t.Errorf("sum over all txs incl. coinbase: want 0 (the bug's cancellation), got %d", got)
+	}
+	// The fix: summing the header set (regular non-coinbase + tickets) yields
+	// the real per-block fee.
+	if got := reg.Fees + tkt.Fees; got != blockFees {
+		t.Errorf("sum excluding coinbase: want %d, got %d", blockFees, got)
+	}
+	// The coinbase carries exactly the negative of the real fees.
+	if cb.Fees != -(reg.Fees + tkt.Fees) {
+		t.Errorf("coinbase fee should equal -(real fees): want %d, got %d", -(reg.Fees + tkt.Fees), cb.Fees)
+	}
+}
+
 func Test_processTransactions_SKAOnly(t *testing.T) {
 	// SKA1 amount exceeding int64 max: 2^63 + 1
 	bigAmt := new(big.Int).Add(new(big.Int).SetInt64(1<<62), big.NewInt(1<<62))

--- a/db/dcrpg/fee_clamp_test.go
+++ b/db/dcrpg/fee_clamp_test.go
@@ -1,0 +1,37 @@
+package dcrpg
+
+import (
+	"math"
+	"testing"
+)
+
+// TestClampNonNegativeFee pins the appendBlockFees invariant from issue #405:
+// per-block fee totals from SelectFeesPerBlockAboveHeight are non-negative (the
+// negative-fee coinbase and votes/stakebase are excluded by the query's
+// FILTER). A negative value is a data anomaly that must be clamped to 0 — not
+// abs()'d into a misleading spike, and not turned into an error that would abort
+// the whole charts update mid-pipeline and desync the block series. ok reports
+// whether the value was already valid so the caller can warn on anomalies.
+func TestClampNonNegativeFee(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     int64
+		want   uint64
+		wantOK bool
+	}{
+		{"positive passes through", 19500, 19500, true},
+		{"zero passes through", 0, 0, true},
+		{"max int64 passes through", math.MaxInt64, math.MaxInt64, true},
+		{"negative clamps to zero and flags anomaly", -19500, 0, false},
+		{"min int64 clamps to zero (no wrap)", math.MinInt64, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := clampNonNegativeFee(tc.in)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("clampNonNegativeFee(%d) = (%d, %v), want (%d, %v)",
+					tc.in, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}

--- a/db/dcrpg/fees_chart_test.go
+++ b/db/dcrpg/fees_chart_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/monetarium/monetarium-explorer/db/dbtypes"
 	"github.com/monetarium/monetarium-explorer/db/dcrpg/internal"
 )
 
@@ -43,32 +44,35 @@ func TestSelectFeesPerBlockExcludesCoinbase(t *testing.T) {
 		}
 	}
 
-	// Shadow the real transactions table with the columns the query touches.
+	// Shadow the real transactions table with the columns the query touches,
+	// matching their production types (see CreateTransactionTable).
 	mustExec(`CREATE TEMP TABLE transactions (
 		block_height INT8,
 		tree         INT2,
-		tx_type      INT2,
+		tx_type      INT4,
 		block_index  INT4,
 		fees         INT8,
 		is_mainchain BOOLEAN
 	) ON COMMIT DROP;`)
 
 	// One mainchain block (height 100) mirroring real mainnet rows:
-	//   - coinbase    (tree 0, index 0): fee = -(all collected fees)  <- the bug
-	//   - regular tx  (tree 0, index 1): fee  13460
-	//   - ticket buy  (tree 1, type 105): fee  3020
-	//   - ticket buy  (tree 1, type 105): fee  3020
-	// Block# header value = 13460 + 3020 + 3020 = 19500 atoms.
+	//   - coinbase    (tree 0, index 0):            fee = -(all collected fees)  <- the bug
+	//   - regular tx  (tree 0, index 1):            fee  13460
+	//   - ticket buy  (tree 1, TxTypeTicketPurchase): fee  3020
+	//   - ticket buy  (tree 1, TxTypeTicketPurchase): fee  3020
+	// Block# header value = 13460 + 3020 + 3020 = 19500 atoms. The ticket
+	// tx_type is bound from dbtypes.TxTypeTicketPurchase — the same constant the
+	// query interpolates — so the two stay tied to one source of truth.
 	const regularFee = 13460
 	const ticketFee = 3020
 	const realBlockFee = regularFee + 2*ticketFee // 19500
 	mustExec(`INSERT INTO transactions
 		(block_height, tree, tx_type, block_index, fees, is_mainchain) VALUES
-		(100, 0,   0, 0, $1, TRUE),
-		(100, 0,   0, 1, $2, TRUE),
-		(100, 1, 105, 0, $3, TRUE),
-		(100, 1, 105, 1, $3, TRUE);`,
-		-realBlockFee, regularFee, ticketFee)
+		(100, 0,  0, 0, $1, TRUE),
+		(100, 0,  0, 1, $2, TRUE),
+		(100, 1, $4, 0, $3, TRUE),
+		(100, 1, $4, 1, $3, TRUE);`,
+		-realBlockFee, regularFee, ticketFee, int(dbtypes.TxTypeTicketPurchase))
 
 	// Guard the premise: the naive SUM(fees) cancels to exactly zero, which is
 	// the symptom the chart exhibited. If this ever stops holding, the fix's

--- a/db/dcrpg/fees_chart_test.go
+++ b/db/dcrpg/fees_chart_test.go
@@ -1,0 +1,117 @@
+//go:build pgonline || chartdata
+
+package dcrpg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/monetarium/monetarium-explorer/db/dcrpg/internal"
+)
+
+// TestSelectFeesPerBlockExcludesCoinbase is a regression test for issue #405:
+// the Fees chart rendered zero for every mainnet block. The per-block query
+// SUM(fees) GROUP BY block_height summed transactions.fees over *all* txs in a
+// block, including the coinbase. A coinbase mints the block subsidy and emits
+// the collected fees as outputs, so with fees = spent - sent its stored fee is
+// negative and equal to -(sum of all real fees in the block). Summing it
+// alongside the real (positive) fees cancels them to exactly zero.
+//
+// The Block# page header instead reports getTotalFee(block.Tx) +
+// getTotalFee(block.Tickets) — regular-tree non-coinbase txs plus ticket
+// purchases, excluding coinbase/votes/stake fees (pgblockchain.go). The chart
+// must match that, so SelectFeesPerBlockAboveHeight must sum only that set.
+//
+// The test seeds one synthetic block into a session-local temp table that
+// shadows the real transactions table, then runs the exact production query.
+func TestSelectFeesPerBlockExcludesCoinbase(t *testing.T) {
+	ctx := context.Background()
+
+	// A transaction binds all statements to a single connection so the temp
+	// table is visible to the query, and ON COMMIT DROP cleans it up even if
+	// the test fails (we always Rollback).
+	tx, err := sqlDb.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	mustExec := func(q string, args ...interface{}) {
+		t.Helper()
+		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("exec failed: %v\nquery: %s", err, q)
+		}
+	}
+
+	// Shadow the real transactions table with the columns the query touches.
+	mustExec(`CREATE TEMP TABLE transactions (
+		block_height INT8,
+		tree         INT2,
+		tx_type      INT2,
+		block_index  INT4,
+		fees         INT8,
+		is_mainchain BOOLEAN
+	) ON COMMIT DROP;`)
+
+	// One mainchain block (height 100) mirroring real mainnet rows:
+	//   - coinbase    (tree 0, index 0): fee = -(all collected fees)  <- the bug
+	//   - regular tx  (tree 0, index 1): fee  13460
+	//   - ticket buy  (tree 1, type 105): fee  3020
+	//   - ticket buy  (tree 1, type 105): fee  3020
+	// Block# header value = 13460 + 3020 + 3020 = 19500 atoms.
+	const regularFee = 13460
+	const ticketFee = 3020
+	const realBlockFee = regularFee + 2*ticketFee // 19500
+	mustExec(`INSERT INTO transactions
+		(block_height, tree, tx_type, block_index, fees, is_mainchain) VALUES
+		(100, 0,   0, 0, $1, TRUE),
+		(100, 0,   0, 1, $2, TRUE),
+		(100, 1, 105, 0, $3, TRUE),
+		(100, 1, 105, 1, $3, TRUE);`,
+		-realBlockFee, regularFee, ticketFee)
+
+	// Guard the premise: the naive SUM(fees) cancels to exactly zero, which is
+	// the symptom the chart exhibited. If this ever stops holding, the fix's
+	// rationale (and this test) must be revisited.
+	var naive int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(fees), 0) FROM transactions WHERE is_mainchain AND block_height > 0`,
+	).Scan(&naive); err != nil {
+		t.Fatalf("naive sum query: %v", err)
+	}
+	if naive != 0 {
+		t.Fatalf("premise broken: expected naive SUM(fees)=0 (coinbase cancellation), got %d", naive)
+	}
+
+	// The production query must report the real per-block fee, not zero.
+	rows, err := tx.QueryContext(ctx, internal.SelectFeesPerBlockAboveHeight, int64(0))
+	if err != nil {
+		t.Fatalf("SelectFeesPerBlockAboveHeight: %v", err)
+	}
+	defer rows.Close()
+
+	var gotRows int
+	var gotHeight uint64
+	var gotFees int64
+	for rows.Next() {
+		gotRows++
+		if err := rows.Scan(&gotHeight, &gotFees); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+
+	// One row per block must be returned (appendBlockFees aligns blocks.Fees to
+	// block height by row order); the coinbase-only grouping must not drop it.
+	if gotRows != 1 {
+		t.Fatalf("expected exactly 1 block row, got %d", gotRows)
+	}
+	if gotHeight != 100 {
+		t.Errorf("block_height: want 100, got %d", gotHeight)
+	}
+	if gotFees != realBlockFee {
+		t.Errorf("issue #405: fees for block 100: want %d, got %d", realBlockFee, gotFees)
+	}
+}

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -213,6 +213,21 @@ const (
 			AND mixed AND value>0
 			AND fund_tx.is_mainchain
 		ORDER BY fund_tx.block_height;`
+
+	// SelectSKAFeesPerBlockAboveHeight fetches per-block SKA fee totals for a
+	// specific coin type ($2) from blocks.ssfee_totals (pow + pos per coin
+	// type). Unlike the VAR fee chart, SKA has no block subsidy, so the SSFee
+	// distribution recorded on the block IS the fee. Selecting straight from
+	// the blocks table means every block in range appears — blocks with no
+	// SSFee for the coin type yield 0 rather than being omitted, keeping the
+	// series continuous for sparse coins.
+	SelectSKAFeesPerBlockAboveHeight = `
+		SELECT b.height, b.time,
+			COALESCE(CAST(ssfee_totals->$2->>'pow' AS NUMERIC), 0) +
+			COALESCE(CAST(ssfee_totals->$2->>'pos' AS NUMERIC), 0) AS fees
+		FROM blocks b
+		WHERE b.is_mainchain AND b.height > $1
+		ORDER BY b.height;`
 )
 
 // SelectFeesPerBlockAboveHeight returns the per-block fee total for the Fees

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -189,8 +189,26 @@ const (
 	// RetrieveVoutDbIDs = `SELECT unnest(vout_db_ids) FROM transactions WHERE id = $1;`
 	// RetrieveVoutDbID  = `SELECT vout_db_ids[$2] FROM transactions WHERE id = $1;`
 
+	// SelectFeesPerBlockAboveHeight returns the per-block fee total for the Fees
+	// chart. It must equal the Block# page header value, which is
+	// getTotalFee(block.Tx) + getTotalFee(block.Tickets) (pgblockchain.go):
+	// regular-tree non-coinbase transactions plus ticket purchases.
+	//
+	// transactions.fees is stored as spent - sent, so the coinbase carries a
+	// negative fee (it mints the subsidy and emits collected fees as outputs)
+	// equal to -(all real fees in the block). A plain SUM(fees) therefore
+	// cancels to exactly zero for every block. The FILTER restricts the sum to
+	// the fee-bearing set the header counts: the coinbase (tree 0, index 0) and
+	// the stake tree's votes/revocations/stake-fees are excluded; only ticket
+	// purchases (tx_type 105, dbtypes.TxTypeTicketPurchase) contribute from the
+	// stake tree. COALESCE keeps fee-only-coinbase blocks at 0 rather than NULL.
+	// See issue #405.
 	SelectFeesPerBlockAboveHeight = `
-		SELECT block_height, SUM(fees) AS fees
+		SELECT block_height,
+			COALESCE(SUM(fees) FILTER (
+				WHERE (tree = 0 AND block_index > 0)
+					OR tx_type = 105
+			), 0) AS fees
 		FROM transactions
 		WHERE is_mainchain
 			AND block_height > $1

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -4,6 +4,12 @@
 
 package internal
 
+import (
+	"fmt"
+
+	"github.com/monetarium/monetarium-explorer/db/dbtypes"
+)
+
 // These queries relate primarily to the "transactions" table.
 const (
 	CreateTransactionTable = `CREATE TABLE IF NOT EXISTS transactions (
@@ -189,32 +195,6 @@ const (
 	// RetrieveVoutDbIDs = `SELECT unnest(vout_db_ids) FROM transactions WHERE id = $1;`
 	// RetrieveVoutDbID  = `SELECT vout_db_ids[$2] FROM transactions WHERE id = $1;`
 
-	// SelectFeesPerBlockAboveHeight returns the per-block fee total for the Fees
-	// chart. It must equal the Block# page header value, which is
-	// getTotalFee(block.Tx) + getTotalFee(block.Tickets) (pgblockchain.go):
-	// regular-tree non-coinbase transactions plus ticket purchases.
-	//
-	// transactions.fees is stored as spent - sent, so the coinbase carries a
-	// negative fee (it mints the subsidy and emits collected fees as outputs)
-	// equal to -(all real fees in the block). A plain SUM(fees) therefore
-	// cancels to exactly zero for every block. The FILTER restricts the sum to
-	// the fee-bearing set the header counts: the coinbase (tree 0, index 0) and
-	// the stake tree's votes/revocations/stake-fees are excluded; only ticket
-	// purchases (tx_type 105, dbtypes.TxTypeTicketPurchase) contribute from the
-	// stake tree. COALESCE keeps fee-only-coinbase blocks at 0 rather than NULL.
-	// See issue #405.
-	SelectFeesPerBlockAboveHeight = `
-		SELECT block_height,
-			COALESCE(SUM(fees) FILTER (
-				WHERE (tree = 0 AND block_index > 0)
-					OR (tx_type = 105 AND tree = 1)
-			), 0) AS fees
-		FROM transactions
-		WHERE is_mainchain
-			AND block_height > $1
-		GROUP BY block_height
-		ORDER BY block_height;`
-
 	SelectMixedTotalPerBlock = `
 		SELECT block_height AS block_height, 
 			SUM(mix_count * mix_denom) AS total_mixed
@@ -234,6 +214,39 @@ const (
 			AND fund_tx.is_mainchain
 		ORDER BY fund_tx.block_height;`
 )
+
+// SelectFeesPerBlockAboveHeight returns the per-block fee total for the Fees
+// chart. It must equal the Block# page header value, which is
+// getTotalFee(block.Tx) + getTotalFee(block.Tickets) (pgblockchain.go):
+// regular-tree non-coinbase transactions plus ticket purchases.
+//
+// transactions.fees is stored as spent - sent, so the coinbase carries a
+// negative fee (it mints the subsidy and emits collected fees as outputs)
+// equal to -(all real fees in the block). A plain SUM(fees) therefore cancels
+// to exactly zero for every block. The FILTER restricts the sum to the
+// fee-bearing set the header counts: the coinbase (tree 0, index 0) and the
+// stake tree's votes/revocations/stake-fees are excluded; only ticket purchases
+// (tx_type = dbtypes.TxTypeTicketPurchase, interpolated below so this can never
+// drift from the value extraction.go stores) contribute from the stake tree.
+// COALESCE keeps fee-only-coinbase blocks at 0 rather than NULL.
+//
+// The sum is restricted to is_mainchain only, deliberately NOT is_valid:
+// getTotalFee runs over the node's block txs without a validity filter, so a
+// stakeholder-disapproved block's regular-tree fees count toward both the chart
+// and the header. Adding an is_valid filter here would re-diverge them. See
+// issue #405.
+var SelectFeesPerBlockAboveHeight = fmt.Sprintf(`
+	SELECT block_height,
+		COALESCE(SUM(fees) FILTER (
+			WHERE (tree = 0 AND block_index > 0)
+				OR (tx_type = %d AND tree = 1)
+		), 0) AS fees
+	FROM transactions
+	WHERE is_mainchain
+		AND block_height > $1
+	GROUP BY block_height
+	ORDER BY block_height;`,
+	dbtypes.TxTypeTicketPurchase)
 
 /*
 var (

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -207,7 +207,7 @@ const (
 		SELECT block_height,
 			COALESCE(SUM(fees) FILTER (
 				WHERE (tree = 0 AND block_index > 0)
-					OR tx_type = 105
+					OR (tx_type = 105 AND tree = 1)
 			), 0) AS fees
 		FROM transactions
 		WHERE is_mainchain

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -6768,6 +6768,11 @@ func (pgb *ChainDB) GetExplorerBlock(ctx context.Context, hash string) *exptypes
 	}
 	block.TotalSent = (getTotalSent(block.Tx) + getTotalSent(block.Treasury) + getTotalSent(block.Revs) +
 		getTotalSent(block.Tickets) + getTotalSent(block.Votes) + getTotalSent(block.StakeFees)).ToCoin()
+	// This per-block fee total (regular-tree non-coinbase txs + ticket purchases)
+	// is the definition the Fees chart must mirror. Its SQL twin is
+	// internal.SelectFeesPerBlockAboveHeight; if you change which txs count here,
+	// update that query too or the chart and this header will silently diverge
+	// (issue #405).
 	block.MiningFee = (getTotalFee(block.Tx) + getTotalFee(block.Tickets)).ToCoin()
 
 	// Aggregate fees per coin type (VAR from MiningFee, SKA from SSFeeTotalsByCoin)

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -1146,6 +1146,19 @@ func (pgb *ChainDB) LoadSKASupplyForCoin(ctx context.Context, charts *cache.Char
 	return fmt.Errorf("no data found for coin type %d", coinType)
 }
 
+// LoadSKAFeesForCoin loads per-block SKA fee data for the specified coin type
+// into charts.SKAFees. Loads all available data (start height 0).
+func (pgb *ChainDB) LoadSKAFeesForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error {
+	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
+	defer cancel()
+
+	rows, err := retrieveSKAFees(ctx, pgb.db, coinType)
+	if err != nil {
+		return fmt.Errorf("LoadSKAFeesForCoin: query failed for coin type %d: %w", coinType, err)
+	}
+	return appendSKAFees(charts, rows, coinType)
+}
+
 // appears, along with the index of the transaction in each of the blocks. The
 // next and previous block hashes are NOT SET in each BlockStatus.
 func (pgb *ChainDB) TransactionBlocks(ctx context.Context, txHash string) ([]*dbtypes.BlockStatus, []uint32, error) {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3622,6 +3622,21 @@ func retrieveBlockFees(ctx context.Context, db *sql.DB, charts *cache.ChartData)
 	return rows, nil
 }
 
+// clampNonNegativeFee guards the appendBlockFees invariant that a per-block fee
+// total from SelectFeesPerBlockAboveHeight is non-negative: the only txs with a
+// negative stored fee (the subsidy-minting coinbase and votes/stakebase) are
+// excluded by that query's FILTER, so the fee-bearing set (regular-tree
+// non-coinbase txs + ticket purchases) sums to >= 0. A negative value is a data
+// anomaly. It is clamped to 0 rather than wrapped via uint64() into a huge chart
+// spike, and ok=false lets the caller log the anomaly without aborting. See
+// issue #405.
+func clampNonNegativeFee(fees int64) (value uint64, ok bool) {
+	if fees < 0 {
+		return 0, false
+	}
+	return uint64(fees), true
+}
+
 // Append the result from retrieveBlockFees to the provided ChartData. This
 // is the Appender half of a pair that make up a cache.ChartUpdater.
 func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
@@ -3635,20 +3650,21 @@ func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 			return err
 		}
 
-		// fees is the per-block total in atoms over the fee-bearing set
-		// (regular-tree non-coinbase txs + ticket purchases); see
-		// SelectFeesPerBlockAboveHeight. It is always >= 0, so a negative value
-		// signals a real data anomaly. Surface it as an error rather than let
-		// uint64(fees) silently wrap it into a huge spike on the chart (the old
-		// code abs()'d it, which hid the same anomaly) (issue #405). We return
-		// rather than skip the row: blocks.Fees is index-aligned with the other
-		// per-block series, so dropping an entry would desync them and make
-		// Lengthen truncate every block chart to the shortest series.
-		if fees < 0 {
-			return fmt.Errorf("appendBlockFees: negative per-block fee total %d at height %d", fees, blockHeight)
+		// A negative per-block total should be impossible (see
+		// clampNonNegativeFee / SelectFeesPerBlockAboveHeight), so warn loudly,
+		// but do NOT return an error here: appendBlockFees runs mid-pipeline as
+		// the "fees" updater, and (*ChartData).Update aborts on the first
+		// appender error before Lengthen() runs. Returning would strand the
+		// already-appended sibling series (Time, Height, …) ahead of a frozen
+		// Fees series with no reconciliation, permanently wedging chart updates
+		// on the offending block. Clamping to 0 keeps blocks.Fees index-aligned
+		// with the other per-block series and lets the update proceed. (#405)
+		fee, ok := clampNonNegativeFee(fees)
+		if !ok {
+			log.Warnf("appendBlockFees: negative per-block fee total %d at height %d; clamping to 0", fees, blockHeight)
 		}
 
-		blocks.Fees = append(blocks.Fees, uint64(fees))
+		blocks.Fees = append(blocks.Fees, fee)
 	}
 	return rows.Err()
 }

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3634,11 +3634,12 @@ func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 			log.Errorf("Unable to scan for FeeInfoPerBlock fields: %v", err)
 			return err
 		}
-		if fees < 0 {
-			fees *= -1
-		}
 
-		// Converting to atoms.
+		// fees is the per-block total in atoms over the fee-bearing set
+		// (regular-tree non-coinbase txs + ticket purchases); see
+		// SelectFeesPerBlockAboveHeight. It is always >= 0, so a value below
+		// zero would signal a real data anomaly and should surface, not be
+		// silently abs()'d as before (issue #405).
 		blocks.Fees = append(blocks.Fees, uint64(fees))
 	}
 	return rows.Err()

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3637,9 +3637,17 @@ func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 
 		// fees is the per-block total in atoms over the fee-bearing set
 		// (regular-tree non-coinbase txs + ticket purchases); see
-		// SelectFeesPerBlockAboveHeight. It is always >= 0, so a value below
-		// zero would signal a real data anomaly and should surface, not be
-		// silently abs()'d as before (issue #405).
+		// SelectFeesPerBlockAboveHeight. It is always >= 0, so a negative value
+		// signals a real data anomaly. Surface it as an error rather than let
+		// uint64(fees) silently wrap it into a huge spike on the chart (the old
+		// code abs()'d it, which hid the same anomaly) (issue #405). We return
+		// rather than skip the row: blocks.Fees is index-aligned with the other
+		// per-block series, so dropping an entry would desync them and make
+		// Lengthen truncate every block chart to the shortest series.
+		if fees < 0 {
+			return fmt.Errorf("appendBlockFees: negative per-block fee total %d at height %d", fees, blockHeight)
+		}
+
 		blocks.Fees = append(blocks.Fees, uint64(fees))
 	}
 	return rows.Err()

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -3669,6 +3669,56 @@ func appendBlockFees(charts *cache.ChartData, rows *sql.Rows) error {
 	return rows.Err()
 }
 
+// retrieveSKAFees retrieves per-block SKA fee data for the given coin type from
+// blocks.ssfee_totals (pow + pos). SKA has no block subsidy, so the SSFee
+// distribution is the fee, and there is no coinbase-cancellation problem like
+// the VAR path (#405). This is the Fetcher half of a cache.ChartUpdater pair.
+func retrieveSKAFees(ctx context.Context, db *sql.DB, coinType uint8) (*sql.Rows, error) {
+	rows, err := db.QueryContext(ctx, internal.SelectSKAFeesPerBlockAboveHeight, 0 /* startHeight */, strconv.FormatUint(uint64(coinType), 10))
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// appendSKAFees appends the results from retrieveSKAFees to the provided
+// ChartData. Fee per block = ssfee_totals[coinType].pow + .pos, carried as an
+// exact-precision string because SKA uses 18 decimals (exceeds float64's
+// significand). This is the Appender half of a cache.ChartUpdater pair.
+func appendSKAFees(charts *cache.ChartData, rows *sql.Rows, coinType uint8) error {
+	defer rows.Close()
+	var heights []int64
+	var timestamps []int64
+	var fees []string
+	for rows.Next() {
+		var blockHeight uint64
+		var blockTime time.Time
+		var fee string
+		if err := rows.Scan(&blockHeight, &blockTime, &fee); err != nil {
+			log.Errorf("Unable to scan for SKA fee fields: %v", err)
+			return err
+		}
+		heights = append(heights, int64(blockHeight))
+		timestamps = append(timestamps, blockTime.Unix())
+		fees = append(fees, fee)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	charts.SKAFeesMtx.Lock()
+	if charts.SKAFees == nil {
+		charts.SKAFees = make(map[uint8]cache.SKAFeeChartData)
+	}
+	charts.SKAFees[coinType] = cache.SKAFeeChartData{
+		Heights:    heights,
+		Timestamps: timestamps,
+		Fees:       fees,
+	}
+	charts.SKAFeesMtx.Unlock()
+	return nil
+}
+
 // retrievePrivacyParticipation retrieves the sum of all mixed vouts that is
 // newer than the data in the provided ChartData. This data is used to plot fees
 // on the /charts page. This is the Fetcher half of a pair that make up a


### PR DESCRIPTION
## Summary

Unifies the two overlapping fixes for #405 (the Fees chart showed zero for every mainnet block) into one non-conflicting branch:

- **VAR Fees-chart fix** — taken from #408 (the tighter, fully-tested version).
- **Per-coin SKA fee charts** — taken from #406 (a new capability #408 lacked).

Both original PRs branch off the same `develop` tip and **conflict** on the three VAR-fix files (`txstmts.go`, `queries.go`, `charts.go`). This branch keeps #408's VAR query + guards + tests and layers #406's SKA feature on top, so the two collapse into a single reviewable change. It supersedes #406; #408's commits are included verbatim in the history.

## VAR fix (from #408)

`transactions.fees` is stored as `spent - sent`, so the **coinbase** carries a **negative** fee equal to `-(all real fees in the block)`. The old `SUM(fees)` over every tx in a block cancelled to exactly zero.

- `SelectFeesPerBlockAboveHeight` now `FILTER`s the per-block sum to the set the Block# header counts — regular-tree non-coinbase txs + ticket purchases (`(tree = 0 AND block_index > 0) OR (tx_type = TxTypeTicketPurchase AND tree = 1)`) — an **allowlist** that mirrors `getTotalFee(block.Tx) + getTotalFee(block.Tickets)` by construction and stays correct as new stake/treasury tx types appear.
- `appendBlockFees` clamps a (now-impossible) negative per-block total to 0 and warns, instead of wrapping into a `uint64` spike or aborting the charts pipeline mid-update.
- `cacheVersion` 6.3.0 → 6.4.0 forces a charts-cache recompute. **No DB resync needed** — `transactions.fees` was always stored correctly.

## SKA fee charts (from #406)

- New `GET /api/chart/fees/{N}` (e.g. `/api/chart/fees/1` for SKA1), lazy-loaded on first request via `LoadSKAFeesForCoin`, mirroring the SKA coin-supply pattern.
- SKA has no block subsidy, so the per-block SSFee distribution recorded on the block **is** the fee: `SelectSKAFeesPerBlockAboveHeight` reads `ssfee_totals->N->>'pow' + 'pos'` straight from `blocks`, matching the per-coin SKA total the block header already reports.
- Values stay exact-precision 18-decimal strings end-to-end; the chart loses precision only on the Y-axis render and is exact on hover (same accepted trade-off as the SKA coin-supply charts).
- Frontend: `Fees (SKA{N})` dropdown options + a big-int rendering branch.

## Tests

- `TestSelectFeesPerBlockExcludesCoinbase` (pgonline) — runs the production VAR query against a synthetic block; **red (0) → green (19500)**.
- `Test_processTransactions_FeeCancellationInvariant` — pins the coinbase-cancellation invariant (no DB).
- `TestClampNonNegativeFee` — the negative-fee clamp.
- `TestAggregateSKAFees` — **new** here; pins the big.Int daily aggregation #406 left untested, including a day-sum that overflows `uint64`.

Full suite green: 3 Go modules build/vet, pgonline/chartdata tagged tests typecheck, prettier/eslint clean, 323/323 vitest.

## Note on SKA visibility per network

The charts dropdown gates SKA options on **circulating on-chain supply** (`SelectSKACoinSupply`), the same as the existing circulation charts. On mainnet, SKA1 is consensus-active but **not yet emitted** (zero circulating supply), so its options — circulation *and* fees — are correctly withheld until emission, matching the live public mainnet. The SKA fee charts are exercisable on testnet, where SKA coins are emitted. This is existing, intended behavior; no change was made to it.

Fixes #405. Supersedes #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)