### PR TITLE
fix(charts): persist chart selection to URL

### DIFF
--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -918,7 +918,7 @@ export default class extends Controller {
     this.validateZoom()
   }
 
-  setBin(e) {
+  async setBin(e) {
     const target = e.srcElement || e.target
     const option = target ? target.dataset.option : e
     if (!option) return
@@ -927,7 +927,7 @@ export default class extends Controller {
     this.updateVSelector()
     if (!target) return // Exit if running for the first time.
     selectedChart = null // Force fetch
-    this.selectChart()
+    await this.selectChart()
   }
 
   setScale(e) {
@@ -956,14 +956,14 @@ export default class extends Controller {
     this.query.replace(this.settings)
   }
 
-  setAxis(e) {
+  async setAxis(e) {
     const target = e.srcElement || e.target
     const option = target ? target.dataset.option : e
     if (!option) return
     this.setActiveOptionBtn(option, this.axisOptionTargets)
     if (!target) return // Exit if running for the first time.
     this.settings.axis = null
-    this.selectChart()
+    await this.selectChart()
   }
 
   updateVSelector(chart) {

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -833,6 +833,7 @@ export default class extends Controller {
       console.log('got api data', chartResponse, this, selection)
       selectedChart = selection
       this.plotGraph(selection, chartResponse)
+      this.query.replace(this.settings)
     } else {
       this.chartWrapperTarget.classList.remove('loading')
     }

--- a/cmd/dcrdata/public/js/controllers/charts_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.test.js
@@ -128,7 +128,6 @@ function makeController() {
 
 describe('ChartsController URL persistence', () => {
   beforeEach(() => {
-    mockReplace.mockClear()
     vi.clearAllMocks()
   })
 

--- a/cmd/dcrdata/public/js/controllers/charts_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.test.js
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockReplace = vi.fn()
+
+vi.mock('@hotwired/stimulus', () => ({
+  Controller: class {
+    constructor(element) {
+      this.element = element
+    }
+  }
+}))
+
+vi.mock('../helpers/turbolinks_helper', () => {
+  return {
+    default: class TurboQuery {
+      constructor() {
+        this.url = {
+          protocol: 'https:',
+          host: 'localhost',
+          set: vi.fn(),
+          query: {}
+        }
+        this.update = vi.fn()
+      }
+      replace(query) {
+        mockReplace(query)
+      }
+      static nullTemplate(keys) {
+        const d = {}
+        keys.forEach((k) => (d[k] = null))
+        return d
+      }
+    }
+  }
+})
+
+vi.mock('../helpers/http', () => ({
+  requestJSON: vi.fn().mockResolvedValue({
+    t: [1000, 2000],
+    price: [10, 20],
+    count: [100, 200],
+    h: [1, 2],
+    supply: [1000, 2000],
+    fees: [1, 2],
+    duration: [10, 20],
+    work: [100, 200],
+    rate: [100, 200],
+    missed: [1, 2],
+    offset: 0,
+    axis: 'time',
+    bin: 'block'
+  })
+}))
+
+vi.mock('../services/event_bus_service', () => ({
+  default: {
+    on: vi.fn(),
+    off: vi.fn()
+  }
+}))
+
+vi.mock('../services/theme_service', () => ({
+  darkEnabled: vi.fn().mockReturnValue(false)
+}))
+
+vi.mock('../helpers/module_helper', () => ({
+  getDefault: vi.fn().mockResolvedValue(
+    class Dygraph {
+      constructor() {
+        this.plotter_ = { clear: vi.fn() }
+        this.updateOptions = vi.fn()
+        this.xAxisExtremes = vi.fn().mockReturnValue([0, 100])
+        this.yAxisRanges = vi.fn().mockReturnValue([0, 100])
+      }
+      static Plugins = {
+        Legend: {
+          generateLegendHTML: vi.fn()
+        }
+      }
+    }
+  )
+}))
+
+vi.mock('../helpers/zoom_helper', () => ({
+  default: {
+    validate: vi.fn().mockReturnValue({ start: 0, end: 100 }),
+    project: vi.fn().mockReturnValue({ start: 0, end: 100 }),
+    object: vi.fn().mockReturnValue({ start: 0, end: 100 }),
+    encode: vi.fn().mockReturnValue('zoom-string'),
+    mapKey: vi.fn().mockReturnValue('zoom-option')
+  }
+}))
+
+vi.mock('../helpers/animation_helper', () => ({
+  animationFrame: vi.fn().mockResolvedValue()
+}))
+
+vi.mock('../helpers/chart_helper', () => ({
+  isEqual: vi.fn().mockReturnValue(false)
+}))
+
+const { default: ChartsController } = await import('./charts_controller.js')
+
+function makeController() {
+  const c = new ChartsController()
+  c.data = { get: vi.fn().mockReturnValue('100') }
+  c.chartSelectTarget = { value: 'ticket-price' }
+  c.chartWrapperTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
+  c.scaleSelectorTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
+  c.vSelectorTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
+  c.vSelectorItemTargets = []
+  c.modeSelectorTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
+  c.binSelectorTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
+  c.binSizeTargets = []
+  c.axisOptionTargets = []
+  c.zoomOptionTargets = []
+  c.scaleTypeTargets = []
+  c.modeOptionTargets = []
+  c.labelsTarget = { appendChild: vi.fn() }
+  c.legendMarkerTarget = { remove: vi.fn(), removeAttribute: vi.fn() }
+  c.legendEntryTarget = { remove: vi.fn(), removeAttribute: vi.fn() }
+  c.rawDataURLTarget = { textContent: '' }
+  c.chartsViewTarget = {}
+  c.ticketsPriceTarget = { checked: true }
+  c.ticketsPurchaseTarget = { checked: true }
+  return c
+}
+
+describe('ChartsController URL persistence', () => {
+  beforeEach(() => {
+    mockReplace.mockClear()
+    vi.clearAllMocks()
+  })
+
+  it('selectChart persists chart/bin/axis to URL via query.replace', async () => {
+    const c = makeController()
+    await c.connect()
+
+    c.chartSelectTarget.value = 'ticket-pool-size'
+
+    // Mock DOM for selected options
+    c.binSizeTargets = [
+      {
+        classList: { contains: (cls) => cls === 'active', add: vi.fn(), remove: vi.fn() },
+        dataset: { option: 'day' }
+      }
+    ]
+    c.axisOptionTargets = [
+      {
+        classList: { contains: (cls) => cls === 'active', add: vi.fn(), remove: vi.fn() },
+        dataset: { option: 'time' }
+      }
+    ]
+
+    await c.selectChart()
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chart: 'ticket-pool-size',
+        bin: 'day',
+        axis: 'time'
+      })
+    )
+  })
+
+  it('setBin delegates to selectChart and persists bin to URL', async () => {
+    const c = makeController()
+    await c.connect()
+
+    c.chartSelectTarget.value = 'ticket-pool-size' // Use chart that supports blocks
+
+    const binOption = {
+      classList: { contains: (cls) => cls === 'active', add: vi.fn(), remove: vi.fn() },
+      dataset: { option: 'block' }
+    }
+    c.binSizeTargets = [binOption]
+    c.axisOptionTargets = [
+      {
+        classList: { contains: (cls) => cls === 'active', add: vi.fn(), remove: vi.fn() },
+        dataset: { option: 'time' }
+      }
+    ]
+
+    const event = { target: binOption }
+    await c.setBin(event)
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bin: 'block'
+      })
+    )
+  })
+
+  it('setAxis delegates to selectChart and persists axis to URL', async () => {
+    const c = makeController()
+    await c.connect()
+
+    const axisOption = {
+      classList: { contains: (cls) => cls === 'active', add: vi.fn(), remove: vi.fn() },
+      dataset: { option: 'height' }
+    }
+    c.axisOptionTargets = [axisOption]
+    c.binSizeTargets = [
+      {
+        classList: { contains: (cls) => cls === 'active', add: vi.fn(), remove: vi.fn() },
+        dataset: { option: 'day' }
+      }
+    ]
+
+    const event = { target: axisOption }
+    await c.setAxis(event)
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        axis: 'height'
+      })
+    )
+  })
+})


### PR DESCRIPTION
Description
Fixed an issue where changing the chart selection in the dropdown updated the graph but did not update the URL query parameters. This caused the selection to be lost on page reload and prevented URLs from being shareable.
The root cause was a missing call to this.query.replace(this.settings) in the selectChart() method. While other controls (zoom, scale, mode, visibility) correctly persisted their state to the URL, the chart selection (and the bin/axis changes that route through it) did not.
Changes
- cmd/dcrdata/public/js/controllers/charts_controller.js: Added this.query.replace(this.settings) to selectChart() after the chart data is fetched and plotted.
- cmd/dcrdata/public/js/controllers/charts_controller.test.js: Added a new test suite to verify that:
- Changing the chart updates the ?chart= parameter.
- Changing the bin via setBin updates the ?bin= parameter.
- Changing the axis via setAxis updates the ?axis= parameter.
Verification Results
- Tests: All 3 new tests passed using npm test.
- Linting: Verified with npm run check (no errors).
- Manual: Verified that selecting different charts, bins, and axes now immediately updates the URL and persists across page reloads.