### PR TITLE
fix(mempool): render '0' when no votes are present in header

### DIFF
--- a/cmd/dcrdata/public/js/controllers/mempool_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.js
@@ -143,6 +143,13 @@ function cloneVoteRow(template, tx) {
   return tr
 }
 
+function makeVoteZeroSpan() {
+  const span = document.createElement('span')
+  span.className = 'text-center position-relative d-inline-block'
+  span.textContent = '0'
+  return span
+}
+
 function buildTable(target, txType, txns, rowFn) {
   while (target.firstChild) target.removeChild(target.firstChild)
   if (txns && txns.length > 0) {
@@ -334,9 +341,14 @@ export default class extends Controller {
     const counts = this.mempool.counts()
     const ct = this.voteCountTarget
     while (ct.firstChild) ct.removeChild(ct.firstChild)
-    this.mempool.voteSpans(counts.vote).forEach((span) => {
-      ct.appendChild(span)
-    })
+    const spans = this.mempool.voteSpans(counts.vote)
+    if (spans.length === 0) {
+      ct.appendChild(makeVoteZeroSpan())
+    } else {
+      spans.forEach((span) => {
+        ct.appendChild(span)
+      })
+    }
     const totals = this.mempool.totals()
     this.mempoolSizeTarget.textContent = humanize.bytes(totals.size)
     this.labelVotes()

--- a/cmd/dcrdata/public/js/controllers/mempool_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/mempool_controller.test.js
@@ -73,3 +73,41 @@ describe('mempool reconnect resync', () => {
     expect(registered.reconnect[0].unsub).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('mempool zero vote count', () => {
+  it('renders "0" in voteCountTarget when no votes are tallied', () => {
+    const c = makeController()
+
+    // Mock targets
+    const voteCountTarget = {
+      firstChild: null,
+      removeChild: vi.fn(),
+      appendChild: vi.fn()
+    }
+    c.voteCountTarget = voteCountTarget
+    c.mempoolSizeTarget = { textContent: '' }
+
+    // Mock dependencies
+    c.lastCoinStats = null
+    c.applyCoinStats = vi.fn()
+    c.labelVotes = vi.fn()
+
+    // Mock Mempool instance
+    c.mempool = {
+      counts: vi.fn().mockReturnValue({ vote: {}, regular: 0, ticket: 0, rev: 0, total: 0 }),
+      voteSpans: vi.fn().mockReturnValue([]),
+      totals: vi
+        .fn()
+        .mockReturnValue({ size: 100, regular: 0, ticket: 0, vote: 0, rev: 0, total: 0 })
+    }
+
+    c.setMempoolFigures()
+
+    expect(voteCountTarget.appendChild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        textContent: '0',
+        className: 'text-center position-relative d-inline-block'
+      })
+    )
+  })
+})

--- a/cmd/dcrdata/views/mempool.tmpl
+++ b/cmd/dcrdata/views/mempool.tmpl
@@ -111,20 +111,24 @@
                         </div>
                         <div class="col-12 col-md-6 col-lg-12 col-xl-6 pb-3">
                             <div class="text-center text-secondary fs13">Votes</div>
-                            <div class="text-center h4 mb-0" data-mempool-target="voteCount">
-                                {{$afterFirst := false -}}
-                                {{- range $hash, $tally := .VotingInfo.VoteTallys -}}
-                                    {{if $afterFirst}} + {{end}}
-                                    <span class="text-center position-relative d-inline-block"
-                                    data-mempool-target="voteTally"
-                                    data-hash="{{$hash}}"
-                                    data-affirmed="{{$tally.Affirmations}}"
-                                    data-count="{{$tally.VoteCount}}"
-                                    data-tooltip="for block {{$hash}}"
-                                    >{{$tally.VoteCount}}</span>
-                                    {{$afterFirst = true}}
-                                {{- end}}
-                            </div>
+                             <div class="text-center h4 mb-0" data-mempool-target="voteCount">
+                                 {{if .VotingInfo.VoteTallys -}}
+                                     {{$afterFirst := false -}}
+                                     {{- range $hash, $tally := .VotingInfo.VoteTallys -}}
+                                         {{if $afterFirst}} + {{end}}
+                                         <span class="text-center position-relative d-inline-block"
+                                         data-mempool-target="voteTally"
+                                         data-hash="{{$hash}}"
+                                         data-affirmed="{{$tally.Affirmations}}"
+                                         data-count="{{$tally.VoteCount}}"
+                                         data-tooltip="for block {{$hash}}"
+                                         >{{$tally.VoteCount}}</span>
+                                         {{$afterFirst = true}}
+                                     {{- end}}
+                                 {{- else -}}
+                                     <span class="text-center position-relative d-inline-block">0</span>
+                                 {{- end}}
+                             </div>
                             <div class="text-center fs13">
                                 <span data-mempool-target="voteTotal">{{formatCoinAtoms $varStats.VoteAmount 0}}</span> VAR
                             </div>


### PR DESCRIPTION
Changes:
- cmd/dcrdata/views/mempool.tmpl: Added an {{else}} block to render a 0 span when .VotingInfo.VoteTallys is empty.
- cmd/dcrdata/public/js/controllers/mempool_controller.js: Added a makeVoteZeroSpan() helper and updated setMempoolFigures() to append this span when no tallies are present.
- cmd/dcrdata/public/js/controllers/mempool_controller.test.js: Added a test case to verify that a 0 span is rendered when there are no votes.