### PR TITLE
fix(charts): prevent CHART dropdown label clipping on /charts

### DIFF
--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -320,6 +320,8 @@ body.darkBG .chartview .dygraph-y2label {
 .chart-form-control {
   width: -moz-fit-content;
   width: fit-content;
+  min-width: 17em;
+  max-width: 100%;
   font-size: 0.9rem !important;
   height: calc(1.5em + 0.5rem + 2px) !important;
   line-height: 1;


### PR DESCRIPTION
Changes:
- Modified cmd/dcrdata/public/scss/charts.scss to add min-width: 17em and max-width: 100% to .chart-form-control. This ensures that the dropdown is wide enough to show the longest labels (like "Duration Between Blocks") while still fitting within the viewport on mobile devices.
Verification:
- Ran npm run check, and all formatting and linting checks passed.
- The change follows the agreed plan to ensure visual consistency across themes and responsive behavior down to 360px.
- All work was done on the fix/chart-dropdown-clipping branch.