### PR TITLE
feat(ui): add Visual Blocks entry to hamburger menu

### DIFF
--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -78,6 +78,7 @@
 				<div id="menu">
 					<a class="menu-item" data-keynav-skip href="/" title="Home">Home</a>
 					<a class="menu-item" data-keynav-skip href="/blocks" title="Monetarium blocks">Blocks</a>
+					<a class="menu-item" data-keynav-skip href="/visualblocks" title="Monetarium Visual Blocks">Visual Blocks</a>
 					<a class="menu-item" data-keynav-skip href="/mempool" title="Monetarium mempool">Mempool</a>
 					<a class="menu-item" data-keynav-skip href="/ticketpool" title="Monetarium ticket pool">Ticket Pool</a>
 					<a class="menu-item jsonly" data-keynav-skip href="/charts" title="Monetarium charts">Charts</a>


### PR DESCRIPTION
Changes:
- Inserted <a class="menu-item" data-keynav-skip href="/visualblocks" title="Monetarium Visual Blocks">Visual Blocks</a> directly after the "Blocks" entry.
Verification:
- The link is placed in the shared navbar template, ensuring it appears on every page.
- The route /visualblocks is already registered and covered by the SyncStatusPageIntercept middleware.
- Consistent style with neighboring menu items.