### PR TITLE
charts: widen CHART dropdown to fit the selected option label

### DIFF
--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -315,6 +315,7 @@ body.darkBG .chartview .dygraph-y2label {
   padding: 2px;
   background: #fff;
   width: max-content;
+  max-width: 100%;
 }
 
 .chart-form-control {
@@ -323,6 +324,19 @@ body.darkBG .chartview .dygraph-y2label {
   font-size: 0.9rem !important;
   height: calc(1.5em + 0.5rem + 2px) !important;
   line-height: 1;
+}
+
+/* The CHART <select> has appearance:none (from .form-control), so it never
+   auto-sizes to its widest <option> and clips long labels ("Duration Between
+   Blocks", "Circulation (SKA{n})", etc.). min-width floors it wide enough to
+   show the longest label in full (with headroom for fallback fonts), while
+   .chart-control's max-width:100% keeps it within .container on narrow
+   viewports (no horizontal overflow). Scoped to .chart-control so the shared
+   .chart-form-control on /attackcost keeps its original width. The dropdown
+   arrow is pinned to a fixed size in navigation.scss (select.dropdown) so it
+   doesn't scale with this wider box. */
+.chart-control select {
+  min-width: 13rem;
 }
 
 .chart-control select,

--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -326,15 +326,9 @@ body.darkBG .chartview .dygraph-y2label {
   line-height: 1;
 }
 
-/* The CHART <select> has appearance:none (from .form-control), so it never
-   auto-sizes to its widest <option> and clips long labels ("Duration Between
-   Blocks", "Circulation (SKA{n})", etc.). min-width floors it wide enough to
-   show the longest label in full (with headroom for fallback fonts), while
-   .chart-control's max-width:100% keeps it within .container on narrow
-   viewports (no horizontal overflow). Scoped to .chart-control so the shared
-   .chart-form-control on /attackcost keeps its original width. The dropdown
-   arrow is pinned to a fixed size in navigation.scss (select.dropdown) so it
-   doesn't scale with this wider box. */
+/* appearance:none (from .form-control) blocks native grow-to-widest-option
+   sizing, so min-width floors the box to its longest label. Scoped to
+   .chart-control so the shared .chart-form-control on /attackcost stays narrow. */
 .chart-control select {
   min-width: 13rem;
 }

--- a/cmd/dcrdata/public/scss/navigation.scss
+++ b/cmd/dcrdata/public/scss/navigation.scss
@@ -143,9 +143,8 @@ select {
 }
 
 select.dropdown {
-  /* Fixed 8px arrow (the svg's natural width) rather than 8% of the box width,
-     so selects wider than the default 100px (e.g. the CHART control on
-     /charts) don't render an oversized arrow. */
+  /* Fixed 8px (the svg's natural width), not 8% of box width, so wider selects
+     (e.g. the CHART control) don't balloon the arrow. */
   background: url("/images/dropdown.svg") 95% / 8px no-repeat #fff;
   width: 100px;
 }

--- a/cmd/dcrdata/public/scss/navigation.scss
+++ b/cmd/dcrdata/public/scss/navigation.scss
@@ -143,7 +143,10 @@ select {
 }
 
 select.dropdown {
-  background: url("/images/dropdown.svg") 95% / 8% no-repeat #fff;
+  /* Fixed 8px arrow (the svg's natural width) rather than 8% of the box width,
+     so selects wider than the default 100px (e.g. the CHART control on
+     /charts) don't render an oversized arrow. */
+  background: url("/images/dropdown.svg") 95% / 8px no-repeat #fff;
   width: 100px;
 }
 
@@ -208,7 +211,7 @@ body.darkBG {
   }
 
   select.dropdown {
-    background: url("/images/dropdown-light.svg") 95% / 8% no-repeat #fff;
+    background: url("/images/dropdown-light.svg") 95% / 8px no-repeat #fff;
   }
 
   .search-bttn:hover {


### PR DESCRIPTION
## Summary

On `/charts`, the CHART `<select>` was styled `width: fit-content` via `.chart-form-control`, but Bootstrap's `.form-control` applies `appearance: none`, which strips the native `<select>`'s grow-to-widest-option behavior — so the box collapsed to a UA-default ~100px and clipped long labels ("Duration Between Blocks", "Stake Participation", "Circulation (SKA{n})").

This sizes the control to show the full selected label, in both themes and down to 360px, without introducing horizontal overflow — and fixes a regression the widening exposed in the shared dropdown-arrow styling.

## Changes

- **`charts.scss`** — `min-width: 13rem` on `.chart-control select` (enough for the longest label + headroom for fallback fonts), plus `max-width: 100%` on `.chart-control` so the widened box stays within `.container`. Scoped to `.chart-control` (charts-only) so the same-classed `.chart-form-control` "Attack Type" dropdown on `/attackcost` keeps its original width.
- **`navigation.scss`** — the dropdown arrow was `background-size: 8%` (8% of the box width). All `select.dropdown` are pinned to `width: 100px`, so `8%` == `8px` everywhere; widening the CHART box ballooned its arrow to ~17px. Pinned to a fixed `8px` (the SVG's natural width) in both the light and dark rules — a no-op for every 100px dropdown, fixed at the source so it also covers the higher-specificity `body.darkBG` rule.

## Verification

Built the bundle and tested against the running explorer (`/charts`):

| Scenario | Width | Clipped | Arrow | Page overflow |
|---|---|---|---|---|
| Desktop, light | 208px | no | 8px | no |
| Desktop, dark (`.darkBG`) | 208px | no | 8px | no |
| 360px mobile | 208px | no | 8px | no |

Confirmed dynamically-generated SKA options (`coin-supply/{n}`, `fees/{n}`) also display in full. `/attackcost` and navbar/other `select.dropdown` controls are unchanged. `prettier`, `stylelint`, and `webpack` build all pass.

Fixes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)