### PR TITLE
address: render first 2 decimal places at full size in balance stats

### DIFF
--- a/cmd/dcrdata/views/address.tmpl
+++ b/cmd/dcrdata/views/address.tmpl
@@ -51,9 +51,9 @@
                 {{- if $cb}}
                   <span class="lh1rem d-block pt-1 fs18 fs14-decimal fw-bold">
                     {{- if eq $ct 0 -}}
-                      {{template "decimalParts" (amountAsDecimalParts $cb.TotalUnspent true)}}
+                      {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount $cb.TotalUnspent) 8 true 2)}}
                     {{- else -}}
-                      {{template "decimalParts" (skaDecimalParts $cb.TotalUnspentSKA true)}}
+                      {{template "decimalParts" (skaDecimalParts $cb.TotalUnspentSKA true 2)}}
                     {{- end -}}
                     <span class="text-secondary fs14 ms-1">{{coinSymbol $ct}}</span>
                   </span>
@@ -70,9 +70,9 @@
                 {{- if $cb}}
                   <span class="lh1rem d-block pt-1 fs18 fs14-decimal fw-bold">
                     {{- if eq $ct 0 -}}
-                      {{template "decimalParts" (amountAsDecimalParts $cb.TotalReceived true)}}
+                      {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount $cb.TotalReceived) 8 true 2)}}
                     {{- else -}}
-                      {{template "decimalParts" (skaDecimalParts $cb.TotalReceivedSKA true)}}
+                      {{template "decimalParts" (skaDecimalParts $cb.TotalReceivedSKA true 2)}}
                     {{- end -}}
                     <span class="text-secondary fs14 ms-1">{{coinSymbol $ct}}</span>
                   </span>
@@ -93,9 +93,9 @@
                 {{- if $cb}}
                   <span class="lh1rem d-block pt-1 fs18 fs14-decimal fw-bold">
                     {{- if eq $ct 0 -}}
-                      {{template "decimalParts" (amountAsDecimalParts $cb.TotalSpent true)}}
+                      {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount $cb.TotalSpent) 8 true 2)}}
                     {{- else -}}
-                      {{template "decimalParts" (skaDecimalParts $cb.TotalSpentSKA true)}}
+                      {{template "decimalParts" (skaDecimalParts $cb.TotalSpentSKA true 2)}}
                     {{- end -}}
                     <span class="text-secondary fs14 ms-1">{{coinSymbol $ct}}</span>
                   </span>


### PR DESCRIPTION
## Summary

- Balance, Received, and Spent amounts on the address page were calling `amountAsDecimalParts` / `skaDecimalParts` without `boldNumPlaces`, which produces 3-part output where **all** decimal digits render at the smaller `fs14-decimal` size (14px)
- Passing `boldNumPlaces=2` switches to 4-part mode: the first 2 decimal digits are included in `<span class="int">` alongside the integer, rendering at the same 18px size — matching the homepage convention used by the supply and mining cards

## Test plan

- [ ] Navigate to an address page and verify Balance, Received, and Spent values show the first 2 decimal digits at the same size as the whole-number digits
- [ ] Check with a VAR-only address, a SKA-only address, and a mixed-coin address
- [ ] Verify addresses with zero balances still render correctly (dash fallback path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)