### PR TITLE
address: render first 2 decimal places at full size in balance stats

### DIFF
--- a/cmd/dcrdata/views/address.tmpl
+++ b/cmd/dcrdata/views/address.tmpl
@@ -51,9 +51,9 @@
                 {{- if $cb}}
                   <span class="lh1rem d-block pt-1 fs18 fs14-decimal fw-bold">
                     {{- if eq $ct 0 -}}
-                      {{template "decimalParts" (amountAsDecimalParts $cb.TotalUnspent true)}}
+                      {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount $cb.TotalUnspent) 8 true 2)}}
                     {{- else -}}
-                      {{template "decimalParts" (skaDecimalParts $cb.TotalUnspentSKA true)}}
+                      {{template "decimalParts" (skaDecimalParts $cb.TotalUnspentSKA true 2)}}
                     {{- end -}}
                     <span class="text-secondary fs14 ms-1">{{coinSymbol $ct}}</span>
                   </span>
@@ -70,9 +70,9 @@
                 {{- if $cb}}
                   <span class="lh1rem d-block pt-1 fs18 fs14-decimal fw-bold">
                     {{- if eq $ct 0 -}}
-                      {{template "decimalParts" (amountAsDecimalParts $cb.TotalReceived true)}}
+                      {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount $cb.TotalReceived) 8 true 2)}}
                     {{- else -}}
-                      {{template "decimalParts" (skaDecimalParts $cb.TotalReceivedSKA true)}}
+                      {{template "decimalParts" (skaDecimalParts $cb.TotalReceivedSKA true 2)}}
                     {{- end -}}
                     <span class="text-secondary fs14 ms-1">{{coinSymbol $ct}}</span>
                   </span>
@@ -93,9 +93,9 @@
                 {{- if $cb}}
                   <span class="lh1rem d-block pt-1 fs18 fs14-decimal fw-bold">
                     {{- if eq $ct 0 -}}
-                      {{template "decimalParts" (amountAsDecimalParts $cb.TotalSpent true)}}
+                      {{template "decimalParts" (float64AsDecimalParts (toFloat64Amount $cb.TotalSpent) 8 true 2)}}
                     {{- else -}}
-                      {{template "decimalParts" (skaDecimalParts $cb.TotalSpentSKA true)}}
+                      {{template "decimalParts" (skaDecimalParts $cb.TotalSpentSKA true 2)}}
                     {{- end -}}
                     <span class="text-secondary fs14 ms-1">{{coinSymbol $ct}}</span>
                   </span>


### PR DESCRIPTION
Balance, Received, and Spent amounts were using amountAsDecimalParts / skaDecimalParts without boldNumPlaces, producing 3-part output where all decimal digits render at the smaller fs14-decimal size. Pass boldNumPlaces=2 so the first 2 decimal digits join the integer in span.int and render at the same 18px size, matching the homepage convention.