### PR TITLE
Fix/charts ticker persistence

### DIFF
--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -526,7 +526,17 @@ export default class extends Controller {
         gOptions.visibility = this.visibility
         gOptions.axes.y2 = {
           valueRange: [0, windowSize * 20 * 8],
-          axisLabelFormatter: (y) => Math.round(y)
+          axisLabelFormatter: (y) => Math.round(y),
+          ticker: (min, max, _pixels, _opts, _dygraph) => {
+            const span = max - min
+            if (span <= 0) return []
+            const step = Math.pow(10, Math.floor(Math.log10(span / 5)))
+            const ticks = []
+            for (let v = Math.ceil(min / step) * step; v <= max; v += step) {
+              ticks.push({ v: v, label: String(v) })
+            }
+            return ticks
+          }
         }
         yFormatter = customYFormatter((y) => `${y.toFixed(8)} VAR`)
         break
@@ -778,6 +788,7 @@ export default class extends Controller {
           gOptions.visibility = this.visibility
           gOptions.axes.y = { valueRange: [null, null] }
           gOptions.axes.y2 = {
+            valueRange: [0, null],
             axisLabelFormatter: (y) => Math.round(y),
             ticker: (min, max, _pixels, _opts, _dygraph) => {
               const ticks = []

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -165,7 +165,7 @@ function nightModeOptions(nightModeOn) {
   return {
     rangeSelectorAlpha: 0.4,
     gridLineColor: '#C4CBD2',
-    colors: ['#2970FF', '#006600', '#FF0090']
+    colors: ['#2970FF', '#c60', '#FF0090']
   }
 }
 


### PR DESCRIPTION
Fixes: #435, #434
Summary
This PR fixes two related chart rendering bugs on the /charts page:
1. Vertical black artifact + broken Active Miners axis when switching charts (#435)
- Dygraphs updateOptions() deep-merges axes config. Switching between dual-axis charts (Hashrate ↔ Ticket Price) caused cross-contamination:
- Ticket Price's large valueRange on y2 persisted to Hashrate → Active Miners scale inverted (max at bottom) and generated thousands of labels
- Hashrate's integer ticker persisted to Ticket Price → Tickets Bought axis flooded with labels
- Fix: Each dual-axis chart now fully specifies y2 axis config (valueRange + ticker) to prevent merge leakage.
2. Series color mismatch with visibility toggle (#434)
- Light mode: Active Miners line was green (#006600) but checkbox was brown (#c60)
- Fix: Updated nightModeOptions() light mode colors array index 1 from #006600 → #c60 to match .hashrate-miners checkbox in charts.scss. Dark mode already matched.
Changes
Commit	File
6909e111	charts_controller.js
3f41a842	charts_controller.js
Testing
- npm run build — passes (0 errors)
- npm test — 327 tests pass
- Manual verification:
- Switch Hashrate ↔ Ticket Price → no artifacts, axes correct
- Light mode: Hashrate=blue, Active Miners=brown (match checkboxes)
- Dark mode: Hashrate=teal, Active Miners=blue (match checkboxes)
- Theme toggle preserves colors
- Reload page → clean initial state