### PR TITLE
cmd/dcrdata: keep Voting "No SKA rewards available" placeholder on live blocks

### DIFF
--- a/cmd/dcrdata/internal/explorer/home_voting_template_test.go
+++ b/cmd/dcrdata/internal/explorer/home_voting_template_test.go
@@ -100,25 +100,29 @@ func TestVotingCardTemplate(t *testing.T) {
 		}
 	})
 
-	// Case 4 — Empty SKA slice
+	// Case 4 — Empty SKA slice. The placeholder text appears twice: once in the
+	// visible {{else}} branch and once in the inert ska-vote-empty-template the
+	// JS clones on live blocks (issue #436).
 	t.Run("EmptySKASlice", func(t *testing.T) {
 		out := renderVotingCard(t, tmpl, makeHomeInfo(types.VoteVARReward{}, []types.SKAVoteReward{}))
-		if !strings.Contains(out, "No SKA rewards available") {
-			t.Error("expected 'No SKA rewards available' in output")
+		if got := strings.Count(out, "No SKA rewards available"); got != 2 {
+			t.Errorf("expected placeholder in visible branch + inert template (2), got %d", got)
 		}
 		if strings.Contains(out, "SKA1") || strings.Contains(out, "SKA2") {
 			t.Error("expected no SKA symbol rows for empty SKA slice")
 		}
 	})
 
-	// Case 5 — Single SKA entry
+	// Case 5 — Single SKA entry. The visible {{else}} branch must not render, so
+	// the placeholder text appears exactly once: in the inert
+	// ska-vote-empty-template only (issue #436).
 	t.Run("SingleSKAEntry", func(t *testing.T) {
 		ska := []types.SKAVoteReward{
 			{CoinType: 1, Symbol: "SKA1", PerBlock: "97178596780181388", PerYear: "38980675541825918"},
 		}
 		out := renderVotingCard(t, tmpl, makeHomeInfo(types.VoteVARReward{}, ska))
-		if strings.Contains(out, "No SKA rewards available") {
-			t.Error("should not show placeholder when SKA entries are present")
+		if got := strings.Count(out, "No SKA rewards available"); got != 1 {
+			t.Errorf("expected placeholder only in inert template (1), got %d", got)
 		}
 		if !strings.Contains(out, "SKA1") {
 			t.Error("expected symbol 'SKA1' in output")
@@ -164,6 +168,17 @@ func TestVotingCardTemplate(t *testing.T) {
 		// rest significant digits must appear
 		if !strings.Contains(out, "456789") {
 			t.Error("expected rest decimal digits in output")
+		}
+	})
+
+	// Case 8 — empty-state template present for JS live-update (issue #436).
+	// The voting controller clears the skaVoteRewards container on every
+	// websocket block and clones this template to restore the placeholder
+	// when a block carries no SKA rewards; without it the text vanishes.
+	t.Run("SKAVoteEmptyTemplatePresent", func(t *testing.T) {
+		out := renderVotingCard(t, tmpl, makeHomeInfo(types.VoteVARReward{}, nil))
+		if !strings.Contains(out, `id="ska-vote-empty-template"`) {
+			t.Error("expected ska-vote-empty-template element for JS live-update")
 		}
 	})
 }

--- a/cmd/dcrdata/public/js/controllers/voting_controller.js
+++ b/cmd/dcrdata/public/js/controllers/voting_controller.js
@@ -62,6 +62,15 @@ export default class extends Controller {
     const container = this.skaVoteRewardsTarget
     container.innerHTML = ''
 
+    // A websocket block with no SKA rewards (e.g. mainnet, where ska_vote_rewards
+    // is omitted from the payload) must restore the server-rendered placeholder
+    // rather than leave the container empty (issue #436).
+    if (!Array.isArray(rewards) || rewards.length === 0) {
+      const emptyTmpl = document.getElementById('ska-vote-empty-template')
+      if (emptyTmpl) container.appendChild(document.importNode(emptyTmpl.content, true))
+      return
+    }
+
     rewards.forEach((r) => {
       const clone = document.importNode(tmpl.content, true)
 

--- a/cmd/dcrdata/public/js/controllers/voting_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/voting_controller.test.js
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@hotwired/stimulus', () => ({
+  Controller: class {
+    constructor(element) {
+      this.element = element
+    }
+  }
+}))
+
+const { default: VotingController } = await import('./voting_controller.js')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// buildContainer mirrors the live-update DOM of home_voting.tmpl: a
+// skaVoteRewards container holding the server-rendered "No SKA rewards
+// available" placeholder, plus the two <template> elements the controller
+// clones from.
+function buildContainer() {
+  document.body.innerHTML = `
+<div data-voting-target="skaVoteRewards" class="d-flex flex-column">
+  <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
+</div>
+<template id="ska-reward-block-template">
+  <div>
+    <a class="text-decoration-none" data-block-height>
+      <div class="mono">
+        <div class="decimal-parts d-inline-block" data-field="block-parts"><span class="int"></span></div>
+        <span class="unit" data-field="unit"></span>
+      </div>
+    </a>
+    <div class="fs12">
+      <div class="decimal-parts d-inline-block" data-field="peryear-parts"><span class="int"></span></div>
+      <span data-field="peryear-unit"></span>
+    </div>
+  </div>
+</template>
+<template id="ska-vote-empty-template">
+  <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
+</template>
+`
+  const container = document.querySelector('[data-voting-target="skaVoteRewards"]')
+  const ctrl = new VotingController(document.body)
+  ctrl.skaVoteRewardsTarget = container
+  ctrl.hasSkaVoteRewardsTarget = true
+  return { container, ctrl }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #436: "No SKA rewards available" disappears on websocket newblock
+// ---------------------------------------------------------------------------
+
+describe('voting_controller — SKA rewards empty-state (issue #436)', () => {
+  let container, ctrl
+  beforeEach(() => {
+    ;({ container, ctrl } = buildContainer())
+  })
+
+  it('keeps the placeholder when rewards is undefined (mainnet: ska_vote_rewards omitted)', () => {
+    expect(() => ctrl._renderSkaRewards(undefined)).not.toThrow()
+    expect(container.textContent).toContain('No SKA rewards available')
+  })
+
+  it('keeps the placeholder when rewards is null', () => {
+    expect(() => ctrl._renderSkaRewards(null)).not.toThrow()
+    expect(container.textContent).toContain('No SKA rewards available')
+  })
+
+  it('keeps the placeholder when rewards is an empty array', () => {
+    ctrl._renderSkaRewards([])
+    expect(container.textContent).toContain('No SKA rewards available')
+  })
+
+  it('restores the placeholder when a later block clears previously rendered rewards', () => {
+    // First a block carrying a reward removes the placeholder and renders it.
+    ctrl._renderSkaRewards([
+      {
+        coin_type: 1,
+        symbol: 'SKA1',
+        per_block: '1000000000000000000',
+        per_year: '365000000000000000000'
+      }
+    ])
+    expect(container.textContent).not.toContain('No SKA rewards available')
+
+    // A subsequent block with no rewards must bring the placeholder back.
+    ctrl._renderSkaRewards([])
+    expect(container.textContent).toContain('No SKA rewards available')
+  })
+
+  it('renders reward rows and drops the placeholder when rewards are present', () => {
+    ctrl._renderSkaRewards([
+      {
+        coin_type: 1,
+        symbol: 'SKA1',
+        per_block: '1000000000000000000',
+        per_year: '365000000000000000000',
+        block_height: 4096
+      }
+    ])
+    expect(container.textContent).not.toContain('No SKA rewards available')
+    expect(container.textContent).toContain('SKA1/Vote')
+    const link = container.querySelector('a[href="/block/4096"]')
+    expect(link).not.toBeNull()
+  })
+})

--- a/cmd/dcrdata/views/home_voting.tmpl
+++ b/cmd/dcrdata/views/home_voting.tmpl
@@ -171,6 +171,13 @@
                             </div>
                         </div>
                     </template>
+
+                    {{/* Empty-state placeholder cloned by voting_controller when a
+                         live block carries no SKA rewards (issue #436). Mirrors the
+                         server-rendered empty branch above. */}}
+                    <template id="ska-vote-empty-template">
+                        <div class="fs12 lh1rem text-black-50">No SKA rewards available</div>
+                    </template>
                 </div>
             </div>
         </div> {{/* end voting card */}}


### PR DESCRIPTION
## Summary

Fixes #436. On the home page Voting section, the **"No SKA rewards available"** text vanished on its own and only returned after a full page refresh — observed on mainnet, typically after the tab was backgrounded then refocused.

## Root cause

The bug is in the websocket live-update path:

```
WS `newblock` → index.js emits BLOCK_RECEIVED
  → homepage_controller._processBlock → dispatch('homepage:block')
  → voting_controller#handleBlock → _renderSkaRewards(ex.ska_vote_rewards)
```

On each new block, `voting_controller._renderSkaRewards()` cleared the `skaVoteRewards` container (`innerHTML = ''`) and then rendered one row per reward. The backend serializes `SKAVoteRewards` with `json:"ska_vote_rewards,omitempty"`, so when there are **no** SKA rewards (mainnet has no SKA coins) the field is omitted entirely and arrives as `undefined` in JS. The handler then wiped the server-rendered `{{else}}` placeholder and crashed on `undefined.forEach`, leaving the container empty until the next reload.

- **Mainnet-only:** testnet has SKA rewards, so a real array renders and this path never runs.
- **"After backgrounding":** the placeholder is actually wiped on the *first* block after load; backgrounding just guarantees a block has arrived before you look again.

## Fix

Mirror the already-correct sibling `mining_controller._renderPoWSkaRewards`: guard for a non-array/empty rewards value and clone a new `ska-vote-empty-template` to restore the placeholder (also removing the `forEach` crash). The new template pairs with the controller exactly as `pow-ska-empty-template` does in `home_mining.tmpl`.

## Test plan

- New `voting_controller.test.js` — covers `undefined` / `null` / empty array and the rewards-then-empty transition; verified failing before the fix (the `undefined`/`null` cases threw), passing after.
- New Go template case `SKAVoteEmptyTemplatePresent`; updated Cases 4/5 to count placeholder occurrences (the inert `<template>` text is never rendered by the browser, so it must be distinguished from the visible `{{else}}` branch).
- All green: 332/332 frontend tests, full `internal/explorer` Go package, gofmt/prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)