### PR TITLE
fix: hide v10 pre-voting meters when no Monetarium agendas exist. Fixes  #438

### DIFF
--- a/cmd/dcrdata/views/agendas.tmpl
+++ b/cmd/dcrdata/views/agendas.tmpl
@@ -102,7 +102,7 @@
                 </div>{{/* END OF PRIMARY INFO CARD */ -}}
 
                 {{/* PRE-VOTING */}}
-                {{if or (not .NetworkUpgraded) .VotingTriggered}}
+                {{if and (or (not .NetworkUpgraded) .VotingTriggered) .Agendas}}
                   <div class="col-24 col-lg-12 pt-2 px-2 text-center">
                     {{if .VotingTriggered}}
                       <div class="bg-white d-inline-block p-2 fs16 text-center mx-2 border">Upgrade complete. A vote has been triggered</div>


### PR DESCRIPTION
The PRE-VOTING section (v{{.Version}} Miners/Voters meters) was shown based only on node-reported NetworkUpgraded/VotingTriggered state. On mainnet with no VoteVersion >= 11 agendas, this incorrectly displayed v10 progress for a version already filtered from the agendas table.

Fix: Also require .Agendas to be non-empty (already filtered to VoteVersion >= MinVoteVersion=11). Now pre-voting meters only appear when there are actual Monetarium-era agendas to show progress for.

Testnet with v11+ agendas: unchanged (meters shown).
Mainnet with no v11+ agendas: pre-voting section hidden.