### PR TITLE
cmd/dcrdata: resilient live block updates (home + /blocks)

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -29,6 +29,12 @@ type mockDataSource struct {
 	tpvHeight  int64
 	tpvErr     error
 	summaries  []*apitypes.BlockDataBasic
+
+	// explorerBlocks is returned by GetExplorerBlocks; gotBlocksStart/End record
+	// the range it was last called with (for latestExplorerBlocks tests).
+	explorerBlocks []*explorerTypes.BlockBasic
+	gotBlocksStart int
+	gotBlocksEnd   int
 }
 
 func (m *mockDataSource) BlockHeight(ctx context.Context, hash string) (int64, error) { return 0, nil }
@@ -120,7 +126,9 @@ func (m *mockDataSource) GetExplorerBlock(ctx context.Context, hash string) *exp
 	return m.blocks[hash]
 }
 func (m *mockDataSource) GetExplorerBlocks(ctx context.Context, start int, end int) []*explorerTypes.BlockBasic {
-	return nil
+	m.gotBlocksStart = start
+	m.gotBlocksEnd = end
+	return m.explorerBlocks
 }
 func (m *mockDataSource) GetBlockHeight(ctx context.Context, hash string) (int64, error) {
 	return 0, nil
@@ -149,7 +157,7 @@ func (m *mockDataSource) SendRawTransaction(ctx context.Context, txhex string) (
 func (m *mockDataSource) GetTransactionByHash(ctx context.Context, txid string) (*wire.MsgTx, error) {
 	return nil, nil
 }
-func (m *mockDataSource) GetHeight(context.Context) (int64, error)                          { return 0, nil }
+func (m *mockDataSource) GetHeight(context.Context) (int64, error)                          { return m.height, nil }
 func (m *mockDataSource) TxHeight(ctx context.Context, txid *chainhash.Hash) (height int64) { return 0 }
 func (m *mockDataSource) DCP0010ActivationHeight() int64                                    { return 0 }
 func (m *mockDataSource) DCP0011ActivationHeight() int64                                    { return 0 }

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -166,14 +166,24 @@ const homeBlocksSpan = 8
 // uncapped client value would let any unauthenticated socket request a
 // tip-to-genesis scan. This mirrors the cap the /blocks HTTP route applies.
 func clampLatestBlocksSpan(message string) int {
-	span := homeBlocksSpan
 	if n, err := strconv.Atoi(message); err == nil && n > 0 {
-		span = n
-		if span > maxExplorerRows {
-			span = maxExplorerRows
-		}
+		return min(n, maxExplorerRows)
 	}
-	return span
+	return homeBlocksSpan
+}
+
+// latestBlocksEnd is the exclusive lower bound (the GetExplorerBlocks "end"
+// argument) for a window of span blocks below height, clamped so the range
+// never reaches below genesis. Shared by Home() and latestExplorerBlocks() so
+// the server-rendered list and the websocket refresh request the identical
+// range — without this single source the two clamps drifted (Home used an
+// unclamped height-span, which at height < span asks for negative heights).
+func latestBlocksEnd(height int64, span int) int {
+	end := int(height) - span
+	if end < 0 {
+		end = -1
+	}
+	return end
 }
 
 // latestExplorerBlocks returns the latest blocks (tip down to tip-span), each
@@ -187,11 +197,19 @@ func (exp *explorerUI) latestExplorerBlocks(ctx context.Context, span int) ([]*t
 	if err != nil {
 		return nil, err
 	}
-	end := int(height) - span
-	if end < 0 {
-		end = -1
+	blocks := exp.dataSource.GetExplorerBlocks(ctx, int(height), latestBlocksEnd(height, span))
+
+	// GetExplorerBlocks pads any height that fails to load with a zero-value
+	// BlockBasic (empty Hash, Height 0). Drop those so the refresh never rebuilds
+	// the table with a /block/0 row carrying a year-0001 timestamp. A real block —
+	// including genesis at height 0 — always has a non-empty hash.
+	filtered := blocks[:0]
+	for _, b := range blocks {
+		if b != nil && b.Hash != "" {
+			filtered = append(filtered, b)
+		}
 	}
-	return exp.dataSource.GetExplorerBlocks(ctx, int(height), end), nil
+	return filtered, nil
 }
 
 // Home is the page handler for the "/" path.
@@ -206,7 +224,7 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blocks := exp.dataSource.GetExplorerBlocks(ctx, int(height), int(height)-homeBlocksSpan)
+	blocks := exp.dataSource.GetExplorerBlocks(ctx, int(height), latestBlocksEnd(height, homeBlocksSpan))
 
 	// Safely retrieve the current inventory pointer.
 	inv := exp.MempoolInventory()

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -158,6 +158,24 @@ func (exp *explorerUI) timeoutErrorPage(w http.ResponseWriter, err error, debugS
 // rendered list and the websocket refresh ("getlatestblocks") never diverge.
 const homeBlocksSpan = 8
 
+// clampLatestBlocksSpan resolves the optional "getlatestblocks" page-size
+// argument to a block span. An empty, non-numeric, or non-positive argument
+// falls back to homeBlocksSpan; a larger value is capped at maxExplorerRows.
+// The cap matters: latestExplorerBlocks turns the span into one DB round-trip
+// per block (GetExplorerBlocks calls getBlockVerbose per height), so an
+// uncapped client value would let any unauthenticated socket request a
+// tip-to-genesis scan. This mirrors the cap the /blocks HTTP route applies.
+func clampLatestBlocksSpan(message string) int {
+	span := homeBlocksSpan
+	if n, err := strconv.Atoi(message); err == nil && n > 0 {
+		span = n
+		if span > maxExplorerRows {
+			span = maxExplorerRows
+		}
+	}
+	return span
+}
+
 // latestExplorerBlocks returns the latest blocks (tip down to tip-span), each
 // with CoinRows populated. It backs the "getlatestblocks" websocket command
 // used to rebuild a block table after a reconnect or a detected height gap.

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -158,16 +158,22 @@ func (exp *explorerUI) timeoutErrorPage(w http.ResponseWriter, err error, debugS
 // rendered list and the websocket refresh ("getlatestblocks") never diverge.
 const homeBlocksSpan = 8
 
-// latestExplorerBlocks returns the same block slice the home page renders (tip
-// down to tip-homeBlocksSpan), each with CoinRows populated. It backs the
-// "getlatestblocks" websocket command used to rebuild the table after a
-// reconnect or a detected height gap.
-func (exp *explorerUI) latestExplorerBlocks(ctx context.Context) ([]*types.BlockBasic, error) {
+// latestExplorerBlocks returns the latest blocks (tip down to tip-span), each
+// with CoinRows populated. It backs the "getlatestblocks" websocket command
+// used to rebuild a block table after a reconnect or a detected height gap.
+// span matches the caller's page size: homeBlocksSpan for the home table, the
+// page row count for /blocks, so the refresh reproduces the server-rendered
+// list exactly.
+func (exp *explorerUI) latestExplorerBlocks(ctx context.Context, span int) ([]*types.BlockBasic, error) {
 	height, err := exp.dataSource.GetHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return exp.dataSource.GetExplorerBlocks(ctx, int(height), int(height)-homeBlocksSpan), nil
+	end := int(height) - span
+	if end < 0 {
+		end = -1
+	}
+	return exp.dataSource.GetExplorerBlocks(ctx, int(height), end), nil
 }
 
 // Home is the page handler for the "/" path.
@@ -677,6 +683,11 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 
 	oldestHeight := bestBlockHeight % rows
 
+	// isLatest marks the page that tracks the tip (no height param, or height ==
+	// tip). Only that page may live-update; historical pages stay static, so the
+	// blocks controller must not push new blocks onto them.
+	isLatest := height == bestBlockHeight
+
 	str, err := exp.templates.exec("blocks", struct {
 		*CommonPageData
 		Data         []*types.BlockBasic
@@ -687,6 +698,7 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 		WindowSize   int64
 		TimeGrouping string
 		Pages        pageNumbers
+		IsLatest     bool
 	}{
 		CommonPageData: exp.commonData(r),
 		Data:           summaries,
@@ -697,6 +709,7 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 		WindowSize:     exp.ChainParams.StakeDiffWindowSize,
 		TimeGrouping:   "Blocks",
 		Pages:          calcPagesDesc(int(bestBlockHeight), int(rows), int(height), linkTemplate),
+		IsLatest:       isLatest,
 	})
 
 	if err != nil {

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -153,6 +153,23 @@ func (exp *explorerUI) timeoutErrorPage(w http.ResponseWriter, err error, debugS
 	return
 }
 
+// homeBlocksSpan is how many blocks below the tip the home "latest blocks"
+// table shows. Shared by Home() and latestExplorerBlocks() so the server-
+// rendered list and the websocket refresh ("getlatestblocks") never diverge.
+const homeBlocksSpan = 8
+
+// latestExplorerBlocks returns the same block slice the home page renders (tip
+// down to tip-homeBlocksSpan), each with CoinRows populated. It backs the
+// "getlatestblocks" websocket command used to rebuild the table after a
+// reconnect or a detected height gap.
+func (exp *explorerUI) latestExplorerBlocks(ctx context.Context) ([]*types.BlockBasic, error) {
+	height, err := exp.dataSource.GetHeight(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return exp.dataSource.GetExplorerBlocks(ctx, int(height), int(height)-homeBlocksSpan), nil
+}
+
 // Home is the page handler for the "/" path.
 func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -165,7 +182,7 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blocks := exp.dataSource.GetExplorerBlocks(ctx, int(height), int(height)-8)
+	blocks := exp.dataSource.GetExplorerBlocks(ctx, int(height), int(height)-homeBlocksSpan)
 
 	// Safely retrieve the current inventory pointer.
 	inv := exp.MempoolInventory()

--- a/cmd/dcrdata/internal/explorer/latest_blocks_test.go
+++ b/cmd/dcrdata/internal/explorer/latest_blocks_test.go
@@ -26,12 +26,12 @@ func TestLatestExplorerBlocks(t *testing.T) {
 	}
 	exp := &explorerUI{dataSource: src}
 
-	blocks, err := exp.latestExplorerBlocks(context.Background())
+	blocks, err := exp.latestExplorerBlocks(context.Background(), homeBlocksSpan)
 	if err != nil {
 		t.Fatalf("latestExplorerBlocks returned error: %v", err)
 	}
 
-	// Requests tip..tip-homeBlocksSpan (the home table range).
+	// Requests tip..tip-span (the home table range for span == homeBlocksSpan).
 	if src.gotBlocksStart != 1000 || src.gotBlocksEnd != 1000-homeBlocksSpan {
 		t.Errorf("requested range = %d..%d, want %d..%d",
 			src.gotBlocksStart, src.gotBlocksEnd, 1000, 1000-homeBlocksSpan)
@@ -48,5 +48,28 @@ func TestLatestExplorerBlocks(t *testing.T) {
 	}
 	if !strings.Contains(string(out), `"coin_rows"`) {
 		t.Errorf("marshaled blocks missing coin_rows: %s", out)
+	}
+}
+
+// span parameterizes the range so /blocks can refresh its own page size, and a
+// span that would reach below genesis clamps the lower bound to -1.
+func TestLatestExplorerBlocksSpan(t *testing.T) {
+	src := &mockDataSource{height: 1000}
+	exp := &explorerUI{dataSource: src}
+
+	if _, err := exp.latestExplorerBlocks(context.Background(), 20); err != nil {
+		t.Fatalf("latestExplorerBlocks returned error: %v", err)
+	}
+	if src.gotBlocksStart != 1000 || src.gotBlocksEnd != 980 {
+		t.Errorf("span=20 range = %d..%d, want 1000..980", src.gotBlocksStart, src.gotBlocksEnd)
+	}
+
+	// A span larger than the tip height clamps the end to -1 (genesis guard).
+	src.height = 5
+	if _, err := exp.latestExplorerBlocks(context.Background(), 20); err != nil {
+		t.Fatalf("latestExplorerBlocks returned error: %v", err)
+	}
+	if src.gotBlocksEnd != -1 {
+		t.Errorf("clamped end = %d, want -1", src.gotBlocksEnd)
 	}
 }

--- a/cmd/dcrdata/internal/explorer/latest_blocks_test.go
+++ b/cmd/dcrdata/internal/explorer/latest_blocks_test.go
@@ -3,6 +3,7 @@ package explorer
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -48,6 +49,35 @@ func TestLatestExplorerBlocks(t *testing.T) {
 	}
 	if !strings.Contains(string(out), `"coin_rows"`) {
 		t.Errorf("marshaled blocks missing coin_rows: %s", out)
+	}
+}
+
+// clampLatestBlocksSpan resolves the optional "getlatestblocks" page-size
+// argument. It must default to the home span for empty/invalid/non-positive
+// input and cap large requests at maxExplorerRows so an unauthenticated client
+// can't ask for a tip-to-genesis range (each block is a DB round-trip).
+func TestClampLatestBlocksSpan(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    int
+	}{
+		{"empty defaults to home span", "", homeBlocksSpan},
+		{"invalid defaults to home span", "abc", homeBlocksSpan},
+		{"zero defaults to home span", "0", homeBlocksSpan},
+		{"negative defaults to home span", "-5", homeBlocksSpan},
+		{"valid in-range value passes through", "20", 20},
+		{"at cap passes through", strconv.Itoa(maxExplorerRows), maxExplorerRows},
+		{"just under cap passes through", strconv.Itoa(maxExplorerRows - 1), maxExplorerRows - 1},
+		{"just over cap clamps", strconv.Itoa(maxExplorerRows + 1), maxExplorerRows},
+		{"huge value clamps (DoS guard)", "999999", maxExplorerRows},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clampLatestBlocksSpan(tt.message); got != tt.want {
+				t.Errorf("clampLatestBlocksSpan(%q) = %d, want %d", tt.message, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/dcrdata/internal/explorer/latest_blocks_test.go
+++ b/cmd/dcrdata/internal/explorer/latest_blocks_test.go
@@ -1,0 +1,52 @@
+package explorer
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	explorerTypes "github.com/monetarium/monetarium-explorer/explorer/types"
+)
+
+// latestExplorerBlocks backs the "getlatestblocks" websocket command. It must
+// request the same range the home page renders (tip down to tip-homeBlocksSpan)
+// and return blocks carrying CoinRows, so the client can rebuild the table
+// identically to the server-rendered list.
+func TestLatestExplorerBlocks(t *testing.T) {
+	src := &mockDataSource{
+		height: 1000,
+		explorerBlocks: []*explorerTypes.BlockBasic{
+			{Height: 1000, CoinRows: []explorerTypes.CoinRowData{
+				{CoinType: 0, Symbol: "VAR", Amount: "12345"},
+				{CoinType: 1, Symbol: "SKA1", Amount: "67890"},
+			}},
+			{Height: 999},
+		},
+	}
+	exp := &explorerUI{dataSource: src}
+
+	blocks, err := exp.latestExplorerBlocks(context.Background())
+	if err != nil {
+		t.Fatalf("latestExplorerBlocks returned error: %v", err)
+	}
+
+	// Requests tip..tip-homeBlocksSpan (the home table range).
+	if src.gotBlocksStart != 1000 || src.gotBlocksEnd != 1000-homeBlocksSpan {
+		t.Errorf("requested range = %d..%d, want %d..%d",
+			src.gotBlocksStart, src.gotBlocksEnd, 1000, 1000-homeBlocksSpan)
+	}
+
+	if len(blocks) != 2 {
+		t.Fatalf("got %d blocks, want 2", len(blocks))
+	}
+
+	// The JSON the websocket sends must carry coin_rows (what the client renders).
+	out, err := json.Marshal(blocks)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	if !strings.Contains(string(out), `"coin_rows"`) {
+		t.Errorf("marshaled blocks missing coin_rows: %s", out)
+	}
+}

--- a/cmd/dcrdata/internal/explorer/latest_blocks_test.go
+++ b/cmd/dcrdata/internal/explorer/latest_blocks_test.go
@@ -15,14 +15,18 @@ import (
 // and return blocks carrying CoinRows, so the client can rebuild the table
 // identically to the server-rendered list.
 func TestLatestExplorerBlocks(t *testing.T) {
+	// A known block time so the marshaled JSON can be checked for the exact
+	// RFC3339 string the client's `new Date(block.time)` depends on.
+	blockTime := explorerTypes.NewTimeDefFromUNIX(1749585600)
 	src := &mockDataSource{
 		height: 1000,
 		explorerBlocks: []*explorerTypes.BlockBasic{
-			{Height: 1000, CoinRows: []explorerTypes.CoinRowData{
-				{CoinType: 0, Symbol: "VAR", Amount: "12345"},
-				{CoinType: 1, Symbol: "SKA1", Amount: "67890"},
-			}},
-			{Height: 999},
+			{Height: 1000, Hash: "hash1000", BlockTime: blockTime,
+				CoinRows: []explorerTypes.CoinRowData{
+					{CoinType: 0, Symbol: "VAR", Amount: "12345"},
+					{CoinType: 1, Symbol: "SKA1", Amount: "67890"},
+				}},
+			{Height: 999, Hash: "hash999", BlockTime: blockTime},
 		},
 	}
 	exp := &explorerUI{dataSource: src}
@@ -42,13 +46,85 @@ func TestLatestExplorerBlocks(t *testing.T) {
 		t.Fatalf("got %d blocks, want 2", len(blocks))
 	}
 
-	// The JSON the websocket sends must carry coin_rows (what the client renders).
 	out, err := json.Marshal(blocks)
 	if err != nil {
 		t.Fatalf("json.Marshal failed: %v", err)
 	}
-	if !strings.Contains(string(out), `"coin_rows"`) {
-		t.Errorf("marshaled blocks missing coin_rows: %s", out)
+	// The client renders the coin amounts straight from this JSON — assert the
+	// actual values survive, not merely that the key exists.
+	for _, want := range []string{`"coin_rows"`, `"amount":"12345"`, `"amount":"67890"`} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("marshaled blocks missing %s: %s", want, out)
+		}
+	}
+	// time must marshal as the RFC3339 string the client parses with new Date();
+	// a regression to a UNIX int or wrapper object would break the refresh.
+	if wantTime := blockTime.RFC3339(); !strings.Contains(string(out), wantTime) {
+		t.Errorf("marshaled blocks missing RFC3339 time %q: %s", wantTime, out)
+	}
+}
+
+// latestExplorerBlocks must drop the zero-value placeholder blocks that
+// GetExplorerBlocks emits for heights that fail to load, so the websocket
+// refresh never rebuilds the table with a /block/0 row. A real block —
+// including genesis at height 0 — has a non-empty hash and must survive.
+func TestLatestExplorerBlocksFiltersPlaceholders(t *testing.T) {
+	src := &mockDataSource{
+		height: 1000,
+		explorerBlocks: []*explorerTypes.BlockBasic{
+			{Height: 1000, Hash: "tip"},
+			{},                           // zero-value placeholder for a height that failed to load
+			{Height: 0, Hash: "genesis"}, // genesis: height 0 but real — must survive
+		},
+	}
+	exp := &explorerUI{dataSource: src}
+
+	blocks, err := exp.latestExplorerBlocks(context.Background(), homeBlocksSpan)
+	if err != nil {
+		t.Fatalf("latestExplorerBlocks returned error: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("got %d blocks, want 2 (zero-value placeholder dropped)", len(blocks))
+	}
+	var sawGenesis bool
+	for _, b := range blocks {
+		if b.Hash == "" {
+			t.Errorf("placeholder block (empty hash) leaked into the refresh list")
+		}
+		if b.Height == 0 && b.Hash == "genesis" {
+			sawGenesis = true
+		}
+	}
+	if !sawGenesis {
+		t.Error("genesis block (height 0, real hash) was incorrectly filtered out")
+	}
+}
+
+// latestBlocksEnd is the single source of the GetExplorerBlocks "end" argument
+// shared by Home() and latestExplorerBlocks(); the two must request the same
+// range so the server-rendered list and the websocket refresh never diverge,
+// including the below-genesis clamp at low chain heights.
+func TestLatestBlocksEnd(t *testing.T) {
+	tests := []struct {
+		name   string
+		height int64
+		span   int
+		want   int
+	}{
+		{"normal range", 1000, homeBlocksSpan, 1000 - homeBlocksSpan},
+		{"full page span", 1000, maxExplorerRows, 1000 - maxExplorerRows},
+		{"end exactly zero", 8, 8, 0},
+		{"end below genesis clamps to -1", 5, 8, -1},
+		{"tip at genesis clamps to -1", 0, homeBlocksSpan, -1},
+		{"span of one at genesis", 1, 1, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := latestBlocksEnd(tt.height, tt.span); got != tt.want {
+				t.Errorf("latestBlocksEnd(%d, %d) = %d, want %d",
+					tt.height, tt.span, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/dcrdata/internal/explorer/websockethandlers.go
+++ b/cmd/dcrdata/internal/explorer/websockethandlers.go
@@ -231,11 +231,19 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				webData.Message = string(msg)
 
 			case "getlatestblocks":
-				// Latest blocks for the home table. The home-latest-blocks
-				// controller requests this on reconnect and on a detected height
-				// gap to rebuild the table from authoritative data (filling any
-				// blocks missed while disconnected).
-				blocks, err := exp.latestExplorerBlocks(ctx)
+				// Latest blocks for a block table. The home-latest-blocks and
+				// blocks controllers request this on reconnect and on a detected
+				// height gap to rebuild the table from authoritative data (filling
+				// any blocks missed while disconnected). The optional message is
+				// the page size (blocks count below the tip); empty defaults to
+				// the home table's span.
+				span := homeBlocksSpan
+				if msg.Message != "" {
+					if n, err := strconv.Atoi(msg.Message); err == nil && n > 0 {
+						span = n
+					}
+				}
+				blocks, err := exp.latestExplorerBlocks(ctx, span)
 				if err != nil {
 					log.Warnf("getlatestblocks failed: %v", err)
 					webData.Message = fmt.Sprintf("Error: %v", err)

--- a/cmd/dcrdata/internal/explorer/websockethandlers.go
+++ b/cmd/dcrdata/internal/explorer/websockethandlers.go
@@ -230,6 +230,25 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				}
 				webData.Message = string(msg)
 
+			case "getlatestblocks":
+				// Latest blocks for the home table. The home-latest-blocks
+				// controller requests this on reconnect and on a detected height
+				// gap to rebuild the table from authoritative data (filling any
+				// blocks missed while disconnected).
+				blocks, err := exp.latestExplorerBlocks(ctx)
+				if err != nil {
+					log.Warnf("getlatestblocks failed: %v", err)
+					webData.Message = fmt.Sprintf("Error: %v", err)
+					break
+				}
+				msg, err := json.Marshal(blocks)
+				if err != nil {
+					log.Warn("Invalid JSON message: ", err)
+					webData.Message = errMsgJSONEncode
+					break
+				}
+				webData.Message = string(msg)
+
 			case "ping":
 				log.Tracef("We've been pinged: %.40s...", msg.Message)
 				continue

--- a/cmd/dcrdata/internal/explorer/websockethandlers.go
+++ b/cmd/dcrdata/internal/explorer/websockethandlers.go
@@ -236,13 +236,10 @@ func (exp *explorerUI) RootWebsocket(w http.ResponseWriter, r *http.Request) {
 				// height gap to rebuild the table from authoritative data (filling
 				// any blocks missed while disconnected). The optional message is
 				// the page size (blocks count below the tip); empty defaults to
-				// the home table's span.
-				span := homeBlocksSpan
-				if msg.Message != "" {
-					if n, err := strconv.Atoi(msg.Message); err == nil && n > 0 {
-						span = n
-					}
-				}
+				// the home table's span. Capped at maxExplorerRows so a client
+				// can't request a tip-to-genesis range (see
+				// clampLatestBlocksSpan).
+				span := clampLatestBlocksSpan(msg.Message)
 				blocks, err := exp.latestExplorerBlocks(ctx, span)
 				if err != nil {
 					log.Warnf("getlatestblocks failed: %v", err)

--- a/cmd/dcrdata/public/index.js
+++ b/cmd/dcrdata/public/index.js
@@ -2,6 +2,7 @@
 import { Application } from '@hotwired/stimulus'
 import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers'
 import 'regenerator-runtime/runtime'
+import { notificationPermission } from './js/helpers/notification_helper'
 import globalEventBus from './js/services/event_bus_service'
 import ws from './js/services/messagesocket_service'
 import { darkEnabled } from './js/services/theme_service'
@@ -24,7 +25,7 @@ document.addEventListener('turbolinks:load', (_e) => {
 })
 
 export function notifyNewBlock(newBlock) {
-  if (window.Notification.permission !== 'granted') return
+  if (notificationPermission() !== 'granted') return
   const block = newBlock.block
   const newBlockNtfn = new window.Notification('New Monetarium Block Mined', {
     body: `Block mined at height ${block.height}`,

--- a/cmd/dcrdata/public/js/controllers/blocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/blocks_controller.js
@@ -2,23 +2,46 @@ import { Controller } from '@hotwired/stimulus'
 import { coinRowsToSKAData, insertSKASubRows, insertVARSubRow } from '../helpers/coin_rows_helper'
 import humanize from '../helpers/humanize_helper'
 import globalEventBus from '../services/event_bus_service'
+import ws from '../services/messagesocket_service'
 
 export default class extends Controller {
   static get targets() {
     return ['table']
   }
 
+  static get values() {
+    // isLatest: this page tracks the chain tip (no height param / height == tip).
+    // rows: the page size, sent to getlatestblocks so the refresh reproduces the
+    // server-rendered window exactly.
+    return { isLatest: Boolean, rows: Number }
+  }
+
   connect() {
     this.processBlock = this._processBlock.bind(this)
     globalEventBus.on('BLOCK_RECEIVED', this.processBlock)
+
+    // Only the latest page may live-update. Historical pages are a fixed window,
+    // so don't wire the reconnect/refresh handlers there — a refresh would
+    // replace a historical page with the latest blocks.
+    if (this.isLatestValue) {
+      this.refreshList = this._refreshList.bind(this)
+      this.latestBlocksUnsub = ws.registerEvtHandler('getlatestblocksResp', this.refreshList)
+      this.reconnectUnsub = ws.registerEvtHandler('reconnect', () =>
+        ws.send('getlatestblocks', String(this.rowsValue))
+      )
+    }
   }
 
   disconnect() {
     globalEventBus.off('BLOCK_RECEIVED', this.processBlock)
+    if (this.latestBlocksUnsub) this.latestBlocksUnsub()
+    if (this.reconnectUnsub) this.reconnectUnsub()
   }
 
   _processBlock(blockData) {
-    if (!this.hasTableTarget) return
+    // Never mutate a historical page: heights there don't track the tip, so a
+    // new block must not be pushed onto it.
+    if (!this.hasTableTarget || !this.isLatestValue) return
     const block = blockData.block
 
     const blockRows = this.tableTarget.querySelectorAll('tr[data-coin-accordion-target="blockRow"]')
@@ -26,25 +49,65 @@ export default class extends Controller {
     const firstBlockRow = blockRows[0]
     const lastHeight = parseInt(firstBlockRow.dataset.height)
 
+    let isGap = false
     if (block.height === lastHeight) {
       // Re-broadcast of the current top block — replace all its rows.
       const toRemove = this.tableTarget.querySelectorAll(`tr[data-block-id="${lastHeight}"]`)
       toRemove.forEach((r) => this.tableTarget.removeChild(r))
-    } else if (block.height === lastHeight + 1) {
-      // New block — drop the last block's rows to keep the page length stable.
+    } else if (block.height > lastHeight) {
+      // Any newer block advances the tip. Using > (not === lastHeight + 1) keeps
+      // the page live across height gaps (a block missed during a disconnect or
+      // slow connect): the old === check froze the page permanently because the
+      // DOM tip never advanced. Drop the oldest block's rows to keep the page
+      // length stable.
+      isGap = block.height > lastHeight + 1
       const lastBlockRow = blockRows[blockRows.length - 1]
       const oldHeight = lastBlockRow.dataset.blockId
       const toRemove = this.tableTarget.querySelectorAll(`tr[data-block-id="${oldHeight}"]`)
       toRemove.forEach((r) => this.tableTarget.removeChild(r))
     } else return
 
-    const { totalTxCount, varTxCount, varAmount, varSize, skaAmount, subRows } =
-      coinRowsToSKAData(block)
-
     // Re-query after removals — firstBlockRow may have been detached.
     const currentFirstBlockRow = this.tableTarget.querySelector(
       'tr[data-coin-accordion-target="blockRow"]'
     )
+    this._insertBlockGroup(block, currentFirstBlockRow)
+
+    // A gap means blocks were missed; the insert above kept the page live, now
+    // pull the full window to fill the missing rows.
+    if (isGap) ws.send('getlatestblocks', String(this.rowsValue))
+  }
+
+  // _refreshList rebuilds the table from the "getlatestblocks" response — an
+  // array of server BlockBasic objects, newest first — recovering the exact
+  // window (including blocks missed while disconnected).
+  _refreshList(evt) {
+    if (!this.hasTableTarget) return
+    let blocks
+    try {
+      blocks = JSON.parse(evt)
+    } catch {
+      return
+    }
+    if (!Array.isArray(blocks) || blocks.length === 0) return
+
+    this.tableTarget.innerHTML = ''
+    for (const block of blocks) {
+      if (block.unixStamp === undefined && block.time) {
+        block.unixStamp = new Date(block.time).getTime() / 1000
+      }
+      // referenceNode null → append, preserving the server's newest-first order.
+      this._insertBlockGroup(block, null)
+    }
+  }
+
+  // _insertBlockGroup clones the row templates for one block (11-column blocks
+  // layout), fills the cells, and inserts the block row (before referenceNode,
+  // or appended when null) followed by its VAR and SKA sub-rows. Shared by the
+  // live insert and the full-list rebuild.
+  _insertBlockGroup(block, referenceNode) {
+    const { totalTxCount, varTxCount, varAmount, varSize, skaAmount, subRows } =
+      coinRowsToSKAData(block)
 
     const tmpl = document.getElementById('blocks-block-row-template')
     if (!tmpl) return
@@ -75,7 +138,7 @@ export default class extends Controller {
 
     clone.querySelector('[data-type="time"]').textContent = humanize.date(block.time, false)
 
-    this.tableTarget.insertBefore(newRow, currentFirstBlockRow)
+    this.tableTarget.insertBefore(newRow, referenceNode)
     const varSubRow = insertVARSubRow(
       this.tableTarget,
       newRow,

--- a/cmd/dcrdata/public/js/controllers/blocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/blocks_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { coinRowsToSKAData, insertSKASubRows, insertVARSubRow } from '../helpers/coin_rows_helper'
 import humanize from '../helpers/humanize_helper'
+import { applyLiveBlock, rebuildBlockTable } from '../helpers/live_block_table'
 import globalEventBus from '../services/event_bus_service'
 import ws from '../services/messagesocket_service'
 
@@ -42,63 +43,23 @@ export default class extends Controller {
     // Never mutate a historical page: heights there don't track the tip, so a
     // new block must not be pushed onto it.
     if (!this.hasTableTarget || !this.isLatestValue) return
-    const block = blockData.block
-
-    const blockRows = this.tableTarget.querySelectorAll('tr[data-coin-accordion-target="blockRow"]')
-    if (blockRows.length === 0) return
-    const firstBlockRow = blockRows[0]
-    const lastHeight = parseInt(firstBlockRow.dataset.height)
-
-    let isGap = false
-    if (block.height === lastHeight) {
-      // Re-broadcast of the current top block — replace all its rows.
-      const toRemove = this.tableTarget.querySelectorAll(`tr[data-block-id="${lastHeight}"]`)
-      toRemove.forEach((r) => this.tableTarget.removeChild(r))
-    } else if (block.height > lastHeight) {
-      // Any newer block advances the tip. Using > (not === lastHeight + 1) keeps
-      // the page live across height gaps (a block missed during a disconnect or
-      // slow connect): the old === check froze the page permanently because the
-      // DOM tip never advanced. Drop the oldest block's rows to keep the page
-      // length stable.
-      isGap = block.height > lastHeight + 1
-      const lastBlockRow = blockRows[blockRows.length - 1]
-      const oldHeight = lastBlockRow.dataset.blockId
-      const toRemove = this.tableTarget.querySelectorAll(`tr[data-block-id="${oldHeight}"]`)
-      toRemove.forEach((r) => this.tableTarget.removeChild(r))
-    } else return
-
-    // Re-query after removals — firstBlockRow may have been detached.
-    const currentFirstBlockRow = this.tableTarget.querySelector(
-      'tr[data-coin-accordion-target="blockRow"]'
+    const isGap = applyLiveBlock(this.tableTarget, blockData.block, (block, ref) =>
+      this._insertBlockGroup(block, ref)
     )
-    this._insertBlockGroup(block, currentFirstBlockRow)
-
     // A gap means blocks were missed; the insert above kept the page live, now
     // pull the full window to fill the missing rows.
     if (isGap) ws.send('getlatestblocks', String(this.rowsValue))
   }
 
-  // _refreshList rebuilds the table from the "getlatestblocks" response — an
-  // array of server BlockBasic objects, newest first — recovering the exact
-  // window (including blocks missed while disconnected).
+  // _refreshList rebuilds the table from the "getlatestblocks" response.
   _refreshList(evt) {
     if (!this.hasTableTarget) return
-    let blocks
-    try {
-      blocks = JSON.parse(evt)
-    } catch {
-      return
-    }
-    if (!Array.isArray(blocks) || blocks.length === 0) return
-
-    this.tableTarget.innerHTML = ''
-    for (const block of blocks) {
-      if (block.unixStamp === undefined && block.time) {
-        block.unixStamp = new Date(block.time).getTime() / 1000
-      }
-      // referenceNode null → append, preserving the server's newest-first order.
-      this._insertBlockGroup(block, null)
-    }
+    rebuildBlockTable(
+      this.tableTarget,
+      evt,
+      (block, ref) => this._insertBlockGroup(block, ref),
+      'blocks refresh'
+    )
   }
 
   // _insertBlockGroup clones the row templates for one block (11-column blocks

--- a/cmd/dcrdata/public/js/controllers/blocks_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/blocks_controller.test.js
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@hotwired/stimulus', () => ({
+  Controller: class {
+    constructor(element) {
+      this.element = element
+    }
+  }
+}))
+
+vi.mock('../services/event_bus_service', () => ({
+  default: { on: vi.fn(), off: vi.fn() }
+}))
+
+vi.mock('../services/messagesocket_service', () => ({
+  default: {
+    send: vi.fn(),
+    registerEvtHandler: vi.fn(() => () => {}),
+    deregisterEvtHandler: vi.fn(),
+    deregisterEvtHandlers: vi.fn()
+  }
+}))
+
+const { default: BlocksController } = await import('./blocks_controller.js')
+const { default: ws } = await import('../services/messagesocket_service')
+
+// 11-column layout matching blocks.tmpl
+const DATA_TYPES = [
+  'height',
+  'tx',
+  'var-amount',
+  'ska-amount',
+  'size',
+  'votes',
+  'tickets',
+  'revocations',
+  'version',
+  'age',
+  'time'
+]
+
+function appendBlock(tbody, height, skaCoinRows = []) {
+  const blockRow = document.createElement('tr')
+  blockRow.dataset.coinAccordionTarget = 'blockRow'
+  blockRow.dataset.blockId = String(height)
+  blockRow.dataset.height = String(height)
+  blockRow.classList.add('block-row-expandable')
+  blockRow.dataset.action = 'click->coin-accordion#toggle'
+  for (const dt of DATA_TYPES) {
+    const td = document.createElement('td')
+    td.dataset.type = dt
+    blockRow.appendChild(td)
+  }
+  tbody.appendChild(blockRow)
+  const subRowCount = 1 + skaCoinRows.length
+  for (let i = 0; i < subRowCount; i++) {
+    const tr = document.createElement('tr')
+    tr.className = 'coin-sub-row'
+    tr.dataset.coinAccordionTarget = 'subRow'
+    tr.dataset.blockId = String(height)
+    tbody.appendChild(tr)
+  }
+}
+
+function ensureTemplates() {
+  if (document.getElementById('blocks-block-row-template')) return
+  const div = document.createElement('div')
+  div.innerHTML = `
+<template id="blocks-block-row-template">
+  <tr class="block-row-expandable" data-coin-accordion-target="blockRow" data-block-id="" data-action="click->coin-accordion#toggle">
+    <td data-type="height" class="text-start ps-0"><span class="chevron me-1"></span><a></a></td>
+    <td class="text-center" data-type="tx"></td>
+    <td class="text-center" data-type="var-amount"></td>
+    <td class="text-center" data-type="ska-amount"></td>
+    <td class="text-center d-none d-sm-table-cell" data-type="size"></td>
+    <td class="text-center d-none d-sm-table-cell" data-type="votes"></td>
+    <td class="text-center d-none d-sm-table-cell" data-type="tickets"></td>
+    <td class="text-center d-none d-sm-table-cell" data-type="revocations"></td>
+    <td class="text-center d-none d-sm-table-cell" data-type="version"></td>
+    <td class="text-end px-0" data-type="age" data-time-target="age"></td>
+    <td class="text-end px-0" data-type="time"></td>
+  </tr>
+</template>
+<template id="blocks-var-sub-row-template">
+  <tr class="coin-sub-row" data-coin-accordion-target="subRow" data-block-id="">
+    <td class="text-end ps-2 ps-sm-4" data-type="sub-label"><span class="coin-label coin-label--var">VAR</span></td>
+    <td class="text-center" data-type="tx"></td>
+    <td class="text-center" data-type="var-amount"></td>
+    <td class="text-center">—</td>
+    <td class="text-center d-none d-sm-table-cell" data-type="size"></td>
+    <td class="text-center d-none d-sm-table-cell">—</td>
+    <td class="text-center d-none d-sm-table-cell">—</td>
+    <td class="text-center d-none d-sm-table-cell">—</td>
+    <td class="text-center d-none d-sm-table-cell">—</td>
+    <td class="text-end px-0">—</td>
+    <td class="text-end px-0">—</td>
+  </tr>
+</template>
+<template id="blocks-ska-sub-row-template">
+  <tr class="coin-sub-row" data-coin-accordion-target="subRow" data-block-id="">
+    <td class="text-end ps-2 ps-sm-4" data-type="sub-label"><span class="coin-label coin-label--ska"></span></td>
+    <td class="text-center" data-type="tx"></td>
+    <td class="text-center">—</td>
+    <td class="text-center" data-type="ska-amount"></td>
+    <td class="text-center d-none d-sm-table-cell" data-type="size"></td>
+    <td class="text-center d-none d-sm-table-cell">—</td>
+    <td class="text-center d-none d-sm-table-cell">—</td>
+    <td class="text-center d-none d-sm-table-cell">—</td>
+    <td class="text-center d-none d-sm-table-cell">—</td>
+    <td class="text-end px-0">—</td>
+    <td class="text-end px-0">—</td>
+  </tr>
+</template>`
+  document.body.appendChild(div)
+}
+
+// buildTable wires a controller over a tbody of blockCount rows topped at
+// topHeight. isLatest/rows mimic the Stimulus values the server renders.
+function buildTable(
+  topHeight,
+  blockCount = 3,
+  { isLatest = true, rows = 20, skaCoinRows = [] } = {}
+) {
+  ensureTemplates()
+  const tbody = document.createElement('tbody')
+  for (let i = 0; i < blockCount; i++) appendBlock(tbody, topHeight - i, skaCoinRows)
+  const ctrl = new BlocksController(tbody)
+  ctrl.tableTarget = tbody
+  ctrl.hasTableTarget = true
+  ctrl.isLatestValue = isLatest
+  ctrl.rowsValue = rows
+  return { tbody, ctrl }
+}
+
+function makeBlock(height, { skaCoinRows = [] } = {}) {
+  const coinRows =
+    skaCoinRows.length > 0
+      ? [
+          { coin_type: 0, symbol: 'VAR', tx_count: 5, amount: '1.23K VAR', size: 12345 },
+          ...skaCoinRows
+        ]
+      : []
+  return {
+    block: {
+      height: height,
+      hash: `hash${height}`,
+      tx: 5,
+      size: 12345,
+      total: 1234.5,
+      votes: 5,
+      tickets: 3,
+      revocations: 0,
+      version: 9,
+      time: '2026-06-10T20:00:00Z',
+      unixStamp: Math.floor(Date.now() / 1000) - 60,
+      coin_rows: coinRows
+    }
+  }
+}
+
+function serverBlock(height) {
+  return {
+    height: height,
+    hash: `hash${height}`,
+    tx: 5,
+    size: 12345,
+    total: 1234.5,
+    votes: 5,
+    tickets: 3,
+    revocations: 0,
+    version: 9,
+    time: '2026-06-10T20:00:00Z',
+    coin_rows: []
+  }
+}
+
+const SKA_ROWS_2 = [
+  { coin_type: 1, symbol: 'SKA1', tx_count: 42, amount: '1.25M SKA1', size: 8400 },
+  { coin_type: 2, symbol: 'SKA2', tx_count: 17, amount: '450K SKA2', size: 3200 }
+]
+
+const tipId = (tbody) =>
+  tbody.querySelector('tr[data-coin-accordion-target="blockRow"]').dataset.blockId
+const blockRowCount = (tbody) =>
+  tbody.querySelectorAll('tr[data-coin-accordion-target="blockRow"]').length
+
+describe('blocks_controller — pagination-aware live updates', () => {
+  beforeEach(() => {
+    ws.send.mockClear()
+    ws.registerEvtHandler.mockClear()
+    ws.registerEvtHandler.mockImplementation(() => () => {})
+  })
+
+  // ---- gate: only the latest page live-updates ---------------------------
+
+  it('does nothing on a historical (non-latest) page', () => {
+    const { tbody, ctrl } = buildTable(1000, 3, { isLatest: false })
+    ctrl._processBlock(makeBlock(1001))
+    expect(tipId(tbody)).toBe('1000') // unchanged
+    expect(ws.send).not.toHaveBeenCalled()
+  })
+
+  it('connect wires refresh handlers only on the latest page', () => {
+    const latest = buildTable(1000, 1, { isLatest: true })
+    latest.ctrl.connect()
+    let events = ws.registerEvtHandler.mock.calls.map((c) => c[0])
+    expect(events).toContain('reconnect')
+    expect(events).toContain('getlatestblocksResp')
+
+    ws.registerEvtHandler.mockClear()
+    const historical = buildTable(900, 1, { isLatest: false })
+    historical.ctrl.connect()
+    events = ws.registerEvtHandler.mock.calls.map((c) => c[0])
+    expect(events).not.toContain('reconnect')
+    expect(events).not.toContain('getlatestblocksResp')
+  })
+
+  // ---- gap resilience on the latest page ---------------------------------
+
+  it('advances on a normal consecutive block', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    ctrl._processBlock(makeBlock(1001))
+    expect(tipId(tbody)).toBe('1001')
+    expect(ws.send).not.toHaveBeenCalled()
+  })
+
+  it('advances across a height gap instead of wedging', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    ctrl._processBlock(makeBlock(1002)) // skips 1001
+    expect(tipId(tbody)).toBe('1002')
+  })
+
+  it('keeps updating after a gap (does not wedge permanently)', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    ctrl._processBlock(makeBlock(1002))
+    ctrl._processBlock(makeBlock(1003))
+    expect(tipId(tbody)).toBe('1003')
+  })
+
+  it('requests a refresh with the page row count on a gap', () => {
+    const { ctrl } = buildTable(1000, 3, { rows: 50 })
+    ctrl._processBlock(makeBlock(1002))
+    expect(ws.send).toHaveBeenCalledWith('getlatestblocks', '50')
+  })
+
+  // ---- refresh rebuild ----------------------------------------------------
+
+  it('_refreshList rebuilds the table from the server list (11 cells/row)', () => {
+    const { tbody, ctrl } = buildTable(1000, 3, { skaCoinRows: SKA_ROWS_2 })
+    const serverBlocks = [1005, 1004, 1003].map((h) => serverBlock(h))
+    ctrl._refreshList(JSON.stringify(serverBlocks))
+
+    const rows = tbody.querySelectorAll('tr[data-coin-accordion-target="blockRow"]')
+    expect(Array.from(rows).map((r) => r.dataset.blockId)).toEqual(['1005', '1004', '1003'])
+    rows.forEach((r) => expect(r.querySelectorAll('td').length).toBe(11))
+  })
+
+  it('_refreshList ignores empty or unparseable payloads', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    const before = blockRowCount(tbody)
+    ctrl._refreshList('not json')
+    ctrl._refreshList(JSON.stringify([]))
+    expect(blockRowCount(tbody)).toBe(before)
+  })
+})

--- a/cmd/dcrdata/public/js/controllers/blocks_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/blocks_controller.test.js
@@ -158,7 +158,14 @@ function makeBlock(height, { skaCoinRows = [] } = {}) {
   }
 }
 
-function serverBlock(height) {
+function serverBlock(height, skaCoinRows = []) {
+  const coinRows =
+    skaCoinRows.length > 0
+      ? [
+          { coin_type: 0, symbol: 'VAR', tx_count: 5, amount: '1.23K VAR', size: 12345 },
+          ...skaCoinRows
+        ]
+      : []
   return {
     height: height,
     hash: `hash${height}`,
@@ -170,7 +177,7 @@ function serverBlock(height) {
     revocations: 0,
     version: 9,
     time: '2026-06-10T20:00:00Z',
-    coin_rows: []
+    coin_rows: coinRows
   }
 }
 
@@ -255,11 +262,57 @@ describe('blocks_controller — pagination-aware live updates', () => {
     rows.forEach((r) => expect(r.querySelectorAll('td').length).toBe(11))
   })
 
+  it('_refreshList rebuilds each block with its VAR + SKA sub-rows', () => {
+    const { tbody, ctrl } = buildTable(1000, 3, { skaCoinRows: SKA_ROWS_2 })
+    const serverBlocks = [1005, 1004, 1003].map((h) => serverBlock(h, SKA_ROWS_2))
+    ctrl._refreshList(JSON.stringify(serverBlocks))
+
+    const rows = tbody.querySelectorAll('tr[data-coin-accordion-target="blockRow"]')
+    expect(Array.from(rows).map((r) => r.dataset.blockId)).toEqual(['1005', '1004', '1003'])
+    // each rebuilt group carries 1 VAR + N SKA sub-rows (the VAR-only test above
+    // never exercises SKA sub-row insertion on the rebuild path)
+    expect(
+      tbody.querySelectorAll('tr[data-block-id="1005"][data-coin-accordion-target="subRow"]').length
+    ).toBe(1 + SKA_ROWS_2.length)
+  })
+
+  it('_refreshList does NOT regress the table when the refresh is older than the current tip', () => {
+    // A live block already advanced the DOM tip to 1005; a getlatestblocks
+    // response computed at an older server tip (1003) must be dropped.
+    const { tbody, ctrl } = buildTable(1005, 3)
+    const staleList = [1003, 1002, 1001].map((h) => serverBlock(h))
+    ctrl._refreshList(JSON.stringify(staleList))
+    expect(tipId(tbody)).toBe('1005') // unchanged
+  })
+
+  it('_refreshList skips zero-value placeholder blocks (no hash)', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    const list = [
+      serverBlock(1005),
+      { height: 0, time: '0001-01-01T00:00:00Z', coin_rows: [] }, // placeholder: no hash
+      serverBlock(1003)
+    ]
+    ctrl._refreshList(JSON.stringify(list))
+    const ids = Array.from(tbody.querySelectorAll('tr[data-coin-accordion-target="blockRow"]')).map(
+      (r) => r.dataset.blockId
+    )
+    expect(ids).toEqual(['1005', '1003']) // placeholder dropped
+  })
+
   it('_refreshList ignores empty or unparseable payloads', () => {
     const { tbody, ctrl } = buildTable(1000, 3)
     const before = blockRowCount(tbody)
     ctrl._refreshList('not json')
     ctrl._refreshList(JSON.stringify([]))
     expect(blockRowCount(tbody)).toBe(before)
+  })
+
+  it('disconnect tears down the refresh handlers wired on the latest page', () => {
+    const unsub = vi.fn()
+    ws.registerEvtHandler.mockReturnValue(unsub)
+    const { ctrl } = buildTable(1000, 1, { isLatest: true })
+    ctrl.connect()
+    ctrl.disconnect()
+    expect(unsub).toHaveBeenCalledTimes(2) // getlatestblocksResp + reconnect
   })
 })

--- a/cmd/dcrdata/public/js/controllers/connection_controller.js
+++ b/cmd/dcrdata/public/js/controllers/connection_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import { requestNotifyPermission as requestNotifyPermissionSafe } from '../helpers/notification_helper'
 import ws from '../services/messagesocket_service'
 
 export default class extends Controller {
@@ -48,7 +49,6 @@ export default class extends Controller {
   }
 
   requestNotifyPermission() {
-    if (window.Notification.permission === 'granted') return
-    if (window.Notification.permission !== 'denied') window.Notification.requestPermission()
+    requestNotifyPermissionSafe()
   }
 }

--- a/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.js
@@ -28,9 +28,17 @@ export default class extends Controller {
     const lastHeight = parseInt(firstBlockRow.dataset.height)
 
     if (block.height === lastHeight) {
+      // Same height re-sent (reorg / tip refresh): drop the current tip's rows so
+      // the rebuilt version below replaces it in place.
       const toRemove = this.tableTarget.querySelectorAll(`tr[data-block-id="${lastHeight}"]`)
       toRemove.forEach((r) => this.tableTarget.removeChild(r))
-    } else if (block.height === lastHeight + 1) {
+    } else if (block.height > lastHeight) {
+      // Any newer block advances the tip. Using > (not === lastHeight + 1) keeps
+      // the table live across height gaps: a skipped block — busy chain, stale
+      // initial render, or one missed during the websocket connect window —
+      // would otherwise match neither branch and freeze updates permanently,
+      // because the DOM tip never advances. Drop the oldest block's rows to keep
+      // the row count stable.
       const lastBlockRow = blockRows[blockRows.length - 1]
       const oldHeight = lastBlockRow.dataset.blockId
       const toRemove = this.tableTarget.querySelectorAll(`tr[data-block-id="${oldHeight}"]`)

--- a/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.js
@@ -2,6 +2,9 @@ import { Controller } from '@hotwired/stimulus'
 import { coinRowsToSKAData, insertSKASubRows, insertVARSubRow } from '../helpers/coin_rows_helper'
 import humanize from '../helpers/humanize_helper'
 import globalEventBus from '../services/event_bus_service'
+import ws from '../services/messagesocket_service'
+
+const DEFAULT_LINK_CLASS = 'fs18'
 
 export default class extends Controller {
   static get targets() {
@@ -12,10 +15,20 @@ export default class extends Controller {
     this.processBlock = this._processBlock.bind(this)
     globalEventBus.on('BLOCK_RECEIVED', this.processBlock)
     this.pageOffset = this.data.get('initialOffset')
+
+    // After a reconnect or a detected height gap, the live stream alone can't
+    // recover the blocks missed while disconnected. Request the authoritative
+    // latest list and rebuild the table from it. The instant insert in
+    // _processBlock keeps the table live in the meantime.
+    this.refreshList = this._refreshList.bind(this)
+    this.latestBlocksUnsub = ws.registerEvtHandler('getlatestblocksResp', this.refreshList)
+    this.reconnectUnsub = ws.registerEvtHandler('reconnect', () => ws.send('getlatestblocks', ''))
   }
 
   disconnect() {
     globalEventBus.off('BLOCK_RECEIVED', this.processBlock)
+    if (this.latestBlocksUnsub) this.latestBlocksUnsub()
+    if (this.reconnectUnsub) this.reconnectUnsub()
   }
 
   _processBlock(blockData) {
@@ -27,6 +40,7 @@ export default class extends Controller {
     const firstBlockRow = blockRows[0]
     const lastHeight = parseInt(firstBlockRow.dataset.height)
 
+    let isGap = false
     if (block.height === lastHeight) {
       // Same height re-sent (reorg / tip refresh): drop the current tip's rows so
       // the rebuilt version below replaces it in place.
@@ -39,19 +53,61 @@ export default class extends Controller {
       // would otherwise match neither branch and freeze updates permanently,
       // because the DOM tip never advances. Drop the oldest block's rows to keep
       // the row count stable.
+      isGap = block.height > lastHeight + 1
       const lastBlockRow = blockRows[blockRows.length - 1]
       const oldHeight = lastBlockRow.dataset.blockId
       const toRemove = this.tableTarget.querySelectorAll(`tr[data-block-id="${oldHeight}"]`)
       toRemove.forEach((r) => this.tableTarget.removeChild(r))
     } else return
 
-    const { totalTxCount, varTxCount, varAmount, varSize, skaAmount, subRows } =
-      coinRowsToSKAData(block)
-
-    // Re-query after removals — firstBlockRow may have been detached.
+    // Insert before the current first block row (re-queried after removals since
+    // the original firstBlockRow may have been detached).
     const currentFirstBlockRow = this.tableTarget.querySelector(
       'tr[data-coin-accordion-target="blockRow"]'
     )
+    this._insertBlockGroup(block, firstBlockRow.dataset.linkClass, currentFirstBlockRow)
+
+    // A gap means blocks were missed (disconnect or slow connect). The insert
+    // above kept the table live; pull the full list to fill the missing rows.
+    if (isGap) ws.send('getlatestblocks', '')
+  }
+
+  // _refreshList rebuilds the entire table from the "getlatestblocks" response —
+  // an array of server BlockBasic objects, newest first. Used to recover the
+  // exact list (including blocks missed while disconnected) after a reconnect or
+  // a detected gap.
+  _refreshList(evt) {
+    if (!this.hasTableTarget) return
+    let blocks
+    try {
+      blocks = JSON.parse(evt)
+    } catch {
+      return
+    }
+    if (!Array.isArray(blocks) || blocks.length === 0) return
+
+    const existing = this.tableTarget.querySelector('tr[data-coin-accordion-target="blockRow"]')
+    const linkClass = (existing && existing.dataset.linkClass) || DEFAULT_LINK_CLASS
+
+    this.tableTarget.innerHTML = ''
+    for (const block of blocks) {
+      // The websocket newblock path stamps unixStamp client-side; the REST-style
+      // list carries RFC3339 `time`, so derive it the same way here.
+      if (block.unixStamp === undefined && block.time) {
+        block.unixStamp = new Date(block.time).getTime() / 1000
+      }
+      // referenceNode null → append, preserving the server's newest-first order.
+      this._insertBlockGroup(block, linkClass, null)
+    }
+  }
+
+  // _insertBlockGroup clones the row templates for one block, fills the cells,
+  // and inserts the block row (before referenceNode, or appended when null)
+  // followed by its VAR and SKA sub-rows. Shared by the live insert and the
+  // full-list rebuild.
+  _insertBlockGroup(block, linkClass, referenceNode) {
+    const { totalTxCount, varTxCount, varAmount, varSize, skaAmount, subRows } =
+      coinRowsToSKAData(block)
 
     const tmpl = document.getElementById('home-block-row-template')
     if (!tmpl) return
@@ -59,7 +115,7 @@ export default class extends Controller {
     const newRow = clone.querySelector('tr')
 
     newRow.dataset.height = block.height
-    newRow.dataset.linkClass = firstBlockRow.dataset.linkClass
+    newRow.dataset.linkClass = linkClass
     newRow.dataset.blockId = String(block.height)
     newRow.dataset.coinAccordionTarget = 'blockRow'
     newRow.dataset.action = 'click->coin-accordion#toggle'
@@ -67,7 +123,7 @@ export default class extends Controller {
     const link = clone.querySelector('[data-type="height"] a')
     link.href = `/block/${block.height}`
     link.textContent = block.height
-    link.classList.add(firstBlockRow.dataset.linkClass)
+    link.classList.add(linkClass)
 
     clone.querySelector('[data-type="tx"]').textContent = String(totalTxCount)
     clone.querySelector('[data-type="var-amount"]').textContent = varAmount
@@ -81,9 +137,7 @@ export default class extends Controller {
     ageTd.dataset.age = block.unixStamp
     ageTd.textContent = humanize.timeSince(block.unixStamp)
 
-    // Insert the new block row before the current first block row (re-queried
-    // after removals since the original firstBlockRow may have been detached).
-    this.tableTarget.insertBefore(newRow, currentFirstBlockRow)
+    this.tableTarget.insertBefore(newRow, referenceNode)
     const varSubRow = insertVARSubRow(
       this.tableTarget,
       newRow,

--- a/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { coinRowsToSKAData, insertSKASubRows, insertVARSubRow } from '../helpers/coin_rows_helper'
 import humanize from '../helpers/humanize_helper'
+import { applyLiveBlock, rebuildBlockTable } from '../helpers/live_block_table'
 import globalEventBus from '../services/event_bus_service'
 import ws from '../services/messagesocket_service'
 
@@ -33,72 +34,32 @@ export default class extends Controller {
 
   _processBlock(blockData) {
     if (!this.hasTableTarget) return
-    const block = blockData.block
-
-    const blockRows = this.tableTarget.querySelectorAll('tr[data-coin-accordion-target="blockRow"]')
-    if (blockRows.length === 0) return
-    const firstBlockRow = blockRows[0]
-    const lastHeight = parseInt(firstBlockRow.dataset.height)
-
-    let isGap = false
-    if (block.height === lastHeight) {
-      // Same height re-sent (reorg / tip refresh): drop the current tip's rows so
-      // the rebuilt version below replaces it in place.
-      const toRemove = this.tableTarget.querySelectorAll(`tr[data-block-id="${lastHeight}"]`)
-      toRemove.forEach((r) => this.tableTarget.removeChild(r))
-    } else if (block.height > lastHeight) {
-      // Any newer block advances the tip. Using > (not === lastHeight + 1) keeps
-      // the table live across height gaps: a skipped block — busy chain, stale
-      // initial render, or one missed during the websocket connect window —
-      // would otherwise match neither branch and freeze updates permanently,
-      // because the DOM tip never advances. Drop the oldest block's rows to keep
-      // the row count stable.
-      isGap = block.height > lastHeight + 1
-      const lastBlockRow = blockRows[blockRows.length - 1]
-      const oldHeight = lastBlockRow.dataset.blockId
-      const toRemove = this.tableTarget.querySelectorAll(`tr[data-block-id="${oldHeight}"]`)
-      toRemove.forEach((r) => this.tableTarget.removeChild(r))
-    } else return
-
-    // Insert before the current first block row (re-queried after removals since
-    // the original firstBlockRow may have been detached).
-    const currentFirstBlockRow = this.tableTarget.querySelector(
-      'tr[data-coin-accordion-target="blockRow"]'
+    // Capture the current tip's link class before applyLiveBlock mutates the
+    // table; the home rows carry it per-row (server-rendered) and the insert
+    // needs it for the new row's height link.
+    const firstRow = this.tableTarget.querySelector('tr[data-coin-accordion-target="blockRow"]')
+    const linkClass = (firstRow && firstRow.dataset.linkClass) || DEFAULT_LINK_CLASS
+    const isGap = applyLiveBlock(this.tableTarget, blockData.block, (block, ref) =>
+      this._insertBlockGroup(block, linkClass, ref)
     )
-    this._insertBlockGroup(block, firstBlockRow.dataset.linkClass, currentFirstBlockRow)
-
     // A gap means blocks were missed (disconnect or slow connect). The insert
     // above kept the table live; pull the full list to fill the missing rows.
     if (isGap) ws.send('getlatestblocks', '')
   }
 
-  // _refreshList rebuilds the entire table from the "getlatestblocks" response —
-  // an array of server BlockBasic objects, newest first. Used to recover the
-  // exact list (including blocks missed while disconnected) after a reconnect or
-  // a detected gap.
+  // _refreshList rebuilds the entire table from the "getlatestblocks" response.
+  // The link class is read from the existing tip row before the rebuild wipes
+  // it, then threaded into each new row.
   _refreshList(evt) {
     if (!this.hasTableTarget) return
-    let blocks
-    try {
-      blocks = JSON.parse(evt)
-    } catch {
-      return
-    }
-    if (!Array.isArray(blocks) || blocks.length === 0) return
-
     const existing = this.tableTarget.querySelector('tr[data-coin-accordion-target="blockRow"]')
     const linkClass = (existing && existing.dataset.linkClass) || DEFAULT_LINK_CLASS
-
-    this.tableTarget.innerHTML = ''
-    for (const block of blocks) {
-      // The websocket newblock path stamps unixStamp client-side; the REST-style
-      // list carries RFC3339 `time`, so derive it the same way here.
-      if (block.unixStamp === undefined && block.time) {
-        block.unixStamp = new Date(block.time).getTime() / 1000
-      }
-      // referenceNode null → append, preserving the server's newest-first order.
-      this._insertBlockGroup(block, linkClass, null)
-    }
+    rebuildBlockTable(
+      this.tableTarget,
+      evt,
+      (block, ref) => this._insertBlockGroup(block, linkClass, ref),
+      'latest blocks refresh'
+    )
   }
 
   // _insertBlockGroup clones the row templates for one block, fills the cells,

--- a/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.test.js
@@ -1190,6 +1190,33 @@ describe('blocklist_controller — reconnect & gap refresh (C1/C2)', () => {
     expect(blockRowCount(tbody)).toBe(before)
   })
 
+  it('_refreshList does NOT regress the table when the refresh is older than the current tip', () => {
+    // A live block already advanced the DOM tip to 1005; a getlatestblocks
+    // response computed at an older server tip (1003) must be dropped, not
+    // rebuild the table backwards.
+    const { tbody, ctrl } = buildTable(1005, 3)
+    const staleList = [1003, 1002, 1001].map((h) => serverBlock(h))
+    ctrl._refreshList(JSON.stringify(staleList))
+    const tipId = tbody.querySelector('tr[data-coin-accordion-target="blockRow"]').dataset.blockId
+    expect(tipId).toBe('1005') // unchanged — the live stream stays authoritative
+  })
+
+  it('_refreshList skips zero-value placeholder blocks (no hash)', () => {
+    // The server pads heights that fail to load with an empty BlockBasic (no
+    // hash, height 0); the rebuild must not render a /block/0 row for them.
+    const { tbody, ctrl } = buildTable(1000, 3)
+    const list = [
+      serverBlock(1005),
+      { height: 0, time: '0001-01-01T00:00:00Z', coin_rows: [] }, // placeholder: no hash
+      serverBlock(1003)
+    ]
+    ctrl._refreshList(JSON.stringify(list))
+    const ids = Array.from(tbody.querySelectorAll('tr[data-coin-accordion-target="blockRow"]')).map(
+      (r) => r.dataset.blockId
+    )
+    expect(ids).toEqual(['1005', '1003']) // placeholder dropped
+  })
+
   it('connect registers reconnect + getlatestblocksResp handlers; disconnect tears them down', () => {
     const unsub = vi.fn()
     ws.registerEvtHandler.mockReturnValue(unsub)

--- a/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.test.js
@@ -1041,3 +1041,60 @@ describe('blocklist_controller — size cell formatting', () => {
     expect(getSubRowSizeCell(tbody, 1001, 2)).toBe('10 kB')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Height-gap resilience — the live websocket can skip a height (busy chain,
+// stale initial render, or a block missed during the connect window). The old
+// code only accepted height === tip or tip+1 and silently dropped anything else;
+// because the DOM tip never advanced, one gap froze the table permanently. The
+// table must always track the newest block it is told about.
+// ---------------------------------------------------------------------------
+
+describe('blocklist_controller — height-gap resilience', () => {
+  const tipId = (tbody) =>
+    tbody.querySelector('tr[data-coin-accordion-target="blockRow"]').dataset.blockId
+  const blockRowCount = (tbody) =>
+    tbody.querySelectorAll('tr[data-coin-accordion-target="blockRow"]').length
+
+  it('inserts a new block whose height skips ahead (gap) instead of wedging', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    ctrl._processBlock(makeBlock(1002)) // skips 1001
+    expect(tipId(tbody)).toBe('1002')
+  })
+
+  it('keeps updating after a height gap (does not wedge permanently)', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    ctrl._processBlock(makeBlock(1002)) // gap
+    ctrl._processBlock(makeBlock(1003)) // next real block
+    expect(tipId(tbody)).toBe('1003')
+  })
+
+  it('keeps the block-row count constant across a gap insert', () => {
+    const { tbody, ctrl } = buildTable(1000, 3, SKA_ROWS_3)
+    const before = blockRowCount(tbody)
+    ctrl._processBlock(makeBlock(1002, { skaCoinRows: SKA_ROWS_3 }))
+    expect(blockRowCount(tbody)).toBe(before)
+  })
+
+  it('ignores a block older than the current tip (stale/reorg-behind)', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    const before = blockRowCount(tbody)
+    ctrl._processBlock(makeBlock(999)) // older than tip
+    expect(tipId(tbody)).toBe('1000') // tip unchanged
+    expect(blockRowCount(tbody)).toBe(before) // nothing added/removed
+  })
+
+  it('still replaces the tip in place when the same height is re-sent (reorg)', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    const before = blockRowCount(tbody)
+    ctrl._processBlock(makeBlock(1000, { tx: 9 })) // same height, new content
+    expect(tipId(tbody)).toBe('1000')
+    expect(blockRowCount(tbody)).toBe(before)
+    const txCell = Array.from(
+      tbody
+        .querySelector('tr[data-block-id="1000"][data-coin-accordion-target="blockRow"]')
+        .querySelectorAll('td')
+    ).find((td) => td.dataset.type === 'tx')
+    expect(txCell.textContent).toBe('9')
+  })
+})

--- a/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/home_latest_blocks_controller.test.js
@@ -13,7 +13,41 @@ vi.mock('../services/event_bus_service', () => ({
   default: { on: vi.fn(), off: vi.fn() }
 }))
 
+vi.mock('../services/messagesocket_service', () => ({
+  default: {
+    send: vi.fn(),
+    registerEvtHandler: vi.fn(() => () => {}),
+    deregisterEvtHandler: vi.fn(),
+    deregisterEvtHandlers: vi.fn()
+  }
+}))
+
 const { default: BlocklistController } = await import('./home_latest_blocks_controller.js')
+const { default: ws } = await import('../services/messagesocket_service')
+
+// serverBlock mimics one BlockBasic entry as the "getlatestblocks" websocket
+// command marshals it: RFC3339 `time` (no unixStamp), coin_rows array.
+function serverBlock(height, skaCoinRows = []) {
+  const coinRows =
+    skaCoinRows.length > 0
+      ? [
+          { coin_type: 0, symbol: 'VAR', tx_count: 5, amount: '1.23K VAR', size: 12345 },
+          ...skaCoinRows
+        ]
+      : []
+  return {
+    height: height,
+    hash: `hash${height}`,
+    tx: 5,
+    size: 12345,
+    total: 1234.5,
+    votes: 5,
+    tickets: 3,
+    revocations: 0,
+    time: '2026-06-10T20:00:00Z',
+    coin_rows: coinRows
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1096,5 +1130,78 @@ describe('blocklist_controller — height-gap resilience', () => {
         .querySelectorAll('td')
     ).find((td) => td.dataset.type === 'tx')
     expect(txCell.textContent).toBe('9')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// C1/C2 — refresh the full list on reconnect and on a detected height gap.
+// The instant gap-fix keeps the table live; a refresh then fills the missing
+// rows from the authoritative server list (getlatestblocks websocket command).
+// ---------------------------------------------------------------------------
+
+describe('blocklist_controller — reconnect & gap refresh (C1/C2)', () => {
+  const blockRowCount = (tbody) =>
+    tbody.querySelectorAll('tr[data-coin-accordion-target="blockRow"]').length
+
+  beforeEach(() => {
+    ws.send.mockClear()
+    ws.registerEvtHandler.mockClear()
+    ws.registerEvtHandler.mockImplementation(() => () => {})
+  })
+
+  it('requests a full refresh (getlatestblocks) when a block arrives with a gap', () => {
+    const { ctrl } = buildTable(1000, 3)
+    ctrl._processBlock(makeBlock(1002)) // gap — skips 1001
+    expect(ws.send).toHaveBeenCalledWith('getlatestblocks', '')
+  })
+
+  it('does NOT request a refresh for a normal consecutive block', () => {
+    const { ctrl } = buildTable(1000, 3)
+    ctrl._processBlock(makeBlock(1001)) // tip + 1
+    expect(ws.send).not.toHaveBeenCalled()
+  })
+
+  it('does NOT request a refresh when the same tip height is re-sent (reorg)', () => {
+    const { ctrl } = buildTable(1000, 3)
+    ctrl._processBlock(makeBlock(1000, { tx: 9 }))
+    expect(ws.send).not.toHaveBeenCalled()
+  })
+
+  it('_refreshList rebuilds the whole table from the server block list (newest first)', () => {
+    const { tbody, ctrl } = buildTable(1000, 3, SKA_ROWS_3)
+    const serverBlocks = [1005, 1004, 1003].map((h) => serverBlock(h, SKA_ROWS_3))
+    ctrl._refreshList(JSON.stringify(serverBlocks))
+
+    const rows = tbody.querySelectorAll('tr[data-coin-accordion-target="blockRow"]')
+    expect(Array.from(rows).map((r) => r.dataset.blockId)).toEqual(['1005', '1004', '1003'])
+    // each rebuilt group has its VAR + SKA sub-rows
+    expect(
+      tbody.querySelectorAll('tr[data-block-id="1005"][data-coin-accordion-target="subRow"]').length
+    ).toBe(1 + SKA_ROWS_3.length)
+    // rebuilt rows are structurally complete (9 cells)
+    rows.forEach((r) => expect(r.querySelectorAll('td').length).toBe(9))
+  })
+
+  it('_refreshList ignores an empty or unparseable payload', () => {
+    const { tbody, ctrl } = buildTable(1000, 3)
+    const before = blockRowCount(tbody)
+    ctrl._refreshList('not json')
+    ctrl._refreshList(JSON.stringify([]))
+    expect(blockRowCount(tbody)).toBe(before)
+  })
+
+  it('connect registers reconnect + getlatestblocksResp handlers; disconnect tears them down', () => {
+    const unsub = vi.fn()
+    ws.registerEvtHandler.mockReturnValue(unsub)
+    const { ctrl } = buildTable(1000, 1)
+    ctrl.data = { get: () => null }
+
+    ctrl.connect()
+    const events = ws.registerEvtHandler.mock.calls.map((c) => c[0])
+    expect(events).toContain('reconnect')
+    expect(events).toContain('getlatestblocksResp')
+
+    ctrl.disconnect()
+    expect(unsub).toHaveBeenCalledTimes(2)
   })
 })

--- a/cmd/dcrdata/public/js/controllers/status_controller.js
+++ b/cmd/dcrdata/public/js/controllers/status_controller.js
@@ -1,6 +1,7 @@
 /* global Turbolinks */
 import { Controller } from '@hotwired/stimulus'
 import dompurify from 'dompurify'
+import { notificationPermission } from '../helpers/notification_helper'
 import globalEventBus from '../services/event_bus_service'
 import ws from '../services/messagesocket_service'
 
@@ -93,7 +94,7 @@ export default class extends Controller {
             'Blockchain synchronization complete. You will be redirected to the home page shortly.'
           this.messageTarget.querySelector('h5').textContent = msg
           setTimeout(() => Turbolinks.visit('/'), 10000)
-          if (window.Notification.permission === 'granted') {
+          if (notificationPermission() === 'granted') {
             const ntfn = new window.Notification('Blockchain Sync Complete', {
               body: msg,
               icon: '/images/monetarium144x128.png?v=2'

--- a/cmd/dcrdata/public/js/helpers/live_block_table.js
+++ b/cmd/dcrdata/public/js/helpers/live_block_table.js
@@ -81,6 +81,10 @@ export function rebuildBlockTable(tableTarget, evt, insertGroup, label) {
   // have advanced the DOM tip after this list was requested, and the response
   // (computed at an older server tip) would visibly regress it. The live stream
   // already has us at or ahead of this list, so drop it.
+  // Strict <, not <=: an equal-tip response is the gap-fill, not a stale one.
+  // applyLiveBlock advances the DOM tip across a height gap but leaves the
+  // skipped rows missing and signals isGap; the refresh that backfills them
+  // arrives at that same tip, so dropping equal-tip would discard the fill.
   const existing = tableTarget.querySelector('tr[data-coin-accordion-target="blockRow"]')
   if (existing) {
     const currentTip = parseInt(existing.dataset.height)

--- a/cmd/dcrdata/public/js/helpers/live_block_table.js
+++ b/cmd/dcrdata/public/js/helpers/live_block_table.js
@@ -1,0 +1,102 @@
+// Live-update mechanics shared by the home "latest blocks" table
+// (home_latest_blocks_controller) and the /blocks listing (blocks_controller).
+// Both render a newest-first, fixed-length block table that advances on live
+// BLOCK_RECEIVED events and is rebuilt from the "getlatestblocks" websocket
+// command on reconnect / detected gap. The two tables differ only in their
+// column layout and template ids, so the row-cell filling stays in each
+// controller (passed in as an insertGroup closure); the table-mutation
+// algorithm — which rows to drop, the gap/stale/placeholder guards, the
+// wipe-and-rebuild loop — lives here, in one copy.
+
+// removeGroup removes every row of one block group (the block row plus its VAR
+// and SKA sub-rows, all sharing data-block-id) from tableTarget.
+function removeGroup(tableTarget, blockId) {
+  const toRemove = tableTarget.querySelectorAll(`tr[data-block-id="${blockId}"]`)
+  toRemove.forEach((r) => tableTarget.removeChild(r))
+}
+
+// applyLiveBlock applies one live block to a newest-first block table, keeping
+// the row count stable. It encapsulates the branch logic the two live tables
+// share:
+//   block.height === tip → replace the tip group in place (reorg / tip re-send)
+//   block.height  >  tip → advance: drop the oldest group, prepend the new one
+//   block.height  <  tip → ignore (stale / behind a reorg)
+// Using > (not === tip+1) keeps the table live across height gaps: a skipped
+// block (busy chain, stale initial render, or one missed during the connect
+// window) would otherwise match neither branch and freeze updates permanently,
+// because the DOM tip never advanced.
+//
+// insertGroup(block, referenceNode) clones and fills the per-table row template
+// (caller-owned, since column layouts differ) and inserts the block group
+// before referenceNode, or appends when referenceNode is null.
+//
+// Returns isGap: true when at least one height was skipped, so the caller should
+// request an authoritative refresh to fill the missing rows. A block that was
+// ignored (older than the tip, or an empty table) returns false.
+export function applyLiveBlock(tableTarget, block, insertGroup) {
+  const blockRows = tableTarget.querySelectorAll('tr[data-coin-accordion-target="blockRow"]')
+  if (blockRows.length === 0) return false
+  const lastHeight = parseInt(blockRows[0].dataset.height)
+
+  let isGap = false
+  if (block.height === lastHeight) {
+    removeGroup(tableTarget, lastHeight)
+  } else if (block.height > lastHeight) {
+    isGap = block.height > lastHeight + 1
+    removeGroup(tableTarget, blockRows[blockRows.length - 1].dataset.blockId)
+  } else {
+    return false
+  }
+
+  // Re-query after removals — the original first row may have been detached.
+  const currentFirstBlockRow = tableTarget.querySelector(
+    'tr[data-coin-accordion-target="blockRow"]'
+  )
+  insertGroup(block, currentFirstBlockRow)
+  return isGap
+}
+
+// rebuildBlockTable rebuilds a newest-first block table from a "getlatestblocks"
+// response payload (a JSON array of server BlockBasic objects, newest first).
+// It parses and validates the payload, refuses to move the table backwards (a
+// stale response that arrived after a newer live block already advanced the DOM
+// tip), then wipes and re-inserts each block — recovering the exact window,
+// including blocks missed while disconnected.
+//
+// insertGroup(block, referenceNode) is the caller-owned per-table inserter
+// (referenceNode null → append, preserving the server's newest-first order).
+// label tags the warning logged for a non-JSON payload (the server sends a
+// non-JSON "Error: ..." string when the refresh fails).
+export function rebuildBlockTable(tableTarget, evt, insertGroup, label) {
+  let blocks
+  try {
+    blocks = JSON.parse(evt)
+  } catch {
+    console.warn(`${label}: discarding non-JSON getlatestblocks payload:`, evt)
+    return
+  }
+  if (!Array.isArray(blocks) || blocks.length === 0) return
+
+  // Don't let a stale refresh move the table backwards: a newer live block may
+  // have advanced the DOM tip after this list was requested, and the response
+  // (computed at an older server tip) would visibly regress it. The live stream
+  // already has us at or ahead of this list, so drop it.
+  const existing = tableTarget.querySelector('tr[data-coin-accordion-target="blockRow"]')
+  if (existing) {
+    const currentTip = parseInt(existing.dataset.height)
+    if (!Number.isNaN(currentTip) && Number(blocks[0].height) < currentTip) return
+  }
+
+  tableTarget.innerHTML = ''
+  for (const block of blocks) {
+    // Skip zero-value placeholder blocks the server pads failed heights with
+    // (empty hash) so we never render a /block/0 row with a year-0001 age.
+    if (!block.hash) continue
+    // The websocket newblock path stamps unixStamp client-side; the REST-style
+    // list carries RFC3339 `time`, so derive it the same way here.
+    if (block.unixStamp === undefined && block.time) {
+      block.unixStamp = new Date(block.time).getTime() / 1000
+    }
+    insertGroup(block, null)
+  }
+}

--- a/cmd/dcrdata/public/js/helpers/notification_helper.js
+++ b/cmd/dcrdata/public/js/helpers/notification_helper.js
@@ -1,0 +1,24 @@
+// Safe wrappers around the Web Notifications API. Some browsers — notably iOS
+// Safari tabs — do not expose window.Notification at all, so reading
+// window.Notification.permission throws a TypeError. Accessed unguarded from a
+// shared event-bus subscriber (notifyNewBlock), that throw aborts publish() and
+// freezes every later subscriber, including the latest-blocks table. These
+// helpers degrade to no-ops where the API is missing.
+
+export function notificationsSupported() {
+  return typeof window !== 'undefined' && 'Notification' in window
+}
+
+// notificationPermission returns the browser's permission string, or
+// 'unsupported' when the Notification API is unavailable.
+export function notificationPermission() {
+  return notificationsSupported() ? window.Notification.permission : 'unsupported'
+}
+
+// requestNotifyPermission prompts for notification permission only when the API
+// exists and the user has not already decided. No-op otherwise.
+export function requestNotifyPermission() {
+  if (!notificationsSupported()) return
+  if (window.Notification.permission === 'granted') return
+  if (window.Notification.permission !== 'denied') window.Notification.requestPermission()
+}

--- a/cmd/dcrdata/public/js/helpers/notification_helper.test.js
+++ b/cmd/dcrdata/public/js/helpers/notification_helper.test.js
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  notificationPermission,
+  notificationsSupported,
+  requestNotifyPermission
+} from './notification_helper'
+
+// iOS Safari tabs (and other browsers) do not expose window.Notification, so
+// reading window.Notification.permission throws a TypeError. These helpers must
+// degrade to no-ops rather than throw — a throw here freezes the live UI via
+// the shared event bus (see event_bus_service.test.js).
+describe('notification_helper — degrades gracefully without the Notification API', () => {
+  afterEach(() => {
+    delete window.Notification
+    vi.restoreAllMocks()
+  })
+
+  it('notificationsSupported() is false when window.Notification is undefined', () => {
+    delete window.Notification
+    expect(notificationsSupported()).toBe(false)
+  })
+
+  it('notificationPermission() returns "unsupported" instead of throwing when the API is missing', () => {
+    delete window.Notification
+    expect(() => notificationPermission()).not.toThrow()
+    expect(notificationPermission()).toBe('unsupported')
+  })
+
+  it('requestNotifyPermission() is a no-op (no throw) when the API is missing', () => {
+    delete window.Notification
+    expect(() => requestNotifyPermission()).not.toThrow()
+  })
+
+  it('notificationPermission() reflects the browser permission when supported', () => {
+    window.Notification = { permission: 'granted', requestPermission: vi.fn() }
+    expect(notificationsSupported()).toBe(true)
+    expect(notificationPermission()).toBe('granted')
+  })
+
+  it('requestNotifyPermission() asks for permission only when undecided', () => {
+    const requestPermission = vi.fn()
+    window.Notification = { permission: 'default', requestPermission: requestPermission }
+    requestNotifyPermission()
+    expect(requestPermission).toHaveBeenCalledTimes(1)
+  })
+
+  it('requestNotifyPermission() does not re-ask when already granted', () => {
+    const requestPermission = vi.fn()
+    window.Notification = { permission: 'granted', requestPermission: requestPermission }
+    requestNotifyPermission()
+    expect(requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('requestNotifyPermission() does not ask when permission was denied', () => {
+    const requestPermission = vi.fn()
+    window.Notification = { permission: 'denied', requestPermission: requestPermission }
+    requestNotifyPermission()
+    expect(requestPermission).not.toHaveBeenCalled()
+  })
+})

--- a/cmd/dcrdata/public/js/services/event_bus_service.js
+++ b/cmd/dcrdata/public/js/services/event_bus_service.js
@@ -33,7 +33,16 @@ class EventBus {
   publish(eventType, args) {
     const eventCallbacksPair = findEventCallbacksPair(eventType)
     if (!eventCallbacksPair) return
-    eventCallbacksPair.callbacks.forEach((callback) => callback(args))
+    // Isolate subscribers: one throwing callback must not prevent the rest from
+    // running. Iterate a copy so a subscriber that unsubscribes mid-publish does
+    // not skip its neighbour.
+    eventCallbacksPair.callbacks.slice().forEach((callback) => {
+      try {
+        callback(args)
+      } catch (err) {
+        console.error(`EventBus: subscriber for "${eventType}" threw:`, err)
+      }
+    })
   }
 }
 

--- a/cmd/dcrdata/public/js/services/event_bus_service.test.js
+++ b/cmd/dcrdata/public/js/services/event_bus_service.test.js
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import globalEventBus from './event_bus_service'
+
+// Regression: one BLOCK_RECEIVED subscriber throwing (e.g. notifyNewBlock on
+// iOS Safari, where window.Notification is undefined) used to abort publish()'s
+// forEach, silently preventing every later subscriber — including the latest-
+// blocks table controller — from running. Subscribers must be isolated.
+describe('EventBus.publish — subscriber error isolation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('runs later subscribers even when an earlier one throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const calls = []
+    const throwing = () => {
+      calls.push('throwing')
+      throw new TypeError(
+        "undefined is not an object (evaluating 'window.Notification.permission')"
+      )
+    }
+    const good = () => {
+      calls.push('good')
+    }
+    globalEventBus.on('TEST_ISOLATION', throwing)
+    globalEventBus.on('TEST_ISOLATION', good)
+
+    globalEventBus.publish('TEST_ISOLATION', {})
+
+    expect(calls).toEqual(['throwing', 'good'])
+
+    globalEventBus.off('TEST_ISOLATION', throwing)
+    globalEventBus.off('TEST_ISOLATION', good)
+  })
+
+  it('logs the error from a throwing subscriber instead of failing silently', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const throwing = () => {
+      throw new Error('boom')
+    }
+    globalEventBus.on('TEST_LOG', throwing)
+
+    globalEventBus.publish('TEST_LOG', {})
+
+    expect(errSpy).toHaveBeenCalled()
+
+    globalEventBus.off('TEST_LOG', throwing)
+  })
+})

--- a/cmd/dcrdata/views/blocks.tmpl
+++ b/cmd/dcrdata/views/blocks.tmpl
@@ -5,7 +5,8 @@
 {{template "html-head" headData .CommonPageData "Monetarium Blocks List"}}
 {{template "navbar" . }}
 {{template "blocksBanner" .}}
-<div class="container px-0 main" data-controller="time pagenavigation blocks">
+<div class="container px-0 main" data-controller="time pagenavigation blocks"
+  data-blocks-is-latest-value="{{.IsLatest}}" data-blocks-rows-value="{{.Rows}}">
   {{$pendingBlocks := 0}}
   {{if gt (len $.Data) 0}}{{$pendingBlocks = ((index .Data 0).Height)}}{{end}}
 


### PR DESCRIPTION
## Summary

Live block updates could **freeze permanently** after a single missed block. The home "latest blocks" table and `/blocks` page 1 both only accepted a new block when its height was exactly `tip` or `tip + 1`; any height gap (a block mined during a temporary disconnect, a slow initial connect, or a busy chain) hit `else return`, and because the DOM's top-row height is the only position state, the table never advanced again — every later block was silently dropped until a full page reload.

Reproduced end-to-end against a running testnet by injecting a synthetic `newblock` through the page's real socket: a `tip+2` frame wedged the table and all subsequent blocks were dropped. This is browser-independent and triggered by chain activity (busy testnet vs calm mainnet), which is why it showed up on the deployed testnet but not mainnet.

This branch fixes the freeze and adds a pull-based refresh that fills in blocks missed while disconnected, on both the home table and `/blocks`.

## Commits (4, kept separate by concern)

1. **`fix: guard Notification API and isolate event-bus subscribers`** — a *separate* iOS-only bug found along the way: `window.Notification` is undefined in iOS Safari tabs, so `notifyNewBlock` threw, and `EventBus.publish` had no per-subscriber error isolation, so that throw aborted every later `BLOCK_RECEIVED` subscriber (incl. the block table). Adds a safe notification helper (routing all 3 call sites through it) and wraps each subscriber in try/catch (logs instead of failing silently).
2. **`fix: keep latest-blocks table live across block-height gaps`** — the core fix: accept any block `> lastHeight` so the home table always advances and never wedges.
3. **`feat: refresh latest-blocks table on reconnect and height gap`** — new `getlatestblocks` websocket command returns the latest blocks (with `coin_rows`) from the explorer's own storage; the home controller rebuilds the table on `reconnect` and on a detected gap, filling missed rows. No `monetarium-node` change required.
4. **`feat: pagination-aware live updates for /blocks`** — same gap-resilience + refresh for `/blocks`, but **gated to the page that tracks the tip** (`IsLatest` Stimulus value) so historical/paginated pages stay static. `getlatestblocks` gains an optional page-size so `/blocks` refreshes its own window.

## Notable design points

- **No node changes:** missed-block replay is served entirely from the explorer's PostgreSQL/caches (`GetExplorerBlocks` populates `coin_rows`); the node is only the live-notification source.
- **Pagination safety:** a naive `> lastHeight` on `/blocks` would push the new tip onto a historical page — hence the server-rendered `IsLatest` gate.
- **Defense in depth:** the event-bus isolation means one bad subscriber can no longer freeze the whole live UI, and failures now surface in the console instead of silently.

## Testing

- **Frontend:** 360 vitest tests pass, including new coverage for gap-insert / no-permanent-wedge / refresh-on-gap / reconnect wiring / pagination gating, plus the event-bus isolation and notification-helper degradation.
- **Backend:** explorer Go tests pass, including the new `latestExplorerBlocks` range/genesis-guard coverage.
- prettier / eslint / gofmt / `go vet` clean; pre-commit hook ran the full suite on every commit.
- The core gap-wedge was reproduced *and* the fix mechanism confirmed live via socket injection.

## Follow-up (out of scope)

`blocks_controller` and `home_latest_blocks_controller` are now near-identical (gap logic, `_refreshList`, `_insertBlockGroup`), differing mainly in columns/template ids — a clean candidate for a shared helper later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
