### PR TITLE
explorer/views: restore tx I/O table column widths

### DIFF
--- a/cmd/dcrdata/public/scss/table.scss
+++ b/cmd/dcrdata/public/scss/table.scss
@@ -89,6 +89,22 @@ table th.addr-hash-column {
   width: 20em;
 }
 
+// SKA amount column. Wider viewports have room for the full 18-decimal value on
+// one line, so default to shrink-to-fit (like VAR). Only at the smallest
+// breakpoint, where horizontal space is tight, do we let the fractional tail
+// wrap — floored at 16ch (15 integer digits + decimal point; ch is exact in a
+// monospace cell) so it can't shatter into tiny chunks when the integer is "0".
+table td.ska-amount-column {
+  width: 1%;
+  white-space: nowrap;
+
+  @media (max-width: #{$breakpoint-sm}) {
+    width: auto;
+    white-space: normal;
+    min-width: 16ch;
+  }
+}
+
 table.table.v3 {
   margin-bottom: 0;
 

--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -486,7 +486,7 @@
                             <a href="/block/{{.BlockHeight}}">{{.BlockHeight}}</a>
                         {{end}}
                         </td>
-                        <td class="mono fs13 text-end wrap-decimal">{{if lt .AmountIn 0.0}} N/A {{else}}
+                        <td class="mono fs13 text-end {{if eq $.Data.CoinType 0}}shrink-to-fit{{else}}wrap-decimal ska-amount-column{{end}}">{{if lt .AmountIn 0.0}} N/A {{else}}
                         {{if eq $.Data.CoinType 0}}{{template "decimalParts" (float64AsDecimalParts .AmountIn 8 false)}}{{else}}{{template "decimalParts" (skaDecimalParts .ValueRaw false)}}{{end}} {{end}}
                         </td>
                     </tr>
@@ -559,7 +559,7 @@
                               {{end}}
                             {{end}}
                         </td>
-			                  <td class="text-end mono fs13 wrap-decimal">
+			                  <td class="text-end mono fs13 {{if eq $.Data.CoinType 0}}shrink-to-fit{{else}}wrap-decimal ska-amount-column{{end}}">
                           {{if eq $.Data.CoinType 0}}{{template "decimalParts" (float64AsDecimalParts .Amount 8 false)}}{{else}}{{template "decimalParts" (skaDecimalParts .ValueRaw false)}}{{end}}
                         </td>
                     </tr>


### PR DESCRIPTION
## Summary

Restores the transaction inputs/outputs table column widths that regressed after the last release (#448), and makes SKA amount rendering responsive.

### Root cause

Commit `3e7f7510` ("responsive layout and decimal wrapping") swapped the amount cells from `shrink-to-fit` to `wrap-decimal`. `shrink-to-fit` (`width: 1%; white-space: nowrap`) hugs the column to its content; `wrap-decimal` sets no width. Under the default `table-layout: auto`, removing the hug re-flowed every column — the visible regression.

### Fix

The amount cells branch on coin type, mirroring the existing value-rendering branch:

- **VAR** → `shrink-to-fit` restored. Tight, non-wrapping column — the pre-update layout (issue attachment 1). ✅ acceptance criterion.
- **SKA** → a new `ska-amount-column` rule that is **shrink-to-fit on wider viewports** (full 18-decimal value on one line, where there's room) and **wraps the fractional tail only at the smallest breakpoint** (`max-width: $breakpoint-sm`, 540px). At that breakpoint it is floored at `min-width: 16ch` (15 integer digits + decimal point; `ch` is exact in a monospace cell) so the tail can't shatter into tiny chunks when the integer part is short (e.g. `0`).

The wrapping is gated purely in SCSS via `white-space` (inherited; `nowrap` suppresses the `wrap-decimal` `break-all`), so the template branch stays a simple coin-type class swap.

### Verification

Rendered both txs on a local node and inspected computed styles across the breakpoint:

- **VAR** tx — amount cells `shrink-to-fit`, `white-space: nowrap`, `min-width: 0`, single line (~94px). Restored.
- **SKA** tx @ 1280px — `white-space: nowrap`, full value `1.116000000000000000` on one line (146px), floor not applied (`min-width: 0`).
- **SKA** tx @ 500px (≤ breakpoint) — `white-space: normal`, `min-width: 104px` (= `16ch`), tail wraps to 2 lines, **no horizontal overflow**.
- **Mobile min-content** — I/O table min-content is 332px (inputs) / 296px (outputs) *including* the floor, so no horizontal overflow at 375px phone width.

Closes #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
