### PR TITLE
explorer/types,views: distinct PoW Reward view for coinbase transactions

### DIFF
--- a/cmd/dcrdata/views/block.tmpl
+++ b/cmd/dcrdata/views/block.tmpl
@@ -190,7 +190,7 @@
 	</div>
 
 	<div>
-		<span class="d-inline-block pt-4 pb-1 h4">Block Reward</span>
+		<span class="d-inline-block pt-4 pb-1 h4">PoW Reward</span>
 		{{range .Tx -}}
 		{{if eq .Coinbase true -}}
 		<div class="table-responsive">

--- a/cmd/dcrdata/views/tx.tmpl
+++ b/cmd/dcrdata/views/tx.tmpl
@@ -21,7 +21,7 @@
             {{else}}
               <span class="fs22 monicon-coin-negative"></span>
             {{end}}
-            <span class="d-inline-block ps-1">{{.Type}}</span>
+            <span class="d-inline-block ps-1">{{if .Coinbase}}PoW Reward{{else}}{{.Type}}{{end}}</span>
               <div class="d-inline-block confirmations-box{{if $.IsConfirmedMainchain}} confirmed{{end}} mx-2 fs14"
                 data-controller="newblock"
                 data-newblock-target="confirmations"
@@ -85,10 +85,10 @@
 
             </div>
             <div class="col-24 col-sm-8 text-start">
-                <span class="text-secondary fs13">Fee</span>
+                <span class="text-secondary fs13">{{if .Coinbase}}Fee Reward{{else}}Fee{{end}}</span>
                 <br>
                  <span class="lh1rem d-inline-block pt-1 wrap-decimal"
-                  ><span class="fs18 fs14-decimal fw-bold">{{if eq .CoinType 0}}{{template "decimalParts" (float64AsDecimalParts .Fee.ToCoin 8 true 2)}}{{else}}{{template "decimalParts" (skaDecimalParts .FeeRaw true 2)}}{{end}}</span>&nbsp;<span class="text-secondary fs14">{{coinSymbol .CoinType}}</span>
+                  ><span class="fs18 fs14-decimal fw-bold">{{if .Coinbase}}{{template "decimalParts" (float64AsDecimalParts .FeeReward 8 true 2)}}{{else if eq .CoinType 0}}{{template "decimalParts" (float64AsDecimalParts .Fee.ToCoin 8 true 2)}}{{else}}{{template "decimalParts" (skaDecimalParts .FeeRaw true 2)}}{{end}}</span>&nbsp;<span class="text-secondary fs14">{{coinSymbol .CoinType}}</span>
                 </span>
 
             </div>

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -487,6 +487,24 @@ func (t *TxInfo) IsImmature() bool {
 	return t.Mature == "False"
 }
 
+// FeeReward is the coinbase "PoW Reward" fee shown on the tx page: the sum of
+// output amounts minus the sum of input amounts, mirroring the values rendered
+// in the "Outputs Created" and "Input Consumed" tables. Inputs displayed as
+// "N/A" (AmountIn < 0) contribute zero, matching the template guard. Coinbase
+// transactions are VAR-only, so float64 (8-dec) is exact here.
+func (t *TxInfo) FeeReward() float64 {
+	var out, in float64
+	for i := range t.Vout {
+		out += t.Vout[i].Amount
+	}
+	for i := range t.Vin {
+		if t.Vin[i].AmountIn >= 0 {
+			in += t.Vin[i].AmountIn
+		}
+	}
+	return out - in
+}
+
 // BlocksToTicketMaturity will return 0 if this isn't an immature ticket.
 func (t *TxInfo) BlocksToTicketMaturity() (blocks int64) {
 	if t.Type != TicketTypeStr {

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -487,15 +487,13 @@ func (t *TxInfo) IsImmature() bool {
 	return t.Mature == "False"
 }
 
-// FeeReward is the coinbase "PoW Reward" fee shown on the tx page: the sum of
-// output amounts minus the sum of input amounts, mirroring the values rendered
-// in the "Outputs Created" and "Input Consumed" tables. Inputs displayed as
-// "N/A" (AmountIn < 0) contribute zero, matching the template guard. Coinbase
-// transactions are VAR-only, so float64 (8-dec) is exact here.
+// FeeReward is the coinbase "PoW Reward" fee shown on the tx page. "N/A" inputs
+// (AmountIn < 0) contribute zero, matching the template guard; coinbase is
+// VAR-only, so float64 is exact.
 func (t *TxInfo) FeeReward() float64 {
 	var out, in float64
 	for i := range t.Vout {
-		out += t.Vout[i].Amount
+		out += t.Vout[i].Amount // deprecated field, safe: VAR-only coinbase sets .Amount (CoinType == 0)
 	}
 	for i := range t.Vin {
 		if t.Vin[i].AmountIn >= 0 {

--- a/explorer/types/explorertypes_test.go
+++ b/explorer/types/explorertypes_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/monetarium/monetarium-node/chaincfg"
+	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
 )
 
 func TestTimeDefMarshal(t *testing.T) {
@@ -606,4 +607,62 @@ func TestAddressPrefixes(t *testing.T) {
 			}
 		}
 	})
+}
+
+// mkVin builds a Vin whose embedded chainjson.Vin carries the given AmountIn
+// (in coins), the value the tx page displays in the "Input Consumed" column.
+func mkVin(amountIn float64) Vin {
+	return Vin{Vin: &chainjson.Vin{AmountIn: amountIn}}
+}
+
+func TestFeeReward(t *testing.T) {
+	tests := []struct {
+		name string
+		vin  []Vin
+		vout []Vout
+		want float64
+	}{
+		{
+			name: "coinbase zero-value input, sum of outputs",
+			vin:  []Vin{mkVin(0)},
+			vout: []Vout{{Amount: 10}, {Amount: 2.5}},
+			want: 12.5,
+		},
+		{
+			name: "input shows subsidy, fee-only remainder",
+			vin:  []Vin{mkVin(8)},
+			vout: []Vout{{Amount: 8}, {Amount: 0.5}},
+			want: 0.5,
+		},
+		{
+			name: "N/A input (AmountIn < 0) excluded from input sum",
+			vin:  []Vin{mkVin(-1)},
+			vout: []Vout{{Amount: 3}},
+			want: 3,
+		},
+		{
+			name: "multiple inputs and outputs",
+			vin:  []Vin{mkVin(1), mkVin(2.5), mkVin(-1)},
+			vout: []Vout{{Amount: 5}, {Amount: 0.5}, {Amount: 1}},
+			want: 3, // (5+0.5+1) - (1+2.5)
+		},
+		{
+			// Realistic coinbase shape: a single input carries the full block
+			// subsidy, outputs split that subsidy across payees plus the
+			// collected fees, and FeeReward nets out to the fee remainder.
+			name: "subsidy split across outputs minus single subsidy input",
+			vin:  []Vin{mkVin(900)},
+			vout: []Vout{{Amount: 600}, {Amount: 300}, {Amount: 0.5}},
+			want: 0.5, // (600+300+0.5) - 900
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &TxInfo{Vin: tt.vin, Vout: tt.vout}
+			if got := tx.FeeReward(); got != tt.want {
+				t.Errorf("FeeReward() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Implements #450. Coinbase / proof-of-work reward transactions — the ones reached via the Transaction ID in the Block# reward table — rendered with the standard **Regular** tx page and a **Fee** of `0`. This gives those transactions (and only those) a reward-specific presentation, leaving every other Regular page untouched.

- **tx page type label** `Regular` → `PoW Reward` when `.Coinbase`
- **header `Fee` field** → `Fee Reward`, valued at `Σ(Outputs Created) − Σ(Input Consumed)` — computed by the new `TxInfo.FeeReward()` method from the **same** `Vin`/`Vout` values the on-page tables render, so the header always matches the table arithmetic (inputs shown as `N/A`, i.e. `AmountIn < 0`, contribute zero, matching the template guard)
- **Block# table heading** `Block Reward` → `PoW Reward`

## Why `.Coinbase` and not `.Type`

A coinbase's `.Type` already resolves to `"Regular"` (`txhelpers.DetermineTxType` sees it as a regular-tree tx), so the type string is left unchanged — only the *displayed* label branches. Detection reuses the existing `.Coinbase` flag, which is also what the block page already gates its reward row on, keeping the two pages in agreement. Coinbases are VAR-only (mining rewards are always VAR), so `FeeReward` is `float64`-exact (8 decimals).

## Test plan

- [x] New `TestFeeReward` (table-driven, TDD-first): zero-value input, fee-only remainder, `N/A`-input exclusion, multiple in/out, realistic subsidy-split coinbase
- [x] `go test ./explorer/types/...` and full root-module suite (pre-commit hook) pass
- [x] `gofmt` clean; `go build` of the explorer binary succeeds
- [x] `tx.tmpl` + `block.tmpl` confirmed to parse with the production template funcmap
- [ ] Manual: open a block → heading reads **PoW Reward** → follow the Transaction ID → tx page reads **PoW Reward** with **Fee Reward** = outputs − inputs; spot-check an ordinary tx still reads **Regular** with an unchanged **Fee**

## Note for review

The *semantic* value of "Fee Reward" depends on what `monetarium-node` reports for a coinbase input's amount (subsidy → fee-only; `0`/`N/A` → full reward). Either way the page stays self-consistent (header == table arithmetic, per the spec); worth eyeballing one real reward tx to confirm it reads as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)