### PR TITLE
cmd/dcrdata/explorer: default block and window list pages to 100 rows

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -44,10 +44,11 @@ import (
 )
 
 const (
-	// maxExplorerRows and minExplorerRows are the limits on the number of
-	// blocks/time-window rows that may be shown on the explorer pages.
-	maxExplorerRows = 400
-	minExplorerRows = 10
+	// maxExplorerRows caps the number of blocks/time-window rows that may be
+	// shown on the explorer list pages; defaultExplorerRows is the page size used
+	// when no rows value is supplied in the request.
+	maxExplorerRows     = 400
+	defaultExplorerRows = 100
 
 	// syncStatusInterval is the frequency with startup synchronization progress
 	// signals are sent to websocket clients.

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -388,11 +388,7 @@ func (exp *explorerUI) StakeDiffWindows(w http.ResponseWriter, r *http.Request) 
 	if offsetWindow > bestWindow {
 		offsetWindow = bestWindow
 	}
-	if rows == 0 {
-		rows = minExplorerRows
-	} else if rows > maxExplorerRows {
-		rows = maxExplorerRows
-	}
+	rows = normalizeExplorerRows(rows)
 
 	windows, err := exp.dataSource.PosIntervals(ctx, rows, offsetWindow)
 	if exp.timeoutErrorPage(w, err, "PosIntervals") {
@@ -519,11 +515,7 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 		offset = uint64(maxOffset)
 	}
 
-	if rows == 0 {
-		rows = minExplorerRows
-	} else if rows > maxExplorerRows {
-		rows = maxExplorerRows
-	}
+	rows = normalizeExplorerRows(rows)
 
 	data, err := exp.dataSource.TimeBasedIntervals(ctx, grouping, rows, offset)
 	if exp.timeoutErrorPage(w, err, "TimeBasedIntervals") {
@@ -585,6 +577,21 @@ func (exp *explorerUI) timeBasedBlocksListing(val string, w http.ResponseWriter,
 	io.WriteString(w, str)
 }
 
+// normalizeExplorerRows applies the default page size when no rows value was
+// supplied (rows == 0) and caps the result at maxExplorerRows. Sizes between 1
+// and the cap pass through unchanged so the per-page control can still select
+// smaller sizes. It is generic over int64/uint64 so the uint64 callers clamp
+// huge values without the overflow a naive int64 conversion would introduce.
+func normalizeExplorerRows[T int64 | uint64](rows T) T {
+	switch {
+	case rows == 0:
+		return defaultExplorerRows
+	case rows > maxExplorerRows:
+		return maxExplorerRows
+	}
+	return rows
+}
+
 // Blocks is the page handler for the "/blocks" path.
 func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -622,11 +629,7 @@ func (exp *explorerUI) Blocks(w http.ResponseWriter, r *http.Request) {
 	if height > bestBlockHeight {
 		height = bestBlockHeight
 	}
-	if rows == 0 {
-		rows = minExplorerRows
-	} else if rows > maxExplorerRows {
-		rows = maxExplorerRows
-	}
+	rows = normalizeExplorerRows(rows)
 	var end int
 	oldestBlock := height - rows + 1
 	if oldestBlock < 0 {

--- a/cmd/dcrdata/internal/explorer/explorerroutes_test.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes_test.go
@@ -377,6 +377,51 @@ func TestPageNumbers(t *testing.T) {
 	}
 }
 
+// TestNormalizeExplorerRows covers the shared page-size defaulting/clamping used
+// by the /blocks, /ticketpricewindows and time-based listing handlers. The
+// default (rows == 0) must be 100 per issue #449; sizes in (0, max] pass through
+// so the per-page control can still select smaller sizes; sizes above the cap
+// clamp to maxExplorerRows. The uint64 path must clamp huge values without
+// overflowing (a naive int64 conversion would wrap them negative).
+func TestNormalizeExplorerRows(t *testing.T) {
+	t.Run("int64", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   int64
+			want int64
+		}{
+			{"zero defaults to 100", 0, 100},
+			{"small size passes through", 10, 10},
+			{"mid size passes through", 50, 50},
+			{"exactly max passes through", 400, 400},
+			{"above max is clamped", 401, 400},
+		}
+		for _, c := range cases {
+			if got := normalizeExplorerRows(c.in); got != c.want {
+				t.Errorf("%s: normalizeExplorerRows(%d) = %d, want %d", c.name, c.in, got, c.want)
+			}
+		}
+	})
+
+	t.Run("uint64", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   uint64
+			want uint64
+		}{
+			{"zero defaults to 100", 0, 100},
+			{"small size passes through", 20, 20},
+			{"above max is clamped", 401, 400},
+			{"huge value is clamped without overflow", ^uint64(0), 400},
+		}
+		for _, c := range cases {
+			if got := normalizeExplorerRows(c.in); got != c.want {
+				t.Errorf("%s: normalizeExplorerRows(%d) = %d, want %d", c.name, c.in, got, c.want)
+			}
+		}
+	})
+}
+
 // func TestTxPageResponseCodes(t *testing.T) {
 // 	var wiredDBStub testTxPageWiredDBStub
 // 	var chainDBStub ChainDBStub


### PR DESCRIPTION
## Summary

The Blocks list page opened with **10 rows per page** by default; per issue #449 it should open with **100**. Following a client clarification, the same default is applied to all three explorer list pages:

- `/blocks`
- `/ticketpricewindows` (StakeDiffWindows)
- `/day`, `/week`, `/month`, `/year` (time-based listings)

The per-page dropdown still switches to other sizes (10/20/30/50/100).

## Changes

- Replace the shared `minExplorerRows = 10` constant (only ever used as a *default*, never a floor) with `defaultExplorerRows = 100`.
- Collapse the identical default/clamp block that was triplicated across the three handlers into one generic `normalizeExplorerRows[T int64 | uint64]` helper (mirrors the existing `toCoin[T int64 | uint64]` pattern in `db/dcrpg`). The generic type also prevents the `uint64` callers from wrapping a huge `?rows=` value negative past the cap.
- No template/JS changes: the dropdowns already offered a "100 per page" option and select on the server-supplied value.

## Test plan

- [x] `go test ./internal/explorer/...` — added `TestNormalizeExplorerRows` (int64 + uint64: default→100, passthrough, clamp→400, uint64 no-overflow); written test-first
- [x] `gofmt -l` clean
- [x] `golangci-lint run -c .golangci.yml ./internal/explorer/` — 0 issues
- [x] `go build` succeeds

Closes #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
