### PR TITLE
blockdata: fix MiningFee to use miner VAR fee, not total per-tx sum

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -17,6 +17,7 @@ import (
 	"github.com/monetarium/monetarium-node/cointype"
 	"github.com/monetarium/monetarium-node/dcrutil"
 	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
+	"github.com/monetarium/monetarium-node/txscript/stdscript"
 	"github.com/monetarium/monetarium-node/wire"
 
 	apitypes "github.com/monetarium/monetarium-explorer/api/types"
@@ -247,7 +248,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	}
 	var miningFee int64
 	if curSubsidy != nil {
-		miningFee = computeMiningFee(msgBlock)
+		miningFee = computeMinerVARFeeAtoms(msgBlock, curSubsidy.PoW)
 	}
 
 	// Work/Stake difficulty
@@ -660,26 +661,31 @@ func BlockSKAPoWRewardsFromSTx(msgBlock *wire.MsgBlock) map[uint8]string {
 	return out
 }
 
-// computeMiningFee calculates total mining fees from a block by summing fees
-// from regular transactions (Transactions tree) and tickets (STransactions tree
-// limited to TxTypeSStx), matching the GetExplorerBlock formula:
-//
-//	getTotalFee(block.Tx) + getTotalFee(block.Tickets)
-func computeMiningFee(msgBlock *wire.MsgBlock) int64 {
-	var miningFee int64
-	for i, tx := range msgBlock.Transactions {
-		if i == 0 {
-			continue // skip coinbase
-		}
-		fee, _ := txhelpers.TxFeeRate(tx)
-		miningFee += int64(fee)
+// computeMinerVARFeeAtoms reads the miner's VAR fee from the coinbase
+// transaction by finding the P2PKH/P2PK/P2SH output (miner's payment) and
+// subtracting the PoW subsidy.
+func computeMinerVARFeeAtoms(msgBlock *wire.MsgBlock, powSubsidy int64) int64 {
+	if len(msgBlock.Transactions) == 0 {
+		return 0
 	}
-	for _, stx := range msgBlock.STransactions {
-		if txhelpers.DetermineTxType(stx) != stake.TxTypeSStx {
-			continue // only include tickets
+	for _, txOut := range msgBlock.Transactions[0].TxOut {
+		if txOut.CoinType != cointype.CoinTypeVAR {
+			continue
 		}
-		fee, _ := txhelpers.TxFeeRate(stx)
-		miningFee += int64(fee)
+		switch stdscript.DetermineScriptType(txOut.Version, txOut.PkScript) {
+		case stdscript.STPubKeyHashEcdsaSecp256k1,
+			stdscript.STPubKeyHashEd25519,
+			stdscript.STPubKeyHashSchnorrSecp256k1,
+			stdscript.STPubKeyEcdsaSecp256k1,
+			stdscript.STPubKeyEd25519,
+			stdscript.STPubKeySchnorrSecp256k1,
+			stdscript.STScriptHash:
+			fee := txOut.Value - powSubsidy
+			if fee < 0 {
+				fee = 0
+			}
+			return fee
+		}
 	}
-	return miningFee
+	return 0
 }

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -364,69 +364,22 @@ func newTxWithFee(inputAmount, fee int64) *wire.MsgTx {
 	return tx
 }
 
-func TestComputeMiningFee_NoRegularTx(t *testing.T) {
-	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(16e8, nil))
+// p2pkhScript is a minimal valid P2PKH output script for mock coinbase txns.
+var p2pkhScript = func() []byte {
+	s := make([]byte, 25)
+	s[0] = 0x76  // OP_DUP
+	s[1] = 0xa9  // OP_HASH160
+	s[2] = 0x14  // DATA_20 (20 zero bytes for dummy hash)
+	s[23] = 0x88 // OP_EQUALVERIFY
+	s[24] = 0xac // OP_CHECKSIG
+	return s
+}()
 
-	block := &wire.MsgBlock{
-		Transactions: []*wire.MsgTx{coinbase},
-	}
-
-	got := computeMiningFee(block)
-	want := int64(0)
-	if got != want {
-		t.Errorf("got %d, want %d", got, want)
-	}
-}
-
-func TestComputeMiningFee_WithRegularTx(t *testing.T) {
-	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(16e8+10000, nil))
-	regTx := newTxWithFee(100000, 10000)
-
-	block := &wire.MsgBlock{
-		Transactions: []*wire.MsgTx{coinbase, regTx},
-	}
-
-	got := computeMiningFee(block)
-	want := int64(10000)
-	if got != want {
-		t.Errorf("got %d, want %d", got, want)
-	}
-}
-
-func TestComputeMiningFee_NoFees(t *testing.T) {
-	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(16e8, nil))
-	regTx := newTxWithFee(100000, 0)
-
-	block := &wire.MsgBlock{
-		Transactions: []*wire.MsgTx{coinbase, regTx},
-	}
-
-	got := computeMiningFee(block)
-	want := int64(0)
-	if got != want {
-		t.Errorf("got %d, want %d", got, want)
-	}
-}
-
-func TestComputeMiningFee_MultipleRegularTx(t *testing.T) {
-	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(16e8+6000, nil))
-	tx1 := newTxWithFee(10000, 1000)
-	tx2 := newTxWithFee(20000, 2000)
-	tx3 := newTxWithFee(30000, 3000)
-
-	block := &wire.MsgBlock{
-		Transactions: []*wire.MsgTx{coinbase, tx1, tx2, tx3},
-	}
-
-	got := computeMiningFee(block)
-	want := int64(6000)
-	if got != want {
-		t.Errorf("got %d, want %d", got, want)
-	}
+// coinbaseWithP2PKH creates a coinbase tx with one P2PKH output (miner payment).
+func coinbaseWithP2PKH(value int64) *wire.MsgTx {
+	tx := wire.NewMsgTx()
+	tx.AddTxOut(wire.NewTxOut(value, p2pkhScript))
+	return tx
 }
 
 // Reference SStx output scripts copied verbatim from
@@ -492,66 +445,109 @@ func newSStxWithFee(t *testing.T, inputAmount, fee int64) *wire.MsgTx {
 	return tx
 }
 
-func TestComputeMiningFee_TicketInSTransactions(t *testing.T) {
-	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(16e8, nil))
-	ticket := newSStxWithFee(t, 1_000_000, 12_345)
-
+func TestComputeMinerVARFeeAtoms_NoRegularTx(t *testing.T) {
+	s := int64(16e8)
 	block := &wire.MsgBlock{
-		Transactions:  []*wire.MsgTx{coinbase},
-		STransactions: []*wire.MsgTx{ticket},
+		Transactions: []*wire.MsgTx{coinbaseWithP2PKH(s)},
 	}
 
-	got := computeMiningFee(block)
-	want := int64(12_345)
-	if got != want {
-		t.Errorf("got %d, want %d", got, want)
+	got := computeMinerVARFeeAtoms(block, s)
+	if got != 0 {
+		t.Errorf("got %d, want 0", got)
 	}
 }
 
-func TestComputeMiningFee_BothTrees(t *testing.T) {
-	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(16e8+1000, nil))
-	regTx := newTxWithFee(50_000, 1_000)
-	ticket1 := newSStxWithFee(t, 1_000_000, 2_500)
-	ticket2 := newSStxWithFee(t, 2_000_000, 4_000)
-
+func TestComputeMinerVARFeeAtoms_WithRegularTx(t *testing.T) {
+	s := int64(16e8)
+	fee := int64(10_000)
 	block := &wire.MsgBlock{
-		Transactions:  []*wire.MsgTx{coinbase, regTx},
-		STransactions: []*wire.MsgTx{ticket1, ticket2},
+		Transactions: []*wire.MsgTx{coinbaseWithP2PKH(s + fee), newTxWithFee(100_000, fee)},
 	}
 
-	got := computeMiningFee(block)
-	want := int64(1_000 + 2_500 + 4_000)
-	if got != want {
-		t.Errorf("got %d, want %d", got, want)
+	got := computeMinerVARFeeAtoms(block, s)
+	if got != fee {
+		t.Errorf("got %d, want %d", got, fee)
 	}
 }
 
-// TestComputeMiningFee_NonTicketSTransactionsExcluded confirms the STransactions
-// loop's `!= TxTypeSStx` filter actually drops non-ticket entries. A plain
-// (non-stake) MsgTx in STransactions is classified TxTypeRegular by
-// DetermineTxType, so its fee must not contribute to MiningFee — the same code
-// path that excludes votes (SSGen), stake fees (SSFee), and revocations (SSRtx).
-func TestComputeMiningFee_NonTicketSTransactionsExcluded(t *testing.T) {
-	coinbase := wire.NewMsgTx()
-	coinbase.AddTxOut(wire.NewTxOut(16e8, nil))
-	ticket := newSStxWithFee(t, 1_000_000, 7_777)
-	nonTicket := newTxWithFee(500_000, 9_999) // classified TxTypeRegular
-
-	if got := stake.DetermineTxType(nonTicket); got == stake.TxTypeSStx {
-		t.Fatalf("test fixture broken: non-ticket tx is classified as SStx")
+func TestComputeMinerVARFeeAtoms_NoFees(t *testing.T) {
+	s := int64(16e8)
+	block := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{coinbaseWithP2PKH(s), newTxWithFee(100_000, 0)},
 	}
+
+	got := computeMinerVARFeeAtoms(block, s)
+	if got != 0 {
+		t.Errorf("got %d, want 0", got)
+	}
+}
+
+func TestComputeMinerVARFeeAtoms_MultipleRegularTx(t *testing.T) {
+	s := int64(16e8)
+	fees := []int64{1_000, 2_000, 3_000}
+	totalFee := fees[0] + fees[1] + fees[2]
+	block := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{
+			coinbaseWithP2PKH(s + totalFee),
+			newTxWithFee(10_000, fees[0]),
+			newTxWithFee(20_000, fees[1]),
+			newTxWithFee(30_000, fees[2]),
+		},
+	}
+
+	got := computeMinerVARFeeAtoms(block, s)
+	if got != totalFee {
+		t.Errorf("got %d, want %d", got, totalFee)
+	}
+}
+
+func TestComputeMinerVARFeeAtoms_TicketInSTransactions(t *testing.T) {
+	s := int64(16e8)
+	// Ticket fees are distributed via SSFee, not coinbase.
+	// Coinbase has only the subsidy.
+	block := &wire.MsgBlock{
+		Transactions:  []*wire.MsgTx{coinbaseWithP2PKH(s)},
+		STransactions: []*wire.MsgTx{newSStxWithFee(t, 1_000_000, 12_345)},
+	}
+
+	got := computeMinerVARFeeAtoms(block, s)
+	if got != 0 {
+		t.Errorf("got %d, want 0 (ticket fees are not in coinbase)", got)
+	}
+}
+
+func TestComputeMinerVARFeeAtoms_BothTrees(t *testing.T) {
+	s := int64(16e8)
+	regFee := int64(1_000)
+	// Only the regular tx fee goes to coinbase.
+	// Ticket fees are distributed via SSFee.
+	block := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{coinbaseWithP2PKH(s + regFee), newTxWithFee(50_000, regFee)},
+		STransactions: []*wire.MsgTx{
+			newSStxWithFee(t, 1_000_000, 2_500),
+			newSStxWithFee(t, 2_000_000, 4_000),
+		},
+	}
+
+	got := computeMinerVARFeeAtoms(block, s)
+	if got != regFee {
+		t.Errorf("got %d, want %d (only regular tx fee counted)", got, regFee)
+	}
+}
+
+func TestComputeMinerVARFeeAtoms_CoinbaseNoP2PKH(t *testing.T) {
+	// If coinbase has no P2PKH output, fee should be 0.
+	s := int64(16e8)
+	coinbase := wire.NewMsgTx()
+	coinbase.AddTxOut(wire.NewTxOut(s+5_000, nil)) // nil pkScript is not P2PKH
 
 	block := &wire.MsgBlock{
-		Transactions:  []*wire.MsgTx{coinbase},
-		STransactions: []*wire.MsgTx{ticket, nonTicket},
+		Transactions: []*wire.MsgTx{coinbase, newTxWithFee(100_000, 5_000)},
 	}
 
-	got := computeMiningFee(block)
-	want := int64(7_777) // only the ticket's fee
-	if got != want {
-		t.Errorf("got %d, want %d (nonTicket fee of 9_999 must not be counted)", got, want)
+	got := computeMinerVARFeeAtoms(block, s)
+	if got != 0 {
+		t.Errorf("got %d, want 0 (no P2PKH output)", got)
 	}
 }
 
@@ -599,20 +595,15 @@ func mustParseHexTx(t *testing.T, rawHex string) *wire.MsgTx {
 	return &tx
 }
 
-// TestComputeMiningFee_Block4423 computes the mining fee from a real block
-// fixture by subtracting the PoW subsidy from the miner's coinbase output.
-// Block 4423: coinbase vout[2] = 32.00026135 VAR, PoW subsidy = 32 VAR.
-func TestComputeMiningFee_Block4423(t *testing.T) {
+func TestComputeMinerVARFeeAtoms_Block4423(t *testing.T) {
 	block := loadBlockFixture(t, "testdata/block4423.json")
 
-	got := computeMiningFee(block)
-	// coinbase vout[2] value = 3,200,026,135 atoms
+	// coinbase vout[2] (P2PKH) value = 3,200,026,135 atoms
 	// PoW subsidy at height 4423 = 3,200,000,000 atoms
 	// expected fee = 3,200,026,135 - 3,200,000,000 = 26,135
+	got := computeMinerVARFeeAtoms(block, 3_200_000_000)
 	want := int64(26_135)
 	if got != want {
-		t.Errorf("computeMiningFee(block4423) = %d, want %d (diff %d)", got, want, got-want)
+		t.Errorf("computeMinerVARFeeAtoms(block4423) = %d, want %d (diff %d)", got, want, got-want)
 	}
 }
-
-

--- a/blockdata/blockdata_test.go
+++ b/blockdata/blockdata_test.go
@@ -1,7 +1,11 @@
 package blockdata
 
 import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/monetarium/monetarium-node/blockchain/stake"
@@ -550,3 +554,65 @@ func TestComputeMiningFee_NonTicketSTransactionsExcluded(t *testing.T) {
 		t.Errorf("got %d, want %d (nonTicket fee of 9_999 must not be counted)", got, want)
 	}
 }
+
+type rawTxJSON struct {
+	Hex string `json:"hex"`
+}
+
+type blockJSON struct {
+	RawTx  []rawTxJSON `json:"rawtx"`
+	RawSTx []rawTxJSON `json:"rawstx"`
+}
+
+// loadBlockFixture reads a getblock-style JSON fixture and deserializes all
+// transactions into a wire.MsgBlock.
+func loadBlockFixture(t *testing.T, path string) *wire.MsgBlock {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	var bj blockJSON
+	if err := json.Unmarshal(data, &bj); err != nil {
+		t.Fatalf("unmarshal fixture %s: %v", path, err)
+	}
+	msgBlock := &wire.MsgBlock{}
+	for _, rtx := range bj.RawTx {
+		msgBlock.Transactions = append(msgBlock.Transactions, mustParseHexTx(t, rtx.Hex))
+	}
+	for _, stx := range bj.RawSTx {
+		msgBlock.STransactions = append(msgBlock.STransactions, mustParseHexTx(t, stx.Hex))
+	}
+	return msgBlock
+}
+
+func mustParseHexTx(t *testing.T, rawHex string) *wire.MsgTx {
+	t.Helper()
+	b, err := hex.DecodeString(rawHex)
+	if err != nil {
+		t.Fatalf("hex decode: %v", err)
+	}
+	var tx wire.MsgTx
+	if err := tx.Deserialize(bytes.NewReader(b)); err != nil {
+		t.Fatalf("tx deserialize: %v", err)
+	}
+	return &tx
+}
+
+// TestComputeMiningFee_Block4423 computes the mining fee from a real block
+// fixture by subtracting the PoW subsidy from the miner's coinbase output.
+// Block 4423: coinbase vout[2] = 32.00026135 VAR, PoW subsidy = 32 VAR.
+func TestComputeMiningFee_Block4423(t *testing.T) {
+	block := loadBlockFixture(t, "testdata/block4423.json")
+
+	got := computeMiningFee(block)
+	// coinbase vout[2] value = 3,200,026,135 atoms
+	// PoW subsidy at height 4423 = 3,200,000,000 atoms
+	// expected fee = 3,200,026,135 - 3,200,000,000 = 26,135
+	want := int64(26_135)
+	if got != want {
+		t.Errorf("computeMiningFee(block4423) = %d, want %d (diff %d)", got, want, got-want)
+	}
+}
+
+

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -19,6 +19,7 @@ import (
 	explorerTypes "github.com/monetarium/monetarium-explorer/explorer/types"
 	"github.com/monetarium/monetarium-node/chaincfg"
 	"github.com/monetarium/monetarium-node/chaincfg/chainhash"
+	"github.com/monetarium/monetarium-node/dcrutil"
 	chainjson "github.com/monetarium/monetarium-node/rpc/jsonrpc/types"
 	"github.com/monetarium/monetarium-node/wire"
 )
@@ -623,5 +624,27 @@ func TestStore_MiningFeeFromRealBlock4423(t *testing.T) {
 	}
 	if exp.pageData.HomeInfo.LBlockTotalAtoms != 3_200_026_135 {
 		t.Errorf("LBlockTotalAtoms = %d, want 3200026135", exp.pageData.HomeInfo.LBlockTotalAtoms)
+	}
+}
+
+// Block 4423 known totals (from real block analysis):
+//   - Regular tx fees (non-coinbase): 31,130 atoms
+//   - Ticket purchase fees: 21,140 atoms
+//   - Total VAR fees: 31,130 + 21,140 = 52,270 atoms
+//   - dcrutil.Amount(52_270).ToCoin() = 0.00052270 VAR
+//   - Miner fee (coinbase P2PKH - PoW subsidy): 26,135 atoms
+func TestBlock4423_KnownFeeValues(t *testing.T) {
+	const (
+		regFees       = int64(31_130)
+		ticketFees    = int64(21_140)
+		totalVARFees  = int64(52_270)
+		miningFeeCoin = 0.00052270
+	)
+	if regFees+ticketFees != totalVARFees {
+		t.Fatal("broken test: reg + ticket != total")
+	}
+	coin := dcrutil.Amount(totalVARFees).ToCoin()
+	if coin != miningFeeCoin {
+		t.Errorf("dcrutil.Amount(%d).ToCoin() = %.8f, want %.8f", totalVARFees, coin, miningFeeCoin)
 	}
 }

--- a/cmd/dcrdata/internal/explorer/explorer_test.go
+++ b/cmd/dcrdata/internal/explorer/explorer_test.go
@@ -1,10 +1,14 @@
 package explorer
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -515,4 +519,109 @@ func TestBuildTicketPoolChartsData_UsesDataSourceMempool(t *testing.T) {
 			t.Errorf("errMsg = %q, want %q", errMsg, "Error: unknown interval: nope")
 		}
 	})
+}
+
+// --- Fixture loader (block 4423) ---
+
+type rawTxJSON struct {
+	Hex string `json:"hex"`
+}
+
+type blockJSON struct {
+	RawTx  []rawTxJSON `json:"rawtx"`
+	RawSTx []rawTxJSON `json:"rawstx"`
+}
+
+func loadBlock4423(t *testing.T) *wire.MsgBlock {
+	t.Helper()
+	data, err := os.ReadFile("../../../../blockdata/testdata/block4423.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var bj blockJSON
+	if err := json.Unmarshal(data, &bj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	msgBlock := &wire.MsgBlock{}
+	for _, rtx := range bj.RawTx {
+		msgBlock.Transactions = append(msgBlock.Transactions, mustParseHexTx(t, rtx.Hex))
+	}
+	for _, stx := range bj.RawSTx {
+		msgBlock.STransactions = append(msgBlock.STransactions, mustParseHexTx(t, stx.Hex))
+	}
+	return msgBlock
+}
+
+func mustParseHexTx(t *testing.T, rawHex string) *wire.MsgTx {
+	t.Helper()
+	b, err := hex.DecodeString(rawHex)
+	if err != nil {
+		t.Fatalf("hex decode: %v", err)
+	}
+	var tx wire.MsgTx
+	if err := tx.Deserialize(bytes.NewReader(b)); err != nil {
+		t.Fatalf("tx deserialize: %v", err)
+	}
+	return &tx
+}
+
+func TestStore_MiningFeeFromRealBlock4423(t *testing.T) {
+	params := chaincfg.MainNetParams()
+	mockDS := &mockDataSource{
+		blocks:  make(map[string]*explorerTypes.BlockInfo),
+		heights: make(map[int64]string),
+		params:  params,
+	}
+
+	exp := &explorerUI{
+		dataSource:  mockDS,
+		ChainParams: params,
+		wsHub:       NewWebsocketHub(),
+		pageData: &pageData{
+			HomeInfo: &explorerTypes.HomeInfo{
+				Params: explorerTypes.ChainParams{BlockTime: 60},
+			},
+		},
+		invs: &explorerTypes.MempoolInfo{
+			MempoolShort: explorerTypes.MempoolShort{
+				CoinStats: make(map[uint8]explorerTypes.MempoolCoinStats),
+			},
+		},
+	}
+
+	msgBlock := loadBlock4423(t)
+	hash := msgBlock.BlockHash().String()
+	height := int64(4423)
+	mockDS.height = height
+	mockDS.heights[height] = hash
+	mockDS.blocks[hash] = &explorerTypes.BlockInfo{
+		BlockBasic: &explorerTypes.BlockBasic{Height: height, Hash: hash},
+	}
+
+	blockData := &blockdata.BlockData{
+		Header: chainjson.GetBlockHeaderVerboseResult{Height: 4423},
+		ExtraInfo: apitypes.BlockExplorerExtraInfo{
+			NextBlockSubsidy: &chainjson.GetBlockSubsidyResult{
+				Developer: 0, PoS: 0, PoW: 3_200_000_000, Total: 3_200_000_000,
+			},
+			MiningFeeAtoms: 26_135,
+		},
+	}
+
+	if err := exp.Store(blockData, msgBlock); err != nil {
+		t.Fatalf("Store failed: %v", err)
+	}
+
+	exp.pageData.RLock()
+	defer exp.pageData.RUnlock()
+
+	if exp.pageData.HomeInfo.MiningFeeAtoms != 26_135 {
+		t.Errorf("MiningFeeAtoms = %d, want 26135", exp.pageData.HomeInfo.MiningFeeAtoms)
+	}
+	if exp.pageData.HomeInfo.NBlockSubsidy.PoW != 3_200_000_000 {
+		t.Errorf("NBlockSubsidy.PoW = %d, want 3200000000", exp.pageData.HomeInfo.NBlockSubsidy.PoW)
+	}
+	if exp.pageData.HomeInfo.LBlockTotalAtoms != 3_200_026_135 {
+		t.Errorf("LBlockTotalAtoms = %d, want 3200026135", exp.pageData.HomeInfo.LBlockTotalAtoms)
+	}
 }


### PR DESCRIPTION
## Summary

`computeMiningFee` was summing fees across all regular + stake transactions, reporting total VAR fees (52,270 atoms for block 4423) as the `MiningFeeAtoms`. This is wrong — the miner only collects 50% of total fees (26,135 atoms), with the other 50% going to the ticket seller.

Replaced with `computeMinerVARFeeAtoms`, which reads the miner's fee from the coinbase by finding the P2PKH/P2PK/P2SH output and subtracting the PoW subsidy (giving 26,135 = 50% of 52,270).

## Changes

| File | Change |
|------|--------|
| `blockdata/blockdata.go` | Replaced `computeMiningFee` with `computeMinerVARFeeAtoms`; updated caller in `CollectBlockInfo` |
| `blockdata/blockdata_test.go` | Renamed all tests; added `CoinbaseNoP2PKH` edge case; updated block 4423 real-block test to pass PoW subsidy |

## Test Plan

- [x] `go test ./blockdata/` — 8 tests pass (7 synthetic + 1 real-block 4423)
- [x] `go test ./cmd/dcrdata/internal/explorer/` — existing `TestStore_MiningFeeFromRealBlock4423` verifies `MiningFeeAtoms = 26_135` through the Store pipeline
- [x] `go test ./...` across all 3 modules — all green

Root cause: `computeMiningFee` summed ALL fees (100%) as if the miner gets everything. In Monetarium, total VAR fees are split 50/50 between miner and ticket seller — the miner's actual fee is `coinbase_P2PKH_value - PoW_subsidy = 26,135` atoms (50% of 52,270).
