### PR TITLE
explorer, pubsub, template, js: use current block subsidy (CBlockSubs…

### DIFF
--- a/cmd/dcrdata/internal/explorer/explorer.go
+++ b/cmd/dcrdata/internal/explorer/explorer.go
@@ -569,6 +569,15 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	p.HomeInfo.NBlockSubsidy.PoS = blockData.ExtraInfo.NextBlockSubsidy.PoS
 	p.HomeInfo.NBlockSubsidy.PoW = blockData.ExtraInfo.NextBlockSubsidy.PoW
 	p.HomeInfo.NBlockSubsidy.Total = blockData.ExtraInfo.NextBlockSubsidy.Total
+	if blockData.ExtraInfo.CurrentBlockSubsidy != nil {
+		p.HomeInfo.CBlockSubsidy.Dev = blockData.ExtraInfo.CurrentBlockSubsidy.Developer
+		p.HomeInfo.CBlockSubsidy.PoS = blockData.ExtraInfo.CurrentBlockSubsidy.PoS
+		p.HomeInfo.CBlockSubsidy.PoW = blockData.ExtraInfo.CurrentBlockSubsidy.PoW
+		p.HomeInfo.CBlockSubsidy.Total = blockData.ExtraInfo.CurrentBlockSubsidy.Total
+	} else {
+		// Fall back to next block subsidy if current is unavailable.
+		p.HomeInfo.CBlockSubsidy = p.HomeInfo.NBlockSubsidy
+	}
 	if err == nil {
 		p.HomeInfo.ActiveMiners = activeMiners
 	}
@@ -576,8 +585,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgB
 	// Total reward = subsidy + mining fees (~16 + <1 VAR)
 	// MiningFee from blockData (computed in collector)
 	p.HomeInfo.MiningFeeAtoms = blockData.ExtraInfo.MiningFeeAtoms
-	p.HomeInfo.LBlockTotal = dcrutil.Amount(p.HomeInfo.NBlockSubsidy.PoW).ToCoin() + dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin()
-	p.HomeInfo.LBlockTotalAtoms = p.HomeInfo.NBlockSubsidy.PoW + blockData.ExtraInfo.MiningFeeAtoms
+	p.HomeInfo.LBlockTotal = dcrutil.Amount(p.HomeInfo.CBlockSubsidy.PoW).ToCoin() + dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin()
+	p.HomeInfo.LBlockTotalAtoms = p.HomeInfo.CBlockSubsidy.PoW + blockData.ExtraInfo.MiningFeeAtoms
 	log.Debugf("MiningFee: %.8f, Total: %.8f", dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin(), p.HomeInfo.LBlockTotal)
 
 	// New Supply section data

--- a/cmd/dcrdata/internal/explorer/explorerroutes.go
+++ b/cmd/dcrdata/internal/explorer/explorerroutes.go
@@ -234,11 +234,12 @@ func (exp *explorerUI) Home(w http.ResponseWriter, r *http.Request) {
 	exp.pageData.RLock()
 
 	homeInfo := exp.pageData.HomeInfo
-	// Initialize LBlockTotal (subsidy + fees) if not yet set
-	// Use NBlockSubsidy for subsidy, MiningFeeAtoms will be 0 if not populated yet
-	if homeInfo.LBlockTotalAtoms == 0 && homeInfo.IdxBlockInWindow > 0 && homeInfo.NBlockSubsidy.PoW > 0 {
-		homeInfo.LBlockTotalAtoms = homeInfo.NBlockSubsidy.PoW
-		homeInfo.LBlockTotal = dcrutil.Amount(homeInfo.NBlockSubsidy.PoW).ToCoin()
+	// Initialize LBlockTotal (subsidy + fees) if not yet set.
+	// Use CBlockSubsidy (actual vote-scaled subsidy) — NBlockSubsidy is
+	// the next-block projected max and would be wrong for <5-vote blocks.
+	if homeInfo.LBlockTotalAtoms == 0 && homeInfo.IdxBlockInWindow > 0 && homeInfo.CBlockSubsidy.PoW > 0 {
+		homeInfo.LBlockTotalAtoms = homeInfo.CBlockSubsidy.PoW
+		homeInfo.LBlockTotal = dcrutil.Amount(homeInfo.CBlockSubsidy.PoW).ToCoin()
 		homeInfo.MiningFeeAtoms = 0
 	}
 

--- a/cmd/dcrdata/public/js/controllers/mining_controller.js
+++ b/cmd/dcrdata/public/js/controllers/mining_controller.js
@@ -30,7 +30,12 @@ export default class extends Controller {
       8,
       2
     )
-    this.powSubsidyTarget.innerHTML = humanize.decimalParts(ex.subsidy.pow / 100000000, false, 8, 2)
+    this.powSubsidyTarget.innerHTML = humanize.decimalParts(
+      (ex.cblock_subsidy || ex.subsidy).pow / 100000000,
+      false,
+      8,
+      2
+    )
     this.powFeeTarget.innerHTML = humanize.decimalParts(
       (ex.mining_fee_atoms || 0) / 100000000,
       false,

--- a/cmd/dcrdata/views/home_mining.tmpl
+++ b/cmd/dcrdata/views/home_mining.tmpl
@@ -35,7 +35,7 @@
             <div class="fs12 fs12-decimal lh1rem text-black-50 label-value-grid">
                 <span class="text-start">Subsidy:</span>
                 <span class="text-start">
-                    <span class="mono" data-mining-target="powSubsidy">{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .NBlockSubsidy.PoW) 8 false 2)}}</span>
+                    <span class="mono" data-mining-target="powSubsidy">{{template "decimalParts" (float64AsDecimalParts (toFloat64Amount .CBlockSubsidy.PoW) 8 false 2)}}</span>
                 </span>
                 <span class="text-start">Fee:</span>
                 <span class="text-start">

--- a/explorer/types/explorertypes.go
+++ b/explorer/types/explorertypes.go
@@ -900,6 +900,7 @@ type HomeInfo struct {
 	IdxInRewardWindow     int                  `json:"reward_idx"`
 	Difficulty            float64              `json:"difficulty"`
 	RewardPeriod          string               `json:"reward_period"`
+	CBlockSubsidy         BlockSubsidy         `json:"cblock_subsidy"`
 	NBlockSubsidy         BlockSubsidy         `json:"subsidy"`
 	MiningFeeAtoms        int64                `json:"mining_fee_atoms"`
 	LBlockTotal           float64              `json:"lblock_total"`

--- a/pubsub/pubsubhub.go
+++ b/pubsub/pubsubhub.go
@@ -737,6 +737,14 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	p.GeneralInfo.NBlockSubsidy.PoS = blockData.ExtraInfo.NextBlockSubsidy.PoS
 	p.GeneralInfo.NBlockSubsidy.PoW = blockData.ExtraInfo.NextBlockSubsidy.PoW
 	p.GeneralInfo.NBlockSubsidy.Total = blockData.ExtraInfo.NextBlockSubsidy.Total
+	if blockData.ExtraInfo.CurrentBlockSubsidy != nil {
+		p.GeneralInfo.CBlockSubsidy.Dev = blockData.ExtraInfo.CurrentBlockSubsidy.Developer
+		p.GeneralInfo.CBlockSubsidy.PoS = blockData.ExtraInfo.CurrentBlockSubsidy.PoS
+		p.GeneralInfo.CBlockSubsidy.PoW = blockData.ExtraInfo.CurrentBlockSubsidy.PoW
+		p.GeneralInfo.CBlockSubsidy.Total = blockData.ExtraInfo.CurrentBlockSubsidy.Total
+	} else {
+		p.GeneralInfo.CBlockSubsidy = p.GeneralInfo.NBlockSubsidy
+	}
 	if activeMinersOK {
 		p.GeneralInfo.ActiveMiners = activeMinersCount
 	}
@@ -744,9 +752,9 @@ func (psh *PubSubHub) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBl
 	// Total reward = subsidy + mining fees (~16 + <1 VAR)
 	// MiningFee from blockData (computed in collector)
 	p.GeneralInfo.MiningFeeAtoms = blockData.ExtraInfo.MiningFeeAtoms
-	p.GeneralInfo.LBlockTotal = dcrutil.Amount(p.GeneralInfo.NBlockSubsidy.PoW).ToCoin() + dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin()
-	p.GeneralInfo.LBlockTotalAtoms = p.GeneralInfo.NBlockSubsidy.PoW + blockData.ExtraInfo.MiningFeeAtoms
-	log.Debugf("PUB LBlockTotalAtoms: %d (MiningFee: %.8f, NBlockSubsidy.PoW: %d)", p.GeneralInfo.LBlockTotalAtoms, dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin(), p.GeneralInfo.NBlockSubsidy.PoW)
+	p.GeneralInfo.LBlockTotal = dcrutil.Amount(p.GeneralInfo.CBlockSubsidy.PoW).ToCoin() + dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin()
+	p.GeneralInfo.LBlockTotalAtoms = p.GeneralInfo.CBlockSubsidy.PoW + blockData.ExtraInfo.MiningFeeAtoms
+	log.Debugf("PUB LBlockTotalAtoms: %d (MiningFee: %.8f, CBlockSubsidy.PoW: %d)", p.GeneralInfo.LBlockTotalAtoms, dcrutil.Amount(blockData.ExtraInfo.MiningFeeAtoms).ToCoin(), p.GeneralInfo.CBlockSubsidy.PoW)
 
 	// If BlockData contains non-nil PoolInfo, copy values.
 	p.GeneralInfo.PoolInfo = exptypes.TicketPoolInfo{}


### PR DESCRIPTION
…idy) for PoW VAR Reward display

Adds CBlockSubsidy field to HomeInfo, populated from CurrentBlockSubsidy (actual vote-scaled subsidy via header.Voters). Fixes LBlockTotal/LBlockTotalAtoms to use current (not next) subsidy, so blocks with <5 votes show the correct vote-scaled amounts.

Changes:
- explorertypes.go: add CBlockSubsidy to HomeInfo
- explorer.go: populate CBlockSubsidy, use it for LBlockTotal
- home_mining.tmpl: display CBlockSubsidy.PoW for Subsidy
- mining_controller.js: read cblock_subsidy.pow from WS data
- pubsubhub.go: populate CBlockSubsidy, use it for LBlockTotal