### PR TITLE
explorer/charts: add miner hashrate shares chart (pie + table)

### DIFF
--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -112,6 +112,7 @@ type DataSource interface {
 	LoadSKASupplyForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
 	LoadSKAFeesForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
 	GetMinerHashrateShares(ctx context.Context, since *time.Time) ([]dbtypes.MinerShareData, error)
+	GetTotalBlocksMined(ctx context.Context, since *time.Time) (int32, error)
 }
 
 // dcrdata application context used by all route handlers
@@ -1966,9 +1967,11 @@ func (c *appContext) ChartTypeData(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		var total int32
-		for _, m := range miners {
-			total += m.BlocksMined
+		total, err := c.DataSource.GetTotalBlocksMined(r.Context(), since)
+		if err != nil {
+			apiLog.Errorf("GetTotalBlocksMined: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 
 		resp := struct {

--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -112,7 +112,7 @@ type DataSource interface {
 	LoadSKASupplyForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
 	LoadSKAFeesForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
 	GetMinerHashrateShares(ctx context.Context, since *time.Time) ([]dbtypes.MinerShareData, error)
-	GetTotalBlocksMined(ctx context.Context, since *time.Time) (int32, error)
+	GetTotalBlocksMined(ctx context.Context, since *time.Time) (int64, error)
 }
 
 // dcrdata application context used by all route handlers
@@ -1976,7 +1976,7 @@ func (c *appContext) ChartTypeData(w http.ResponseWriter, r *http.Request) {
 
 		resp := struct {
 			Interval string                   `json:"interval"`
-			Total    int32                    `json:"total"`
+			Total    int64                    `json:"total"`
 			Miners   []dbtypes.MinerShareData `json:"miners"`
 		}{
 			Interval: interval,

--- a/cmd/dcrdata/internal/api/apiroutes.go
+++ b/cmd/dcrdata/internal/api/apiroutes.go
@@ -111,6 +111,7 @@ type DataSource interface {
 	GetMempoolPriceCountTime() *apitypes.PriceCountTime
 	LoadSKASupplyForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
 	LoadSKAFeesForCoin(ctx context.Context, charts *cache.ChartData, coinType uint8) error
+	GetMinerHashrateShares(ctx context.Context, since *time.Time) ([]dbtypes.MinerShareData, error)
 }
 
 // dcrdata application context used by all route handlers
@@ -1937,6 +1938,50 @@ func (c *appContext) ChartTypeData(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+	}
+
+	// Hashrate shares chart is special: it queries the miners table directly,
+	// not the in-memory chart cache.
+	if chartType == cache.HashrateShares {
+		var since *time.Time
+		switch cache.ParseInterval(interval) {
+		case cache.YearInterval:
+			t := time.Now().AddDate(-1, 0, 0)
+			since = &t
+		case cache.MonthInterval:
+			t := time.Now().AddDate(0, -1, 0)
+			since = &t
+		case cache.WeekInterval:
+			t := time.Now().AddDate(0, 0, -7)
+			since = &t
+		case cache.DayInterval:
+			t := time.Now().AddDate(0, 0, -1)
+			since = &t
+		}
+
+		miners, err := c.DataSource.GetMinerHashrateShares(r.Context(), since)
+		if err != nil {
+			apiLog.Errorf("GetMinerHashrateShares: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		var total int32
+		for _, m := range miners {
+			total += m.BlocksMined
+		}
+
+		resp := struct {
+			Interval string                   `json:"interval"`
+			Total    int32                    `json:"total"`
+			Miners   []dbtypes.MinerShareData `json:"miners"`
+		}{
+			Interval: interval,
+			Total:    total,
+			Miners:   miners,
+		}
+		writeJSON(w, resp, m.GetIndentCtx(r))
+		return
 	}
 
 	if c.charts == nil {

--- a/cmd/dcrdata/internal/api/noop_ds_test.go
+++ b/cmd/dcrdata/internal/api/noop_ds_test.go
@@ -134,3 +134,6 @@ func (noopDS) LoadSKAFeesForCoin(_ context.Context, _ *cache.ChartData, _ uint8)
 func (noopDS) GetMinerHashrateShares(_ context.Context, _ *time.Time) ([]dbtypes.MinerShareData, error) {
 	return nil, nil
 }
+func (noopDS) GetTotalBlocksMined(_ context.Context, _ *time.Time) (int32, error) {
+	return 0, nil
+}

--- a/cmd/dcrdata/internal/api/noop_ds_test.go
+++ b/cmd/dcrdata/internal/api/noop_ds_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	apitypes "github.com/monetarium/monetarium-explorer/api/types"
 	"github.com/monetarium/monetarium-explorer/db/cache"
@@ -129,4 +130,7 @@ func (noopDS) LoadSKASupplyForCoin(_ context.Context, _ *cache.ChartData, _ uint
 }
 func (noopDS) LoadSKAFeesForCoin(_ context.Context, _ *cache.ChartData, _ uint8) error {
 	return nil
+}
+func (noopDS) GetMinerHashrateShares(_ context.Context, _ *time.Time) ([]dbtypes.MinerShareData, error) {
+	return nil, nil
 }

--- a/cmd/dcrdata/internal/api/noop_ds_test.go
+++ b/cmd/dcrdata/internal/api/noop_ds_test.go
@@ -134,6 +134,6 @@ func (noopDS) LoadSKAFeesForCoin(_ context.Context, _ *cache.ChartData, _ uint8)
 func (noopDS) GetMinerHashrateShares(_ context.Context, _ *time.Time) ([]dbtypes.MinerShareData, error) {
 	return nil, nil
 }
-func (noopDS) GetTotalBlocksMined(_ context.Context, _ *time.Time) (int32, error) {
+func (noopDS) GetTotalBlocksMined(_ context.Context, _ *time.Time) (int64, error) {
 	return 0, nil
 }

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -1282,7 +1282,7 @@ export default class extends Controller {
       const tr = document.createElement('tr')
       tr.innerHTML = `
         <td>${i + 1}</td>
-        <td><span class="color-swatch" style="display:inline-block;width:12px;height:12px;border-radius:2px;background:${color}"></span></td>
+        <td><span class="color-swatch" style="background:${color}"></span></td>
         <td>${pct}%</td>
         <td><a href="/address/${encodeURIComponent(addr)}">${dompurify.sanitize(displayAddr)}</a></td>
       `

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -25,6 +25,7 @@ const multiYAxisChart = ['ticket-price', 'privacy-participation', 'hashrate']
 const yValueRanges = { 'ticket-price': [1] }
 const chainworkUnits = ['H', 'kH', 'MH', 'GH', 'TH', 'PH', 'EH', 'ZH', 'YH']
 const hashrateUnits = ['H/s', 'kH/s', 'MH/s', 'GH/s', 'TH/s', 'PH/s', 'EH/s']
+const pieCharts = ['hashrate-shares']
 let ticketPoolSizeTarget, windowSize, avgBlockTime
 let rawCoinSupply, rawPoolValue
 let yFormatter, legendEntry, legendMarker, legendElement
@@ -47,6 +48,10 @@ function isModeEnabled(chart) {
 
 function hasMultipleVisibility(chart) {
   return multiYAxisChart.indexOf(chart) > -1
+}
+
+function isPieChart(chart) {
+  return pieCharts.indexOf(chart) > -1
 }
 
 function intComma(amount) {
@@ -365,7 +370,8 @@ export default class extends Controller {
       'modeOption',
       'intervalSelector',
       'intervalOption',
-      'rawDataURL'
+      'rawDataURL',
+      'hashrateSharesContainer'
     ]
   }
 
@@ -853,6 +859,37 @@ export default class extends Controller {
     const selection = (this.settings.chart = this.chartSelectTarget.value)
     this.customLimits = null
     this.chartWrapperTarget.classList.add('loading')
+
+    if (isPieChart(selection)) {
+      this.binSelectorTarget.classList.add('d-hide')
+      this.scaleSelectorTarget.classList.add('d-hide')
+      this.modeSelectorTarget.classList.add('d-hide')
+      this.vSelectorTarget.classList.add('d-hide')
+      this.zoomSelectorTarget.classList.add('d-hide')
+      this.intervalSelectorTarget.classList.remove('d-hide')
+      this.chartsViewTarget.classList.add('d-hide')
+      this.hashrateSharesContainerTarget.classList.remove('d-hide')
+
+      this.showIntervalOption('month')
+      this.hideIntervalOption('year')
+
+      if (!this.settings.interval) this.settings.interval = 'month'
+      const url = `/api/chart/${selection}?interval=${this.settings.interval}`
+      this.setActiveOptionBtn(this.settings.interval, this.intervalOptionTargets)
+      const chartResponse = await requestJSON(url)
+      selectedChart = selection
+      this.renderHashrateShares(chartResponse)
+
+      const baseURL = `${this.query.url.protocol}//${this.query.url.host}`
+      this.rawDataURLTarget.textContent = `${baseURL}/api/chart/${selection}?interval=${this.settings.interval}`
+      this.query.replace(this.settings)
+      return
+    }
+
+    this.chartsViewTarget.classList.remove('d-hide')
+    this.hashrateSharesContainerTarget.classList.add('d-hide')
+    this.zoomSelectorTarget.classList.remove('d-hide')
+
     if (isScaleDisabled(selection)) {
       this.scaleSelectorTarget.classList.add('d-hide')
       this.vSelectorTarget.classList.remove('d-hide')
@@ -872,8 +909,14 @@ export default class extends Controller {
     }
     if (selection === 'hashrate') {
       this.intervalSelectorTarget.classList.remove('d-hide')
+      this.showIntervalOption('year')
+      this.hideIntervalOption('month')
     } else {
       this.intervalSelectorTarget.classList.add('d-hide')
+    }
+    if (selection !== 'hashrate') {
+      this.showIntervalOption('year')
+      this.showIntervalOption('month')
     }
     if (
       selectedChart !== selection ||
@@ -1127,6 +1170,109 @@ export default class extends Controller {
     this.chartsView.updateOptions({ visibility: this.visibility })
     this.settings.visibility = this.visibility.join('-')
     this.query.replace(this.settings)
+  }
+
+  showIntervalOption(option) {
+    this.intervalOptionTargets.forEach((el) => {
+      if (el.dataset.option === option) el.classList.remove('d-hide')
+    })
+  }
+
+  hideIntervalOption(option) {
+    this.intervalOptionTargets.forEach((el) => {
+      if (el.dataset.option === option) el.classList.add('d-hide')
+    })
+  }
+
+  renderHashrateShares(data) {
+    const miners = data.miners || []
+    const total = data.total || 0
+
+    const canvas = document.getElementById('hashrateSharesPie')
+    const ctx = canvas.getContext('2d')
+    const dpr = window.devicePixelRatio || 1
+    const rect = canvas.getBoundingClientRect()
+    canvas.width = rect.width * dpr
+    canvas.height = rect.height * dpr
+    ctx.scale(dpr, dpr)
+    const w = rect.width
+    const h = rect.height
+    const cx = w / 2
+    const cy = h / 2
+    const r = Math.min(cx, cy) - 10
+
+    ctx.clearRect(0, 0, w, h)
+
+    if (!miners.length || !total) {
+      ctx.fillStyle = '#999'
+      ctx.font = '14px monospace'
+      ctx.textAlign = 'center'
+      ctx.fillText('No data', cx, cy)
+      this.buildTableRows(miners, total, [])
+      this.chartWrapperTarget.classList.remove('loading')
+      return
+    }
+
+    const colors = miners.map((_, i) => `hsl(${(i * 137.5) % 360}, 65%, 55%)`)
+
+    // Sort miners by blocks_mined descending (server should already do this)
+    let startAngle = -Math.PI / 2
+    miners.forEach((m, i) => {
+      const pct = m.blocks_mined / total
+      const endAngle = startAngle + pct * Math.PI * 2
+      ctx.beginPath()
+      ctx.moveTo(cx, cy)
+      ctx.arc(cx, cy, r, startAngle, endAngle)
+      ctx.closePath()
+      ctx.fillStyle = colors[i]
+      ctx.fill()
+      startAngle = endAngle
+    })
+
+    // Draw rank labels on top 5 segments (if segment is large enough)
+    startAngle = -Math.PI / 2
+    miners.forEach((m, i) => {
+      const pct = m.blocks_mined / total
+      const endAngle = startAngle + pct * Math.PI * 2
+      const midAngle = startAngle + (endAngle - startAngle) / 2
+      const labelR = r * 0.65
+      const lx = cx + Math.cos(midAngle) * labelR
+      const ly = cy + Math.sin(midAngle) * labelR
+
+      if (i < 5 && pct >= 0.03) {
+        ctx.fillStyle = '#fff'
+        ctx.font = 'bold 14px monospace'
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'middle'
+        ctx.fillText(String(i + 1), lx, ly)
+      }
+      startAngle = endAngle
+    })
+
+    this.buildTableRows(miners, total, colors)
+    this.chartWrapperTarget.classList.remove('loading')
+  }
+
+  buildTableRows(miners, total, colors) {
+    const tbody = document.getElementById('hashrateSharesTableBody')
+    if (!tbody) return
+    tbody.innerHTML = ''
+
+    miners.forEach((m, i) => {
+      const pct = total > 0 ? ((m.blocks_mined / total) * 100).toFixed(1) : '0.0'
+      const color = colors[i] || '#ccc'
+      const addr = m.address || ''
+      const displayAddr = addr.length > 20 ? `${addr.slice(0, 12)}…${addr.slice(-8)}` : addr
+
+      const tr = document.createElement('tr')
+      tr.innerHTML = `
+        <td>${i + 1}</td>
+        <td><span class="color-swatch" style="display:inline-block;width:12px;height:12px;border-radius:2px;background:${color}"></span></td>
+        <td>${pct}%</td>
+        <td><a href="/address/${encodeURIComponent(addr)}">${dompurify.sanitize(displayAddr)}</a></td>
+      `
+      tbody.appendChild(tr)
+    })
   }
 
   setActiveOptionBtn(opt, optTargets) {

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -18,7 +18,7 @@ let Dygraph // lazy loaded on connect
 const atomsToVAR = 1e-8
 const windowScales = ['ticket-price', 'pow-difficulty', 'missed-votes']
 const hybridScales = ['privacy-participation']
-const lineScales = ['ticket-price', 'privacy-participation']
+const lineScales = ['ticket-price', 'privacy-participation', 'hashrate']
 const modeScales = ['ticket-price', 'hashrate']
 const multiYAxisChart = ['ticket-price', 'privacy-participation', 'hashrate']
 // index 0 represents y1 and 1 represents y2 axes.

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -1200,6 +1200,10 @@ export default class extends Controller {
     const ctx = canvas.getContext('2d')
     const dpr = window.devicePixelRatio || 1
     const rect = canvas.getBoundingClientRect()
+    if (!rect.width || !rect.height) {
+      window.requestAnimationFrame(() => this.renderHashrateShares(data))
+      return
+    }
     canvas.width = rect.width * dpr
     canvas.height = rect.height * dpr
     ctx.scale(dpr, dpr)

--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -1187,6 +1187,14 @@ export default class extends Controller {
   renderHashrateShares(data) {
     const miners = data.miners || []
     const total = data.total || 0
+    const sumTop = miners.reduce((s, m) => s + m.blocks_mined, 0)
+    const othersBlocks = total - sumTop
+    const othersPresent = othersBlocks > 0
+
+    // Build pie segments: top 25 + an "Others" slice for the remainder
+    const segments = othersPresent
+      ? miners.concat([{ address: 'Others', blocks_mined: othersBlocks }])
+      : miners
 
     const canvas = document.getElementById('hashrateSharesPie')
     const ctx = canvas.getContext('2d')
@@ -1213,11 +1221,13 @@ export default class extends Controller {
       return
     }
 
-    const colors = miners.map((_, i) => `hsl(${(i * 137.5) % 360}, 65%, 55%)`)
+    const colors = segments.map((_, i) =>
+      i === segments.length - 1 && othersPresent ? '#ccc' : `hsl(${(i * 137.5) % 360}, 65%, 55%)`
+    )
 
-    // Sort miners by blocks_mined descending (server should already do this)
+    // Draw pie segments (includes Others)
     let startAngle = -Math.PI / 2
-    miners.forEach((m, i) => {
+    segments.forEach((m, i) => {
       const pct = m.blocks_mined / total
       const endAngle = startAngle + pct * Math.PI * 2
       ctx.beginPath()
@@ -1249,7 +1259,8 @@ export default class extends Controller {
       startAngle = endAngle
     })
 
-    this.buildTableRows(miners, total, colors)
+    // Show table only for top miners (no Others row)
+    this.buildTableRows(miners, total, colors.slice(0, miners.length))
     this.chartWrapperTarget.classList.remove('loading')
   }
 

--- a/cmd/dcrdata/public/js/controllers/charts_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.test.js
@@ -120,7 +120,9 @@ function makeController() {
   c.legendMarkerTarget = { remove: vi.fn(), removeAttribute: vi.fn() }
   c.legendEntryTarget = { remove: vi.fn(), removeAttribute: vi.fn() }
   c.rawDataURLTarget = { textContent: '' }
-  c.chartsViewTarget = {}
+  c.chartsViewTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
+  c.hashrateSharesContainerTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
+  c.zoomSelectorTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
   c.ticketsPriceTarget = { checked: true }
   c.ticketsPurchaseTarget = { checked: true }
   c.hashrateRateTarget = { checked: true }

--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -569,6 +569,13 @@ body.darkBG .customcheck input:checked ~ .hashrate-miners {
   height: 80px;
 }
 
+.hashrate-shares-container canvas {
+  display: block;
+  margin: 0 auto;
+  max-width: 100%;
+  max-height: 65vh;
+}
+
 .meter > canvas {
   width: 110px;
   height: 110px;
@@ -624,4 +631,49 @@ body.darkBG {
 
 .tp-outputs-align {
   width: inherit;
+}
+
+.hashrate-shares-container {
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
+  min-height: 73vh;
+}
+
+.hashrate-shares-container .row {
+  min-height: 73vh;
+}
+
+.hashrate-shares-table {
+  font-size: 0.9rem;
+}
+
+.hashrate-shares-table th,
+.hashrate-shares-table td {
+  padding: 0.3rem 0.5rem;
+  vertical-align: middle;
+}
+
+.hashrate-shares-table .color-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+.hashrate-shares-table td:first-child {
+  text-align: center;
+  font-weight: 600;
+  width: 2rem;
+}
+
+.hashrate-shares-table td:nth-child(3) {
+  text-align: right;
+  width: 5rem;
+}
+
+.hashrate-shares-table td:nth-child(4) {
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/cmd/dcrdata/views/charts.tmpl
+++ b/cmd/dcrdata/views/charts.tmpl
@@ -37,8 +37,9 @@
                               {{end}}
                              <option value="duration-btw-blocks">Duration Between Blocks</option>
                             <option value="chainwork">Total Work</option>
-                            <option value="hashrate">Hashrate</option>
-                            <option value="missed-votes">Missed Votes</option>
+                             <option value="hashrate">Hashrate</option>
+                             <option value="hashrate-shares">Hashrate Shares</option>
+                             <option value="missed-votes">Missed Votes</option>
                         </select>
                     </div>
                 </div>
@@ -199,6 +200,7 @@
                         <div class="btn-group" role="group">
                             <button type="button" class="btn btn-outline-secondary" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="all">All</button>
                             <button type="button" class="btn btn-outline-secondary" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="year">Year</button>
+                            <button type="button" class="btn btn-outline-secondary" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="month">Month</button>
                             <button type="button" class="btn btn-outline-secondary active" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="week">Week</button>
                             <button type="button" class="btn btn-outline-secondary" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="day">Day</button>
                         </div>
@@ -212,6 +214,26 @@
             <div
                 class="chartview"
                 data-charts-target="chartsView">
+            </div>
+            <div class="d-hide hashrate-shares-container" data-charts-target="hashrateSharesContainer">
+                <div class="row">
+                    <div class="col-md-12">
+                        <canvas id="hashrateSharesPie" width="400" height="400"></canvas>
+                    </div>
+                    <div class="col-md-12">
+                        <table class="table table-sm hashrate-shares-table">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th></th>
+                                    <th>%</th>
+                                    <th>Address</th>
+                                </tr>
+                            </thead>
+                            <tbody id="hashrateSharesTableBody"></tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
             <div class="d-flex flex-wrap justify-content-center align-items-center mb-1 mt-1">
                 <div class="chart-control chart-control-wrapper">

--- a/db/cache/charts.go
+++ b/db/cache/charts.go
@@ -66,16 +66,20 @@ const (
 
 	// SKA fee chart prefix (fees/N where N is coin type)
 	SKAFeePrefix = "fees/"
+
+	// HashrateShares chart type for pie chart + table of miner distribution.
+	HashrateShares = "hashrate-shares"
 )
 
 // intervalType specifies the lookback interval for the active-miner rolling count.
 type intervalType string
 
 const (
-	AllInterval  intervalType = "all"
-	YearInterval intervalType = "year"
-	WeekInterval intervalType = "week"
-	DayInterval  intervalType = "day"
+	AllInterval   intervalType = "all"
+	MonthInterval intervalType = "month"
+	YearInterval  intervalType = "year"
+	WeekInterval  intervalType = "week"
+	DayInterval   intervalType = "day"
 
 	DefaultInterval = WeekInterval
 )
@@ -172,7 +176,7 @@ func ParseAxis(aType string) axisType {
 // ParseInterval returns the matching interval type, else the default.
 func ParseInterval(s string) intervalType {
 	switch intervalType(s) {
-	case AllInterval, YearInterval, WeekInterval, DayInterval:
+	case AllInterval, MonthInterval, YearInterval, WeekInterval, DayInterval:
 		return intervalType(s)
 	}
 	return DefaultInterval
@@ -938,6 +942,8 @@ func (charts *ChartData) activeMinersCounts(numBlocks int, interval intervalType
 		switch interval {
 		case YearInterval:
 			duration = uint64(365 * 24 * 60 * 60)
+		case MonthInterval:
+			duration = uint64(30 * 24 * 60 * 60)
 		case WeekInterval:
 			duration = uint64(7 * 24 * 60 * 60)
 		case DayInterval:

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -2641,3 +2641,9 @@ func (a *AddressInfo) PostProcess(tipHeight uint32) {
 		tx.BlockHeight = tipHeight - uint32(tx.Confirmations) + 1
 	}
 }
+
+// MinerShareData holds per-address miner share data for the hashrate-shares chart.
+type MinerShareData struct {
+	Address     string `json:"address"`
+	BlocksMined int32  `json:"blocks_mined"`
+}

--- a/db/dcrpg/internal/minerstmts.go
+++ b/db/dcrpg/internal/minerstmts.go
@@ -104,7 +104,7 @@ const (
 	// SelectTotalBlocksMinedSince returns the total block count within a time
 	// window, using the same DISTINCT (addr, height) approach as SelectMinersByBlocksMinedSince.
 	SelectTotalBlocksMinedSince = `
-		SELECT COUNT(*)::INT4
+		SELECT COUNT(*)::INT8
 		FROM (
 			SELECT DISTINCT v.script_addresses AS addr, t.block_height AS height
 			FROM vouts v

--- a/db/dcrpg/internal/minerstmts.go
+++ b/db/dcrpg/internal/minerstmts.go
@@ -70,4 +70,31 @@ const (
 		);`
 
 	CleanupMinerZeros = `DELETE FROM miners WHERE blocks_mined <= 0;`
+
+	// SelectMinersByBlocksMined returns top 25 miners ordered by blocks_mined (all-time).
+	SelectMinersByBlocksMined = `SELECT address, blocks_mined FROM miners WHERE blocks_mined > 0 ORDER BY blocks_mined DESC LIMIT 25`
+
+	// SelectMinersByBlocksMinedSince returns top 25 miners ordered by blocks_mined
+	// within a time window (block_time >= $1::TIMESTAMPTZ). This is the same approach
+	// as BackfillMiners but bounded by block time.
+	SelectMinersByBlocksMinedSince = `
+		SELECT sub.addr, COUNT(*)::INT4 as blocks_mined
+		FROM (
+			SELECT DISTINCT v.script_addresses AS addr, t.block_height AS height
+			FROM vouts v
+			JOIN transactions t ON v.tx_hash = t.tx_hash
+			WHERE t.tree = 0
+			  AND t.block_index = 0
+			  AND t.is_mainchain = true
+			  AND v.script_type IN ('pubkeyhash', 'scripthash', 'pubkey', 'pubkeyalt', 'pubkeyhashalt')
+			  AND v.value > 0
+			  AND v.script_addresses IS NOT NULL
+			  AND v.script_addresses NOT IN ('', 'unknown')
+			  AND v.script_addresses NOT LIKE '{%}'
+			  AND t.block_time >= $1
+		) sub
+		WHERE sub.addr IS NOT NULL AND sub.addr != ''
+		GROUP BY sub.addr
+		ORDER BY blocks_mined DESC
+		LIMIT 25`
 )

--- a/db/dcrpg/internal/minerstmts.go
+++ b/db/dcrpg/internal/minerstmts.go
@@ -74,6 +74,9 @@ const (
 	// SelectMinersByBlocksMined returns top 25 miners ordered by blocks_mined (all-time).
 	SelectMinersByBlocksMined = `SELECT address, blocks_mined FROM miners WHERE blocks_mined > 0 ORDER BY blocks_mined DESC LIMIT 25`
 
+	// SelectTotalBlocksMined returns the sum of all blocks mined (all-time total).
+	SelectTotalBlocksMined = `SELECT COALESCE(SUM(blocks_mined), 0) FROM miners WHERE blocks_mined > 0`
+
 	// SelectMinersByBlocksMinedSince returns top 25 miners ordered by blocks_mined
 	// within a time window (block_time >= $1::TIMESTAMPTZ). This is the same approach
 	// as BackfillMiners but bounded by block time.
@@ -97,4 +100,24 @@ const (
 		GROUP BY sub.addr
 		ORDER BY blocks_mined DESC
 		LIMIT 25`
+
+	// SelectTotalBlocksMinedSince returns the total block count within a time
+	// window, using the same DISTINCT (addr, height) approach as SelectMinersByBlocksMinedSince.
+	SelectTotalBlocksMinedSince = `
+		SELECT COUNT(*)::INT4
+		FROM (
+			SELECT DISTINCT v.script_addresses AS addr, t.block_height AS height
+			FROM vouts v
+			JOIN transactions t ON v.tx_hash = t.tx_hash
+			WHERE t.tree = 0
+			  AND t.block_index = 0
+			  AND t.is_mainchain = true
+			  AND v.script_type IN ('pubkeyhash', 'scripthash', 'pubkey', 'pubkeyalt', 'pubkeyhashalt')
+			  AND v.value > 0
+			  AND v.script_addresses IS NOT NULL
+			  AND v.script_addresses NOT IN ('', 'unknown')
+			  AND v.script_addresses NOT LIKE '{%}'
+			  AND t.block_time >= $1
+		) sub
+		WHERE sub.addr IS NOT NULL AND sub.addr != ''`
 )

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -3469,7 +3469,7 @@ func (pgb *ChainDB) GetMinerHashrateShares(ctx context.Context, since *time.Time
 // GetTotalBlocksMined returns the total number of blocks mined across all
 // miners, optionally filtered by a time threshold. If since is nil, returns
 // all-time data.
-func (pgb *ChainDB) GetTotalBlocksMined(ctx context.Context, since *time.Time) (int32, error) {
+func (pgb *ChainDB) GetTotalBlocksMined(ctx context.Context, since *time.Time) (int64, error) {
 	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
 	defer cancel()
 	total, err := retrieveTotalBlocksMined(ctx, pgb.db, since)

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -3454,6 +3454,18 @@ func (pgb *ChainDB) minerRanges(ctx context.Context, _ *cache.ChartData) (*sql.R
 	return rows, cancel, nil
 }
 
+// GetMinerHashrateShares returns top 25 miners ordered by blocks_mined,
+// optionally filtered by a time threshold. If since is nil, returns all-time data.
+func (pgb *ChainDB) GetMinerHashrateShares(ctx context.Context, since *time.Time) ([]dbtypes.MinerShareData, error) {
+	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
+	defer cancel()
+	miners, err := retrieveMinerHashrateShares(ctx, pgb.db, since)
+	if err != nil {
+		return nil, pgb.replaceCancelError(fmt.Errorf("GetMinerHashrateShares: %w", err))
+	}
+	return miners, nil
+}
+
 // coinSupply fetches the coin supply chart data from retrieveCoinSupply.
 // This is the Fetcher half of a pair that make up a cache.ChartUpdater. The
 // Appender half is appendCoinSupply.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -3466,6 +3466,19 @@ func (pgb *ChainDB) GetMinerHashrateShares(ctx context.Context, since *time.Time
 	return miners, nil
 }
 
+// GetTotalBlocksMined returns the total number of blocks mined across all
+// miners, optionally filtered by a time threshold. If since is nil, returns
+// all-time data.
+func (pgb *ChainDB) GetTotalBlocksMined(ctx context.Context, since *time.Time) (int32, error) {
+	ctx, cancel := context.WithTimeout(ctx, pgb.queryTimeout)
+	defer cancel()
+	total, err := retrieveTotalBlocksMined(ctx, pgb.db, since)
+	if err != nil {
+		return 0, pgb.replaceCancelError(fmt.Errorf("GetTotalBlocksMined: %w", err))
+	}
+	return total, nil
+}
+
 // coinSupply fetches the coin supply chart data from retrieveCoinSupply.
 // This is the Fetcher half of a pair that make up a cache.ChartUpdater. The
 // Appender half is appendCoinSupply.

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -5156,3 +5156,22 @@ func retrieveMinerHashrateShares(ctx context.Context, db *sql.DB, since *time.Ti
 	}
 	return miners, nil
 }
+
+// retrieveTotalBlocksMined returns the total number of blocks mined by all
+// miners. If since is nil, uses the miners table sum; otherwise counts
+// coinbase outputs within the time window.
+func retrieveTotalBlocksMined(ctx context.Context, db *sql.DB, since *time.Time) (int32, error) {
+	var total int32
+	if since != nil {
+		err := db.QueryRowContext(ctx, internal.SelectTotalBlocksMinedSince, *since).Scan(&total)
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		err := db.QueryRowContext(ctx, internal.SelectTotalBlocksMined).Scan(&total)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return total, nil
+}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -5160,8 +5160,8 @@ func retrieveMinerHashrateShares(ctx context.Context, db *sql.DB, since *time.Ti
 // retrieveTotalBlocksMined returns the total number of blocks mined by all
 // miners. If since is nil, uses the miners table sum; otherwise counts
 // coinbase outputs within the time window.
-func retrieveTotalBlocksMined(ctx context.Context, db *sql.DB, since *time.Time) (int32, error) {
-	var total int32
+func retrieveTotalBlocksMined(ctx context.Context, db *sql.DB, since *time.Time) (int64, error) {
+	var total int64
 	if since != nil {
 		err := db.QueryRowContext(ctx, internal.SelectTotalBlocksMinedSince, *since).Scan(&total)
 		if err != nil {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -5126,3 +5126,33 @@ func bigAddSKA(acc *big.Int, s string) {
 		acc.Add(acc, v)
 	}
 }
+
+// retrieveMinerHashrateShares returns top 25 miners ordered by blocks_mined.
+// If since is nil, returns all-time data from the miners table.
+// If since is set, counts coinbase outputs >= since.
+func retrieveMinerHashrateShares(ctx context.Context, db *sql.DB, since *time.Time) ([]dbtypes.MinerShareData, error) {
+	var rows *sql.Rows
+	var err error
+	if since != nil {
+		rows, err = db.QueryContext(ctx, internal.SelectMinersByBlocksMinedSince, *since)
+	} else {
+		rows, err = db.QueryContext(ctx, internal.SelectMinersByBlocksMined)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closeRows(rows)
+
+	var miners []dbtypes.MinerShareData
+	for rows.Next() {
+		var m dbtypes.MinerShareData
+		if err := rows.Scan(&m.Address, &m.BlocksMined); err != nil {
+			return nil, err
+		}
+		miners = append(miners, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return miners, nil
+}


### PR DESCRIPTION
Implement a new 'Hashrate Shares' chart showing what percentage of total hashrate each miner contributed, displayed as a canvas pie chart with a ranked table.

- Add MinerShareData type and GetMinerHashrateShares query (all-time/time-bounded)
- Add HashrateShares const and special-case handler in chart data pipeline
- Add controller logic: pie drawing, table rendering, interval/mobile controls
- Use 24-column grid (col-md-12) with max-width 1000px for centered 50/50 layout
- Mobile falls back to vertical stack via Bootstrap responsive grid