### PR TITLE
explorer/charts: color Active Miners y2label to match series line

### DIFF
--- a/cmd/dcrdata/public/js/controllers/charts_controller.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.js
@@ -872,8 +872,10 @@ export default class extends Controller {
     }
     if (selection === 'hashrate') {
       this.intervalSelectorTarget.classList.remove('d-hide')
+      this.chartsViewTarget.classList.add('chart-hashrate')
     } else {
       this.intervalSelectorTarget.classList.add('d-hide')
+      this.chartsViewTarget.classList.remove('chart-hashrate')
     }
     if (
       selectedChart !== selection ||

--- a/cmd/dcrdata/public/js/controllers/charts_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.test.js
@@ -120,7 +120,7 @@ function makeController() {
   c.legendMarkerTarget = { remove: vi.fn(), removeAttribute: vi.fn() }
   c.legendEntryTarget = { remove: vi.fn(), removeAttribute: vi.fn() }
   c.rawDataURLTarget = { textContent: '' }
-  c.chartsViewTarget = {}
+  c.chartsViewTarget = { classList: { add: vi.fn(), remove: vi.fn() } }
   c.ticketsPriceTarget = { checked: true }
   c.ticketsPurchaseTarget = { checked: true }
   c.hashrateRateTarget = { checked: true }

--- a/cmd/dcrdata/public/js/controllers/charts_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/charts_controller.test.js
@@ -220,3 +220,33 @@ describe('ChartsController URL persistence', () => {
     )
   })
 })
+
+describe('ChartsController hashrate chart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('selecting hashrate adds chart-hashrate class to chartview', async () => {
+    const c = makeController()
+    await c.connect()
+
+    c.chartSelectTarget.value = 'hashrate'
+    await c.selectChart()
+
+    expect(c.chartsViewTarget.classList.add).toHaveBeenCalledWith('chart-hashrate')
+  })
+
+  it('switching away from hashrate removes chart-hashrate class', async () => {
+    const c = makeController()
+    await c.connect()
+
+    c.chartSelectTarget.value = 'hashrate'
+    await c.selectChart()
+
+    c.chartSelectTarget.value = 'ticket-price'
+    await c.selectChart()
+
+    expect(c.chartsViewTarget.classList.add).toHaveBeenCalledWith('chart-hashrate')
+    expect(c.chartsViewTarget.classList.remove).toHaveBeenCalledWith('chart-hashrate')
+  })
+})

--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -257,7 +257,15 @@ body.darkBG .chartview .dygraph-ylabel {
   color: #066;
 }
 
+.chart-hashrate .dygraph-y2label {
+  color: #c60;
+}
+
 body.darkBG .chartview .dygraph-y2label {
+  color: #2970ff;
+}
+
+body.darkBG .chart-hashrate .dygraph-y2label {
   color: #2970ff;
 }
 

--- a/cmd/dcrdata/public/scss/charts.scss
+++ b/cmd/dcrdata/public/scss/charts.scss
@@ -257,15 +257,11 @@ body.darkBG .chartview .dygraph-ylabel {
   color: #066;
 }
 
-.chart-hashrate .dygraph-y2label {
+.chartview.chart-hashrate .dygraph-y2label {
   color: #c60;
 }
 
 body.darkBG .chartview .dygraph-y2label {
-  color: #2970ff;
-}
-
-body.darkBG .chart-hashrate .dygraph-y2label {
   color: #2970ff;
 }
 

--- a/cmd/dcrdata/views/charts.tmpl
+++ b/cmd/dcrdata/views/charts.tmpl
@@ -199,6 +199,7 @@
                         <div class="btn-group" role="group">
                             <button type="button" class="btn btn-outline-secondary" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="all">All</button>
                             <button type="button" class="btn btn-outline-secondary" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="year">Year</button>
+                            <button type="button" class="btn btn-outline-secondary" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="month">Month</button>
                             <button type="button" class="btn btn-outline-secondary active" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="week">Week</button>
                             <button type="button" class="btn btn-outline-secondary" data-charts-target="intervalOption" data-action="click->charts#setIntervalOption" data-option="day">Day</button>
                         </div>


### PR DESCRIPTION
The 'Active Miners' y2-axis label on the hashrate chart now inherits the series color (#c60 light mode, #2970ff dark mode) instead of the generic y2label color. A chart-hashrate class is applied to the chartview element when the hashrate chart is selected.