### PR TITLE
public/js: resync footer last-block Age on reconnect

### DIFF
--- a/cmd/dcrdata/public/js/controllers/time_controller.js
+++ b/cmd/dcrdata/public/js/controllers/time_controller.js
@@ -65,6 +65,9 @@ export default class extends Controller {
   _processBlock(blockData) {
     const block = blockData.block
     this.blocktimeTarget.dataset.stamp = block.unixStamp
+    // A live new block is by definition fresh, so clear the stale flag outright
+    // here — unlike the reconnect resync (_refreshBlocktime), which can land on
+    // a genuinely overdue tip and so lets setAges re-evaluate the red.
     this.blocktimeTarget.classList.remove('text-danger')
     this.blocktimeTarget.textContent = humanize.timeSince(block.unixStamp)
   }

--- a/cmd/dcrdata/public/js/controllers/time_controller.js
+++ b/cmd/dcrdata/public/js/controllers/time_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import humanize from '../helpers/humanize_helper'
 import globalEventBus from '../services/event_bus_service'
+import ws from '../services/messagesocket_service'
 
 function isCorrectVal(value) {
   return /^\d+$/.test(value) && value > 0
@@ -17,6 +18,33 @@ export default class extends Controller {
     this.targetBlockTime = parseInt(document.getElementById('navBar').dataset.blocktime)
     if (this.hasBlocktimeTarget) {
       globalEventBus.on('BLOCK_RECEIVED', this.processBlock)
+      // The footer's last-block Age (this is the only `time` instance with a
+      // blocktime target) is seeded once at page load and otherwise only moved
+      // by the live new-block push. After a reconnect — e.g. the tab was
+      // backgrounded long enough to drop the socket — the server pushes future
+      // blocks only, never the current tip, so the stamp would stay frozen and
+      // setAges would render an ever-growing stale (red) age. Resync from the
+      // authoritative latest blocks on reconnect, reading the tip out of the
+      // shared "getlatestblocks" response.
+      this.refreshBlocktime = this._refreshBlocktime.bind(this)
+      this.latestBlocksUnsub = ws.registerEvtHandler('getlatestblocksResp', this.refreshBlocktime)
+      // Only request the latest blocks ourselves on pages whose live block
+      // table won't already do it. The home and latest-/blocks tables request
+      // getlatestblocks on reconnect with their own page size and share the one
+      // getlatestblocksResp broadcast (forward() delivers every response to
+      // every handler), so there we just resync from their response. Issuing
+      // our own empty-span request there would hand blocks_controller a
+      // home-span (8-row) reply, which it rebuilds its (up to 100-row) listing
+      // from and shrinks. A historical /blocks page (is-latest=false) does not
+      // refresh, so there we still self-request.
+      const liveBlockTable = document.querySelector(
+        '[data-controller~="home-latest-blocks"], [data-blocks-is-latest-value="true"]'
+      )
+      if (!liveBlockTable) {
+        this.reconnectUnsub = ws.registerEvtHandler('reconnect', () =>
+          ws.send('getlatestblocks', '')
+        )
+      }
     }
     if (this.hasHeaderTarget) {
       this.headerTargets.forEach((h) => {
@@ -29,6 +57,8 @@ export default class extends Controller {
     this.stopAgeRefresh()
     if (this.hasBlocktimeTarget) {
       globalEventBus.off('BLOCK_RECEIVED', this.processBlock)
+      if (this.latestBlocksUnsub) this.latestBlocksUnsub()
+      if (this.reconnectUnsub) this.reconnectUnsub()
     }
   }
 
@@ -37,6 +67,33 @@ export default class extends Controller {
     this.blocktimeTarget.dataset.stamp = block.unixStamp
     this.blocktimeTarget.classList.remove('text-danger')
     this.blocktimeTarget.textContent = humanize.timeSince(block.unixStamp)
+  }
+
+  // _refreshBlocktime resyncs the footer's last-block Age from a
+  // "getlatestblocks" response (a JSON array of BlockBasic objects, newest
+  // first). Only the newest block matters here. The list carries RFC3339
+  // `time`, so derive the unix stamp the same way live_block_table.js does for
+  // the block tables. A stale response (a live block already advanced the tip
+  // after this list was requested) must not move the Age backwards.
+  _refreshBlocktime(evt) {
+    let blocks
+    try {
+      blocks = JSON.parse(evt)
+    } catch {
+      return // server sends a non-JSON "Error: ..." string when the refresh fails
+    }
+    if (!Array.isArray(blocks) || blocks.length === 0) return
+    const tip = blocks[0]
+    if (!tip || !tip.time) return
+    const stamp = new Date(tip.time).getTime() / 1000
+    if (!(stamp > 0)) return
+    if (stamp < Number(this.blocktimeTarget.dataset.stamp)) return
+    this.blocktimeTarget.dataset.stamp = stamp
+    // Render the text and (re)evaluate the staleness red from the new stamp in
+    // one place. Unlike the live new-block path, a reconnect can resync onto a
+    // tip that is itself genuinely overdue (a stalled chain), so don't just
+    // clear the red — let setAges toggle it.
+    this.setAges()
   }
 
   startAgeRefresh() {
@@ -58,10 +115,11 @@ export default class extends Controller {
     if (this.hasBlocktimeTarget) {
       const lbt = this.blocktimeTarget.dataset.stamp
       this.blocktimeTarget.textContent = humanize.timeSince(lbt)
-      if (new Date().getTime() / 1000 - lbt > 8 * this.targetBlockTime) {
-        // 8*blocktime = 40minutes = 12000 seconds
-        this.element.classList.add('text-danger')
-      }
+      // 8*blocktime (e.g. 40 min for 5-min blocks) overdue -> flag stale in red.
+      // Toggle (not one-way add) so the red clears once the Age is fresh again,
+      // e.g. after a reconnect resync (_refreshBlocktime) with no new live block.
+      const stale = new Date().getTime() / 1000 - lbt > 8 * this.targetBlockTime
+      this.blocktimeTarget.classList.toggle('text-danger', stale)
     }
     if (!this.hasAgeTarget) return
     this.ageTargets.forEach((el) => {

--- a/cmd/dcrdata/public/js/controllers/time_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/time_controller.test.js
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import humanize from '../helpers/humanize_helper'
+
+vi.mock('@hotwired/stimulus', () => ({
+  Controller: class {
+    constructor(element) {
+      this.element = element
+    }
+  }
+}))
+
+vi.mock('../services/event_bus_service', () => ({
+  default: { on: vi.fn(), off: vi.fn() }
+}))
+
+const registered = {}
+const send = vi.fn()
+
+vi.mock('../services/messagesocket_service', () => ({
+  default: {
+    registerEvtHandler: vi.fn((event, handler) => {
+      const unsub = vi.fn()
+      ;(registered[event] = registered[event] || []).push({ handler, unsub })
+      return unsub
+    }),
+    deregisterEvtHandler: vi.fn(),
+    deregisterEvtHandlers: vi.fn(),
+    send: send
+  }
+}))
+
+const { default: TimeController } = await import('./time_controller.js')
+
+const NOW = new Date('2021-06-01T01:00:00Z')
+const NOW_SEC = Math.floor(NOW.getTime() / 1000)
+const BLOCKTIME = 300 // seconds; stale threshold is 8 * 300 = 2400s
+
+// makeFooterController builds the standalone footer `time` instance: the only
+// one carrying a `blocktime` target. element === blocktimeTarget for the footer
+// span (extras.tmpl), so they share the same DOM node here too.
+function makeFooterController(stamp) {
+  const span = document.createElement('span')
+  span.dataset.stamp = String(stamp)
+  const c = new TimeController()
+  c.element = span
+  c.hasBlocktimeTarget = true
+  c.blocktimeTarget = span
+  c.hasAgeTarget = false
+  c.hasHeaderTarget = false
+  return c
+}
+
+// makeTableController builds a non-footer `time` instance: age targets, no
+// blocktime target (e.g. the home/blocks table container).
+function makeTableController() {
+  const c = new TimeController()
+  c.element = document.createElement('div')
+  c.hasBlocktimeTarget = false
+  c.hasAgeTarget = false
+  c.hasHeaderTarget = false
+  return c
+}
+
+function latestBlocksPayload(unixSec, height = 1000) {
+  const time = new Date(unixSec * 1000).toISOString()
+  const hash = `hash${height}`
+  return JSON.stringify([{ height, hash, time }])
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+  document.body.innerHTML = `<div id="navBar" data-blocktime="${BLOCKTIME}"></div>`
+  for (const key of Object.keys(registered)) delete registered[key]
+  send.mockClear()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('footer blocktime reconnect resync', () => {
+  it("re-requests the latest blocks on 'reconnect'", () => {
+    const c = makeFooterController(NOW_SEC)
+    c.connect()
+
+    expect(registered.reconnect).toHaveLength(1)
+    registered.reconnect[0].handler()
+    // Empty span — matches home_latest_blocks_controller, the other empty-span
+    // requester — so a no-table page's footer reply has the home shape.
+    expect(send).toHaveBeenCalledWith('getlatestblocks', '')
+    c.disconnect()
+  })
+
+  it('updates the stamp, text, and clears red on a newer getlatestblocksResp', () => {
+    const staleStamp = NOW_SEC - 5000 // older than the 2400s threshold -> red
+    const c = makeFooterController(staleStamp)
+    c.blocktimeTarget.classList.add('text-danger')
+    c.connect()
+
+    const freshSec = NOW_SEC - 60 // tip mined 1 min ago
+    registered.getlatestblocksResp[0].handler(latestBlocksPayload(freshSec))
+
+    expect(Number(c.blocktimeTarget.dataset.stamp)).toBe(freshSec)
+    expect(c.blocktimeTarget.textContent).toBe(humanize.timeSince(freshSec))
+    expect(c.blocktimeTarget.classList.contains('text-danger')).toBe(false)
+    c.disconnect()
+  })
+
+  it('does not move the stamp backwards on a stale getlatestblocksResp', () => {
+    const c = makeFooterController(NOW_SEC)
+    c.connect()
+
+    const olderSec = NOW_SEC - 100 // older than the current stamp
+    registered.getlatestblocksResp[0].handler(latestBlocksPayload(olderSec))
+
+    expect(Number(c.blocktimeTarget.dataset.stamp)).toBe(NOW_SEC)
+    c.disconnect()
+  })
+
+  it('ignores a non-JSON or empty getlatestblocksResp', () => {
+    const c = makeFooterController(NOW_SEC)
+    c.connect()
+
+    registered.getlatestblocksResp[0].handler('Error: boom')
+    registered.getlatestblocksResp[0].handler('[]')
+
+    expect(Number(c.blocktimeTarget.dataset.stamp)).toBe(NOW_SEC)
+    c.disconnect()
+  })
+
+  it("removes its own 'reconnect' and 'getlatestblocksResp' handlers on disconnect", () => {
+    const c = makeFooterController(NOW_SEC)
+    c.connect()
+    c.disconnect()
+
+    expect(registered.reconnect[0].unsub).toHaveBeenCalledTimes(1)
+    expect(registered.getlatestblocksResp[0].unsub).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('footer blocktime red toggle is symmetric', () => {
+  it('adds text-danger when the block is stale', () => {
+    const c = makeFooterController(NOW_SEC - 3000) // > 2400s threshold
+    c.targetBlockTime = BLOCKTIME
+
+    c.setAges()
+
+    expect(c.blocktimeTarget.classList.contains('text-danger')).toBe(true)
+  })
+
+  it('removes text-danger once the block is fresh again', () => {
+    const c = makeFooterController(NOW_SEC - 60) // < 2400s threshold
+    c.targetBlockTime = BLOCKTIME
+    c.blocktimeTarget.classList.add('text-danger')
+
+    c.setAges()
+
+    expect(c.blocktimeTarget.classList.contains('text-danger')).toBe(false)
+  })
+})
+
+describe('footer reconnect self-request is gated on the page block table', () => {
+  // The home and latest-/blocks tables already request getlatestblocks on
+  // reconnect and share the response, so the footer must not double-request
+  // there: its empty-span (home-span) reply would be rebuilt by
+  // blocks_controller and shrink the larger /blocks listing. The footer still
+  // resyncs passively from whatever response the table fetches.
+  function withMarker(markup) {
+    document.body.innerHTML = `<div id="navBar" data-blocktime="${BLOCKTIME}"></div>${markup}`
+  }
+
+  it('skips its own reconnect request when a live /blocks table is present', () => {
+    withMarker(
+      '<div data-controller="time pagenavigation blocks" data-blocks-is-latest-value="true"></div>'
+    )
+    const c = makeFooterController(NOW_SEC - 5000)
+    c.connect()
+
+    expect(registered.reconnect).toBeUndefined()
+    // Still resyncs from the table's shared getlatestblocksResp.
+    expect(registered.getlatestblocksResp).toHaveLength(1)
+    registered.getlatestblocksResp[0].handler(latestBlocksPayload(NOW_SEC - 60))
+    expect(Number(c.blocktimeTarget.dataset.stamp)).toBe(NOW_SEC - 60)
+    c.disconnect()
+  })
+
+  it('skips its own reconnect request when the home latest-blocks table is present', () => {
+    withMarker('<div data-controller="time home-latest-blocks"></div>')
+    const c = makeFooterController(NOW_SEC)
+    c.connect()
+
+    expect(registered.reconnect).toBeUndefined()
+    expect(send).not.toHaveBeenCalled()
+    c.disconnect()
+  })
+
+  it('still self-requests on a historical /blocks page (is-latest=false)', () => {
+    withMarker(
+      '<div data-controller="time pagenavigation blocks" data-blocks-is-latest-value="false"></div>'
+    )
+    const c = makeFooterController(NOW_SEC)
+    c.connect()
+
+    expect(registered.reconnect).toHaveLength(1)
+    registered.reconnect[0].handler()
+    expect(send).toHaveBeenCalledWith('getlatestblocks', '')
+    c.disconnect()
+  })
+})
+
+describe('non-footer time instance', () => {
+  it('registers no reconnect/getlatestblocksResp handlers', () => {
+    const c = makeTableController()
+    c.connect()
+    c.disconnect()
+
+    expect(registered.reconnect).toBeUndefined()
+    expect(registered.getlatestblocksResp).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem (#467)

On **mobile**, the footer (left side) shows the Age of the latest block — duplicating
the latest-block Age in the home table. After the browser is backgrounded for a long
time and then refocused, the table recovers correctly but the **footer Age stays stale
and red**, out of sync with the table.

Root cause: the footer's "since last block" Age is the only `time` controller instance
with a blocktime target. It was seeded once at page load from `{{$.Tip.Time}}` and
otherwise only advanced by the live new-block push. On reconnect — e.g. a backgrounded
mobile tab whose socket silently dropped and is force-reconnected by the liveness
watchdog (see `wiki/code-analysis/websocket/`) — the server pushes only future blocks,
never the current tip, so the footer stamp stayed frozen and `setAges()` rendered an
ever-growing stale age. Because the red `text-danger` flag was added but never removed,
it stayed red.

## Fix

- **Resync on reconnect** from the authoritative latest blocks, refusing to move the
  Age backwards behind a live block, then render via `setAges()` so the staleness red is
  re-evaluated from the new stamp (a resync onto a genuinely overdue tip stays red).
- **Symmetric red toggle** in `setAges()` so the `text-danger` flag clears once the Age
  is fresh again, instead of only on a live new block.
- **Gated self-request.** The footer reads the tip out of the shared
  `getlatestblocks`/`getlatestblocksResp` broadcast, which `forward()` delivers to *every*
  handler. The home and latest-`/blocks` tables already request it on reconnect with their
  own page size, so the footer only issues its own (empty-span) request on pages where no
  live block table will (historical `/blocks`, `/tx`, `/address`, …) and otherwise resyncs
  from their response — keeping the footer Age sourced identically to the table's.

## Acceptance criteria (from #467)

- ✅ After backgrounding and refocus, the footer Age **matches the latest block's Age in
  the table** — both now derive from the same `getlatestblocks` response (on home the
  footer rides the table's own reply; `blocks[0]` is the shared tip).
- ✅ The footer renders **black, not red**, once fresh — the symmetric `text-danger`
  toggle clears the stale styling on resync.
- ✅ No discrepancy between the footer Age and the table's latest-block Age after refocus.

## Regression this avoids

An earlier cut had the footer unconditionally send `getlatestblocks ''` on every page.
On the latest `/blocks` page that handed `blocks_controller` a home-span (8-row) reply —
which it rebuilt its up-to-100-row listing from and **shrank the table to 8 rows on every
reconnect**. The gating above prevents the footer from emitting that colliding request
where a live table is present.

## Tests

`cmd/dcrdata/public/js/controllers/time_controller.test.js`: exact-string Age assertion,
reconnect handler exercised while connected, and new coverage for the self-request gating
(live `/blocks`, home, historical `/blocks`). Full frontend suite green (377).

## Manual verification (Chrome DevTools, live testnet)

| Page | Footer self-requests? | `getlatestblocks` on reconnect | Table |
|---|---|---|---|
| Latest `/blocks?rows=100` | No (rides table's reply) | 1 × `"100"` | stays 100 ✓ |
| Home `/` | No (rides table's reply) | 1 × `""` | intact ✓ |
| Historical `/blocks?height=…` | Yes (fallback) | 1 × `""` | untouched ✓ |

On reconnect the footer Age resynced to the live tip (e.g. `/blocks`: "59s" → "14s") and
cleared red, matching the table. Injecting the pre-fix `message:""` frame on the latest
`/blocks` page reproduced the 100 → 8 collapse, confirming both the mechanism and that the
fix prevents it.

> Note: GitHub auto-closes issues only on merges to the default branch (`main`); this PR
> targets `develop`, so #467 will close when `develop` reaches `main` (the commit carries
> `Fixes #467`), or can be closed manually on merge.

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
