### PR TITLE
Fix/visualblocks duplicate mempool

### DIFF
--- a/cmd/dcrdata/public/js/controllers/visualBlocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/visualBlocks_controller.js
@@ -387,6 +387,7 @@ export default class extends Controller {
 
     const box = this.boxTarget
     const mempoolTile = box.firstChild
+    if (!mempoolTile) return
     box.insertBefore(newBlockHtmlElement(tile), mempoolTile.nextSibling)
     const vis = this.visibleBlocks()
     vis[vis.length - 1].classList.remove('visible')

--- a/cmd/dcrdata/public/js/controllers/visualBlocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/visualBlocks_controller.js
@@ -242,7 +242,7 @@ export function makeMempoolBlock(mempool) {
 
   const countFor = (symbol) => mempoolRegularCountForSymbol(mempool.CoinStats, symbol)
 
-  return makeNode(`<div class="block visible" data-visualBlocks-target="block">
+  return makeNode(`<div class="block visible" data-role="mempool-tile" data-visualBlocks-target="block">
     ${header}
     <div class="block-rows">
         ${makeVoteElements(mempool.Votes)}
@@ -386,7 +386,8 @@ export default class extends Controller {
     const tile = normaliseWsBlock(block)
 
     const box = this.boxTarget
-    box.insertBefore(newBlockHtmlElement(tile), box.firstChild.nextSibling)
+    const mempoolTile = box.firstChild
+    box.insertBefore(newBlockHtmlElement(tile), mempoolTile.nextSibling)
     const vis = this.visibleBlocks()
     vis[vis.length - 1].classList.remove('visible')
     box.removeChild(box.lastChild)
@@ -397,7 +398,10 @@ export default class extends Controller {
     const raw = JSON.parse(evt)
     raw.Time = Math.round(new Date().getTime() / 1000)
     const tile = normaliseMempool(raw)
-    this.boxTarget.replaceChild(makeMempoolBlock(tile), this.boxTarget.firstChild)
+    const mempoolTile = this.boxTarget.querySelector('[data-role="mempool-tile"]')
+    if (mempoolTile) {
+      mempoolTile.replaceWith(makeMempoolBlock(tile))
+    }
     this.setupTooltips()
   }
 

--- a/cmd/dcrdata/public/js/controllers/visualBlocks_controller.js
+++ b/cmd/dcrdata/public/js/controllers/visualBlocks_controller.js
@@ -386,7 +386,7 @@ export default class extends Controller {
     const tile = normaliseWsBlock(block)
 
     const box = this.boxTarget
-    const mempoolTile = box.firstChild
+    const mempoolTile = box.querySelector('[data-role="mempool-tile"]')
     if (!mempoolTile) return
     box.insertBefore(newBlockHtmlElement(tile), mempoolTile.nextSibling)
     const vis = this.visibleBlocks()

--- a/cmd/dcrdata/public/js/controllers/visualBlocks_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/visualBlocks_controller.test.js
@@ -434,4 +434,23 @@ describe('controller mempool-tile lifecycle', () => {
     expect(boxTarget.children).toHaveLength(4)
     expect(mempoolTiles[0]).toBe(boxTarget.firstChild)
   })
+
+  it('_handleVisualBlocksUpdate with empty boxTarget does not throw', () => {
+    const emptyBox = document.createElement('div')
+    c.boxTarget = emptyBox
+    expect(() =>
+      c._handleVisualBlocksUpdate({
+        block: {
+          height: 1,
+          time: '2026-01-01T00:00:00Z',
+          size: 1,
+          formatted_bytes: '1 B',
+          Votes: [],
+          Tickets: [],
+          Revs: []
+        }
+      })
+    ).not.toThrow()
+    expect(emptyBox.children).toHaveLength(0)
+  })
 })

--- a/cmd/dcrdata/public/js/controllers/visualBlocks_controller.test.js
+++ b/cmd/dcrdata/public/js/controllers/visualBlocks_controller.test.js
@@ -354,3 +354,84 @@ describe('visualBlocks reconnect resync', () => {
     expect(wsRegistered.reconnect[0].unsub).toHaveBeenCalledTimes(1)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Controller method integration — DOM mutation from mempool/block events
+// ---------------------------------------------------------------------------
+
+describe('controller mempool-tile lifecycle', () => {
+  let c
+  let boxTarget
+
+  beforeEach(() => {
+    c = new mod.default()
+    boxTarget = document.createElement('div')
+    c.boxTarget = boxTarget
+    c.setupTooltips = vi.fn()
+
+    // Initial state: mempool tile + 3 block tiles
+    const mempoolEl = document.createElement('div')
+    mempoolEl.className = 'block visible'
+    mempoolEl.setAttribute('data-role', 'mempool-tile')
+    mempoolEl.setAttribute('data-visualBlocks-target', 'block')
+    boxTarget.appendChild(mempoolEl)
+
+    for (let i = 0; i < 3; i++) {
+      const el = document.createElement('div')
+      el.className = 'block visible'
+      el.setAttribute('data-visualBlocks-target', 'block')
+      el.textContent = `block-${i}`
+      boxTarget.appendChild(el)
+    }
+  })
+
+  it('handleMempoolUpdate replaces the mempool tile in place, preserving count', () => {
+    c.handleMempoolUpdate(JSON.stringify(makeMempoolFixture()))
+
+    const mempoolTiles = boxTarget.querySelectorAll('[data-role="mempool-tile"]')
+    expect(mempoolTiles).toHaveLength(1)
+    expect(mempoolTiles[0]).toBe(boxTarget.firstChild)
+    expect(boxTarget.children).toHaveLength(4)
+  })
+
+  it('_handleVisualBlocksUpdate inserts new block after mempool tile, trims last', () => {
+    c._handleVisualBlocksUpdate({
+      block: {
+        height: 100,
+        time: '2026-01-01T00:00:00Z',
+        size: 4096,
+        formatted_bytes: '4.1 kB',
+        Votes: [],
+        Tickets: [],
+        Revs: []
+      }
+    })
+
+    const mempoolTiles = boxTarget.querySelectorAll('[data-role="mempool-tile"]')
+    expect(mempoolTiles).toHaveLength(1)
+    expect(mempoolTiles[0]).toBe(boxTarget.firstChild)
+    expect(boxTarget.children).toHaveLength(4)
+    // Second child should be the new block tile (not block-0)
+    expect(boxTarget.children[1].textContent).not.toBe('block-0')
+  })
+
+  it('mempool tile remains singular after both mempool and block updates', () => {
+    c.handleMempoolUpdate(JSON.stringify(makeMempoolFixture()))
+    c._handleVisualBlocksUpdate({
+      block: {
+        height: 101,
+        time: '2026-01-01T00:00:01Z',
+        size: 2048,
+        formatted_bytes: '2.0 kB',
+        Votes: [],
+        Tickets: [],
+        Revs: []
+      }
+    })
+
+    const mempoolTiles = boxTarget.querySelectorAll('[data-role="mempool-tile"]')
+    expect(mempoolTiles).toHaveLength(1)
+    expect(boxTarget.children).toHaveLength(4)
+    expect(mempoolTiles[0]).toBe(boxTarget.firstChild)
+  })
+})

--- a/cmd/dcrdata/views/visualblocks.tmpl
+++ b/cmd/dcrdata/views/visualblocks.tmpl
@@ -23,9 +23,8 @@
                 class="blocks-holder"
                 data-visualBlocks-target="box"
             >
-                <!-- Mempool tile -->
                 {{with .Mempool}}
-                <div class="block visible" data-visualBlocks-target="block">
+                <div class="block visible" data-role="mempool-tile" data-visualBlocks-target="block">
                     <div class="block-info">
                         <a class="color-code" href="/mempool">Mempool</a>
                         <div class="mono amount" style="line-height: 1;">
@@ -138,7 +137,6 @@
                 </div>
                 {{end}}
 
-                <!-- Block tiles -->
                 {{range $index, $block := .Blocks}}
                 <div class="{{if lt $index 10}}block visible{{else}}block{{end}}" data-visualBlocks-target="block">
                 {{with $block}}


### PR DESCRIPTION
Closes #466

## Summary

- Remove `<!-- Mempool tile -->` and `<!-- Block tiles -->` HTML comments from `visualblocks.tmpl` — these created whitespace text nodes that broke the `box.firstChild` assumption
- Switch both websocket handlers from positional `firstChild` to `[data-role="mempool-tile"]` selector for finding the mempool tile
- Add 4 controller integration tests covering the mempool tile lifecycle (replace-in-place, insert-after-mempool, combined, empty-box null guard)

## Changes

| File | Change |
|------|--------|
| `cmd/dcrdata/views/visualblocks.tmpl` | Remove HTML comments; add `data-role="mempool-tile"` to mempool tile |
| `cmd/dcrdata/public/js/controllers/visualBlocks_controller.js` | Use `querySelector` + `replaceWith` in both handlers; add `data-role` to `makeMempoolBlock`; add null guard |
| `cmd/dcrdata/public/js/controllers/visualBlocks_controller.test.js` | Add 4 lifecycle tests |

## Test Plan

- [x] `npm test` — all tests pass
